### PR TITLE
Move translation of assignments to linearizer

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -523,13 +523,7 @@ data class Assign(val lhs: ExpEmbedding, val rhs: ExpEmbedding) : UnitResultExpE
     override val type: TypeEmbedding = lhs.type
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        val lhsViper = lhs.toViper(ctx)
-        if (lhsViper is Exp.LocalVar) {
-            rhs.withType(lhs.type).toViperStoringIn(LinearizationVariableEmbedding(lhsViper.name, lhs.type), ctx)
-        } else {
-            val rhsViper = rhs.withType(lhs.type).toViper(ctx)
-            ctx.addStatement { Stmt.assign(lhsViper, rhsViper, ctx.source.asPosition) }
-        }
+        ctx.addAssignment(lhs, rhs)
     }
 
     context(nameResolver: NameResolver)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.core.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.PretypeBuilder
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeBuilder
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
@@ -42,6 +43,7 @@ interface LinearizationContext {
 
     fun addStatement(buildStmt: LinearizationContext.() -> Stmt)
     fun addDeclaration(decl: Declaration)
+    fun addAssignment(lhs: ExpEmbedding, rhs: ExpEmbedding)
 
     fun addModifier(mod: StmtModifier)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureLinearizer.kt
@@ -50,6 +50,10 @@ class PureLinearizer(override val source: KtSourceElement?) : LinearizationConte
         throw PureLinearizerMisuseException("addDeclaration")
     }
 
+    override fun addAssignment(lhs: ExpEmbedding, rhs: ExpEmbedding) {
+        throw PureLinearizerMisuseException("addAssignment")
+    }
+
     override fun addModifier(mod: StmtModifier) {
         throw PureLinearizerMisuseException("addModifier")
     }
@@ -62,7 +66,8 @@ fun ExpEmbedding.pureToViper(toBuiltin: Boolean, source: KtSourceElement? = null
     } catch (e: PureLinearizerMisuseException) {
         val catchNameResolver = SimpleNameResolver()
         val debugView = with(catchNameResolver) { debugTreeView.print() }
-        val msg = "PureLinearizer used to convert non-pure ExpEmbedding; operation ${e.offendingFunction} is not supported in a pure context.\nEmbedding debug view:\n${debugView}"
+        val msg =
+            "PureLinearizer used to convert non-pure ExpEmbedding; operation ${e.offendingFunction} is not supported in a pure context.\nEmbedding debug view:\n${debugView}"
         throw IllegalStateException(msg)
     }
 }


### PR DESCRIPTION
This PR moves the translation of assignments to the linearizer. For this the following was done:
- Introduce new addAssignment function in the LinearizationContext
- Translate the corresponding ExpEmbeddings in the general Linearizer
- The pure linearizer for now throws a MisuseException (will later track the assignments and translate into let-bindings)

