### PR TITLE
[claude-experiments] permissions system test probes

### DIFF
--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -753,6 +753,40 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/permissions")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Permissions {
+      @Test
+      public void testAllFilesPresentInPermissions() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/verification/permissions"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("borrowed_unique.kt")
+      public void testBorrowed_unique() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/permissions/borrowed_unique.kt");
+      }
+
+      @Test
+      @TestMetadata("constructor_permissions.kt")
+      public void testConstructor_permissions() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/permissions/constructor_permissions.kt");
+      }
+
+      @Test
+      @TestMetadata("val_field_reasoning.kt")
+      public void testVal_field_reasoning() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/permissions/val_field_reasoning.kt");
+      }
+
+      @Test
+      @TestMetadata("var_field_reasoning.kt")
+      public void testVar_field_reasoning() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/permissions/var_field_reasoning.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields")
     @TestDataPath("$PROJECT_ROOT")
     public class Properties_and_fields {

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/borrowed_unique.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/borrowed_unique.fir.diag.txt
@@ -1,0 +1,52 @@
+/borrowed_unique.kt:(271,289): info: Generated Viper text for borrowedUniqueRead:
+field bf$value: Ref
+
+method f$borrowedUniqueRead$TF$T$Box$T$Int(p$b: Ref) returns (ret$0: Ref)
+  requires acc(p$c$Box$unique(p$b), write)
+  ensures acc(p$c$Box$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Box())
+  inhale acc(p$c$Box$shared(p$b), wildcard)
+  ret$0 := havoc$T$Int()
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/borrowed_unique.kt:(402,420): info: Generated Viper text for consumedUniqueRead:
+field bf$value: Ref
+
+method f$consumedUniqueRead$TF$T$Box$T$Int(p$b: Ref) returns (ret$0: Ref)
+  requires acc(p$c$Box$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Box())
+  inhale acc(p$c$Box$shared(p$b), wildcard)
+  ret$0 := havoc$T$Int()
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/borrowed_unique.kt:(534,553): info: Generated Viper text for callBorrowedThenUse:
+field bf$value: Ref
+
+method f$borrowedUniqueRead$TF$T$Box$T$Int(p$b: Ref) returns (ret: Ref)
+  requires acc(p$c$Box$unique(p$b), write)
+  ensures acc(p$c$Box$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+
+
+method f$callBorrowedThenUse$TF$T$Box$T$Int(p$b: Ref) returns (ret$0: Ref)
+  requires acc(p$c$Box$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var l0$x: Ref
+  var l0$y: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Box())
+  inhale acc(p$c$Box$shared(p$b), wildcard)
+  l0$x := f$borrowedUniqueRead$TF$T$Box$T$Int(p$b)
+  l0$y := f$borrowedUniqueRead$TF$T$Box$T$Int(p$b)
+  ret$0 := sp$plusInts(l0$x, l0$y)
+  goto lbl$ret$0
+  label lbl$ret$0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/borrowed_unique.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/borrowed_unique.kt
@@ -1,0 +1,24 @@
+// ALWAYS_VALIDATE
+// Probe: @Borrowed @Unique parameter behavior
+
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+
+class Box(var value: Int)
+
+// @Borrowed @Unique: unique permission should be returned after call
+fun <!VIPER_TEXT!>borrowedUniqueRead<!>(@Borrowed @Unique b: Box): Int {
+    return b.value
+}
+
+// @Unique without @Borrowed: permission is consumed
+fun <!VIPER_TEXT!>consumedUniqueRead<!>(@Unique b: Box): Int {
+    return b.value
+}
+
+// Call a borrowed-unique function and then use the value again
+fun <!VIPER_TEXT!>callBorrowedThenUse<!>(@Unique b: Box): Int {
+    val x = borrowedUniqueRead(b)
+    val y = borrowedUniqueRead(b)  // should work: permission returned
+    return x + y
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/constructor_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/constructor_permissions.fir.diag.txt
@@ -1,0 +1,75 @@
+/constructor_permissions.kt:(344,354): info: Generated Viper text for takeUnique:
+field bf$x: Ref
+
+field bf$y: Ref
+
+method f$takeUnique$TF$T$Simple$T$Int(p$s: Ref) returns (ret$0: Ref)
+  requires acc(p$c$Simple$unique(p$s), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$c$Simple())
+  inhale acc(p$c$Simple$shared(p$s), wildcard)
+  unfold acc(p$c$Simple$shared(p$s), wildcard)
+  ret$0 := p$s.bf$x
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/constructor_permissions.kt:(403,425): info: Generated Viper text for constructAndPassUnique:
+field bf$x: Ref
+
+field bf$y: Ref
+
+method con$c$Simple$T$Int$T$Int$T$Simple(p$x: Ref, p$y: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Simple())
+  ensures acc(p$c$Simple$shared(ret), wildcard)
+  ensures acc(p$c$Simple$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(p$c$Simple$shared(ret), wildcard) in
+      ret.bf$x)) ==
+    df$rt$intFromRef(p$x)
+
+
+method f$constructAndPassUnique$TF$T$Int() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var l0$s: Ref
+  l0$s := con$c$Simple$T$Int$T$Int$T$Simple(df$rt$intToRef(1), df$rt$intToRef(2))
+  ret$0 := f$takeUnique$TF$T$Simple$T$Int(l0$s)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+method f$takeUnique$TF$T$Simple$T$Int(p$s: Ref) returns (ret: Ref)
+  requires acc(p$c$Simple$unique(p$s), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+
+
+/constructor_permissions.kt:(586,605): info: Generated Viper text for constructAndReadVal:
+field bf$x: Ref
+
+field bf$y: Ref
+
+method con$c$Simple$T$Int$T$Int$T$Simple(p$x: Ref, p$y: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Simple())
+  ensures acc(p$c$Simple$shared(ret), wildcard)
+  ensures acc(p$c$Simple$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(p$c$Simple$shared(ret), wildcard) in
+      ret.bf$x)) ==
+    df$rt$intFromRef(p$x)
+
+
+method f$constructAndReadVal$TF$T$Boolean() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true
+{
+  var l0$s: Ref
+  var anon$0: Ref
+  l0$s := con$c$Simple$T$Int$T$Int$T$Simple(df$rt$intToRef(10), df$rt$intToRef(20))
+  unfold acc(p$c$Simple$shared(l0$s), wildcard)
+  anon$0 := l0$s.bf$x
+  ret$0 := df$rt$boolToRef(df$rt$intFromRef(anon$0) == 10)
+  goto lbl$ret$0
+  label lbl$ret$0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/constructor_permissions.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/constructor_permissions.kt
@@ -1,0 +1,29 @@
+// ALWAYS_VALIDATE
+// Probe: what permissions does a constructor provide?
+
+import org.jetbrains.kotlin.formver.plugin.Unique
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+class Simple(val x: Int, var y: Int)
+
+// After construction, we get unique ownership
+// Can we pass the result to a @Unique parameter?
+fun <!VIPER_TEXT!>takeUnique<!>(@Unique s: Simple): Int {
+    return s.x
+}
+
+fun <!VIPER_TEXT!>constructAndPassUnique<!>(): Int {
+    val s = Simple(1, 2)
+    return takeUnique(s)
+}
+
+// Can we read val fields of freshly constructed object?
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>constructAndReadVal<!>(): Boolean {
+    contract {
+        returns(true)
+    }
+    val s = Simple(10, 20)
+    return s.x == 10
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/val_field_reasoning.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/val_field_reasoning.fir.diag.txt
@@ -1,0 +1,60 @@
+/val_field_reasoning.kt:(279,296): info: Generated Viper text for valFieldPreserved:
+field bf$first: Ref
+
+field bf$second: Ref
+
+method f$valFieldPreserved$TF$T$Pair$T$Boolean(p$p: Ref)
+  returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true
+{
+  var l0$x: Ref
+  var l0$y: Ref
+  inhale df$rt$isSubtype(df$rt$typeOf(p$p), df$rt$c$Pair())
+  inhale acc(p$c$Pair$shared(p$p), wildcard)
+  unfold acc(p$c$Pair$shared(p$p), wildcard)
+  l0$x := p$p.bf$first
+  unfold acc(p$c$Pair$shared(p$p), wildcard)
+  l0$y := p$p.bf$first
+  ret$0 := df$rt$boolToRef(df$rt$intFromRef(l0$x) == df$rt$intFromRef(l0$y))
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/val_field_reasoning.kt:(518,542): info: Generated Viper text for constructorValueRetained:
+field bf$first: Ref
+
+field bf$second: Ref
+
+method con$c$Pair$T$Int$T$Int$T$Pair(p$first: Ref, p$second: Ref)
+  returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Pair())
+  ensures acc(p$c$Pair$shared(ret), wildcard)
+  ensures acc(p$c$Pair$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(p$c$Pair$shared(ret), wildcard) in
+      ret.bf$first)) ==
+    df$rt$intFromRef(p$first) &&
+    df$rt$intFromRef((unfolding acc(p$c$Pair$shared(ret), wildcard) in
+      ret.bf$second)) ==
+    df$rt$intFromRef(p$second)
+
+
+method f$constructorValueRetained$TF$T$Boolean() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+  ensures df$rt$boolFromRef(ret$0) == true
+{
+  var l0$p: Ref
+  var anon$0: Ref
+  l0$p := con$c$Pair$T$Int$T$Int$T$Pair(df$rt$intToRef(1), df$rt$intToRef(2))
+  unfold acc(p$c$Pair$shared(l0$p), wildcard)
+  anon$0 := l0$p.bf$first
+  if (df$rt$intFromRef(anon$0) == 1) {
+    var anon$1: Ref
+    unfold acc(p$c$Pair$shared(l0$p), wildcard)
+    anon$1 := l0$p.bf$second
+    ret$0 := df$rt$boolToRef(df$rt$intFromRef(anon$1) == 2)
+  } else {
+    ret$0 := df$rt$boolToRef(false)}
+  goto lbl$ret$0
+  label lbl$ret$0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/val_field_reasoning.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/val_field_reasoning.kt
@@ -1,0 +1,28 @@
+// ALWAYS_VALIDATE
+// Probe: can we reason about val field values?
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+class Pair(val first: Int, val second: Int)
+
+// Can we prove a property about val fields?
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>valFieldPreserved<!>(p: Pair): Boolean {
+    contract {
+        returns(true)
+    }
+    val x = p.first
+    val y = p.first
+    return x == y
+}
+
+// Can we prove constructor-provided value is retained?
+@OptIn(ExperimentalContracts::class)
+fun <!VIPER_TEXT!>constructorValueRetained<!>(): Boolean {
+    contract {
+        returns(true)
+    }
+    val p = Pair(1, 2)
+    return p.first == 1 && p.second == 2
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/var_field_reasoning.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/var_field_reasoning.fir.diag.txt
@@ -1,0 +1,74 @@
+/var_field_reasoning.kt:(224,241): info: Generated Viper text for sharedReadIsHavoc:
+field bf$count: Ref
+
+method f$sharedReadIsHavoc$TF$T$Counter$T$Int(p$c: Ref)
+  returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$Counter())
+  inhale acc(p$c$Counter$shared(p$c), wildcard)
+  ret$0 := havoc$T$Int()
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/var_field_reasoning.kt:(362,382): info: Generated Viper text for sharedWriteIsDropped:
+field bf$count: Ref
+
+method f$sharedWriteIsDropped$TF$T$Counter$T$Unit(p$c: Ref)
+  returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$Counter())
+  inhale acc(p$c$Counter$shared(p$c), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/var_field_reasoning.kt:(500,518): info: Generated Viper text for uniqueReadBehavior:
+field bf$count: Ref
+
+method f$uniqueReadBehavior$TF$T$Counter$T$Int(p$c: Ref)
+  returns (ret$0: Ref)
+  requires acc(p$c$Counter$unique(p$c), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$Counter())
+  inhale acc(p$c$Counter$shared(p$c), wildcard)
+  ret$0 := havoc$T$Int()
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/var_field_reasoning.kt:(650,669): info: Generated Viper text for uniqueWriteBehavior:
+field bf$count: Ref
+
+method f$uniqueWriteBehavior$TF$T$Counter$T$Unit(p$c: Ref)
+  returns (ret$0: Ref)
+  requires acc(p$c$Counter$unique(p$c), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$Counter())
+  inhale acc(p$c$Counter$shared(p$c), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/var_field_reasoning.kt:(815,829): info: Generated Viper text for freshObjectVar:
+field bf$count: Ref
+
+method con$c$Counter$T$Int$T$Counter(p$count: Ref) returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Counter())
+  ensures acc(p$c$Counter$shared(ret), wildcard)
+  ensures acc(p$c$Counter$unique(ret), write)
+
+
+method f$freshObjectVar$TF$T$Int() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var l0$c: Ref
+  l0$c := con$c$Counter$T$Int$T$Counter(df$rt$intToRef(0))
+  ret$0 := havoc$T$Int()
+  goto lbl$ret$0
+  label lbl$ret$0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/var_field_reasoning.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/var_field_reasoning.kt
@@ -1,0 +1,32 @@
+// ALWAYS_VALIDATE
+// Probe: what can we reason about var fields?
+
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class Counter(var count: Int)
+
+// Shared receiver: read returns havoc, so we can't reason about value
+fun <!VIPER_TEXT!>sharedReadIsHavoc<!>(c: Counter): Int {
+    return c.count  // expect: havoc
+}
+
+// Shared receiver: write is dropped, so this is a no-op
+fun <!VIPER_TEXT!>sharedWriteIsDropped<!>(c: Counter) {
+    c.count = 42  // expect: silently dropped
+}
+
+// Unique receiver: does @Unique help with reads?
+fun <!VIPER_TEXT!>uniqueReadBehavior<!>(@Unique c: Counter): Int {
+    return c.count  // does this still havoc?
+}
+
+// Unique receiver: does @Unique help with writes?
+fun <!VIPER_TEXT!>uniqueWriteBehavior<!>(@Unique c: Counter) {
+    c.count = 42  // is the write actually performed?
+}
+
+// Can we verify anything about a freshly constructed object?
+fun <!VIPER_TEXT!>freshObjectVar<!>(): Int {
+    val c = Counter(0)
+    return c.count  // freshly constructed, can we get 0?
+}


### PR DESCRIPTION
## Summary
- Adds 4 verification-level test probes for the shared/unique predicate system
- Tests val field reasoning, var field behavior, @Borrowed/@Unique interaction, and constructor permissions
- Confirms @Unique doesn't currently enable var field reasoning (reads havoc, writes dropped)

## Test probes
- `val_field_reasoning.kt` — val fields preserve values ✓, constructor values verifiable ✓
- `var_field_reasoning.kt` — var reads always havoc ✗, writes dropped ✗ (even with @Unique)
- `borrowed_unique.kt` — @Borrowed @Unique returns permission ✓, enabling multiple calls
- `constructor_permissions.kt` — constructors provide both predicates ✓, fresh objects usable as @Unique ✓

## Key finding
`@Unique` gates access (adds precondition) but doesn't enable mutation in method bodies.
The unique predicate is never unfolded to gain write access to var fields. This matches
the folding-unfolding.md note: "Currently, contexts (Δ) are not implemented in the plugin."

Companion investigation doc: https://github.com/jesyspa/snakt-botspace/pull/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)