### PR TITLE
add constant separator for mangled name

### DIFF
--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/MangledName.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/MangledName.kt
@@ -11,6 +11,7 @@ package org.jetbrains.kotlin.formver.viper
  * We could directly convert names and pass them around as strings, but this
  * approach makes it easier to see where they came from during debugging.
  */
+const val SEPARATOR = "$"
 interface MangledName {
     val mangledType: String?
         get() = null
@@ -20,4 +21,4 @@ interface MangledName {
 }
 
 val MangledName.mangled: String
-    get() = listOfNotNull(mangledType, mangledScope, mangledBaseName).joinToString("$")
+    get() = listOfNotNull(mangledType, mangledScope, mangledBaseName).joinToString(SEPARATOR)


### PR DESCRIPTION
Introduce a constant SEPARATOR for constructing mangled names and replace hardcoded separator usage.