### PR TITLE
Delegate assignment to lineraizer

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
@@ -7,11 +7,13 @@ package org.jetbrains.kotlin.formver.core.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.PretypeBuilder
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeBuilder
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
+import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Label
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
@@ -44,6 +46,8 @@ interface LinearizationContext {
     fun addDeclaration(decl: Declaration)
 
     fun addModifier(mod: StmtModifier)
+
+    fun emitAssignment(lhs: ExpEmbedding, rhs: ExpEmbedding): Exp?
 }
 
 fun LinearizationContext.freshAnonVar(init: TypeBuilder.() -> PretypeBuilder): AnonymousVariableEmbedding =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -8,8 +8,12 @@ package org.jetbrains.kotlin.formver.core.linearization
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.core.asPosition
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.LinearizationVariableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.withType
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
+import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Position
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
@@ -62,5 +66,19 @@ data class Linearizer(
 
     override fun addModifier(mod: StmtModifier) {
         stmtModifierTracker?.add(mod) ?: error("Not in a statement")
+    }
+
+    override fun emitAssignment(
+        lhs: ExpEmbedding,
+        rhs: ExpEmbedding
+    ): Exp? {
+        val lhsViper = lhs.toViper(this)
+        if (lhsViper is Exp.LocalVar) {
+            rhs.withType(lhs.type).toViperStoringIn(LinearizationVariableEmbedding(lhsViper.name, lhs.type), this)
+        } else {
+            val rhsViper = rhs.withType(lhs.type).toViper(this)
+            addStatement { Stmt.assign(lhsViper, rhsViper, source.asPosition) }
+        }
+        return null
     }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureLinearizer.kt
@@ -53,6 +53,10 @@ class PureLinearizer(override val source: KtSourceElement?) : LinearizationConte
     override fun addModifier(mod: StmtModifier) {
         throw PureLinearizerMisuseException("addModifier")
     }
+
+    override fun emitAssignment(lhs: ExpEmbedding, rhs: ExpEmbedding): Exp {
+        throw PureLinearizerMisuseException("emitAssignment")
+    }
 }
 
 fun ExpEmbedding.pureToViper(toBuiltin: Boolean, source: KtSourceElement? = null): Exp {
@@ -62,7 +66,8 @@ fun ExpEmbedding.pureToViper(toBuiltin: Boolean, source: KtSourceElement? = null
     } catch (e: PureLinearizerMisuseException) {
         val catchNameResolver = SimpleNameResolver()
         val debugView = with(catchNameResolver) { debugTreeView.print() }
-        val msg = "PureLinearizer used to convert non-pure ExpEmbedding; operation ${e.offendingFunction} is not supported in a pure context.\nEmbedding debug view:\n${debugView}"
+        val msg =
+            "PureLinearizer used to convert non-pure ExpEmbedding; operation ${e.offendingFunction} is not supported in a pure context.\nEmbedding debug view:\n${debugView}"
         throw IllegalStateException(msg)
     }
 }


### PR DESCRIPTION
This PR delegates the translation work for assignments to the linearizer. This will later be used to emit Let-Expressions, rather than adding statements. Therefore, the Assign embedding returns an Expression and was converted to a "OnlyToViperExpEmbedding". As the tests are still running this transformation has not changed the translation behaviour