### PR TITLE
Remove PureExpEmbedding

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
@@ -8,7 +8,6 @@ package org.jetbrains.kotlin.formver.core.embeddings
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 
 interface ExpVisitor<R> {
-    fun visitPureExpEmbedding(e: PureExpEmbedding): R
     fun visitBlock(e: Block): R
     fun visitFunctionExp(e: FunctionExp): R
     fun visitGotoChainNode(e: GotoChainNode): R
@@ -51,4 +50,7 @@ interface ExpVisitor<R> {
     fun visitSharingContext(e: SharingContext): R
     fun visitWithPosition(e: WithPosition): R
     fun visitDefault(e: ExpEmbedding): R
+    fun visitLiteralEmbedding(e: LiteralEmbedding): R
+    fun visitExpWrapper(e: ExpWrapper): R
+    fun visitVariableEmbedding(e: VariableEmbedding): R
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.expression
 
-import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.core.asPosition
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
@@ -269,18 +268,6 @@ sealed interface NoResultExpEmbedding : DefaultMaybeStoringInExpEmbedding, Defau
         toViperUnusedResult(ctx)
         return RuntimeTypeDomain.unitValue(pos = ctx.source.asPosition)
     }
-}
-
-/**
- * `ExpEmbedding` that can be converted to an `Exp` without any linearization context.
- *
- * Note that such an expression of course cannot have (non-pure) subexpressions, since otherwise they would have to be linearized as well.
- */
-sealed interface PureExpEmbedding : NullaryDirectResultExpEmbedding {
-    fun toViper(source: KtSourceElement? = null): Exp
-    override fun toViper(ctx: LinearizationContext): Exp = toViper(ctx.source)
-
-    override fun <R> accept(v: ExpVisitor<R>): R = v.visitPureExpEmbedding(this)
 }
 
 /**

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.expression
 
-import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.core.asPosition
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
@@ -21,8 +20,9 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
  * We will eventually want to solve this somehow, but there are still open design questions there, so for now this wrapper will
  * do the job.
  */
-data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : PureExpEmbedding {
-    override fun toViper(source: KtSourceElement?): Exp = value
+data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : NullaryDirectResultExpEmbedding {
+    override fun toViper(ctx: LinearizationContext): Exp = value
+    override fun <R> accept(v: ExpVisitor<R>): R = v.visitExpWrapper(this)
 }
 
 data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
@@ -11,10 +11,12 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 internal object ExprPurityVisitor : ExpVisitor<Boolean> {
 
     /* ————— pure nodes ————— */
-    override fun visitPureExpEmbedding(e: PureExpEmbedding) = true
     override fun visitUnitLit(e: UnitLit) = true
     override fun visitFunctionCall(e: FunctionCall) = true
     override fun visitDeclare(e: Declare) = e.initializer != null
+    override fun visitLiteralEmbedding(e: LiteralEmbedding) = true
+    override fun visitExpWrapper(e: ExpWrapper) = true
+    override fun visitVariableEmbedding(e: VariableEmbedding) = true
 
     /* ————— structural nodes without side effects ————— */
     override fun visitReturn(e: Return) = e.allChildrenPure(this)


### PR DESCRIPTION
This PR removes the previously introduced PureExpEmbedding interface and delegates decisions on purity to the purity checker