### PR TITLE
Remark: Z3_EXE captured by publishToMavenLocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ You need to (additionally) set `Z3_EXE` in `~/.xprofile` and/or
 `~/.bash_profile` depending on your shell, window manager, display
 manager, operating system, etc.
 
+**Note**: The `Z3_EXE` environmental variable is captured in the local Maven repository when `publishToMavenLocal`
+is run. Changing the environment variable later has no effect until the task is executed again.
+
 ## Contact
 
 Reach out to komi.golov@jetbrains.com if you'd like to use or contribute to the plugin!


### PR DESCRIPTION
When `publishToMavenLocal` is run, the current value of the `Z3_EXE` environmental variable is captured in the local Maven repository. Changes to the variable thus have no effect until the task is re-run.

This PR adds a small remark to the README.md which explains this.