### PR TITLE
Update annotations API dump for triggers() and @Manual

### DIFF
--- a/formver.annotations/api/formver.annotations.api
+++ b/formver.annotations/api/formver.annotations.api
@@ -18,6 +18,10 @@ public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/D
 public final class org/jetbrains/kotlin/formver/plugin/InvariantBuilder {
 	public fun <init> ()V
 	public final fun forAll (Lkotlin/jvm/functions/Function1;)Z
+	public final fun triggers ([Ljava/lang/Object;)V
+}
+
+public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/Manual : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/NeverConvert : java/lang/annotation/Annotation {


### PR DESCRIPTION
## Summary
- The API declaration file for `formver.annotations` was not regenerated after the addition of `InvariantBuilder.triggers()` and the `@Manual` annotation, causing `apiCheck` to fail on a clean build.

## Test plan
- [x] `./gradlew build` passes (including `apiCheck`)
- [x] All 132 tests pass with z3 4.8.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)