### PR TITLE
Stop Silicon verifier after use to prevent Z3 process leak

### DIFF
--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -80,16 +80,20 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
                 }
             }
             val verifier = Verifier()
-            val onFailure = { err: VerifierError ->
-                val source = err.position.unwrapOr { declaration.source }
-                reporter.reportVerifierError(source, err, config.errorStyle)
-            }
-            val viperProgram = with(programConversionContext.nameResolver) { program.toSilver() }
-            val consistent = verifier.checkConsistency(viperProgram, onFailure)
-            // If the Viper program is not consistent, that's our error; we shouldn't surface it to the user as an unverified contract.
-            if (!consistent || !config.shouldVerify(declaration)) return
+            try {
+                val onFailure = { err: VerifierError ->
+                    val source = err.position.unwrapOr { declaration.source }
+                    reporter.reportVerifierError(source, err, config.errorStyle)
+                }
+                val viperProgram = with(programConversionContext.nameResolver) { program.toSilver() }
+                val consistent = verifier.checkConsistency(viperProgram, onFailure)
+                // If the Viper program is not consistent, that's our error; we shouldn't surface it to the user as an unverified contract.
+                if (!consistent || !config.shouldVerify(declaration)) return
 
-            verifier.verify(viperProgram, onFailure)
+                verifier.verify(viperProgram, onFailure)
+            } finally {
+                verifier.stop()
+            }
         } catch (e: SnaktInternalException) {
             reporter.reportOn(e.source, PluginErrors.INTERNAL_ERROR, e.message)
         } catch (e: Exception) {

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/Verifier.kt
@@ -24,7 +24,11 @@ class Verifier {
     init {
         // Viper requires a file to be passed as part of the configuration, hence we need to specify a
         // dummy file name and also specify that that file should be ignored.
-        val config = Config(seqOf("--ignoreFile", "dummy.vpr"))
+        val args = mutableListOf("--ignoreFile", "dummy.vpr")
+        System.getenv("SILICON_PARALLEL_VERIFIERS")?.let {
+            args += listOf("--numberOfParallelVerifiers", it)
+        }
+        val config = Config(seqOf(*args.toTypedArray()))
         @Suppress("UNCHECKED_CAST")
         verifier = DefaultMainVerifier(
             config,
@@ -58,5 +62,9 @@ class Verifier {
                 onFailure(VerificationError.fromSilver(result))
             }
         }
+    }
+
+    fun stop() {
+        verifier.stop()
     }
 }


### PR DESCRIPTION
## Summary

- **Z3 process leak fix**: `ViperPoweredDeclarationChecker.check()` creates a new `Verifier` (and `DefaultMainVerifier`) per declaration but never calls `stop()`. This causes Z3 processes to accumulate across verifications within a single compilation, eventually exhausting memory.
- **`Verifier.stop()`**: New method that delegates to `DefaultMainVerifier.stop()`, called in a `try/finally` to ensure cleanup on all code paths (including early returns and exceptions).
- **`SILICON_PARALLEL_VERIFIERS` env var**: Optionally limits Silicon's internal Z3 parallelism via `--numberOfParallelVerifiers`. Defaults to Silicon's existing behavior (all cores) when unset, useful for memory-constrained machines.

## Measurements (12GB machine, `--max-workers=2`)

Running full `*Verification*` test suite:

| | Z3 processes (peak) | RAM (peak) | Result |
|---|---|---|---|
| Before | ~283 | 8GB+ (OOM killed) | FAIL |
| After (stop + `SILICON_PARALLEL_VERIFIERS=2`) | ~16 | ~3.5GB | PASS (2m43s) |

## Test plan

- [x] Full `*Verification*` test suite passes with `--rerun`
- [x] No golden file changes
- [x] All other test suites (Conversion, Purity_checker, Uniqueness_checker) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)