### PR TITLE
Avoid non-data object in Var

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/FunctionBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/FunctionBuilder.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.core.domains
 
+import org.jetbrains.kotlin.formver.core.names.PlaceholderArgumentName
 import org.jetbrains.kotlin.formver.core.names.SpecialName
 import org.jetbrains.kotlin.formver.viper.ast.BuiltinFunction
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -68,7 +69,7 @@ class FunctionBuilder private constructor() {
 
     fun argument(action: () -> Type): Exp.LocalVar {
         val argType = action()
-        val variable = Var("arg${formalArgs.size + 1}", argType)
+        val variable = Var(PlaceholderArgumentName(formalArgs.size + 1), argType)
         formalArgs.add(variable)
         return variable.use()
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/Injection.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/Injection.kt
@@ -42,8 +42,8 @@ class Injection(
     val viperType: Type,
     val typeFunction: DomainFunc
 ) {
-    private val v = Var("v", viperType)
-    private val r = Var("r", Type.Ref)
+    private val v = domainVar("v", viperType)
+    private val r = domainVar("r", Type.Ref)
     val toRef = RuntimeTypeDomain.createDomainFunc("${injectionName}ToRef", listOf(v.decl()), Type.Ref)
     val fromRef = RuntimeTypeDomain.createDomainFunc("${injectionName}FromRef", listOf(r.decl()), viperType)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/RuntimeTypeDomain.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/RuntimeTypeDomain.kt
@@ -231,11 +231,11 @@ class RuntimeTypeDomain(classes: List<ClassTypeEmbedding>) : BuiltinDomain(RUNTI
         )
 
         // variables for readability improving
-        private val t = Var("t", RuntimeType)
-        private val t1 = Var("t1", RuntimeType)
-        private val t2 = Var("t2", RuntimeType)
-        private val t3 = Var("t3", RuntimeType)
-        private val r = Var("r", Ref)
+        private val t = domainVar("t", RuntimeType)
+        private val t1 = domainVar("t1", RuntimeType)
+        private val t2 = domainVar("t2", RuntimeType)
+        private val t3 = domainVar("t3", RuntimeType)
+        private val r = domainVar("r", Ref)
 
         // three basic functions
         /** `isSubtype: (Type, Type) -> Bool` */

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/Utils.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/Utils.kt
@@ -1,0 +1,7 @@
+package org.jetbrains.kotlin.formver.core.domains
+
+import org.jetbrains.kotlin.formver.core.names.DomainFuncParameterName
+import org.jetbrains.kotlin.formver.viper.ast.Type
+import org.jetbrains.kotlin.formver.viper.ast.Var
+
+fun domainVar(name: String, type: Type) = Var(DomainFuncParameterName(name), type)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshNames.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshNames.kt
@@ -72,3 +72,10 @@ data class ContinueLabelName(val n: Int) : NumberedLabelName("continue", n)
 data class CatchLabelName(val n: Int) : NumberedLabelName("catch", n)
 data class TryExitLabelName(val n: Int) : NumberedLabelName("try_exit", n)
 
+data class PlaceholderArgumentName(val n: Int) : MangledName {
+    override val mangledBaseName: String
+        get() = "arg$n"
+
+}
+
+data class DomainFuncParameterName(override val mangledBaseName: String) : MangledName

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Var.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Var.kt
@@ -11,15 +11,8 @@ import org.jetbrains.kotlin.formver.viper.MangledName
  *
  * This is like a `VariableEmbedding` but already at the Viper level, making expressions
  * that involve variables less cumbersome to write.
- *
- * Note that we do not mangle the name here: it is assumed that these variables are only
- * used in very controlled scopes.
  */
-data class Var(val name: String, val type: Type) {
-    val mangledName = object : MangledName {
-        override val mangledBaseName: String = name
-    }
-
-    fun use(): Exp.LocalVar = Exp.LocalVar(mangledName, type)
-    fun decl(): Declaration.LocalVarDecl = Declaration.LocalVarDecl(mangledName, type)
+data class Var(val name: MangledName, val type: Type) {
+    fun use(): Exp.LocalVar = Exp.LocalVar(name, type)
+    fun decl(): Declaration.LocalVarDecl = Declaration.LocalVarDecl(name, type)
 }


### PR DESCRIPTION
Previously, we had a MangledName subtype that was non-data, causing spurious comparison failures.  This replaces it with dedicated names.