### PR TITLE
Require proven invariants instead of inhaling them.

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -409,11 +409,11 @@ class ProgramConverter(
         }
 
         return object : FullNamedFunctionSignature, NamedFunctionSignature by subSignature {
-            // TODO (inhale vs require) Decide if `predicateAccessInvariant` should be required rather than inhaled in the beginning of the body.
             override fun getPreconditions() = buildList {
                 subSignature.formalArgs.forEach {
                     addAll(it.pureInvariants())
                     addAll(it.accessInvariants())
+                    addAll(it.provenInvariants())
                     if (it.isUnique) {
                         addIfNotNull(it.type.uniquePredicateAccessInvariant()?.fillHole(it))
                     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -277,11 +277,9 @@ data class FunctionExp(
 
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
         signature?.formalArgs?.forEach { arg ->
-            // Ideally we would want to assume these rather than inhale them to prevent inconsistencies with permissions.
-            // Unfortunately Silicon for some reason does not allow Assumes. However, it doesn't matter as long as the
-            // provenInvariants don't contain permissions.
-            // TODO (inhale vs require) Decide if `predicateAccessInvariant` should be required rather than inhaled in the beginning of the body.
-            (arg.provenInvariants() + listOfNotNull(arg.sharedPredicateAccessInvariant())).forEach { invariant ->
+            // Ideally, we would want to assume these rather than inhale them to prevent inconsistencies with
+            // permissions. Unfortunately, Silicon for some reason does not allow Assumes.
+            listOfNotNull(arg.sharedPredicateAccessInvariant()).forEach { invariant ->
                 ctx.addStatement { Stmt.Inhale(invariant.toViperBuiltinType(ctx), ctx.source.asPosition) }
             }
         }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/basic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/basic.fir.diag.txt
@@ -17,18 +17,18 @@ method f$returnInt$TF$T$Int() returns (ret$0: Ref)
 
 /basic.kt:(77,94): info: Generated Viper text for takeIntReturnUnit:
 method f$takeIntReturnUnit$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /basic.kt:(140,156): info: Generated Viper text for takeIntReturnInt:
 method f$takeIntReturnInt$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -36,9 +36,9 @@ method f$takeIntReturnInt$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 
 /basic.kt:(187,207): info: Generated Viper text for takeIntReturnIntExpr:
 method f$takeIntReturnIntExpr$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
@@ -5,11 +5,11 @@ field bf$b: Ref
 
 method f$testPrimitiveFieldGetter$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   l0$a := p$pf.bf$a
@@ -29,6 +29,7 @@ field bf$g: Ref
 
 method f$testReferenceFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
@@ -37,7 +38,6 @@ method f$testReferenceFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$fb: Ref
   var l0$ga: Ref
   var l0$gb: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   l0$f := p$rf.bf$f
@@ -63,6 +63,7 @@ field bf$g: Ref
 
 method f$testCascadingFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$fa: Ref
@@ -71,7 +72,6 @@ method f$testCascadingFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$ga: Ref
   var anon$1: Ref
   var l0$gb: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := p$rf.bf$f

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
@@ -9,6 +9,7 @@ field bf$uniqueVar: Ref
 
 method f$testPrimitiveFieldGetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   requires acc(p$c$PrimitiveFields$unique(p$pf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -16,7 +17,6 @@ method f$testPrimitiveFieldGetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   l0$sharedVal := p$pf.bf$sharedVal
@@ -39,13 +39,13 @@ field bf$uniqueVar: Ref
 
 method f$testPrimitiveFieldGetterShared$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   l0$sharedVal := p$pf.bf$sharedVal
@@ -68,6 +68,7 @@ field bf$uniqueVar: Ref
 
 method f$testReferenceFieldGetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   requires acc(p$c$ReferenceFields$unique(p$rf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -75,7 +76,6 @@ method f$testReferenceFieldGetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   l0$sharedVal := p$rf.bf$sharedVal
@@ -98,13 +98,13 @@ field bf$uniqueVar: Ref
 
 method f$testReferenceFieldGetterShared$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   l0$sharedVal := p$rf.bf$sharedVal

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
@@ -5,10 +5,10 @@ field bf$unique: Ref
 
 method f$testPrimitiveFieldSetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   requires acc(p$c$PrimitiveFields$unique(p$pf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -21,9 +21,9 @@ field bf$unique: Ref
 
 method f$testPrimitiveFieldSetterShared$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -36,6 +36,8 @@ field bf$unique: Ref
 
 method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$unique: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$shared), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$unique), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
   ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveFields$unique(ret), write)
@@ -43,12 +45,12 @@ method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$uniq
 
 method f$testReferenceFieldSetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   requires acc(p$c$ReferenceFields$unique(p$rf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(5),
     df$rt$intToRef(6))
@@ -65,6 +67,8 @@ field bf$unique: Ref
 
 method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$unique: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$shared), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$unique), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
   ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveFields$unique(ret), write)
@@ -72,11 +76,11 @@ method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$uniq
 
 method f$testReferenceFieldSetterShared$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(9),
     df$rt$intToRef(10))

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
@@ -6,9 +6,9 @@ field bf$x: Ref
 field bf$y: Ref
 
 method f$c$Foo$getY$TF$T$Foo$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$y
@@ -26,11 +26,11 @@ field bf$y: Ref
 field bf$z: Ref
 
 method f$c$Bar$sum$TF$T$Bar$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
   unfold acc(p$c$Bar$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
@@ -52,13 +52,14 @@ field bf$y: Ref
 field bf$z: Ref
 
 method f$c$Foo$getY$TF$T$Foo$T$Int(this$dispatch: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$callSuperMethod$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := f$c$Foo$getY$TF$T$Foo$T$Int(p$bar)
   goto lbl$ret$0
@@ -76,9 +77,9 @@ field bf$z: Ref
 
 method f$accessSuperField$TF$T$Bar$T$Boolean(p$bar: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := havoc$T$Boolean()
   goto lbl$ret$0
@@ -95,9 +96,9 @@ field bf$y: Ref
 field bf$z: Ref
 
 method f$accessNewField$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   unfold acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := p$bar.bf$z
@@ -115,13 +116,14 @@ field bf$y: Ref
 field bf$z: Ref
 
 method f$c$Bar$sum$TF$T$Bar$T$Int(this$dispatch: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$callNewMethod$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := f$c$Bar$sum$TF$T$Bar$T$Int(p$bar)
   goto lbl$ret$0
@@ -138,9 +140,9 @@ field bf$y: Ref
 field bf$z: Ref
 
 method f$setSuperField$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -157,9 +159,9 @@ field bf$z: Ref
 
 method f$accessSuperSuperField$TF$T$Baz$T$Int(p$baz: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$baz), df$rt$c$Baz())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$baz), df$rt$c$Baz())
   inhale acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Bar$shared(p$baz), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
@@ -2,6 +2,7 @@
 field bf$fieldNotOverride: Ref
 
 method con$c$B$T$FieldB$T$B(p$fieldOverride: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$fieldOverride), df$rt$c$FieldB())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$B())
   ensures acc(p$c$B$shared(ret), wildcard)
   ensures acc(p$c$B$unique(ret), write)
@@ -55,6 +56,7 @@ method con$c$NoBackingFieldClass$T$NoBackingFieldClass() returns (ret: Ref)
 
 method con$c$SecondBackingFieldClass$T$Int$T$SecondBackingFieldClass(p$x: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$SecondBackingFieldClass())
   ensures acc(p$c$SecondBackingFieldClass$shared(ret), wildcard)
   ensures acc(p$c$SecondBackingFieldClass$unique(ret), write)
@@ -96,6 +98,7 @@ method pg$public$x(this$dispatch: Ref) returns (ret: Ref)
 field bf$a: Ref
 
 method con$c$Y$T$Int$T$Y(p$a: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Y())
   ensures acc(p$c$Y$shared(ret), wildcard)
   ensures acc(p$c$Y$unique(ret), write)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
@@ -1,5 +1,6 @@
 /interface.kt:(84,98): info: Generated Viper text for testProperties:
 method f$testProperties$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -8,7 +9,6 @@ method f$testProperties$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
   var anon$2: Ref
   var anon$3: Ref
   var anon$4: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   anon$0 := ps$public$varProp(p$foo, df$rt$intToRef(0))
   anon$2 := pg$public$varProp(p$foo)
@@ -36,6 +36,7 @@ method ps$public$varProp(this$dispatch: Ref, anon$0: Ref)
 field bf$number: Ref
 
 method con$c$Impl$T$Int$T$Impl(p$number: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$number), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl())
   ensures acc(p$c$Impl$shared(ret), wildcard)
   ensures acc(p$c$Impl$unique(ret), write)
@@ -57,4 +58,3 @@ method f$createImpl$TF$T$Unit() returns (ret$0: Ref)
 }
 
 method pg$public$number(this$dispatch: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
@@ -5,11 +5,11 @@ field bf$b: Ref
 
 method f$testManualPermissionFieldGetter$TF$T$ManualPermissionFields$T$Unit(p$mpf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
   inhale acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   unfold acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   l0$a := p$mpf.bf$a
@@ -26,9 +26,9 @@ field bf$b: Ref
 
 method f$testManualPermissionFieldSetter$TF$T$ManualPermissionFields$T$Unit(p$mpf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
   inhale acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   p$mpf.bf$b := df$rt$intToRef(123)
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
@@ -3,9 +3,9 @@ field bf$x: Ref
 
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$x
@@ -18,10 +18,10 @@ field bf$x: Ref
 
 method f$c$Foo$callMemberFun$TF$T$Foo$T$Unit(this$dispatch: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch)
   label lbl$ret$0
@@ -30,6 +30,7 @@ method f$c$Foo$callMemberFun$TF$T$Foo$T$Unit(this$dispatch: Ref)
 
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
@@ -38,17 +39,18 @@ field bf$x: Ref
 
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$c$Foo$siblingCall$TF$T$Foo$T$Foo$T$Unit(this$dispatch: Ref, p$other: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$other), wildcard)
   anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(p$other)
   label lbl$ret$0
@@ -60,14 +62,15 @@ field bf$x: Ref
 
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$outerMemberFunCall$TF$T$Foo$T$Unit(p$f: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$f), wildcard)
   anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(p$f)
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
@@ -63,4 +63,3 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 method ps$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
@@ -57,11 +57,11 @@ predicate p$c$ReferenceField$unique(this$dispatch: Ref) {
 
 method f$useClasses$TF$T$ReferenceField$T$Recursive$T$Unit(p$rf: Ref, p$rec: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
+  requires df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$c$Recursive())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
   inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$c$Recursive())
   inhale acc(p$c$Recursive$shared(p$rec), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -101,9 +101,9 @@ predicate p$c$C$unique(this$dispatch: Ref) {
 }
 
 method f$threeLayersHierarchy$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   inhale acc(p$c$C$shared(p$c), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -168,11 +168,11 @@ method f$listHierarchy$TF$T$MutableList$T$Unit(p$xs: Ref)
   returns (ret$0: Ref)
   requires acc(p$xs.sp$size, write)
   requires df$rt$intFromRef(p$xs.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$xs), df$rt$c$pkg$kotlin_collections$MutableList())
   ensures acc(p$xs.sp$size, write)
   ensures df$rt$intFromRef(p$xs.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$xs), df$rt$c$pkg$kotlin_collections$MutableList())
   inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$xs), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
@@ -58,10 +58,10 @@ predicate p$c$D$unique(this$dispatch: Ref) {
 
 method f$accessSuperTypeProperty$TF$T$C$T$Unit(p$c: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   inhale acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$B$shared(p$c), wildcard)
@@ -133,11 +133,11 @@ predicate p$c$D$unique(this$dispatch: Ref) {
 }
 
 method f$accessNested$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
   inhale acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$C$shared(p$c), wildcard)
   anon$0 := p$c.bf$x
@@ -164,10 +164,10 @@ predicate p$c$A$unique(this$dispatch: Ref) {
 }
 
 method f$accessNullable$TF$NT$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$A()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$A()))
   inhale p$x != df$rt$nullValue() ==> acc(p$c$A$shared(p$x), wildcard)
   if (!(p$x == df$rt$nullValue())) {
     unfold acc(p$c$A$shared(p$x), wildcard)
@@ -205,10 +205,10 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 }
 
 method f$accessCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   inhale acc(p$c$A$shared(p$x), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())
   inhale acc(p$c$B$shared(p$x), wildcard)
@@ -246,11 +246,11 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 }
 
 method f$accessSafeCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   inhale acc(p$c$A$shared(p$x), wildcard)
   l0$n := df$rt$intToRef(0)
   if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {
@@ -295,10 +295,10 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 }
 
 method f$accessSmartCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
   inhale acc(p$c$A$shared(p$x), wildcard)
   l0$n := df$rt$intToRef(0)
   if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
@@ -5,6 +5,8 @@ field bf$b: Ref
 
 method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$a: Ref, p$b: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
   ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveFields$unique(ret), write)
@@ -31,6 +33,7 @@ field bf$a: Ref
 
 method con$c$Recursive$NT$Recursive$T$Recursive(p$a: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$nullable(df$rt$c$Recursive()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret), wildcard)
   ensures acc(p$c$Recursive$unique(ret), write)
@@ -53,6 +56,7 @@ field bf$a: Ref
 field bf$c: Ref
 
 method con$c$FieldInBody$T$Int$T$FieldInBody(p$c: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FieldInBody())
   ensures acc(p$c$FieldInBody$shared(ret), wildcard)
   ensures acc(p$c$FieldInBody$unique(ret), write)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
@@ -1,10 +1,10 @@
 /property_getters.kt:(102,129): info: Generated Viper text for testPrimitivePropertyGetter:
 method f$testPrimitivePropertyGetter$TF$T$PrimitiveProperty$T$Int(p$pp: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
   inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   anon$0 := pg$public$nProp(p$pp)
   ret$0 := anon$0
@@ -19,13 +19,13 @@ method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 /property_getters.kt:(286,313): info: Generated Viper text for testReferencePropertyGetter:
 method f$testReferencePropertyGetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$pp: Ref
   var anon$0: Ref
   var l0$ppn: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$0 := pg$public$rProp(p$rp)
   l0$pp := anon$0
@@ -47,13 +47,13 @@ method pg$public$rProp(this$dispatch: Ref) returns (ret: Ref)
 /property_getters.kt:(391,418): info: Generated Viper text for testCascadingPropertyGetter:
 method f$testCascadingPropertyGetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$ppn: Ref
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$2 := pg$public$rProp(p$rp)
   anon$1 := anon$2
@@ -70,4 +70,3 @@ method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 
 
 method pg$public$rProp(this$dispatch: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
@@ -3,6 +3,7 @@ field bf$a: Ref
 
 method con$c$NoPrimaryConstructor$T$Boolean$T$NoPrimaryConstructor(p$b: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoPrimaryConstructor())
   ensures acc(p$c$NoPrimaryConstructor$shared(ret), wildcard)
   ensures acc(p$c$NoPrimaryConstructor$unique(ret), write)
@@ -10,6 +11,7 @@ method con$c$NoPrimaryConstructor$T$Boolean$T$NoPrimaryConstructor(p$b: Ref)
 
 method con$c$NoPrimaryConstructor$T$Int$T$NoPrimaryConstructor(p$n: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoPrimaryConstructor())
   ensures acc(p$c$NoPrimaryConstructor$shared(ret), wildcard)
   ensures acc(p$c$NoPrimaryConstructor$unique(ret), write)
@@ -31,6 +33,7 @@ field bf$a: Ref
 
 method con$c$BothConstructors$T$Boolean$T$BothConstructors(p$b: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$BothConstructors())
   ensures acc(p$c$BothConstructors$shared(ret), wildcard)
   ensures acc(p$c$BothConstructors$unique(ret), write)
@@ -38,6 +41,7 @@ method con$c$BothConstructors$T$Boolean$T$BothConstructors(p$b: Ref)
 
 method con$c$BothConstructors$T$Int$T$BothConstructors(p$a: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$BothConstructors())
   ensures acc(p$c$BothConstructors$shared(ret), wildcard)
   ensures acc(p$c$BothConstructors$unique(ret), write)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
@@ -3,9 +3,9 @@ field bf$a: Ref
 
 method f$testPrimitiveFieldSetter$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -18,6 +18,7 @@ field bf$pf: Ref
 
 method con$c$PrimitiveField$T$Int$T$PrimitiveField(p$a: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveField())
   ensures acc(p$c$PrimitiveField$shared(ret), wildcard)
   ensures acc(p$c$PrimitiveField$unique(ret), write)
@@ -25,10 +26,10 @@ method con$c$PrimitiveField$T$Int$T$PrimitiveField(p$a: Ref)
 
 method f$testReferenceFieldSetter$TF$T$ReferenceField$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
   inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
   anon$0 := con$c$PrimitiveField$T$Int$T$PrimitiveField(df$rt$intToRef(0))
   label lbl$ret$0
@@ -38,10 +39,10 @@ method f$testReferenceFieldSetter$TF$T$ReferenceField$T$Unit(p$rf: Ref)
 /setters.kt:(427,454): info: Generated Viper text for testPrimitivePropertySetter:
 method f$testPrimitivePropertySetter$TF$T$PrimitiveProperty$T$Unit(p$pp: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
   inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   anon$0 := ps$public$aProp(p$pp, df$rt$intToRef(0))
   label lbl$ret$0
@@ -63,11 +64,11 @@ method con$c$PrimitiveProperty$T$PrimitiveProperty() returns (ret: Ref)
 
 method f$testReferencePropertySetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
   inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$1 := con$c$PrimitiveProperty$T$PrimitiveProperty()
   anon$0 := ps$public$ppProp(p$rp, anon$1)
@@ -85,4 +86,3 @@ method ps$public$aProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
 
 
 method ps$public$ppProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
@@ -1,8 +1,8 @@
 /subtyping.kt:(80,89): info: Generated Viper text for smartCast:
 method f$smartCast$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   if (p$x == df$rt$nullValue()) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
@@ -45,5 +45,5 @@ method f$functionParameterSubtyping$TF$T$Unit() returns (ret$0: Ref)
 
 method f$nullableParameter$TF$NT$Boolean$T$Unit(p$b: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$nullable(df$rt$boolType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
@@ -49,10 +49,10 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 }
 
 method f$unique_foo_arg$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   requires acc(p$c$Foo$unique(p$foo), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -68,10 +68,10 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 }
 
 method f$nullable_unique_arg$TF$NT$T$T$Unit(p$t: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$c$T()))
   requires p$t != df$rt$nullValue() ==> acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$c$T()))
   inhale p$t != df$rt$nullValue() ==> acc(p$c$T$shared(p$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -87,11 +87,11 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 }
 
 method f$borrowed_unique_arg$TF$T$T$T$Unit(p$t: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$c$T())
   requires acc(p$c$T$unique(p$t), write)
   ensures acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$c$T())
   inhale acc(p$c$T$shared(p$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -108,10 +108,10 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 
 method f$unique_receiver$TF$T$T$T$Unit(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
   requires acc(p$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
   inhale acc(p$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -128,11 +128,11 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 
 method f$borrowed_unique_receiver$TF$T$T$T$Unit(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
   requires acc(p$c$T$unique(this$extension), write)
   ensures acc(p$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
   inhale acc(p$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
@@ -1,5 +1,6 @@
 /function_call.kt:(118,130): info: Generated Viper text for functionCall:
 method f$f$TF$T$Int$T$Int(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
@@ -16,6 +17,7 @@ method f$functionCall$TF$T$Unit() returns (ret$0: Ref)
 
 /function_call.kt:(160,178): info: Generated Viper text for functionCallNested:
 method f$f$TF$T$Int$T$Int(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
@@ -14,9 +14,9 @@ method f$simpleIf$TF$T$Int() returns (ret$0: Ref)
 
 /if.kt:(116,129): info: Generated Viper text for ifOnParameter:
 method f$ifOnParameter$TF$T$Boolean$T$Int(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   if (df$rt$boolFromRef(p$b)) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
@@ -47,9 +47,9 @@ method f$ifAsExpression$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 method f$ifOnParameter$TF$T$Boolean$T$Int(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$simpleIf$TF$T$Int() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
@@ -1,9 +1,9 @@
 /loop.kt:(23,32): info: Generated Viper text for whileLoop:
 method f$whileLoop$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   anon$0 := p$b
@@ -37,5 +37,5 @@ method f$whileFunctionCondition$TF$T$Unit() returns (ret$0: Ref)
 }
 
 method f$whileLoop$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
@@ -1,10 +1,10 @@
 /loop_invariants.kt:(146,168): info: Generated Viper text for dynamicLambdaInvariant:
 method f$dynamicLambdaInvariant$TF$TF$T$Int$T$Unit(p$f: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
   anon$0 := f$returnsBoolean$TF$T$Boolean()
@@ -26,11 +26,11 @@ method f$returnsBoolean$TF$T$Boolean() returns (ret: Ref)
 /loop_invariants.kt:(241,259): info: Generated Viper text for functionAssignment:
 method f$functionAssignment$TF$TF$T$Int$T$Unit(p$f: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$g: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
   l0$g := p$f
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$functionType())
@@ -56,13 +56,13 @@ method f$returnsBoolean$TF$T$Boolean() returns (ret: Ref)
 method f$conditionalFunctionAssignment$TF$T$Boolean$TF$T$Int$TF$T$Int$T$Unit(p$b: Ref,
   p$f: Ref, p$h: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$h), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$g: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$h), df$rt$functionType())
   if (df$rt$boolFromRef(p$b)) {
     l0$g := p$f
   } else {
@@ -89,4 +89,3 @@ method f$conditionalFunctionAssignment$TF$T$Boolean$TF$T$Int$TF$T$Int$T$Unit(p$b
 
 method f$returnsBoolean$TF$T$Boolean() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/return_break_continue.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/return_break_continue.fir.diag.txt
@@ -29,11 +29,11 @@ method f$returnFromLoop$TF$T$Int() returns (ret$0: Ref)
 
 /return_break_continue.kt:(162,172): info: Generated Viper text for whileBreak:
 method f$whileBreak$TF$T$Boolean$T$Int(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$i: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   l0$i := df$rt$intToRef(0)
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
@@ -75,10 +75,10 @@ method f$whileContinue$TF$T$Unit() returns (ret$0: Ref)
 
 /return_break_continue.kt:(375,386): info: Generated Viper text for whileNested:
 method f$whileNested$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   anon$0 := p$b
@@ -115,10 +115,10 @@ method f$whileNested$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
 
 /return_break_continue.kt:(556,569): info: Generated Viper text for labelledBreak:
 method f$labelledBreak$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   anon$0 := p$b
@@ -148,10 +148,10 @@ method f$labelledBreak$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
 /return_break_continue.kt:(754,770): info: Generated Viper text for labelledContinue:
 method f$labelledContinue$TF$T$Boolean$T$Unit(p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   anon$0 := p$b
@@ -181,10 +181,10 @@ method f$labelledContinue$TF$T$Boolean$T$Unit(p$b: Ref)
 /return_break_continue.kt:(970,992): info: Generated Viper text for labelledWhileShadowing:
 method f$labelledWhileShadowing$TF$T$Boolean$T$Unit(p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   anon$0 := p$b

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
@@ -1,5 +1,6 @@
 /try_catch.kt:(158,166): info: Generated Viper text for tryCatch:
 method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -37,6 +38,7 @@ method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 /try_catch.kt:(271,285): info: Generated Viper text for nestedTryCatch:
 method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -87,6 +89,7 @@ method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 /try_catch.kt:(574,592): info: Generated Viper text for tryCatchWithInline:
 method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -160,6 +163,7 @@ method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 /try_catch.kt:(813,828): info: Generated Viper text for multipleCatches:
 method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -210,10 +214,12 @@ method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 /try_catch.kt:(1044,1056): info: Generated Viper text for useException:
 method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$ignore$TF$T$Exception$T$Unit(p$e: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$e), df$rt$c$pkg$java_lang$Exception())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -245,4 +251,3 @@ method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
 method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
@@ -2,11 +2,11 @@
 method f$returnWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
   p$c: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
   if (df$rt$boolFromRef(p$a)) {
     ret$0 := df$rt$intToRef(0)
   } elseif (df$rt$boolFromRef(p$b)) {
@@ -23,11 +23,11 @@ method f$returnWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
 method f$whenReturn$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
   p$c: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
   if (df$rt$boolFromRef(p$a)) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
@@ -46,10 +46,10 @@ method f$whenReturn$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
 
 /when.kt:(340,356): info: Generated Viper text for singleBranchWhen:
 method f$singleBranchWhen$TF$T$Boolean$T$Int(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$x: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
   l0$x := df$rt$intToRef(1)
   if (df$rt$boolFromRef(p$a)) {
     l0$x := df$rt$intToRef(2)
@@ -63,12 +63,12 @@ method f$singleBranchWhen$TF$T$Boolean$T$Int(p$a: Ref) returns (ret$0: Ref)
 method f$noElseWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
   p$c: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
   l0$y := df$rt$intToRef(0)
   if (df$rt$boolFromRef(p$a)) {
     l0$y := df$rt$intToRef(1)
@@ -84,10 +84,10 @@ method f$noElseWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
 
 /when.kt:(608,626): info: Generated Viper text for whenWithSubjectVar:
 method f$whenWithSubjectVar$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   anon$0 := p$x
   if (df$rt$intFromRef(anon$0) == 1) {
     ret$0 := df$rt$intToRef(2)
@@ -101,10 +101,10 @@ method f$whenWithSubjectVar$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 
 /when.kt:(726,745): info: Generated Viper text for whenWithSubjectCall:
 method f$whenWithSubjectCall$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   anon$0 := f$whenWithSubjectVar$TF$T$Int$T$Int(p$x)
   if (df$rt$intFromRef(anon$0) == 1) {
     ret$0 := df$rt$intToRef(2)
@@ -125,6 +125,7 @@ method f$whenWithSubjectCall$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 method f$whenWithSubjectVar$TF$T$Int$T$Int(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
@@ -150,10 +151,10 @@ method f$unusedResult$TF$T$Int() returns (ret$0: Ref)
 
 /when.kt:(1221,1227): info: Generated Viper text for whenIs:
 method f$whenIs$TF$T$Foo$T$Boolean(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$x), wildcard)
   anon$0 := p$x
   if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Bar())) {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
@@ -50,11 +50,11 @@ method eg$pfValProp$TF$T$PrimitiveField$T$Int(this$dispatch: Ref)
 
 method f$extensionGetterPropertyUserDefinedClass$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   anon$0 := eg$pfValProp$TF$T$PrimitiveField$T$Int(p$pf)
   l0$x := anon$0
@@ -76,10 +76,10 @@ method es$pfVarProp$TF$T$PrimitiveField$T$Int$T$Unit(this$dispatch: Ref, anon$0:
 
 method f$extensionSetterPropertyUserDefinedClass$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
   inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   anon$0 := es$pfVarProp$TF$T$PrimitiveField$T$Int$T$Unit(p$pf, df$rt$intToRef(42))
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
@@ -405,6 +405,7 @@ predicate p$c$Foo$unique(this$dispatch: Ref) {
 }
 
 method con$c$Foo$T$Int$T$Foo(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
   ensures acc(p$c$Foo$shared(ret), wildcard)
   ensures acc(p$c$Foo$unique(ret), write)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_object.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_object.fir.diag.txt
@@ -1,8 +1,8 @@
 /function_object.kt:(23,35): info: Generated Viper text for unitFunction:
 method f$unitFunction$TF$TF$T$Unit$T$Unit(p$f: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -10,10 +10,10 @@ method f$unitFunction$TF$TF$T$Unit$T$Unit(p$f: Ref) returns (ret$0: Ref)
 /function_object.kt:(90,108): info: Generated Viper text for functionObjectCall:
 method f$functionObjectCall$TF$TF$T$Boolean$T$Int$T$Int$T$Int(p$g: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   ret$0 := anon$0
   goto lbl$ret$0
@@ -24,13 +24,13 @@ method f$functionObjectCall$TF$TF$T$Boolean$T$Int$T$Int$T$Int(p$g: Ref)
 method f$functionObjectNestedCall$TF$TF$T$Int$T$Int$TF$T$Boolean$T$Int$T$Int(p$f: Ref,
   p$g: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
@@ -1,11 +1,11 @@
 /function_overloading.kt:(49,52): info: Generated Viper text for baz:
 method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -14,11 +14,11 @@ method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
 /function_overloading.kt:(74,77): info: Generated Viper text for baz:
 method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -26,9 +26,9 @@ method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
 
 /function_overloading.kt:(98,107): info: Generated Viper text for fakePrint:
 method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -36,9 +36,9 @@ method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret$0: Ref)
 
 /function_overloading.kt:(125,134): info: Generated Viper text for fakePrint:
 method f$fakePrint$TF$T$Foo$T$Unit(p$f: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -46,27 +46,27 @@ method f$fakePrint$TF$T$Foo$T$Unit(p$f: Ref) returns (ret$0: Ref)
 
 /function_overloading.kt:(152,161): info: Generated Viper text for fakePrint:
 method f$fakePrint$TF$T$Int$T$Unit(p$value: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$value), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$value), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(183,192): info: Generated Viper text for fakePrint:
 method f$fakePrint$TF$T$Boolean$T$Unit(p$truth: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$truth), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$truth), df$rt$boolType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(219,238): info: Generated Viper text for differInNullability:
 method f$differInNullability$TF$T$Int$T$Unit(p$i: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -74,9 +74,9 @@ method f$differInNullability$TF$T$Int$T$Unit(p$i: Ref) returns (ret$0: Ref)
 /function_overloading.kt:(256,275): info: Generated Viper text for differInNullability:
 method f$differInNullability$TF$NT$Int$T$Unit(p$i: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$nullable(df$rt$intType()))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -95,18 +95,22 @@ method con$c$Foo$T$Foo() returns (ret: Ref)
 
 
 method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$fakePrint$TF$T$Boolean$T$Unit(p$truth: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$truth), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$fakePrint$TF$T$Foo$T$Unit(p$f: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$fakePrint$TF$T$Int$T$Unit(p$value: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$value), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -144,11 +148,15 @@ method con$c$Foo$T$Foo() returns (ret: Ref)
 
 method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
@@ -481,6 +481,7 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 }
 
 method f$havoc$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$localUnit: Ref
@@ -499,7 +500,6 @@ method f$havoc$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   var l0$localCharNull: Ref
   var l0$localStringNull: Ref
   var l0$localClassTypeNull: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
   inhale acc(p$c$A$shared(p$a), wildcard)
   l0$localUnit := havoc$T$Unit()
   l0$localNothing := havoc$T$Nothing()
@@ -585,4 +585,3 @@ method havoc$T$String() returns (ret: Ref)
 
 method havoc$T$Unit() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
-

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
@@ -1,12 +1,12 @@
 /captured.kt:(155,165): info: Generated Viper text for captureArg:
 method f$captureArg$TF$TF$T$Int$T$Int$T$Int(p$g: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
   var ret$2: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
   anon$0 := df$rt$intToRef(0)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
   ret$2 := anon$1
@@ -43,6 +43,7 @@ method f$captureVar$TF$T$Int() returns (ret$0: Ref)
 
 /captured.kt:(295,311): info: Generated Viper text for captureAndShadow:
 method f$captureAndShadow$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -50,7 +51,6 @@ method f$captureAndShadow$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var l2$y: Ref
   var l2$x: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   anon$0 := df$rt$intToRef(0)
   l2$y := p$x
   l2$x := df$rt$intToRef(1)
@@ -67,6 +67,7 @@ method f$captureAndShadow$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 
 /captured.kt:(513,528): info: Generated Viper text for captureVarClash:
 method f$captureVarClash$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -74,7 +75,6 @@ method f$captureVarClash$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   var anon$1: Ref
   var ret$2: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l1$x := df$rt$intToRef(1)
   anon$0 := df$rt$intToRef(0)
   ret$2 := sp$timesInts(anon$0, p$x)
@@ -92,6 +92,7 @@ method f$captureVarClash$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 /captured.kt:(585,606): info: Generated Viper text for captureAndShadowClash:
 method f$captureAndShadowClash$TF$T$Int$T$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -101,7 +102,6 @@ method f$captureAndShadowClash$TF$T$Int$T$Int(p$x: Ref)
   var anon$0: Ref
   var l2$y: Ref
   var l2$x: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l1$x := df$rt$intToRef(1)
   anon$0 := df$rt$intToRef(0)
   l2$y := p$x
@@ -121,6 +121,7 @@ method f$captureAndShadowClash$TF$T$Int$T$Int(p$x: Ref)
 /captured.kt:(715,736): info: Generated Viper text for nestedLambdaShadowing:
 method f$nestedLambdaShadowing$TF$T$Int$T$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -136,7 +137,6 @@ method f$nestedLambdaShadowing$TF$T$Int$T$Int(p$x: Ref)
   var l4$x: Ref
   var l2$y: Ref
   var l2$x: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l1$x := df$rt$intToRef(1)
   anon$0 := df$rt$intToRef(0)
   l3$x := df$rt$intToRef(1)
@@ -165,6 +165,7 @@ method f$nestedLambdaShadowing$TF$T$Int$T$Int(p$x: Ref)
 
 /captured.kt:(1008,1024): info: Generated Viper text for callDoubleInvoke:
 method f$callDoubleInvoke$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -174,7 +175,6 @@ method f$callDoubleInvoke$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   var ret$3: Ref
   var anon$1: Ref
   var l3$x: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   anon$0 := df$rt$intToRef(0)
   l2$x := anon$0
   ret$2 := l2$x

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
@@ -1,5 +1,6 @@
 /inline.kt:(230,239): info: Generated Viper text for quadruple:
 method f$quadruple$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
@@ -8,7 +9,6 @@ method f$quadruple$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   var anon$1: Ref
   var ret$2: Ref
   var l2$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l1$y := sp$plusInts(p$x, p$x)
   ret$1 := l1$y
   goto lbl$ret$1

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/arithmetic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/arithmetic.fir.diag.txt
@@ -1,9 +1,9 @@
 /arithmetic.kt:(23,31): info: Generated Viper text for addition:
 method f$addition$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l0$y := sp$plusInts(p$x, p$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -11,10 +11,10 @@ method f$addition$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 
 /arithmetic.kt:(66,77): info: Generated Viper text for subtraction:
 method f$subtraction$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l0$y := sp$minusInts(p$x, p$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -22,10 +22,10 @@ method f$subtraction$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 
 /arithmetic.kt:(112,126): info: Generated Viper text for multiplication:
 method f$multiplication$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l0$y := sp$timesInts(p$x, p$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -33,10 +33,10 @@ method f$multiplication$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 
 /arithmetic.kt:(161,169): info: Generated Viper text for division:
 method f$division$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l0$y := sp$divInts(p$x, p$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
@@ -1,9 +1,9 @@
 /as_operator.kt:(57,63): info: Generated Viper text for testAs:
 method f$testAs$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$foo), wildcard)
@@ -14,11 +14,11 @@ method f$testAs$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
 
 /as_operator.kt:(97,111): info: Generated Viper text for testNullableAs:
 method f$testNullableAs$TF$NT$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
@@ -31,11 +31,11 @@ method f$testNullableAs$TF$NT$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
 
 /as_operator.kt:(148,158): info: Generated Viper text for testSafeAs:
 method f$testSafeAs$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {
     ret$0 := p$foo
@@ -51,11 +51,11 @@ method f$testSafeAs$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
 /as_operator.kt:(194,212): info: Generated Viper text for testNullableSafeAs:
 method f$testNullableSafeAs$TF$NT$Foo$NT$Bar(p$foo: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
   if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
@@ -1,8 +1,8 @@
 /boolean_logic.kt:(23,31): info: Generated Viper text for negation:
 method f$negation$TF$T$Boolean$T$Boolean(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
   ret$0 := sp$notBool(p$x)
   goto lbl$ret$0
   label lbl$ret$0
@@ -11,10 +11,10 @@ method f$negation$TF$T$Boolean$T$Boolean(p$x: Ref) returns (ret$0: Ref)
 /boolean_logic.kt:(75,86): info: Generated Viper text for conjunction:
 method f$conjunction$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
   if (df$rt$boolFromRef(p$x)) {
     ret$0 := p$y
   } else {
@@ -26,11 +26,11 @@ method f$conjunction$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
 /boolean_logic.kt:(146,168): info: Generated Viper text for conjunctionSideEffects:
 method f$conjunctionSideEffects$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
   anon$0 := f$negation$TF$T$Boolean$T$Boolean(p$x)
   if (df$rt$boolFromRef(anon$0)) {
     ret$0 := f$negation$TF$T$Boolean$T$Boolean(p$y)
@@ -41,16 +41,17 @@ method f$conjunctionSideEffects$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: 
 }
 
 method f$negation$TF$T$Boolean$T$Boolean(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 
 /boolean_logic.kt:(341,352): info: Generated Viper text for disjunction:
 method f$disjunction$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
   if (df$rt$boolFromRef(p$x)) {
     ret$0 := df$rt$boolToRef(true)
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/comparison.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/comparison.fir.diag.txt
@@ -1,10 +1,10 @@
 /comparison.kt:(23,27): info: Generated Viper text for less:
 method f$less$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ret$0 := sp$ltInts(p$x, p$y)
   goto lbl$ret$0
   label lbl$ret$0
@@ -13,10 +13,10 @@ method f$less$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
 /comparison.kt:(79,88): info: Generated Viper text for lessEqual:
 method f$lessEqual$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ret$0 := sp$leInts(p$x, p$y)
   goto lbl$ret$0
   label lbl$ret$0
@@ -25,10 +25,10 @@ method f$lessEqual$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
 /comparison.kt:(141,148): info: Generated Viper text for greater:
 method f$greater$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ret$0 := sp$gtInts(p$x, p$y)
   goto lbl$ret$0
   label lbl$ret$0
@@ -37,10 +37,10 @@ method f$greater$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
 /comparison.kt:(200,212): info: Generated Viper text for greaterEqual:
 method f$greaterEqual$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ret$0 := sp$geInts(p$x, p$y)
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
@@ -1,8 +1,8 @@
 /elvis.kt:(121,134): info: Generated Viper text for elvisOperator:
 method f$elvisOperator$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   if (p$x != df$rt$nullValue()) {
     ret$0 := p$x
   } else {
@@ -13,15 +13,16 @@ method f$elvisOperator$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 
 /elvis.kt:(176,196): info: Generated Viper text for elvisOperatorComplex:
 method f$elvisOperator$TF$NT$Int$T$Int(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$elvisOperatorComplex$TF$NT$Int$T$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   anon$0 := f$id$TF$NT$Int$NT$Int(p$x)
   if (anon$0 != df$rt$nullValue()) {
     ret$0 := anon$0
@@ -32,15 +33,16 @@ method f$elvisOperatorComplex$TF$NT$Int$T$Int(p$x: Ref)
 }
 
 method f$id$TF$NT$Int$NT$Int(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /elvis.kt:(257,276): info: Generated Viper text for elvisOperatorReturn:
 method f$elvisOperatorReturn$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$y: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   if (p$x != df$rt$nullValue()) {
     l0$y := p$x
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/is_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/is_operator.fir.diag.txt
@@ -1,8 +1,8 @@
 /is_operator.kt:(23,36): info: Generated Viper text for isNonNullable:
 method f$isNonNullable$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -10,9 +10,9 @@ method f$isNonNullable$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
 
 /is_operator.kt:(84,97): info: Generated Viper text for notIsNullable:
 method f$notIsNullable$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ret$0 := sp$notBool(df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nothingType())))
   goto lbl$ret$0
   label lbl$ret$0
@@ -20,9 +20,9 @@ method f$notIsNullable$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
 
 /is_operator.kt:(150,159): info: Generated Viper text for smartCast:
 method f$smartCast$TF$NT$Any$T$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())) {
     ret$0 := p$x
     goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
@@ -2,13 +2,14 @@
 field bf$x: Ref
 
 method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$testSafeCall$TF$NT$Foo$NT$Unit(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
@@ -25,14 +26,15 @@ method f$testSafeCall$TF$NT$Foo$NT$Unit(p$foo: Ref) returns (ret$0: Ref)
 field bf$x: Ref
 
 method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$testSafeCallNonNullable$TF$T$Foo$NT$Unit(p$foo: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
@@ -49,9 +51,9 @@ field bf$x: Ref
 
 method f$testSafeCallProperty$TF$NT$Foo$NT$Int(p$foo: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
@@ -70,9 +72,9 @@ field bf$x: Ref
 
 method f$testSafeCallPropertyNonNullable$TF$T$Foo$NT$Int(p$foo: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
@@ -90,16 +92,17 @@ field bf$v: Ref
 
 method f$c$Rec$nullable$TF$T$Rec$NT$Rec(this$dispatch: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Rec())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$c$Rec()))
   ensures ret != df$rt$nullValue() ==> acc(p$c$Rec$shared(ret), wildcard)
 
 
 method f$safeCallChain$TF$NT$Rec$NT$Int(p$rec: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$nullable(df$rt$c$Rec()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$nullable(df$rt$c$Rec()))
   inhale p$rec != df$rt$nullValue() ==>
     acc(p$c$Rec$shared(p$rec), wildcard)
   if (p$rec != df$rt$nullValue()) {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_function_with_assignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_function_with_assignments.fir.diag.txt
@@ -52,6 +52,8 @@ function f$laterInitializersCanRelyOnPrevious$TF$T$Int(): Ref
 
 /pure_function_with_assignments.kt:(541,572): info: Generated Viper text for initializersCanRelyOnParameters:
 function f$initializersCanRelyOnParameters$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$sum$0 ==

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_function_with_branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_function_with_branching.fir.diag.txt
@@ -1,5 +1,6 @@
 /pure_function_with_branching.kt:(59,79): info: Generated Viper text for noAssignmentInBlocks:
 function f$noAssignmentInBlocks$TF$T$Boolean$T$Int(p$a: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$result$0 ==
@@ -11,6 +12,7 @@ function f$noAssignmentInBlocks$TF$T$Boolean$T$Int(p$a: Ref): Ref
 
 /pure_function_with_branching.kt:(197,212): info: Generated Viper text for simpleBranching:
 function f$simpleBranching$TF$T$Boolean$T$Int(p$a: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$result$0 ==
@@ -30,6 +32,8 @@ function f$simpleBranching$TF$T$Boolean$T$Int(p$a: Ref): Ref
 
 /pure_function_with_branching.kt:(370,385): info: Generated Viper text for nestedBranching:
 function f$nestedBranching$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$result$0 ==
@@ -73,6 +77,7 @@ function f$nestedBranching$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
 
 /pure_function_with_branching.kt:(795,815): info: Generated Viper text for whenExpressionSimple:
 function f$whenExpressionSimple$TF$T$Int$T$Int(p$x: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$y$0 ==
@@ -98,6 +103,8 @@ function f$whenExpressionSimple$TF$T$Int$T$Int(p$x: Ref): Ref
 
 /pure_function_with_branching.kt:(1034,1057): info: Generated Viper text for whenNoArgumentBranching:
 function f$whenNoArgumentBranching$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l5$z$0 ==
@@ -120,6 +127,7 @@ function f$whenNoArgumentBranching$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
 
 /pure_function_with_branching.kt:(1280,1303): info: Generated Viper text for stringEqualityBranching:
 function f$stringEqualityBranching$TF$T$String$T$Boolean(p$input: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$input), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$isValid$0 ==
@@ -166,6 +174,7 @@ function f$sequentialIfWithMutation$TF$T$Int(): Ref
 
 /pure_function_with_branching.kt:(1749,1769): info: Generated Viper text for complexBooleanReturn:
 function f$complexBooleanReturn$TF$T$Int$T$Boolean(p$x: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$result$0 ==

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_function_with_reassignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_function_with_reassignments.fir.diag.txt
@@ -66,6 +66,8 @@ function f$overwriteNotSelfReferential$TF$T$Int(): Ref
 /pure_function_with_reassignments.kt:(565,592): info: Generated Viper text for nestedConditionalAssignment:
 function f$nestedConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
   p$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$1$0 ==
@@ -100,6 +102,8 @@ function f$nestedConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
 /pure_function_with_reassignments.kt:(710,736): info: Generated Viper text for blockConditionalAssignment:
 function f$blockConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
   p$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$1$0 ==
@@ -127,6 +131,8 @@ function f$blockConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
 
 /pure_function_with_reassignments.kt:(893,907): info: Generated Viper text for whenAssignment:
 function f$whenAssignment$TF$T$Int$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$0$0 ==

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_literal_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_literal_function.fir.diag.txt
@@ -53,6 +53,7 @@ field bf$a: Ref
 field bf$b: Ref
 
 function f$annotatedReferenceReturn$TF$T$X$T$X(p$x: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$c$X())
 {
   p$x

--- a/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
@@ -23,11 +23,11 @@ method f$shadowLocal$TF$T$Unit() returns (ret$0: Ref)
 
 /shadowing.kt:(232,243): info: Generated Viper text for shadowParam:
 method f$shadowParam$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$foo: Ref
   var l0$x: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l0$foo := p$x
   l0$x := df$rt$intToRef(0)
   l0$foo := l0$x
@@ -37,11 +37,11 @@ method f$shadowParam$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 
 /shadowing.kt:(322,334): info: Generated Viper text for shadowNested:
 method f$shadowNested$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$foo: Ref
   var l0$x: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   l0$foo := p$x
   l0$x := df$rt$intToRef(0)
   l0$foo := l0$x

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/any.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/any.fir.diag.txt
@@ -1,8 +1,8 @@
 /any.kt:(23,40): info: Generated Viper text for anyArgumentReturn:
 method f$anyArgumentReturn$TF$T$Any$T$Any(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$anyType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$anyType())
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -10,9 +10,9 @@ method f$anyArgumentReturn$TF$T$Any$T$Any(p$x: Ref) returns (ret$0: Ref)
 
 /any.kt:(76,83): info: Generated Viper text for anyCast:
 method f$anyCast$TF$T$Int$T$Any(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$anyType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
@@ -3,11 +3,11 @@ field bf$t: Ref
 
 method f$c$Box$genericMethod$TF$T$Box$NT$Any$NT$Any(this$dispatch: Ref, p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Box())
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Box())
   inhale acc(p$c$Box$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -17,6 +17,7 @@ method f$c$Box$genericMethod$TF$T$Box$NT$Any$NT$Any(this$dispatch: Ref, p$x: Ref
 field bf$t: Ref
 
 method con$c$Box$NT$Any$T$Box(p$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -46,6 +47,7 @@ method f$createBox$TF$T$Int() returns (ret$0: Ref)
 field bf$t: Ref
 
 method con$c$Box$NT$Any$T$Box(p$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -62,9 +64,9 @@ method f$setGenericField$TF$T$Unit() returns (ret$0: Ref)
 
 /generics.kt:(293,303): info: Generated Viper text for genericFun:
 method f$genericFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ret$0 := p$t
   goto lbl$ret$0
   label lbl$ret$0
@@ -84,6 +86,7 @@ method f$callGenericFunc$TF$T$Unit() returns (ret$0: Ref)
 }
 
 method f$genericFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -92,11 +95,11 @@ field bf$t: Ref
 
 method f$genericAsIfCondition$TF$T$Box$T$Int(p$box: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
   inhale acc(p$c$Box$shared(p$box), wildcard)
   anon$1 := havoc$NT$Any()
   anon$0 := anon$1

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
@@ -1,10 +1,10 @@
 /nullable.kt:(80,96): info: Generated Viper text for useNullableTwice:
 method f$useNullableTwice$TF$NT$Int$NT$Int(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   l0$a := p$x
   l0$b := p$x
   ret$0 := l0$a
@@ -15,10 +15,10 @@ method f$useNullableTwice$TF$NT$Int$NT$Int(p$x: Ref) returns (ret$0: Ref)
 /nullable.kt:(162,183): info: Generated Viper text for passNullableParameter:
 method f$passNullableParameter$TF$NT$Int$NT$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   anon$0 := f$useNullableTwice$TF$NT$Int$NT$Int(p$x)
   ret$0 := p$x
   goto lbl$ret$0
@@ -26,16 +26,17 @@ method f$passNullableParameter$TF$NT$Int$NT$Int(p$x: Ref)
 }
 
 method f$useNullableTwice$TF$NT$Int$NT$Int(p$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /nullable.kt:(245,271): info: Generated Viper text for nullableNullableComparison:
 method f$nullableNullableComparison$TF$NT$Int$NT$Int$T$Boolean(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
   ret$0 := df$rt$boolToRef(p$x == p$y)
   goto lbl$ret$0
   label lbl$ret$0
@@ -45,10 +46,10 @@ method f$nullableNullableComparison$TF$NT$Int$NT$Int$T$Boolean(p$x: Ref, p$y: Re
 method f$nullableNonNullableComparison$TF$NT$Int$NT$Int$T$Boolean(p$x: Ref,
   p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
   ret$0 := sp$notBool(df$rt$boolToRef(p$x == df$rt$intToRef(3)))
   goto lbl$ret$0
   label lbl$ret$0
@@ -56,9 +57,9 @@ method f$nullableNonNullableComparison$TF$NT$Int$NT$Int$T$Boolean(p$x: Ref,
 
 /nullable.kt:(410,424): info: Generated Viper text for nullComparison:
 method f$nullComparison$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ret$0 := df$rt$boolToRef(p$x == df$rt$nullValue())
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
@@ -1,8 +1,8 @@
 /smartcast.kt:(23,38): info: Generated Viper text for smartcastReturn:
 method f$smartcastReturn$TF$NT$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$nullable(df$rt$intType()))
   if (!(p$n == df$rt$nullValue())) {
     ret$0 := p$n
   } else {
@@ -14,9 +14,9 @@ method f$smartcastReturn$TF$NT$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
 /smartcast.kt:(88,106): info: Generated Viper text for isNullOrEmptyWrong:
 method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   inhale p$seq != df$rt$nullValue() ==>
     acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   if (p$seq == df$rt$nullValue()) {
@@ -38,4 +38,3 @@ method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
 }
 
 method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/purity_checker/wrongly_annotated.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/purity_checker/wrongly_annotated.fir.diag.txt
@@ -18,9 +18,9 @@ field bf$value: Ref
 
 method f$impureExtension$TF$T$Field$T$Unit(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Field())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Field())
   inhale acc(p$c$Field$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
@@ -2,12 +2,12 @@
 field bf$x: Ref
 
 method f$getX$TF$T$Any$NT$Int(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 != df$rt$nullValue() ==>
     !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
   if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())) {
     anon$0 := p$a
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/binary_search.fir.diag.txt
@@ -5,6 +5,8 @@ method f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -13,9 +15,7 @@ method f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -56,6 +56,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -70,6 +72,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -86,6 +89,9 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
   requires df$rt$intFromRef(p$fromIndex) >= 0
   requires df$rt$intFromRef(p$toIndex) <=
@@ -111,6 +117,8 @@ method f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -119,9 +127,7 @@ method f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -162,6 +168,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -176,6 +184,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -192,6 +201,9 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
   requires df$rt$intFromRef(p$fromIndex) >= 0
   requires df$rt$intFromRef(p$toIndex) <=
@@ -218,6 +230,8 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(p$arr: Ref,
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -226,9 +240,7 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(p$arr: Ref,
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -271,6 +283,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -285,6 +299,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -301,6 +316,9 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
   requires df$rt$intFromRef(p$fromIndex) >= 0
   requires df$rt$intFromRef(p$toIndex) <=
@@ -327,6 +345,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -342,17 +362,17 @@ method f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr: Ref,
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var l0$mid: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
   if (df$rt$intFromRef(p$left) > df$rt$intFromRef(p$right)) {
     ret$0 := df$rt$boolToRef(false)
     goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
@@ -1,10 +1,10 @@
 /cond_effects.kt:(121,146): info: Generated Viper text for compoundConditionalEffect:
 method f$compoundConditionalEffect$TF$T$Boolean$T$Unit(p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==> df$rt$boolFromRef(p$b) && false
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -13,11 +13,11 @@ method f$compoundConditionalEffect$TF$T$Boolean$T$Unit(p$b: Ref)
 
 /cond_effects.kt:(271,287): info: Generated Viper text for mayReturnNonNull:
 method f$mayReturnNonNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 == df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -27,11 +27,11 @@ method f$mayReturnNonNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
 
 /cond_effects.kt:(424,437): info: Generated Viper text for mayReturnNull:
 method f$mayReturnNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 != df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -42,10 +42,10 @@ method f$mayReturnNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(723,741): info: Generated Viper text for isNullOrEmptyWrong:
 method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false ==> p$seq != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   inhale p$seq != df$rt$nullValue() ==>
     acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   if (!(p$seq == df$rt$nullValue())) {
@@ -69,12 +69,12 @@ method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
 /cond_effects.kt:(925,942): info: Generated Viper text for recursiveContract:
 method f$recursiveContract$TF$T$Int$NT$Any$T$Boolean(p$n: Ref, p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   if (df$rt$intFromRef(p$n) == 0) {
     ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType()))
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
@@ -1,11 +1,11 @@
 /contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
 method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl1())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
@@ -18,13 +18,13 @@ method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
 method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
@@ -35,11 +35,11 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
 method f$is1$TF$T$Class$T$Boolean(this$extension: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/is_type_contract.fir.diag.txt
@@ -1,10 +1,10 @@
 /is_type_contract.kt:(151,172): info: Generated Viper text for unverifiableTypeCheck:
 method f$unverifiableTypeCheck$TF$NT$Int$T$Boolean(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -15,10 +15,10 @@ method f$unverifiableTypeCheck$TF$NT$Int$T$Boolean(p$x: Ref)
 /is_type_contract.kt:(319,341): info: Generated Viper text for nullableNotNonNullable:
 method f$nullableNotNonNullable$TF$NT$Int$T$Unit(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
@@ -18,6 +18,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -58,6 +60,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -86,6 +90,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -99,12 +105,12 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
 method f$unsafe_last$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   anon$0 := p$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -122,13 +128,13 @@ field sp$size: Ref
 method f$add_get$TF$T$MutableList$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
   inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
   anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(p$l,
     df$rt$intToRef(1))
@@ -143,6 +149,8 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boole
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires df$rt$isSubtype(df$rt$typeOf(p$element), df$rt$intType())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -155,6 +163,8 @@ method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(t
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -187,6 +197,9 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
   requires df$rt$intFromRef(p$fromIndex) >= 0
   requires df$rt$intFromRef(p$toIndex) <=
@@ -233,6 +246,9 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
   requires df$rt$intFromRef(p$fromIndex) >= 0
   requires df$rt$intFromRef(p$toIndex) <=

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_null.fir.diag.txt
@@ -1,10 +1,10 @@
 /returns_null.kt:(121,146): info: Generated Viper text for returns_null_unverifiable:
 method f$returns_null_unverifiable$TF$NT$Int$NT$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures true ==> false
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ret$0 := df$rt$nullValue()
   goto lbl$ret$0
   label lbl$ret$0
@@ -15,10 +15,10 @@ method f$returns_null_unverifiable$TF$NT$Int$NT$Int(p$x: Ref)
 /returns_null.kt:(277,302): info: Generated Viper text for non_nullable_returns_null:
 method f$non_nullable_returns_null$TF$T$Int$T$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures ret$0 == df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
@@ -1,10 +1,10 @@
 /as_type_contract.kt:(152,162): info: Generated Viper text for asOperator:
 method f$asOperator$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret$0), wildcard)
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$foo), wildcard)
@@ -15,13 +15,13 @@ method f$asOperator$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
 
 /as_type_contract.kt:(307,321): info: Generated Viper text for safeAsOperator:
 method f$safeAsOperator$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
   inhale p$foo != df$rt$nullValue() ==>
@@ -35,6 +35,7 @@ method f$safeAsOperator$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
 field bf$x: Ref
 
 method f$getX$TF$T$Any$NT$Int(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 != df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
@@ -42,7 +43,6 @@ method f$getX$TF$T$Any$NT$Int(p$a: Ref) returns (ret$0: Ref)
     !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
   if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())) {
     anon$0 := p$a
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
@@ -1,11 +1,11 @@
 /contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
 method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
@@ -16,13 +16,13 @@ method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
 method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
@@ -31,11 +31,11 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
 method f$is1$TF$T$Class$T$Boolean(this$extension: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -1,10 +1,10 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
 method f$isString$TF$NT$Any$T$Boolean(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -13,11 +13,11 @@ method f$isString$TF$NT$Any$T$Boolean(p$x: Ref) returns (ret$0: Ref)
 /is_type_contract.kt:(322,330): info: Generated Viper text for isString:
 method f$isString$TF$T$Any$T$Boolean(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$anyType())
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -25,11 +25,11 @@ method f$isString$TF$T$Any$T$Boolean(this$extension: Ref)
 
 /is_type_contract.kt:(491,508): info: Generated Viper text for subtypeTransitive:
 method f$subtypeTransitive$TF$T$Unit$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==>
     df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -58,10 +58,10 @@ method f$constructorReturnType$TF$T$Boolean() returns (ret$0: Ref)
 field bf$bar: Ref
 
 method f$subtypeSuperType$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Foo())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$bar), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -71,11 +71,11 @@ method f$subtypeSuperType$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
 field bf$bar: Ref
 
 method f$typeOfField$TF$T$Foo$T$Boolean(p$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
   inhale acc(p$c$Foo$shared(p$foo), wildcard)
   unfold acc(p$c$Foo$shared(p$foo), wildcard)
   anon$0 := p$foo.bf$bar

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
@@ -23,11 +23,11 @@ method f$returns_false$TF$T$Boolean() returns (ret$0: Ref)
 /returns_booleans.kt:(418,435): info: Generated Viper text for conditional_basic:
 method f$conditional_basic$TF$T$Boolean$T$Boolean(p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> true
   ensures df$rt$boolFromRef(ret$0) == false ==> df$rt$boolFromRef(p$b)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ret$0 := df$rt$boolToRef(true)
   goto lbl$ret$0
   label lbl$ret$0
@@ -37,14 +37,14 @@ method f$conditional_basic$TF$T$Boolean$T$Boolean(p$b: Ref)
 method f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$a: Ref,
   p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false ==>
     df$rt$boolFromRef(p$b) && false
   ensures df$rt$boolFromRef(ret$0) == true ==>
     (true || df$rt$boolFromRef(p$a)) && (df$rt$boolFromRef(p$b) || true)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ret$0 := df$rt$boolToRef(true)
   goto lbl$ret$0
   label lbl$ret$0
@@ -52,13 +52,13 @@ method f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$a: Ref,
 
 /returns_booleans.kt:(855,866): info: Generated Viper text for logical_not:
 method f$logical_not$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$b)
   ensures df$rt$boolFromRef(ret$0) == false ==>
     df$rt$boolFromRef(p$b) || !df$rt$boolFromRef(p$b)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ret$0 := df$rt$boolToRef(false)
   goto lbl$ret$0
   label lbl$ret$0
@@ -68,6 +68,8 @@ method f$logical_not$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret$0: Ref)
 method f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$a: Ref,
   p$b: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
   ensures df$rt$boolFromRef(ret) == false ==>
     df$rt$boolFromRef(p$b) && false
@@ -77,11 +79,11 @@ method f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$a: Ref,
 
 method f$call_fun_with_contracts$TF$T$Boolean$T$Boolean(p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
   var l0$a: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   l0$a := f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$b, p$b)
   ret$0 := l0$a
   goto lbl$ret$0
@@ -97,6 +99,7 @@ method f$isNullOrEmpty$TF$NT$Collection$T$Boolean(this$extension: Ref)
     acc(this$extension.sp$size, write)
   requires this$extension != df$rt$nullValue() ==>
     df$rt$intFromRef(this$extension.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$nullable(df$rt$c$pkg$kotlin_collections$Collection()))
   ensures this$extension != df$rt$nullValue() ==>
     acc(this$extension.sp$size, write)
   ensures this$extension != df$rt$nullValue() ==>
@@ -105,7 +108,6 @@ method f$isNullOrEmpty$TF$NT$Collection$T$Boolean(this$extension: Ref)
   ensures df$rt$boolFromRef(ret$0) == false ==>
     this$extension != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$nullable(df$rt$c$pkg$kotlin_collections$Collection()))
   inhale this$extension != df$rt$nullValue() ==>
     acc(p$pkg$kotlin_collections$c$Collection$shared(this$extension), wildcard)
   if (this$extension == df$rt$nullValue()) {
@@ -120,6 +122,7 @@ method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection$T$Boolean(t
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$Collection())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -129,4 +132,3 @@ method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection$T$Boolean(t
     df$rt$intFromRef(this$dispatch.sp$size) == 0
   ensures !df$rt$boolFromRef(ret) ==>
     df$rt$intFromRef(this$dispatch.sp$size) > 0
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_null.fir.diag.txt
@@ -1,11 +1,11 @@
 /returns_null.kt:(121,140): info: Generated Viper text for simple_returns_null:
 method f$simple_returns_null$TF$NT$Int$NT$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> false
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
   ret$0 := df$rt$nullValue()
   goto lbl$ret$0
   label lbl$ret$0
@@ -14,11 +14,11 @@ method f$simple_returns_null$TF$NT$Int$NT$Int(p$x: Ref)
 /returns_null.kt:(300,320): info: Generated Viper text for returns_null_implies:
 method f$returns_null_implies$TF$NT$Boolean$NT$Boolean(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$boolType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$boolType()))
   ensures ret$0 == df$rt$nullValue() ==> p$x == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$boolType()))
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -28,6 +28,9 @@ method f$returns_null_implies$TF$NT$Boolean$NT$Boolean(p$x: Ref)
 method f$returns_null_with_if$TF$NT$Int$NT$Int$NT$Int$NT$Int(p$x: Ref, p$y: Ref,
   p$z: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==>
     p$x == df$rt$nullValue() && p$y == df$rt$nullValue() ||
@@ -35,9 +38,6 @@ method f$returns_null_with_if$TF$NT$Int$NT$Int$NT$Int$NT$Int(p$x: Ref, p$y: Ref,
   ensures ret$0 != df$rt$nullValue() ==>
     p$x != df$rt$nullValue() || p$y != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
-  inhale df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$nullable(df$rt$intType()))
   if (p$x == df$rt$nullValue()) {
     ret$0 := p$y
     goto lbl$ret$0
@@ -51,10 +51,10 @@ method f$returns_null_with_if$TF$NT$Int$NT$Int$NT$Int$NT$Int(p$x: Ref, p$y: Ref,
 /returns_null.kt:(833,862): info: Generated Viper text for non_nullable_returns_not_null:
 method f$non_nullable_returns_not_null$TF$T$Int$T$Int(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures ret$0 != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -63,11 +63,11 @@ method f$non_nullable_returns_not_null$TF$T$Int$T$Int(p$x: Ref)
 /returns_null.kt:(981,1010): info: Generated Viper text for non_nullable_compared_to_null:
 method f$non_nullable_compared_to_null$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures true ==> p$y == df$rt$nullValue() || p$x != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/expensive_diagnostics/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/expensive_diagnostics/merge_sort_of_string.fir.diag.txt
@@ -2,12 +2,17 @@
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
   p$other: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
 method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
   p$hi: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
   requires 0 <= df$rt$intFromRef(p$lo) &&
     df$rt$intFromRef(p$lo) <= df$rt$intFromRef(p$hi) &&
     df$rt$intFromRef(p$hi) <= |df$rt$stringFromRef(this$extension)|
@@ -23,9 +28,6 @@ method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
   var l0$res: Ref
   var l0$i: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
   l0$res := df$rt$stringToRef(Seq[Int]())
   l0$i := p$lo
   label lbl$continue$0
@@ -74,6 +76,8 @@ method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
 /merge_sort_of_string.kt:(705,717): info: Generated Viper text for mergeStrings:
 method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
   requires (forall anon$builtin$3: Int ::(1 <= anon$builtin$3 &&
       anon$builtin$3 < |df$rt$stringFromRef(p$a)| ==>
       df$rt$stringFromRef(p$a)[anon$builtin$3 - 1] <=
@@ -94,8 +98,6 @@ method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
   var l0$res: Ref
   var l0$n: Ref
   var anon$4: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
   l0$pa := df$rt$intToRef(0)
   l0$pb := df$rt$intToRef(0)
   l0$res := df$rt$stringToRef(Seq[Int]())
@@ -194,12 +196,15 @@ method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
   p$other: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
 /merge_sort_of_string.kt:(1883,1894): info: Generated Viper text for mergeSorted:
 method f$mergeSorted$TF$T$String$T$String(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
     |df$rt$stringFromRef(this$extension)|
@@ -208,7 +213,6 @@ method f$mergeSorted$TF$T$String$T$String(this$extension: Ref)
       df$rt$stringFromRef(ret$0)[anon$builtin$4 - 1] <=
       df$rt$stringFromRef(ret$0)[anon$builtin$4])
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   if (|df$rt$stringFromRef(this$extension)| <= 1) {
     ret$0 := this$extension
   } else {
@@ -230,6 +234,8 @@ method f$mergeSorted$TF$T$String$T$String(this$extension: Ref)
 
 method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
   requires (forall anon$builtin$5: Int ::(1 <= anon$builtin$5 &&
       anon$builtin$5 < |df$rt$stringFromRef(p$a)| ==>
       df$rt$stringFromRef(p$a)[anon$builtin$5 - 1] <=
@@ -249,6 +255,9 @@ method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
 method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
   p$hi: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
   requires 0 <= df$rt$intFromRef(p$lo) &&
     df$rt$intFromRef(p$lo) <= df$rt$intFromRef(p$hi) &&
     df$rt$intFromRef(p$hi) <= |df$rt$stringFromRef(this$extension)|
@@ -260,4 +269,3 @@ method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
       df$rt$stringFromRef(ret)[anon$builtin$7] ==
       df$rt$stringFromRef(this$extension)[anon$builtin$7 +
       df$rt$intFromRef(p$lo)])
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/expensive_diagnostics/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/expensive_diagnostics/quick_sort_of_string.fir.diag.txt
@@ -1,6 +1,8 @@
 /quick_sort_of_string.kt:(282,294): info: Generated Viper text for minOrMaxChar:
 method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMin: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$calcMin), df$rt$boolType())
   requires |df$rt$stringFromRef(this$extension)| >= 1
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$charType())
   ensures df$rt$boolFromRef(p$calcMin) ==>
@@ -17,8 +19,6 @@ method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMi
   var l0$res: Ref
   var l0$i: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$calcMin), df$rt$boolType())
   l0$res := sp$stringGet(this$extension, df$rt$intToRef(0))
   l0$i := df$rt$intToRef(1)
   label lbl$continue$0
@@ -81,6 +81,8 @@ method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMi
 /quick_sort_of_string.kt:(1135,1144): info: Generated Viper text for quickSort:
 method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMin: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$calcMin), df$rt$boolType())
   requires |df$rt$stringFromRef(this$extension)| >= 1
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$charType())
   ensures df$rt$boolFromRef(p$calcMin) ==>
@@ -97,6 +99,7 @@ method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMi
 
 method f$quickSort$TF$T$String$T$String(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
     |df$rt$stringFromRef(this$extension)|
@@ -107,7 +110,6 @@ method f$quickSort$TF$T$String$T$String(this$extension: Ref)
 {
   var l0$minVal: Ref
   var l0$maxVal: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   if (|df$rt$stringFromRef(this$extension)| <= 1) {
     ret$0 := this$extension
     goto lbl$ret$0
@@ -123,6 +125,9 @@ method f$quickSort$TF$T$String$T$String(this$extension: Ref)
 method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
   p$minVal: Ref, p$maxVal: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$minVal), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$maxVal), df$rt$charType())
   requires (forall anon$builtin$9: Int ::0 <= anon$builtin$9 &&
       anon$builtin$9 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$charFromRef(p$minVal) <=
@@ -147,6 +152,7 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
 /quick_sort_of_string.kt:(1507,1519): info: Generated Viper text for quickSortRec:
 method f$chooseIndex$TF$T$String$T$Int(this$extension: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   requires |df$rt$stringFromRef(this$extension)| >= 1
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
   ensures 0 <= df$rt$intFromRef(ret) &&
@@ -156,12 +162,17 @@ method f$chooseIndex$TF$T$String$T$Int(this$extension: Ref)
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
   p$other: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
 method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
   p$minVal: Ref, p$maxVal: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$minVal), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$maxVal), df$rt$charType())
   requires (forall anon$builtin$6: Int ::0 <= anon$builtin$6 &&
       anon$builtin$6 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$charFromRef(p$minVal) <=
@@ -191,9 +202,6 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
   var anon$2: Ref
   var anon$4: Ref
   var anon$5: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$minVal), df$rt$charType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$maxVal), df$rt$charType())
   if (|df$rt$stringFromRef(this$extension)| <= 1) {
     ret$0 := this$extension
     goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/expensive_diagnostics/z_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/expensive_diagnostics/z_function.fir.diag.txt
@@ -2,6 +2,11 @@
 method f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(p$s: Ref,
   p$res: Ref, p$i: Ref, p$checkedLeft: Ref, p$checkedRight: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$res), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$checkedLeft), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$checkedRight), df$rt$intType())
   requires 1 <= df$rt$intFromRef(p$i) &&
     df$rt$intFromRef(p$i) < |df$rt$stringFromRef(p$s)|
   requires |df$rt$stringFromRef(p$res)| == df$rt$intFromRef(p$i)
@@ -40,11 +45,6 @@ method f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(p$s: Ref,
       df$rt$stringFromRef(p$s)[anon$builtin$7])
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$res), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$checkedLeft), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$checkedRight), df$rt$intType())
   if (df$rt$intFromRef(p$checkedLeft) == 0) {
     anon$0 := df$rt$boolToRef(true)
   } else {
@@ -68,12 +68,19 @@ method f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(p$s: Ref,
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
   p$other: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
 method f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(p$s: Ref,
   p$res: Ref, p$i: Ref, p$checkedLeft: Ref, p$checkedRight: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$res), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$checkedLeft), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$checkedRight), df$rt$intType())
   requires 1 <= df$rt$intFromRef(p$i) &&
     df$rt$intFromRef(p$i) < |df$rt$stringFromRef(p$s)|
   requires |df$rt$stringFromRef(p$res)| == df$rt$intFromRef(p$i)
@@ -114,6 +121,7 @@ method f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(p$s: Ref,
 
 method f$zFunction$TF$T$String$T$String(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
     |df$rt$stringFromRef(this$extension)|
@@ -139,7 +147,6 @@ method f$zFunction$TF$T$String$T$String(this$extension: Ref)
   var l0$checkedLeft: Ref
   var l0$checkedRight: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   if (|df$rt$stringFromRef(this$extension)| == 0) {
     ret$0 := this$extension
     goto lbl$ret$0
@@ -293,11 +300,14 @@ method f$zFunction$TF$T$String$T$String(this$extension: Ref)
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
   p$other: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
 method f$zFunctionNaive$TF$T$String$T$String(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
     |df$rt$stringFromRef(this$extension)|
@@ -320,7 +330,6 @@ method f$zFunctionNaive$TF$T$String$T$String(this$extension: Ref)
   var l0$i: Ref
   var l0$res: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   if (|df$rt$stringFromRef(this$extension)| == 0) {
     ret$0 := this$extension
     goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
@@ -363,6 +363,7 @@ method f$useRun$TF$T$Unit() returns (ret$0: Ref)
 /custom_run_functions.kt:(2354,2369): info: Generated Viper text for complexScenario:
 method f$complexScenario$TF$T$Boolean$T$Boolean(p$arg: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> df$rt$boolFromRef(p$arg)
   ensures df$rt$boolFromRef(ret$0) == false ==> !df$rt$boolFromRef(p$arg)
@@ -370,7 +371,6 @@ method f$complexScenario$TF$T$Boolean$T$Boolean(p$arg: Ref)
   var anon$11: Ref
   var anon$12: Ref
   var ret$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
   if (df$rt$boolFromRef(p$arg)) {
     var anon$13: Ref
     var ret$2: Ref

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
@@ -3,6 +3,7 @@ field bf$size: Ref
 
 method f$with_run_extension_labeled$TF$NT$Int$T$Unit(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -55,7 +56,6 @@ method f$with_run_extension_labeled$TF$NT$Int$T$Unit(this$extension: Ref)
   var anon$33: Ref
   var ret$17: Ref
   var anon$12: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$nullable(df$rt$intType()))
   ret$1 := df$rt$boolToRef(this$extension == df$rt$nullValue())
   goto lbl$ret$1
   label lbl$ret$1

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -1,8 +1,8 @@
 /viper_casts_while_inlining.kt:(250,255): info: Generated Viper text for idFun:
 method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
   ret$0 := p$arg
   goto lbl$ret$0
   label lbl$ret$0
@@ -13,6 +13,7 @@ field bf$member: Ref
 
 method con$c$ClassWithMember$T$Int$T$ClassWithMember(p$member: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$member), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithMember())
   ensures acc(p$c$ClassWithMember$shared(ret), wildcard)
   ensures acc(p$c$ClassWithMember$unique(ret), write)
@@ -83,6 +84,7 @@ method f$checkMemberAccess$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -90,6 +92,7 @@ method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret: Ref)
 field bf$wrapped: Ref
 
 method con$c$Box$NT$Any$T$Box(p$wrapped: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$wrapped), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
   ensures acc(p$c$Box$shared(ret), wildcard)
   ensures acc(p$c$Box$unique(ret), write)
@@ -99,6 +102,7 @@ method con$c$Box$NT$Any$T$Box(p$wrapped: Ref) returns (ret: Ref)
 
 method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -118,7 +122,6 @@ method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
   var anon$3: Ref
   var anon$10: Ref
   var anon$11: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
   inhale acc(p$c$Box$shared(p$box), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$box
@@ -160,6 +163,7 @@ method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
 }
 
 method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -168,6 +172,7 @@ field bf$a: Ref
 
 method f$checkArgumentIsCopied$TF$T$ClassWithVar$T$Unit(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$ClassWithVar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -178,7 +183,6 @@ method f$checkArgumentIsCopied$TF$T$ClassWithVar$T$Unit(p$x: Ref)
   var anon$5: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$ClassWithVar())
   inhale acc(p$c$ClassWithVar$shared(p$x), wildcard)
   anon$4 := havoc$T$Int()
   anon$0 := anon$4
@@ -211,6 +215,7 @@ field bf$i: Ref
 
 method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$c$ManyMembers())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$4: Ref
@@ -240,7 +245,6 @@ method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
   var anon$20: Ref
   var anon$21: Ref
   var anon$22: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(p$m), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$m
@@ -302,6 +306,7 @@ method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
 }
 
 method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -318,6 +323,8 @@ field bf$size: Ref
 
 method f$checkEvaluatedOnce$TF$T$Int$T$ManyMembers$T$Unit(p$i: Ref, p$mm: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$mm), df$rt$c$ManyMembers())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -329,8 +336,6 @@ method f$checkEvaluatedOnce$TF$T$Int$T$ManyMembers$T$Unit(p$i: Ref, p$mm: Ref)
   var anon$6: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$mm), df$rt$c$ManyMembers())
   inhale acc(p$c$ManyMembers$shared(p$mm), wildcard)
   anon$5 := havoc$T$Boolean()
   if (df$rt$boolFromRef(anon$5)) {

--- a/formver.compiler-plugin/testData/diagnostics/verification/list/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/list/binary_search.fir.diag.txt
@@ -6,6 +6,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -20,6 +22,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -36,6 +39,9 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
   requires df$rt$intFromRef(p$fromIndex) >= 0
   requires df$rt$intFromRef(p$toIndex) <=
@@ -56,6 +62,8 @@ method f$safe_binary_search$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -64,9 +72,7 @@ method f$safe_binary_search$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -110,6 +116,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -125,6 +133,10 @@ method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr:
   returns (ret$0: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -133,11 +145,7 @@ method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr:
   var anon$1: Ref
   var l0$mid: Ref
   var anon$3: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
   if (df$rt$intFromRef(p$left) > df$rt$intFromRef(p$right)) {
     anon$1 := df$rt$boolToRef(true)
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/list/custom_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/list/custom_list.fir.diag.txt
@@ -7,6 +7,8 @@ method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$inde
   returns (ret$0: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -16,9 +18,7 @@ method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$inde
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
   inhale acc(p$c$CustomList$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   unfold acc(p$c$CustomList$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$c$CustomList$private$value
   goto lbl$ret$0
@@ -32,6 +32,8 @@ field sp$size: Ref
 
 method con$c$CustomList$T$Int$T$Int$T$CustomList(p$size: Ref, p$value: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$size), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$value), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CustomList())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
@@ -43,6 +45,8 @@ method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$inde
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -57,6 +61,7 @@ method f$c$CustomList$isEmpty$TF$T$CustomList$T$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -69,11 +74,11 @@ method f$c$CustomList$isEmpty$TF$T$CustomList$T$Boolean(this$dispatch: Ref)
 
 
 method f$test$TF$T$Int$T$Unit(p$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$customList: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   l0$customList := con$c$CustomList$T$Int$T$Int$T$CustomList(p$n, df$rt$intToRef(0))
   anon$0 := f$c$CustomList$isEmpty$TF$T$CustomList$T$Boolean(l0$customList)
   if (!df$rt$boolFromRef(anon$0)) {

--- a/formver.compiler-plugin/testData/diagnostics/verification/list/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/list/list.fir.diag.txt
@@ -17,13 +17,13 @@ field sp$size: Ref
 method f$initialization$TF$T$List$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$myList: Ref
   var l0$myEmptyList: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   l0$myList := p$l
   l0$myEmptyList := f$pkg$kotlin_collections$emptyList$TF$T$List()
@@ -45,13 +45,13 @@ field sp$size: Ref
 method f$add_get$TF$T$MutableList$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
   inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
   anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(p$l,
     df$rt$intToRef(1))
@@ -66,6 +66,8 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boole
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires df$rt$isSubtype(df$rt$typeOf(p$element), df$rt$intType())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -78,6 +80,8 @@ method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(t
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -94,12 +98,12 @@ field sp$size: Ref
 method f$last_or_null$TF$T$List$NT$Int(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$size: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   l0$size := p$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
@@ -121,6 +125,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -137,12 +143,12 @@ field sp$size: Ref
 method f$is_empty$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
   inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   anon$0 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$l)
   if (!df$rt$boolFromRef(anon$0)) {
@@ -159,6 +165,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -173,6 +181,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -190,12 +199,12 @@ field sp$size: Ref
 method f$nullable_list$TF$NT$List$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
   requires p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$nullable(df$rt$c$pkg$kotlin_collections$List()))
   ensures p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
   ensures p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$nullable(df$rt$c$pkg$kotlin_collections$List()))
   inhale p$l != df$rt$nullValue() ==>
     acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   if (!(p$l == df$rt$nullValue())) {
@@ -221,6 +230,8 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
     df$rt$intFromRef(p$index)
@@ -235,6 +246,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -244,4 +256,3 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
     df$rt$intFromRef(this$dispatch.sp$size) == 0
   ensures !df$rt$boolFromRef(ret) ==>
     df$rt$intFromRef(this$dispatch.sp$size) > 0
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -6,15 +6,15 @@ field bf$size: Ref
 method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$withoutLabels: Ref
   var anon$0: Ref
   var l0$withLabels: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$intType())
   unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   anon$0 := this$dispatch.bf$delta
   l0$withoutLabels := sp$plusInts(this$extension, anon$0)
@@ -32,9 +32,9 @@ field bf$delta: Ref
 
 method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$delta
@@ -47,9 +47,9 @@ field bf$delta: Ref
 
 method f$extensionReturnDelta$TF$T$ClassWithExtension$T$Int(this$extension: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
   inhale acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   unfold acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   ret$0 := this$extension.bf$delta
@@ -64,6 +64,7 @@ field bf$size: Ref
 
 method con$c$ClassWithExtension$T$Int$T$ClassWithExtension(p$delta: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$delta), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithExtension())
   ensures acc(p$c$ClassWithExtension$shared(ret), wildcard)
   ensures acc(p$c$ClassWithExtension$unique(ret), write)
@@ -75,11 +76,14 @@ method con$c$ClassWithExtension$T$Int$T$ClassWithExtension(p$delta: Ref)
 method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
@@ -135,5 +139,5 @@ method f$checkClassWithExtension$TF$T$Unit() returns (ret$0: Ref)
 
 method f$extensionReturnDelta$TF$T$ClassWithExtension$T$Int(this$extension: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/backing_field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/backing_field_getters.fir.diag.txt
@@ -4,11 +4,11 @@ field bf$y: Ref
 field bf$z: Ref
 
 method f$cascadeGet$TF$T$X$T$Z(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Z())
   ensures acc(p$c$Z$shared(ret$0), wildcard)
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
   inhale acc(p$c$X$shared(p$x), wildcard)
   unfold acc(p$c$X$shared(p$x), wildcard)
   anon$0 := p$x.bf$y
@@ -25,11 +25,11 @@ field bf$z: Ref
 
 method f$receiverNotNullProved$TF$NT$X$T$Boolean(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$X()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> p$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$X()))
   inhale p$x != df$rt$nullValue() ==> acc(p$c$X$shared(p$x), wildcard)
   if (p$x != df$rt$nullValue()) {
     var anon$1: Ref
@@ -50,12 +50,12 @@ field bf$z: Ref
 
 method f$cascadeNullableGet$TF$NT$NullableX$NT$Z(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
   inhale p$x != df$rt$nullValue() ==>
     acc(p$c$NullableX$shared(p$x), wildcard)
   if (p$x != df$rt$nullValue()) {
@@ -79,11 +79,11 @@ field bf$z: Ref
 
 method f$cascadeNullableSmartcastGet$TF$NT$NullableX$NT$Z(p$x: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
   inhale p$x != df$rt$nullValue() ==>
     acc(p$c$NullableX$shared(p$x), wildcard)
   if (p$x == df$rt$nullValue()) {
@@ -210,6 +210,8 @@ field bf$z: Ref
 
 method con$c$ClassI$T$Int$T$Int$T$ClassI(p$x: Ref, p$y: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassI())
   ensures acc(p$c$ClassI$shared(ret), wildcard)
   ensures acc(p$c$ClassI$unique(ret), write)
@@ -222,6 +224,7 @@ method con$c$ClassI$T$Int$T$Int$T$ClassI(p$x: Ref, p$y: Ref)
 
 
 method con$c$ClassII$T$Z$T$ClassII(p$z: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$c$Z())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassII())
   ensures acc(p$c$ClassII$shared(ret), wildcard)
   ensures acc(p$c$ClassII$unique(ret), write)
@@ -237,6 +240,8 @@ method con$c$Z$T$Z() returns (ret: Ref)
 
 method f$checkPrimary$TF$T$Int$T$Int$T$Unit(p$x: Ref, p$y: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$classI: Ref
@@ -245,8 +250,6 @@ method f$checkPrimary$TF$T$Int$T$Int$T$Unit(p$x: Ref, p$y: Ref)
   var l0$cond2: Ref
   var anon$2: Ref
   var anon$3: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   l0$classI := con$c$ClassI$T$Int$T$Int$T$ClassI(p$x, p$y)
   l0$z := con$c$Z$T$Z()
   if (!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y))) {
@@ -272,4 +275,3 @@ method f$checkPrimary$TF$T$Int$T$Int$T$Unit(p$x: Ref, p$y: Ref)
 }
 
 method pg$public$z(this$dispatch: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/multiple_interfaces.fir.diag.txt
@@ -1,11 +1,11 @@
 /multiple_interfaces.kt:(799,804): info: Generated Viper text for take1:
 method f$take1$TF$T$InterfaceWithImplementation1$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
   inhale acc(p$c$InterfaceWithImplementation1$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
@@ -20,11 +20,11 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 /multiple_interfaces.kt:(863,868): info: Generated Viper text for take2:
 method f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
   inhale acc(p$c$InterfaceWithoutImplementation2$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
@@ -41,9 +41,9 @@ field bf$field: Ref
 
 method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
   inhale acc(p$c$AbstractWithFinalImplementation3$shared(p$obj), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -52,11 +52,11 @@ method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
 /multiple_interfaces.kt:(998,1003): info: Generated Viper text for take4:
 method f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
   inhale acc(p$c$AbstractWithOpenImplementation4$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
@@ -217,23 +217,26 @@ method f$createImpls$TF$T$Unit() returns (ret$0: Ref)
 
 method f$take1$TF$T$InterfaceWithImplementation1$T$Unit(p$obj: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(p$obj: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(p$obj: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/override_properties_types.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/override_properties_types.fir.diag.txt
@@ -3,12 +3,12 @@ field bf$field: Ref
 
 method f$extractInt$TF$T$Base$T$Boolean$NT$Int(p$base: Ref, p$returnNull: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$Base())
+  requires df$rt$isSubtype(df$rt$typeOf(p$returnNull), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==> df$rt$boolFromRef(p$returnNull)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$Base())
   inhale acc(p$c$Base$shared(p$base), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$returnNull), df$rt$boolType())
   if (df$rt$boolFromRef(p$returnNull)) {
     var anon$0: Ref
     anon$0 := df$rt$nullValue()
@@ -43,4 +43,3 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 method ps$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/private_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/properties_and_fields/private_properties.fir.diag.txt
@@ -1,10 +1,10 @@
 /private_properties.kt:(222,237): info: Generated Viper text for getBooleanField:
 method f$c$A$getBooleanField$TF$T$A$T$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$A())
   inhale acc(p$c$A$shared(this$dispatch), wildcard)
   anon$0 := pg$c$A$private$field(this$dispatch)
   ret$0 := anon$0
@@ -25,9 +25,9 @@ field bf$c$B$private$field: Ref
 
 method f$c$B$getStringField$TF$T$B$T$String(this$dispatch: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$B())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$B())
   inhale acc(p$c$B$shared(this$dispatch), wildcard)
   unfold acc(p$c$B$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$c$B$private$field
@@ -88,4 +88,3 @@ method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
 
 method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_function_rely_on_branch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_function_rely_on_branch.fir.diag.txt
@@ -1,5 +1,7 @@
 /pure_function_rely_on_branch.kt:(70,80): info: Generated Viper text for safeDivide:
 function f$safeDivide$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$res$0 ==
@@ -13,6 +15,7 @@ function f$safeDivide$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
 
 /pure_function_rely_on_branch.kt:(206,221): info: Generated Viper text for getStringLength:
 function f$getStringLength$TF$T$Any$T$Int(p$obj: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$len$0 ==
@@ -30,6 +33,9 @@ function f$getStringLength$TF$T$Any$T$Int(p$obj: Ref): Ref
 
 /pure_function_rely_on_branch.kt:(354,370): info: Generated Viper text for safeNestedDivide:
 function f$safeNestedDivide$TF$T$Int$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref, p$z: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$res$0 ==
@@ -47,6 +53,8 @@ function f$safeNestedDivide$TF$T$Int$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref, p$z: 
 
 /pure_function_rely_on_branch.kt:(546,567): info: Generated Viper text for safeInverseDifference:
 function f$safeInverseDifference$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$res$0 ==

--- a/formver.compiler-plugin/testData/diagnostics/verification/stdlib_replacement_tests.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/stdlib_replacement_tests.fir.diag.txt
@@ -20,6 +20,7 @@ method f$useChecks$TF$T$Unit() returns (ret$0: Ref)
 field bf$size: Ref
 
 method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -36,7 +37,6 @@ method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$7: Ref
   var ret$4: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ret$2 := sp$plusInts(p$x, df$rt$intToRef(1))
   goto lbl$ret$2
   label lbl$ret$2
@@ -77,6 +77,7 @@ method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 field bf$size: Ref
 
 method f$useAlso$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -85,7 +86,6 @@ method f$useAlso$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -107,6 +107,7 @@ method f$useAlso$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 field bf$size: Ref
 
 method f$useLet$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -117,7 +118,6 @@ method f$useLet$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$4: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$x
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -144,6 +144,7 @@ method f$useLet$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 field bf$size: Ref
 
 method f$useWith$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -153,7 +154,6 @@ method f$useWith$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$4: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -177,6 +177,7 @@ method f$useWith$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 field bf$size: Ref
 
 method f$useApply$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -185,7 +186,6 @@ method f$useApply$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/string/chars.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/string/chars.fir.diag.txt
@@ -4,6 +4,7 @@ field bf$char: Ref
 field bf$size: Ref
 
 method con$c$CharBox$T$Char$T$CharBox(p$char: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$char), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CharBox())
   ensures acc(p$c$CharBox$shared(ret), wildcard)
   ensures acc(p$c$CharBox$unique(ret), write)
@@ -13,6 +14,7 @@ method con$c$CharBox$T$Char$T$CharBox(p$char: Ref) returns (ret: Ref)
 
 
 method f$testChars$TF$T$Char$T$Unit(p$c: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$box: Ref
@@ -20,7 +22,6 @@ method f$testChars$TF$T$Char$T$Unit(p$c: Ref) returns (ret$0: Ref)
   var l0$cond1: Ref
   var anon$0: Ref
   var l0$charZ: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
   l0$box := con$c$CharBox$T$Char$T$CharBox(df$rt$charToRef(97))
   l0$charA := df$rt$charToRef(97)
   unfold acc(p$c$CharBox$shared(l0$box), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/verification/string/strings.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/string/strings.fir.diag.txt
@@ -44,6 +44,7 @@ predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
 }
 
 method con$c$StringBox$T$String$T$StringBox(p$str: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$StringBox())
   ensures acc(p$c$StringBox$shared(ret), wildcard)
   ensures acc(p$c$StringBox$unique(ret), write)
@@ -53,6 +54,7 @@ method con$c$StringBox$T$String$T$StringBox(p$str: Ref) returns (ret: Ref)
 
 
 method f$testType$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -61,7 +63,6 @@ method f$testType$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
   var l0$cond2: Ref
   var anon$2: Ref
   var anon$3: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   anon$1 := con$c$StringBox$T$String$T$StringBox(p$s)
   unfold acc(p$c$StringBox$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$str
@@ -125,6 +126,7 @@ predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
 }
 
 method con$c$StringBox$T$String$T$StringBox(p$str: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$StringBox())
   ensures acc(p$c$StringBox$shared(ret), wildcard)
   ensures acc(p$c$StringBox$unique(ret), write)
@@ -134,13 +136,13 @@ method con$c$StringBox$T$String$T$StringBox(p$str: Ref) returns (ret: Ref)
 
 
 method f$testLengthField$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$len: Ref
   var l0$cond1: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   l0$len := sp$stringLength(p$s)
   anon$1 := con$c$StringBox$T$String$T$StringBox(df$rt$stringToRef(Seq(115,
     116, 114)))
@@ -188,10 +190,13 @@ predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
   p$other: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
 method f$testOps$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$c: Ref
@@ -199,7 +204,6 @@ method f$testOps$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
   var l0$str: Ref
   var l0$helloWorld: Ref
   var l0$stringPlusInteger: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   if (|df$rt$stringFromRef(p$s)| > 0) {
     l0$c := sp$stringGet(p$s, df$rt$intToRef(0))
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
@@ -34,11 +34,11 @@ predicate p$c$Node$unique(this$dispatch: Ref) {
 }
 
 method f$get_left_val$TF$T$Node$NT$Int(p$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
   requires acc(p$c$Node$unique(p$n), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
   inhale acc(p$c$Node$shared(p$n), wildcard)
   unfold acc(p$c$Node$shared(p$n), wildcard)
   anon$0 := p$n.bf$left
@@ -121,8 +121,11 @@ predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
 
 method con$c$Node$T$Int$NT$Node$NT$Node$T$Node(p$data: Ref, p$left: Ref, p$right: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$data), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$nullable(df$rt$c$Node()))
   requires p$left != df$rt$nullValue() ==>
     acc(p$c$Node$unique(p$left), write)
+  requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$nullable(df$rt$c$Node()))
   requires p$right != df$rt$nullValue() ==>
     acc(p$c$Node$unique(p$right), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Node())

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
@@ -22,11 +22,11 @@ predicate p$c$Link$unique(this$dispatch: Ref) {
 }
 
 method f$getVal$TF$T$Link$NT$Int(p$l: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$Link())
   requires acc(p$c$Link$unique(p$l), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$Link())
   inhale acc(p$c$Link$shared(p$l), wildcard)
   unfold acc(p$c$Link$shared(p$l), wildcard)
   anon$0 := p$l.bf$next
@@ -97,6 +97,8 @@ predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
 
 method con$c$Link$T$Int$NT$Link$T$Link(p$data: Ref, p$next: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$data), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$next), df$rt$nullable(df$rt$c$Link()))
   requires p$next != df$rt$nullValue() ==>
     acc(p$c$Link$unique(p$next), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Link())

--- a/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
@@ -1,8 +1,8 @@
 /unit_return_type.kt:(171,176): info: Generated Viper text for idFun:
 method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ret$0 := p$t
   goto lbl$ret$0
   label lbl$ret$0
@@ -10,9 +10,9 @@ method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret$0: Ref)
 
 /unit_return_type.kt:(195,208): info: Generated Viper text for directReturns:
 method f$directReturns$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   if (df$rt$boolFromRef(p$b)) {
     ret$0 := df$rt$unitValue()
     goto lbl$ret$0
@@ -32,6 +32,7 @@ method f$directReturns$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
 }
 
 method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -39,10 +40,12 @@ method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret: Ref)
 field bf$size: Ref
 
 method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 method f$useInlineUnit$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$unitRes: Ref
@@ -50,7 +53,6 @@ method f$useInlineUnit$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$b
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/and_or_then.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/and_or_then.fir.diag.txt
@@ -1,10 +1,10 @@
 /and_or_then.kt:(64,75): info: Generated Viper text for resultOrArg:
 method f$resultOrArg$TF$T$Boolean$T$Boolean(p$arg: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) || df$rt$boolFromRef(p$arg)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
   ret$0 := sp$notBool(p$arg)
   goto lbl$ret$0
   label lbl$ret$0
@@ -13,13 +13,13 @@ method f$resultOrArg$TF$T$Boolean$T$Boolean(p$arg: Ref)
 /and_or_then.kt:(200,211): info: Generated Viper text for testImplies:
 method f$testImplies$TF$T$Boolean$T$Boolean(p$arg: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(p$arg) ==> !df$rt$boolFromRef(ret$0)
   ensures df$rt$boolFromRef(ret$0) ==> !df$rt$boolFromRef(p$arg)
   ensures !df$rt$boolFromRef(p$arg) ==> df$rt$boolFromRef(ret$0)
   ensures !df$rt$boolFromRef(ret$0) ==> df$rt$boolFromRef(p$arg)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
   ret$0 := sp$notBool(p$arg)
   goto lbl$ret$0
   label lbl$ret$0
@@ -28,6 +28,8 @@ method f$testImplies$TF$T$Boolean$T$Boolean(p$arg: Ref)
 /and_or_then.kt:(417,424): info: Generated Viper text for testAnd:
 method f$testAnd$TF$T$Boolean$T$Boolean$T$Boolean(p$arg1: Ref, p$arg2: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg1), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg2), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) ==>
     df$rt$boolFromRef(p$arg1) && df$rt$boolFromRef(p$arg2)
@@ -38,8 +40,6 @@ method f$testAnd$TF$T$Boolean$T$Boolean$T$Boolean(p$arg1: Ref, p$arg2: Ref)
   ensures !df$rt$boolFromRef(p$arg1) ==> !df$rt$boolFromRef(ret$0)
   ensures !df$rt$boolFromRef(p$arg2) ==> !df$rt$boolFromRef(ret$0)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arg1), df$rt$boolType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$arg2), df$rt$boolType())
   if (df$rt$boolFromRef(p$arg1)) {
     ret$0 := p$arg2
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
@@ -28,12 +28,12 @@ method f$forAllWithMultipleTriggers$TF$T$Int() returns (ret$0: Ref)
 /forall_with_triggers.kt:(590,614): info: Generated Viper text for forAllWithTriggersInLoop:
 method f$forAllWithTriggersInLoop$TF$T$String$T$Int(p$str: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$res: Ref
   var l0$i: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
   l0$res := df$rt$intToRef(0)
   l0$i := df$rt$intToRef(10)
   label lbl$continue$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/pure_function_with_literal_return.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/pure_function_with_literal_return.fir.diag.txt
@@ -1,5 +1,6 @@
 /pure_function_with_literal_return.kt:(70,91): info: Generated Viper text for annotatedIntLitReturn:
 function f$annotatedIntLitReturn$TF$T$Int$T$Int(p$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$intType())
   requires true
   requires df$rt$intFromRef(p$arg) >= 42
   requires df$rt$intFromRef(p$arg) <= 42
@@ -15,6 +16,7 @@ function f$annotatedIntLitReturn$TF$T$Int$T$Int(p$arg: Ref): Ref
 
 /pure_function_with_literal_return.kt:(403,425): info: Generated Viper text for annotatedBoolLitReturn:
 function f$annotatedBoolLitReturn$TF$T$Int$T$Boolean(p$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$intType())
   requires df$rt$intFromRef(p$arg) <= 0
   requires df$rt$intFromRef(p$arg) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
@@ -26,6 +28,7 @@ function f$annotatedBoolLitReturn$TF$T$Int$T$Boolean(p$arg: Ref): Ref
 
 /pure_function_with_literal_return.kt:(628,650): info: Generated Viper text for annotatedCharLitReturn:
 function f$annotatedCharLitReturn$TF$T$String$T$Char(p$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$stringType())
   requires df$rt$stringFromRef(p$arg) ==
     Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
@@ -36,6 +39,7 @@ function f$annotatedCharLitReturn$TF$T$String$T$Char(p$arg: Ref): Ref
 
 /pure_function_with_literal_return.kt:(834,858): info: Generated Viper text for annotatedStringLitReturn:
 function f$annotatedStringLitReturn$TF$T$Boolean$T$String(p$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
   requires df$rt$boolFromRef(p$arg)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
   ensures df$rt$stringFromRef(result) ==

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
@@ -25,12 +25,12 @@ method f$anyIntegerSquaredIsAtLeastOneExceptZero$TF$T$Int()
 /simple_forall.kt:(460,503): info: Generated Viper text for anyIntegerSquaredIsAtLeastZeroStringVersion:
 method f$anyIntegerSquaredIsAtLeastZeroStringVersion$TF$T$String$T$Int(p$str: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$res: Ref
   var l0$i: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
   l0$res := df$rt$intToRef(0)
   l0$i := df$rt$intToRef(10)
   label lbl$continue$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
@@ -2,12 +2,12 @@
 field bf$size: Ref
 
 method f$test$TF$T$Int$T$Unit(p$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$it: Ref
   var l0$holds: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   l0$it := df$rt$intToRef(0)
   l0$holds := df$rt$boolToRef(true)
   label lbl$continue$0
@@ -126,6 +126,7 @@ field bf$e: Ref
 field bf$size: Ref
 
 method con$c$WithVar$T$Int$T$WithVar(p$e: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$e), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$WithVar())
   ensures acc(p$c$WithVar$shared(ret), wildcard)
   ensures acc(p$c$WithVar$unique(ret), write)
@@ -133,6 +134,7 @@ method con$c$WithVar$T$Int$T$WithVar(p$e: Ref) returns (ret: Ref)
 
 method f$c$WithVar$doSomething$TF$T$WithVar$T$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$WithVar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
@@ -1,9 +1,9 @@
 /simple_postcondition.kt:(64,75): info: Generated Viper text for testGreater:
 method f$testGreater$TF$T$Int$T$Int(p$init: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$init), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) > df$rt$intFromRef(p$init)
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$init), df$rt$intType())
   ret$0 := sp$plusInts(p$init, df$rt$intToRef(5))
   goto lbl$ret$0
   label lbl$ret$0
@@ -22,11 +22,11 @@ method f$testString$TF$T$Char() returns (ret$0: Ref)
 /simple_postcondition.kt:(323,343): info: Generated Viper text for testWithPrecondition:
 method f$testWithPrecondition$TF$T$Int$T$Int(p$int: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$int), df$rt$intType())
   requires df$rt$intFromRef(p$int) > 10
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) > 0
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$int), df$rt$intType())
   ret$0 := sp$minusInts(p$int, df$rt$intToRef(10))
   goto lbl$ret$0
   label lbl$ret$0
@@ -60,7 +60,7 @@ method f$testPostconditionIsUsedByPrecondition$TF$T$Int()
 }
 
 method f$testWithPrecondition$TF$T$Int$T$Int(p$int: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$int), df$rt$intType())
   requires df$rt$intFromRef(p$int) > 10
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
   ensures df$rt$intFromRef(ret) > 0
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
@@ -2,11 +2,11 @@
 field bf$size: Ref
 
 method f$test$TF$T$Int$T$Unit(p$idx: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$idx), df$rt$intType())
   requires 0 <= df$rt$intFromRef(p$idx)
   requires df$rt$intFromRef(p$idx) < 3
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$idx), df$rt$intType())
   assert 0 <= df$rt$intFromRef(p$idx)
   assert df$rt$intFromRef(p$idx) < 3
   assert !(df$rt$intFromRef(p$idx) == 100)
@@ -18,11 +18,11 @@ method f$test$TF$T$Int$T$Unit(p$idx: Ref) returns (ret$0: Ref)
 /simple_precondition.kt:(446,469): info: Generated Viper text for inlineWithSpecification:
 method f$inlineWithSpecification$TF$T$Boolean$T$Unit(p$bool: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$bool), df$rt$boolType())
   requires true
   requires df$rt$boolFromRef(p$bool)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$bool), df$rt$boolType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -48,7 +48,7 @@ method f$good_call$TF$T$Unit() returns (ret$0: Ref)
 }
 
 method f$test$TF$T$Int$T$Unit(p$idx: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$idx), df$rt$intType())
   requires 0 <= df$rt$intFromRef(p$idx)
   requires df$rt$intFromRef(p$idx) < 3
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,6 +1,8 @@
 /string_iterations.kt:(71,83): info: Generated Viper text for firstAtLeast:
 method f$firstAtLeast$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures 0 <= df$rt$intFromRef(ret$0) &&
     df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(this$extension)|
@@ -15,8 +17,6 @@ method f$firstAtLeast$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
 {
   var l0$i: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
   l0$i := df$rt$intToRef(0)
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
@@ -53,6 +53,8 @@ method f$firstAtLeast$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
 /string_iterations.kt:(606,614): info: Generated Viper text for lastLess:
 method f$lastLess$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures -1 <= df$rt$intFromRef(ret$0) &&
     df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(this$extension)| - 1
@@ -67,8 +69,6 @@ method f$lastLess$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
 {
   var l0$i: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
   l0$i := sp$minusInts(sp$stringLength(this$extension), df$rt$intToRef(1))
   label lbl$continue$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
@@ -1,6 +1,7 @@
 /strings_in_conditions.kt:(50,69): info: Generated Viper text for firstNotSortedIndex:
 method f$firstNotSortedIndex$TF$T$String$T$Int(p$s: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures 0 <= df$rt$intFromRef(ret$0) &&
     df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(p$s)|
@@ -9,7 +10,6 @@ method f$firstNotSortedIndex$TF$T$String$T$Int(p$s: Ref)
       df$rt$stringFromRef(p$s)[anon$builtin$2] <=
       df$rt$stringFromRef(p$s)[anon$builtin$2 + 1])
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
   if (|df$rt$stringFromRef(p$s)| == 0) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
@@ -59,6 +59,9 @@ method f$returnNewString$TF$T$String() returns (ret$0: Ref)
 method f$addCharacterTimes$TF$T$String$T$Char$T$Int$T$String(p$s: Ref, p$c: Ref,
   p$n: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   requires df$rt$intFromRef(p$n) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
@@ -71,9 +74,6 @@ method f$addCharacterTimes$TF$T$String$T$Char$T$Int$T$String(p$s: Ref, p$c: Ref,
   var l0$i: Ref
   var l0$res: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   l0$i := df$rt$intToRef(0)
   l0$res := p$s
   label lbl$continue$0
@@ -118,5 +118,6 @@ method f$addCharacterTimes$TF$T$String$T$Char$T$Int$T$String(p$s: Ref, p$c: Ref,
 method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
   p$other: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/sum_of_1_to_n.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/sum_of_1_to_n.fir.diag.txt
@@ -1,12 +1,12 @@
 /sum_of_1_to_n.kt:(64,91): info: Generated Viper text for recursiveSumOfIntegersUpToN:
 method f$recursiveSumOfIntegersUpToN$TF$T$Int$T$Int(p$n: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   requires df$rt$intFromRef(p$n) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) ==
     df$rt$intFromRef(p$n) * (df$rt$intFromRef(p$n) + 1) / 2
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   if (df$rt$intFromRef(p$n) == 0) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
@@ -22,6 +22,7 @@ method f$recursiveSumOfIntegersUpToN$TF$T$Int$T$Int(p$n: Ref)
 
 /sum_of_1_to_n.kt:(296,314): info: Generated Viper text for sumOfIntegersUpToN:
 method f$sumOfIntegersUpToN$TF$T$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   requires df$rt$intFromRef(p$n) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) ==
@@ -30,7 +31,6 @@ method f$sumOfIntegersUpToN$TF$T$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
   var l0$sum: Ref
   var l0$i: Ref
   var anon$0: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
   l0$sum := df$rt$intToRef(0)
   l0$i := df$rt$intToRef(0)
   label lbl$continue$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
@@ -5,6 +5,7 @@ field bf$size: Ref
 
 method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$field), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithField())
   ensures acc(p$c$ClassWithField$shared(ret), wildcard)
   ensures acc(p$c$ClassWithField$unique(ret), write)
@@ -15,11 +16,13 @@ method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
 
 method f$pkg$kotlin$c$Int$unaryMinus$TF$T$Int$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$test_while$TF$T$ClassWithField$T$Unit(p$param: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$c: Ref
@@ -30,7 +33,6 @@ method f$test_while$TF$T$ClassWithField$T$Unit(p$param: Ref)
   var anon$2: Ref
   var l0$cond2: Ref
   var anon$3: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
   inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
   l0$c := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(13))
   unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
@@ -89,6 +91,7 @@ field bf$size: Ref
 
 method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
   returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$field), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithField())
   ensures acc(p$c$ClassWithField$shared(ret), wildcard)
   ensures acc(p$c$ClassWithField$unique(ret), write)
@@ -99,6 +102,7 @@ method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
 
 method f$test_while_with_inlining$TF$T$ClassWithField$T$Unit(p$param: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$local: Ref
@@ -114,7 +118,6 @@ method f$test_while_with_inlining$TF$T$ClassWithField$T$Unit(p$param: Ref)
   var anon$6: Ref
   var anon$7: Ref
   var anon$8: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
   inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
   l0$local := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(13))
   anon$4 := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(42))
@@ -179,10 +182,10 @@ field bf$field: Ref
 
 method f$test_while_with_smartcast$TF$T$Any$T$Any$T$Unit(p$param: Ref, p$innerParam: Ref)
   returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$anyType())
+  requires df$rt$isSubtype(df$rt$typeOf(p$innerParam), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$anyType())
-  inhale df$rt$isSubtype(df$rt$typeOf(p$innerParam), df$rt$anyType())
   if (df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())) {
     var l2$iteration: Ref
     var anon$0: Ref


### PR DESCRIPTION
For parameters, we know that certain conditions hold because the Kotlin type system guarantees that they do.  Previously, we inhaled these facts at the start of generated methods.  After this change, we require them in preconditions instead.