### PR TITLE
Permission Management

### DIFF
--- a/formver.compiler-plugin/core/build.gradle.kts
+++ b/formver.compiler-plugin/core/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     compileOnly(project(":formver.common"))
     compileOnly(project(":formver.compiler-plugin:viper"))
+    compileOnly(project(":formver.compiler-plugin:uniqueness"))
     compileOnly(kotlin("compiler"))
 
     // TODO: figure out how to avoid this dependency

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodContextFactory.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodContextFactory.kt
@@ -15,5 +15,5 @@ class MethodContextFactory(
     fun create(
         programCtx: ProgramConversionContext,
         scopeDepth: ScopeIndex,
-    ): MethodConversionContext = MethodConverter(programCtx, signature, paramResolver, scopeDepth, parent)
+    ): MethodConversionContext = MethodConverter(programCtx, signature, paramResolver, scopeDepth, parent = parent)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConversionContext.kt
@@ -35,6 +35,7 @@ interface MethodConversionContext : ProgramConversionContext {
     val signature: FunctionSignature
     val defaultResolvedReturnTarget: ReturnTarget
     val isValidForForAllBlock: Boolean
+    val uniqueness: UniquenessInformation?
 
     fun resolveParameter(symbol: FirValueParameterSymbol): ExpEmbedding
     fun resolveLocal(symbol: FirVariableSymbol<*>): VariableEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConverter.kt
@@ -28,6 +28,7 @@ class MethodConverter(
     override val signature: FunctionSignature,
     private val paramResolver: ParameterResolver,
     scopeDepth: ScopeIndex,
+    override val uniqueness: UniquenessInformation? = null,
     private val parent: MethodConversionContext? = null,
 ) : MethodConversionContext, ProgramConversionContext by programCtx {
     private var propertyResolver = PropertyResolver(scopeDepth)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/Path.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/Path.kt
@@ -1,0 +1,74 @@
+package org.jetbrains.kotlin.formver.core.conversion
+
+import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
+import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.PrimitiveFieldAccess
+import org.jetbrains.kotlin.formver.core.embeddings.expression.VariableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.withType
+import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+
+/**
+ * Path abstraction to handle paths. The core functionality is to associate the `ExpEmbedding` paths with the `firPaths`.
+ * This is necessary, because the uniqueness checker works on the fir level, whereas the permission management works
+ * on the `ExpEmbedding` level.
+ */
+sealed interface Path {
+    fun addField(field: FieldEmbedding): Path {
+        return PathElement(this, field)
+    }
+
+    val length: Int
+
+    val firPath: List<FirBasedSymbol<*>>
+
+    fun pathWithoutLast(): Path?
+
+    val type: TypeEmbedding
+
+    val expEmbedding: ExpEmbedding
+
+    /**
+     * Returns a list of all prefixes from the path, ordered ascending by the length.
+     */
+    fun traverse(): List<Path>
+
+}
+
+
+data class PathRoot(val base: VariableEmbedding) : Path {
+    override val length: Int
+        get() = 1
+
+    override val firPath = listOf((base.sourceRole!! as SourceRole.FirSymbolHolder).firSymbol)
+    override val type = base.type
+    override val expEmbedding = base
+
+    override fun pathWithoutLast(): Path? = null
+    override fun traverse() = listOf(this)
+}
+
+data class PathElement(val base: Path, val field: FieldEmbedding) : Path {
+    override val length: Int
+        get() = base.length + 1
+
+    override val firPath = base.firPath + field.symbol!!
+    override val type = field.type
+    override val expEmbedding = PrimitiveFieldAccess(base.expEmbedding, field)
+
+    override fun pathWithoutLast(): Path = base
+
+    override fun traverse() = base.traverse() + this
+
+}
+
+data class PathCast(val base: Path, val newType: TypeEmbedding) : Path {
+
+    override val length: Int = base.length
+    override val firPath: List<FirBasedSymbol<*>> = base.firPath
+    override fun pathWithoutLast(): Path? = base.pathWithoutLast()
+    override val type: TypeEmbedding = newType
+    override val expEmbedding: ExpEmbedding = base.expEmbedding.withType(newType)
+    override fun traverse(): List<Path> = base.traverse().dropLast(1) + this
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/Path.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/Path.kt
@@ -1,13 +1,13 @@
 package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
-import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.FirVariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.PrimitiveFieldAccess
-import org.jetbrains.kotlin.formver.core.embeddings.expression.VariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.withType
-import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.properties.UserFieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.uniqueness.Path as FirPath
 
 /**
  * Path abstraction to handle paths. The core functionality is to associate the `ExpEmbedding` paths with the `firPaths`.
@@ -15,13 +15,13 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
  * on the `ExpEmbedding` level.
  */
 sealed interface Path {
-    fun addField(field: FieldEmbedding): Path {
+    fun addField(field: UserFieldEmbedding): Path {
         return PathElement(this, field)
     }
 
     val length: Int
 
-    val firPath: List<FirBasedSymbol<*>>
+    val firPath: FirPath
 
     fun pathWithoutLast(): Path?
 
@@ -37,11 +37,11 @@ sealed interface Path {
 }
 
 
-data class PathRoot(val base: VariableEmbedding) : Path {
+data class PathRoot(val base: FirVariableEmbedding) : Path {
     override val length: Int
         get() = 1
 
-    override val firPath = listOf((base.sourceRole!! as SourceRole.FirSymbolHolder).firSymbol)
+    override val firPath = listOf(base.symbol)
     override val type = base.type
     override val expEmbedding = base
 
@@ -49,11 +49,11 @@ data class PathRoot(val base: VariableEmbedding) : Path {
     override fun traverse() = listOf(this)
 }
 
-data class PathElement(val base: Path, val field: FieldEmbedding) : Path {
+data class PathElement(val base: Path, val field: UserFieldEmbedding) : Path {
     override val length: Int
         get() = base.length + 1
 
-    override val firPath = base.firPath + field.symbol!!
+    override val firPath = base.firPath + field.symbol
     override val type = field.type
     override val expEmbedding = PrimitiveFieldAccess(base.expEmbedding, field)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.fir.declarations.utils.correspondingValueParameterFr
 import org.jetbrains.kotlin.fir.declarations.utils.hasBackingField
 import org.jetbrains.kotlin.fir.declarations.utils.isFinal
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
+import org.jetbrains.kotlin.fir.resolve.dfa.controlFlowGraph
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -101,9 +102,22 @@ class ProgramConverter(
             },
         )
 
+    fun extractUniquenessInformation(declaration: FirSimpleFunction): UniquenessInformation {
+        val graph = declaration.controlFlowGraphReference?.controlFlowGraph
+            ?: error("Control flow graph is null for declaration: ${declaration.name}")
+        val resolver = UniquenessResolver(session)
+        val initial = UniquenessTrie(resolver)
+        val graphChecker = UniquenessGraphChecker(session, initial, errorCollector)
+        graphChecker.check(graph)
+        val analyzer = UniquenessGraphAnalyzer(resolver, initial)
+        val facts = analyzer.analyze(graph)
+        return UniquenessInformation(graph.nodes.first(), facts)
+    }
+
     fun registerForVerification(declaration: FirSimpleFunction) {
         val signature = embedFullSignature(declaration.symbol)
         val returnTarget = returnTargetProducer.getFresh(signature.callableType.returnType)
+        val uniqueness = extractUniquenessInformation(declaration)
         val paramResolver =
             RootParameterResolver(
                 this@ProgramConverter,

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -32,6 +32,10 @@ import org.jetbrains.kotlin.formver.core.embeddings.properties.*
 import org.jetbrains.kotlin.formver.core.embeddings.types.*
 import org.jetbrains.kotlin.formver.core.names.*
 import org.jetbrains.kotlin.formver.names.SimpleNameResolver
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessGraphAnalyzer
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessGraphChecker
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessResolver
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Method
 import org.jetbrains.kotlin.formver.viper.ast.Program

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -136,6 +136,7 @@ class ProgramConverter(
                 signature,
                 paramResolver,
                 scopeIndexProducer.getFresh(),
+                uniqueness = uniqueness,
             ).statementCtxt()
 
         // Note: it is important that `body` is only set after `embedUserFunction` is complete, as we need to

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -48,7 +48,7 @@ import org.jetbrains.kotlin.utils.filterIsInstanceAnd
  */
 interface StmtConversionContext : MethodConversionContext {
     val whenSubject: VariableEmbedding?
-
+    val methodCtx: MethodConversionContext
     /**
      * In a safe call `callSubject?.foo()` we evaluate the call subject first to check for nullness.
      * In case it is not null, we evaluate the call to `callSubject.foo()`. Here we don't want to evaluate

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.core.conversion
 
+import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirLabel
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.isFinal
@@ -33,6 +34,7 @@ import org.jetbrains.kotlin.formver.core.linearization.SeqnBuilder
 import org.jetbrains.kotlin.formver.core.linearization.SharedLinearizationState
 import org.jetbrains.kotlin.formver.core.purity.checkValidity
 import org.jetbrains.kotlin.formver.core.purity.isPure
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.utils.addIfNotNull
@@ -74,6 +76,13 @@ interface StmtConversionContext : MethodConversionContext {
         action: StmtConversionContext.(catchBlockListData: CatchBlockListData) -> R,
     ): Pair<CatchBlockListData, R>
 }
+
+fun StmtConversionContext.flowBefore(fir: FirElement): UniquenessTrie? =
+    methodCtx.uniqueness?.flowBefore(fir)
+
+fun StmtConversionContext.flowAfter(fir: FirElement): UniquenessTrie? =
+    methodCtx.uniqueness?.flowAfter(fir)
+
 
 fun StmtConversionContext.declareLocalProperty(symbol: FirPropertySymbol, initializer: ExpEmbedding?): Declare {
     registerLocalProperty(symbol)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -75,7 +75,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         // returnTarget is null when it is the implicit return of a lambda
         val returnTargetName = returnExpression.target.labelName
         val target = data.resolveReturnTarget(returnTargetName)
-        return Return(expr, target)
+        return Return(expr, target).apply {
+            uniquenessBefore = data.flowBefore(returnExpression)
+            uniquenessAfter = data.flowAfter(returnExpression)
+        }
     }
 
     override fun visitResolvedQualifier(
@@ -90,7 +93,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     }
 
     override fun visitBlock(block: FirBlock, data: StmtConversionContext): ExpEmbedding =
-        block.statements.map(data::convert).toBlock()
+        block.statements.map(data::convert).toBlock().apply {
+            uniquenessBefore = data.flowBefore(block)
+            uniquenessAfter = data.flowAfter(block)
+        }
 
     override fun visitLiteralExpression(
         literalExpression: FirLiteralExpression,
@@ -105,7 +111,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             literalExpression.source,
             "Constant Expression of type ${literalExpression.kind} is not yet implemented.",
             data
-        )
+        ).apply {
+            uniquenessBefore = data.flowBefore(literalExpression)
+            uniquenessAfter = data.flowAfter(literalExpression)
+        }
     }
 
     private val FirLiteralExpression.stringValue: String
@@ -122,20 +131,29 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             }
             arg.stringValue
         }
-        return StringLit(combinedLiteral)
+        return StringLit(combinedLiteral).apply {
+            uniquenessBefore = data.flowBefore(stringConcatenationCall)
+            uniquenessAfter = data.flowAfter(stringConcatenationCall)
+        }
     }
 
     override fun visitIntegerLiteralOperatorCall(
         integerLiteralOperatorCall: FirIntegerLiteralOperatorCall,
         data: StmtConversionContext,
     ): ExpEmbedding {
-        return visitFunctionCall(integerLiteralOperatorCall, data)
+        return visitFunctionCall(integerLiteralOperatorCall, data).apply {
+            uniquenessBefore = data.flowBefore(integerLiteralOperatorCall)
+            uniquenessAfter = data.flowAfter(integerLiteralOperatorCall)
+        }
     }
 
     override fun visitWhenSubjectExpression(
         whenSubjectExpression: FirWhenSubjectExpression,
         data: StmtConversionContext,
-    ): ExpEmbedding = data.whenSubject!!
+    ): ExpEmbedding = data.whenSubject!!.apply {
+        uniquenessBefore = data.flowBefore(whenSubjectExpression)
+        uniquenessAfter = data.flowAfter(whenSubjectExpression)
+    }
 
     private fun convertWhenBranches(
         whenBranches: Iterator<FirWhenBranch>,
@@ -150,7 +168,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         return if (branch.condition is FirElseIfTrueCondition) {
             data.withNewScope { convert(branch.result) }
         } else {
-            val cond = data.convert(branch.condition).withType { boolean() }
+            val cond = data.convert(branch.condition).withType { boolean() }.apply {
+                uniquenessBefore = data.flowBefore(branch)
+                uniquenessAfter = data.flowAfter(branch)
+            }
             val thenExp = data.withNewScope { convert(branch.result) }
             val elseExp = convertWhenBranches(whenBranches, type, data)
             If(cond, thenExp, elseExp, type)
@@ -166,11 +187,17 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                     declareAnonVar(subjExp.type, subjExp)
                 else
                     declareLocalVariable(firSubjVar.symbol, subjExp)
+            }?.apply {
+                uniquenessBefore = data.flowBefore(whenExpression.subjectVariable!!)
+                uniquenessAfter = data.flowAfter(whenExpression.subjectVariable!!)
             }
             val body = withWhenSubject(subj?.variable) {
                 convertWhenBranches(whenExpression.branches.iterator(), type, this)
             }
-            subj?.let { blockOf(it, body) } ?: body
+            (subj?.let { blockOf(it, body) } ?: body).apply {
+                uniquenessBefore = data.flowBefore(whenExpression)
+                uniquenessAfter = data.flowAfter(whenExpression)
+            }
         }
 
     override fun visitPropertyAccessExpression(
@@ -178,7 +205,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         data: StmtConversionContext,
     ): ExpEmbedding {
         val propertyAccess = data.embedPropertyAccess(propertyAccessExpression)
-        return propertyAccess.getValue(data)
+        return propertyAccess.getValue(data).apply {
+            uniquenessBefore = data.flowBefore(propertyAccessExpression)
+            uniquenessAfter = data.flowAfter(propertyAccessExpression)
+        }
     }
 
     override fun visitEqualityOperatorCall(
@@ -202,6 +232,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 "Equality comparison operation ${equalityOperatorCall.operation} not yet implemented.",
                 data
             )
+        }.apply {
+            uniquenessBefore = data.flowBefore(equalityOperatorCall)
+            uniquenessAfter = data.flowAfter(equalityOperatorCall)
         }
     }
 
@@ -238,7 +271,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 return IntComparisonExpEmbeddingsTemplate.retrieve(comparisonExpression.operation)(result, IntLit(0))
             }
         }
-        return comparisonTemplate.retrieve(comparisonExpression.operation)(left, right)
+        return comparisonTemplate.retrieve(comparisonExpression.operation)(left, right).apply {
+            uniquenessBefore = data.flowBefore(comparisonExpression)
+            uniquenessAfter = data.flowAfter(comparisonExpression)
+        }
     }
 
     private interface ComparisonExpEmbeddingsTemplate {
@@ -293,7 +329,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                     functionCall.functionCallArguments.withVarargsHandled(data, callee),
                     data,
                     data.embedType(functionCall.resolvedType),
-                )
+                ).apply {
+                    uniquenessBefore = data.flowBefore(functionCall)
+                    uniquenessAfter = data.flowAfter(functionCall)
+                }
             }
 
             else -> {
@@ -306,7 +345,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 val forAllBody = forAllLambda.body ?: throw SnaktInternalException(
                     forAllLambda.body?.source, "Lambda body should be accessible in `forAll` function call."
                 )
-                return data.insertForAllFunctionCall(forAllArg.symbol, forAllBody)
+                return data.insertForAllFunctionCall(forAllArg.symbol, forAllBody).apply {
+                    uniquenessBefore = data.flowBefore(functionCall)
+                    uniquenessAfter = data.flowAfter(functionCall)
+                }
             }
         }
     }
@@ -333,6 +375,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             else -> {
                 InvokeFunctionObject(data.convert(receiver), args, returnType)
             }
+        }.apply {
+            uniquenessBefore = data.flowBefore(implicitInvokeCall)
+            uniquenessAfter = data.flowAfter(implicitInvokeCall)
         }
     }
 
@@ -346,7 +391,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         }
 
         val type = data.embedType(symbol.resolvedReturnType)
-        return data.declareLocalProperty(symbol, property.initializer?.let { data.convert(it).withType(type) })
+        return data.declareLocalProperty(symbol, property.initializer?.let { data.convert(it).withType(type) }).apply {
+            uniquenessBefore = data.flowBefore(property)
+            uniquenessAfter = data.flowAfter(property)
+        }
     }
 
     override fun visitWhileLoop(whileLoop: FirWhileLoop, data: StmtConversionContext): ExpEmbedding {
@@ -362,7 +410,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         }
         return data.withFreshWhile(whileLoop.label) {
             val body = convert(whileLoop.block)
-            While(condition, body, breakLabelName(), continueLabelName(), invariants)
+            While(condition, body, breakLabelName(), continueLabelName(), invariants).apply {
+                uniquenessBefore = data.flowBefore(whileLoop)
+                uniquenessAfter = data.flowAfter(whileLoop)
+            }
         }
     }
 
@@ -372,7 +423,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     ): ExpEmbedding {
         val targetName = breakExpression.target.labelName
         val breakLabel = LabelLink(data.breakLabelName(targetName))
-        return Goto(breakLabel)
+        return Goto(breakLabel).apply {
+            uniquenessBefore = data.flowBefore(breakExpression)
+            uniquenessAfter = data.flowAfter(breakExpression)
+        }
     }
 
     override fun visitContinueExpression(
@@ -381,7 +435,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     ): ExpEmbedding {
         val targetName = continueExpression.target.labelName
         val continueLabel = LabelLink(data.continueLabelName(targetName))
-        return Goto(continueLabel)
+        return Goto(continueLabel).apply {
+            uniquenessBefore = data.flowBefore(continueExpression)
+            uniquenessAfter = data.flowAfter(continueExpression)
+        }
     }
 
     override fun visitDesugaredAssignmentValueReferenceExpression(
@@ -409,7 +466,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             )
         }
         val convertedRValue = data.convert(variableAssignment.rValue)
-        return embedding.setValue(convertedRValue, data)
+        return embedding.setValue(convertedRValue, data).apply {
+            uniquenessBefore = data.flowBefore(variableAssignment)
+            uniquenessAfter = data.flowAfter(variableAssignment)
+        }
     }
 
     override fun visitSmartCastExpression(
@@ -419,13 +479,16 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         val exp = data.convert(smartCastExpression.originalExpression)
         val newType = data.embedType(smartCastExpression.smartcastType.coneType)
         // If the smart-cast is from A? to A, then is not necessary to inhale invariants
-        return if (exp.type.getNonNullable() == newType) {
+        return (if (exp.type.getNonNullable() == newType) {
             exp.withType(newType)
         } else {
             // TODO: when there is a cast from B to A, only inhale invariants of A - invariants of B
             exp.withNewTypeInvariants(newType) {
                 access = true
             }
+        }).apply {
+            uniquenessBefore = data.flowBefore(smartCastExpression)
+            uniquenessAfter = data.flowAfter(smartCastExpression)
         }
     }
 
@@ -438,6 +501,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         return when (booleanOperatorExpression.kind) {
             LogicOperationKind.AND -> SequentialAnd(left, right)
             LogicOperationKind.OR -> SequentialOr(left, right)
+        }.apply {
+            uniquenessBefore = data.flowBefore(booleanOperatorExpression)
+            uniquenessAfter = data.flowAfter(booleanOperatorExpression)
         }
     }
 
@@ -467,13 +533,23 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         }
 
         val symbol = thisReceiverExpression.calleeReference.boundSymbol
-        tryResolve(symbol as FirBasedSymbol<*>)?.let { return it }
+        tryResolve(symbol as FirBasedSymbol<*>)?.let {
+            return it.apply {
+                uniquenessBefore = data.flowBefore(thisReceiverExpression)
+                uniquenessAfter = data.flowAfter(thisReceiverExpression)
+            }
+        }
         val declSymbol = when (symbol) {
             is FirReceiverParameterSymbol -> symbol.containingDeclarationSymbol
             is FirValueParameterSymbol -> symbol.containingDeclarationSymbol
             else -> throw SnaktInternalException(symbol.source, "Unsupported receiver expression type.")
         }
-        tryResolve(declSymbol)?.let { return it }
+        tryResolve(declSymbol)?.let {
+            return it.apply {
+                uniquenessBefore = data.flowBefore(thisReceiverExpression)
+                uniquenessAfter = data.flowAfter(thisReceiverExpression)
+            }
+        }
 
         throw SnaktInternalException(thisReceiverExpression.source, "No resolution approach to this symbol worked.")
     }
@@ -500,6 +576,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             else -> handleUnimplementedElement(
                 typeOperatorCall.source, "Can't embed type operator ${typeOperatorCall.operation}.", data
             )
+        }.apply {
+            uniquenessBefore = data.flowBefore(typeOperatorCall)
+            uniquenessAfter = data.flowAfter(typeOperatorCall)
         }
     }
 
@@ -508,7 +587,15 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         data: StmtConversionContext,
     ): ExpEmbedding {
         val function = anonymousFunctionExpression.anonymousFunction
-        return LambdaExp(data.embedFunctionSignature(function.symbol), function, data, function.symbol.label!!.name)
+        return LambdaExp(
+            data.embedFunctionSignature(function.symbol),
+            function,
+            data,
+            function.symbol.label!!.name
+        ).apply {
+            uniquenessBefore = data.flowBefore(anonymousFunctionExpression)
+            uniquenessAfter = data.flowAfter(anonymousFunctionExpression)
+        }
     }
 
     override fun visitTryExpression(tryExpression: FirTryExpression, data: StmtConversionContext): ExpEmbedding {
@@ -547,6 +634,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             add(tryBody)
             addAll(catches)
             add(LabelExp(catchData.exitLabel))
+        }.apply {
+            uniquenessBefore = data.flowBefore(tryExpression)
+            uniquenessAfter = data.flowAfter(tryExpression)
         }
     }
 
@@ -557,7 +647,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         val lhs = data.convert(elvisExpression.lhs)
         val rhs = data.convert(elvisExpression.rhs)
         val expType = data.embedType(elvisExpression.resolvedType)
-        return Elvis(lhs, rhs, expType)
+        return Elvis(lhs, rhs, expType).apply {
+            uniquenessBefore = data.flowBefore(elvisExpression)
+            uniquenessAfter = data.flowAfter(elvisExpression)
+        }
     }
 
     override fun visitSafeCallExpression(
@@ -575,7 +668,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 data.withCheckedSafeCallSubject(sharedReceiver.withType(checkedSafeCallSubjectType)) { convert(selector) },
                 NullLit,
                 expType
-            )
+            ).apply {
+                uniquenessBefore = data.flowBefore(safeCallExpression)
+                uniquenessAfter = data.flowAfter(safeCallExpression)
+            }
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConverter.kt
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.formver.viper.SymbolicName
  * NOTE: If you add parameters, be sure to update the `withResultFactory` function!
  */
 data class StmtConverter(
-    private val methodCtx: MethodConversionContext,
+    override val methodCtx: MethodConversionContext,
     private val whileIndex: Int = 0,
     override val whenSubject: VariableEmbedding? = null,
     override val checkedSafeCallSubject: ExpEmbedding? = null,

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.conversion
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.EnterNodeMarker
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ExitNodeMarker
+import org.jetbrains.kotlin.formver.uniqueness.FlowFacts
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
+
+
+class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<UniquenessTrie>) {
+
+    private val nodeCollectionMap by lazy { extract() }
+
+    fun flowBefore(firElement: FirElement): UniquenessTrie? {
+        return nodeCollectionMap[firElement]?.entry?.let { flowFacts.flowBefore(it) }
+    }
+
+    fun flowAfter(firElement: FirElement): UniquenessTrie? {
+        return nodeCollectionMap[firElement]?.exit?.let { flowFacts.flowAfter(it) }
+    }
+
+    class NodeCollection {
+        private var _entry: CFGNode<*>? = null
+        private var _exit: CFGNode<*>? = null
+        private val _all: MutableList<CFGNode<*>> = mutableListOf()
+
+
+        val entry: CFGNode<*>? get() = _entry ?: _all.firstOrNull()
+        val exit: CFGNode<*>? get() = _exit ?: _all.lastOrNull()
+
+        fun update(node: CFGNode<*>) {
+            when (node) {
+                is EnterNodeMarker -> _entry = node
+                is ExitNodeMarker -> _exit = node
+                else -> {}
+            }
+            _all.add(node)
+        }
+    }
+
+    fun extract(): Map<FirElement, NodeCollection> {
+        val visited = mutableSetOf<CFGNode<*>>()
+        val result = mutableMapOf<FirElement, NodeCollection>()
+
+        val stack = mutableListOf(root)
+
+        while (stack.isNotEmpty()) {
+            val node = stack.removeAt(stack.size - 1)
+            if (!visited.add(node)) continue
+
+            result.getOrPut(node.fir) { NodeCollection() }.update(node)
+
+            for (followingNode in node.followingNodes) {
+                stack.add(followingNode)
+            }
+        }
+
+        return result
+    }
+}
+

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.EnterNodeMarker
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ExitNodeMarker
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.FunctionCallExitNode
 import org.jetbrains.kotlin.formver.uniqueness.FlowFacts
 import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 
@@ -38,6 +39,7 @@ class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<Uniqu
             when (node) {
                 is EnterNodeMarker -> _entry = node
                 is ExitNodeMarker -> _exit = node
+                is FunctionCallExitNode -> _exit = node
                 else -> {}
             }
             _all.add(node)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/AccEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/AccEmbedding.kt
@@ -19,7 +19,7 @@ class AccEmbedding(
     val field: FieldEmbedding,
     val access: ExpEmbedding,
     val perm: PermExp,
-) : OnlyToBuiltinTypeExpEmbedding {
+) : OnlyToBuiltinTypeExpEmbedding, DefaultUniqueness() {
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp {
         val field = Exp.FieldAccess(
             access.toViper(ctx),

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
@@ -51,7 +51,7 @@ data class EqCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
     override val sourceRole: SourceRole? = null,
-) : AnyComparisonExpression {
+) : AnyComparisonExpression, DefaultUniqueness() {
     override val comparisonOperation = EqAny
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitEqCmp(this)
 }
@@ -60,7 +60,7 @@ data class NeCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
     override val sourceRole: SourceRole? = null,
-) : AnyComparisonExpression {
+) : AnyComparisonExpression, DefaultUniqueness() {
 
     override val comparisonOperation = NeAny
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitNeCmp(this)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -61,13 +61,13 @@ data class If(
 ) :
     OptionalResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
-        val permissionManager = UniquePermissionManager.create(condition)
-        permissionManager?.unfold(ctx)
-        val condViper = condition.toViperBuiltinType(ctx)
-        permissionManager?.fold(ctx)
-        val thenViper = ctx.asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, ctx) }
-        val elseViper = ctx.asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, ctx) }
         ctx.addStatement {
+            val permissionManager = UniquePermissionManager.create(condition)
+            permissionManager?.unfold(ctx)
+            val condViper = condition.toViperBuiltinType(this)
+            permissionManager?.fold(ctx)
+            val thenViper = asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, this) }
+            val elseViper = asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, this) }
             Stmt.If(condViper, thenViper, elseViper, source.asPosition)
         }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
-private data class BlockImpl(override val exps: List<ExpEmbedding>) : Block
+private data class BlockImpl(override val exps: List<ExpEmbedding>) : Block, DefaultUniqueness()
 
 fun blockOf(vararg exps: ExpEmbedding): Block = BlockImpl(exps.toList())
 
@@ -62,7 +62,7 @@ data class If(
     val elseBranch: ExpEmbedding,
     override val type: TypeEmbedding
 ) :
-    OptionalResultExpEmbedding, DefaultDebugTreeViewImplementation {
+    OptionalResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
         ctx.addBranch(condition, thenBranch, elseBranch, type, result)
     }
@@ -80,7 +80,7 @@ data class While(
     val breakLabelName: SymbolicName,
     val continueLabelName: SymbolicName,
     val invariants: List<ExpEmbedding>,
-) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
+) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override val type: TypeEmbedding = buildType { unit() }
 
     val continueLabel = LabelEmbedding(continueLabelName, invariants)
@@ -122,7 +122,7 @@ data class While(
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitWhile(this)
 }
 
-data class Goto(val target: LabelLink) : NoResultExpEmbedding, DefaultDebugTreeViewImplementation {
+data class Goto(val target: LabelLink) : NoResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override val type: TypeEmbedding = buildType { nothing() }
     override fun toViperUnusedResult(ctx: LinearizationContext) {
         ctx.addStatement { target.toViperGoto(ctx) }
@@ -139,7 +139,7 @@ data class Goto(val target: LabelLink) : NoResultExpEmbedding, DefaultDebugTreeV
 }
 
 // Using this name to avoid clashes with all our other `Label` types.
-data class LabelExp(val label: LabelEmbedding) : UnitResultExpEmbedding {
+data class LabelExp(val label: LabelEmbedding) : UnitResultExpEmbedding, DefaultUniqueness() {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addLabel(label.toViper(ctx))
     }
@@ -157,7 +157,7 @@ data class LabelExp(val label: LabelEmbedding) : UnitResultExpEmbedding {
  * The result of the intermediate expression is stored.
  */
 data class GotoChainNode(val label: LabelEmbedding?, val exp: ExpEmbedding, val next: LabelLink) :
-    OptionalResultExpEmbedding {
+    OptionalResultExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding = exp.type
 
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
@@ -176,7 +176,8 @@ data class GotoChainNode(val label: LabelEmbedding?, val exp: ExpEmbedding, val 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitGotoChainNode(this)
 }
 
-data class NonDeterministically(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
+data class NonDeterministically(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation,
+    DefaultUniqueness() {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addStatement {
             val choice = ctx.freshAnonVar { boolean() }
@@ -192,7 +193,8 @@ data class NonDeterministically(val exp: ExpEmbedding) : UnitResultExpEmbedding,
 }
 
 // Note: this is always a *real* Viper method call.
-data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbedding>) : StoredResultExpEmbedding {
+data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbedding>) : StoredResultExpEmbedding,
+    DefaultUniqueness() {
     override val type: TypeEmbedding = method.callableType.returnType
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
@@ -218,7 +220,8 @@ data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbe
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitMethodCall(this)
 }
 
-data class FunctionCall(val function: NamedFunctionSignature, val args: List<ExpEmbedding>) : DirectResultExpEmbedding {
+data class FunctionCall(val function: NamedFunctionSignature, val args: List<ExpEmbedding>) : DirectResultExpEmbedding,
+    DefaultUniqueness() {
     override val type: TypeEmbedding = function.callableType.returnType
 
     override val subexpressions: List<ExpEmbedding>
@@ -243,7 +246,7 @@ data class InvokeFunctionObject(
     val args: List<ExpEmbedding>,
     override val type: TypeEmbedding
 ) :
-    OnlyToViperExpEmbedding {
+    OnlyToViperExpEmbedding, DefaultUniqueness() {
     override fun toViper(ctx: LinearizationContext): Exp {
         val variable = ctx.freshAnonVar(type)
         receiver.toViperUnusedResult(ctx)
@@ -272,7 +275,7 @@ data class FunctionExp(
     val body: ExpEmbedding,
     val returnLabel: LabelEmbedding
 ) :
-    OptionalResultExpEmbedding {
+    OptionalResultExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding = body.type
 
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
@@ -304,7 +307,7 @@ data class FunctionExp(
 
 data class Elvis(val left: ExpEmbedding, val right: ExpEmbedding, override val type: TypeEmbedding) :
     StoredResultExpEmbedding,
-    DefaultDebugTreeViewImplementation {
+    DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
         val leftViper = left.toViper(ctx)
         val leftWrapped = ExpWrapper(leftViper, left.type)
@@ -321,7 +324,7 @@ data class Elvis(val left: ExpEmbedding, val right: ExpEmbedding, override val t
 
 data class Return(
     val returnExp: ExpEmbedding, val target: ReturnTarget
-) : OptionalResultExpEmbedding {
+) : OptionalResultExpEmbedding, DefaultUniqueness() {
     override val type = buildType { nothing() }
 
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -80,20 +80,23 @@ data class While(
 ) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override val type: TypeEmbedding = buildType { unit() }
 
+    val permissionManager = WhilePermissionManager.create(this)
     val continueLabel = LabelEmbedding(continueLabelName, invariants)
     val breakLabel = LabelEmbedding(breakLabelName)
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        val loopPermissionManager = PermissionManager(this)
-        val permissionInvariants = loopPermissionManager.extractWhileInvariants(ctx)
-        val newContinueLabel = LabelEmbedding(continueLabelName, invariants + permissionInvariants)
+
+        val permissionInvariants = permissionManager?.extractWhileInvariants()
+        val newContinueLabel =
+            permissionInvariants?.let { LabelEmbedding(continueLabelName, invariants + permissionInvariants) }
+                ?: continueLabel
 
         ctx.addLabel(newContinueLabel.toViper(ctx))
         val condVar = ctx.freshAnonVar { boolean() }
-        val conditionPermissionManager = PermissionManager(condition)
-        conditionPermissionManager.addUniqueUnfolds(ctx)
+        val conditionPermissionManager = UniquePermissionManager.create(condition)
+        conditionPermissionManager?.unfold(ctx)
         condition.toViperStoringIn(condVar, ctx)
-        conditionPermissionManager.addUniqueFolds(ctx)
+        conditionPermissionManager?.fold(ctx)
 
 
         ctx.addStatement {
@@ -205,8 +208,8 @@ data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbe
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
 
-        val permissionManager = PermissionManager(this)
-        permissionManager.addUniqueUnfolds(ctx)
+        val permissionManager = UniquePermissionManager.create(this)
+        permissionManager?.unfold(ctx)
         ctx.addStatement {
             method.toMethodCall(
                 args.map { it.toViper(ctx) },
@@ -214,7 +217,7 @@ data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbe
                 ctx.source.asPosition
             )
         }
-        permissionManager.addUniqueFolds(ctx)
+        permissionManager?.fold(ctx)
     }
 
     context(nameResolver: NameResolver)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -88,12 +88,11 @@ data class While(
 ) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override val type: TypeEmbedding = buildType { unit() }
 
-    val permissionManager = WhilePermissionManager.create(this)
     val continueLabel = LabelEmbedding(continueLabelName, invariants)
     val breakLabel = LabelEmbedding(breakLabelName)
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
-
+        val permissionManager = WhilePermissionManager.create(this)
         val permissionInvariants = permissionManager?.extractWhileInvariants()
         val newContinueLabel =
             permissionInvariants?.let { LabelEmbedding(continueLabelName, invariants + permissionInvariants) }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -15,10 +15,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.callables.toMethodCall
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.*
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildType
-import org.jetbrains.kotlin.formver.core.linearization.LinearizationContext
-import org.jetbrains.kotlin.formver.core.linearization.addLabel
-import org.jetbrains.kotlin.formver.core.linearization.freshAnonVar
-import org.jetbrains.kotlin.formver.core.linearization.pureToViper
+import org.jetbrains.kotlin.formver.core.linearization.*
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -198,6 +195,9 @@ data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbe
     override val type: TypeEmbedding = method.callableType.returnType
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
+
+        val permissionManager = PermissionManager(this)
+        permissionManager.addUniqueUnfolds(ctx)
         ctx.addStatement {
             method.toMethodCall(
                 args.map { it.toViper(ctx) },
@@ -205,6 +205,7 @@ data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbe
                 ctx.source.asPosition
             )
         }
+        permissionManager.addUniqueFolds(ctx)
     }
 
     context(nameResolver: NameResolver)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -84,13 +84,22 @@ data class While(
     val breakLabel = LabelEmbedding(breakLabelName)
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        ctx.addLabel(continueLabel.toViper(ctx))
+        val loopPermissionManager = PermissionManager(this)
+        val permissionInvariants = loopPermissionManager.extractWhileInvariants(ctx)
+        val newContinueLabel = LabelEmbedding(continueLabelName, invariants + permissionInvariants)
+
+        ctx.addLabel(newContinueLabel.toViper(ctx))
         val condVar = ctx.freshAnonVar { boolean() }
+        val conditionPermissionManager = PermissionManager(condition)
+        conditionPermissionManager.addUniqueUnfolds(ctx)
         condition.toViperStoringIn(condVar, ctx)
+        conditionPermissionManager.addUniqueFolds(ctx)
+
+
         ctx.addStatement {
             val bodyBlock = ctx.asBlock {
                 body.toViperUnusedResult(this)
-                addStatement { continueLabel.toLink().toViperGoto(this) }
+                addStatement { newContinueLabel.toLink().toViperGoto(this) }
             }
             Stmt.If(condVar.toViperBuiltinType(ctx), bodyBlock, els = Stmt.Seqn(), ctx.source.asPosition)
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -61,7 +61,15 @@ data class If(
 ) :
     OptionalResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
-        ctx.addBranch(condition, thenBranch, elseBranch, type, result)
+        val permissionManager = UniquePermissionManager.create(condition)
+        permissionManager?.unfold(ctx)
+        val condViper = condition.toViperBuiltinType(ctx)
+        permissionManager?.fold(ctx)
+        val thenViper = ctx.asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, ctx) }
+        val elseViper = ctx.asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, ctx) }
+        ctx.addStatement {
+            Stmt.If(condViper, thenViper, elseViper, source.asPosition)
+        }
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
@@ -324,8 +332,7 @@ data class Elvis(val left: ExpEmbedding, val right: ExpEmbedding, override val t
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
         val leftViper = left.toViper(ctx)
         val leftWrapped = ExpWrapper(leftViper, left.type)
-        val conditional = If(leftWrapped.notNullCmp(), leftWrapped, right, type)
-        conditional.toViperStoringIn(result, ctx)
+        ctx.addBranch(leftWrapped.notNullCmp(), leftWrapped, right, type, result)
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -61,15 +61,7 @@ data class If(
 ) :
     OptionalResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
-        ctx.addStatement {
-            val permissionManager = UniquePermissionManager.create(condition)
-            permissionManager?.unfold(ctx)
-            val condViper = condition.toViperBuiltinType(this)
-            permissionManager?.fold(ctx)
-            val thenViper = asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, this) }
-            val elseViper = asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, this) }
-            Stmt.If(condViper, thenViper, elseViper, source.asPosition)
-        }
+        ctx.addBranchWithFolding(condition, thenBranch, elseBranch, type, result)
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -549,14 +549,6 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
         }
     }
 
-    private fun ClassTypeEmbedding.predicateAccess(
-        receiver: ExpEmbedding,
-        ctx: LinearizationContext
-    ): Exp.PredicateAccess =
-        sharedPredicateAccessInvariant()?.fillHole(receiver)
-            ?.pureToViper(toBuiltin = true, ctx.source) as? Exp.PredicateAccess
-            ?: error("Attempt to unfold a predicate of ${name.debugMangled}.")
-
     context(nameResolver: NameResolver)
     override val debugTreeView: TreeView
         get() = OperatorNode(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -51,6 +51,18 @@ sealed interface ExpEmbedding : DebugPrintable {
     var uniquenessAfter: UniquenessTrie?
 
     /**
+     * All paths that appear inside the `ExpEmbedding`.
+     */
+    val containingPaths: Lazy<Set<Path>>
+        get() = lazy { emptySet() }
+
+    /**
+     * The path that is ending in this `ExpEmbedding`.
+     */
+    val endingPath: Lazy<Path?>
+        get() = lazy { null }
+
+    /**
      * Convert this `ExpEmbedding` into a Viper `Exp` of type `Ref`, using the provided context for auxiliary statements and declarations.
      *
      * The `Exp` returned contains the result of the expression.
@@ -101,9 +113,15 @@ sealed interface ExpEmbedding : DebugPrintable {
     fun isValid(ctx: PurityContext): Boolean = true
 }
 
+/**
+ * Used to set default behavior for the permission related fields.
+ */
 abstract class DefaultUniqueness : ExpEmbedding {
     override var uniquenessBefore: UniquenessTrie? = null
     override var uniquenessAfter: UniquenessTrie? = null
+
+    override val containingPaths: Lazy<Set<Path>> =
+        lazy { (children().flatMap { it.containingPaths.value } + listOfNotNull(endingPath.value)).toSet() }
 }
 
 sealed class ToViperBuiltinMisuseError(msg: String) : RuntimeException(msg)
@@ -310,6 +328,11 @@ sealed interface PassthroughExpEmbedding : ExpEmbedding {
     override val type: TypeEmbedding
         get() = inner.type
 
+    override val endingPath: Lazy<Path?>
+        get() = lazy {
+            inner.endingPath.value
+        }
+
     override fun toViper(ctx: LinearizationContext): Exp = withPassthroughHook(ctx) { inner.toViper(this) }
 
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp = withPassthroughHook(ctx) {
@@ -367,6 +390,10 @@ data class PrimitiveFieldAccess(override val inner: ExpEmbedding, val field: Fie
     override val type: TypeEmbedding
         get() = this.field.type
 
+    override val endingPath: Lazy<Path?> = lazy {
+        inner.endingPath.value?.addField(field)
+    }
+
     override fun toViper(ctx: LinearizationContext): Exp =
         Exp.FieldAccess(inner.toViper(ctx), field.toViper(), ctx.source.asPosition)
 
@@ -380,6 +407,11 @@ data class PrimitiveFieldAccess(override val inner: ExpEmbedding, val field: Fie
 data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : DefaultMaybeStoringInExpEmbedding,
     DefaultToBuiltinExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding = field.type
+
+    override val endingPath: Lazy<Path?> = lazy {
+        receiver.endingPath.value?.addField(field)
+    }
+
     override fun toViper(ctx: LinearizationContext): Exp {
         if (field.accessPolicy == AccessPolicy.ALWAYS_WRITEABLE) {
             return PrimitiveFieldAccess(receiver, field).toViper(ctx)
@@ -459,6 +491,11 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
  */
 data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbedding, val newValue: ExpEmbedding) :
     UnitResultExpEmbedding, DefaultUniqueness() {
+
+    override val endingPath: Lazy<Path?> = lazy {
+        receiver.endingPath.value?.addField(field)
+    }
+
     override fun toViperSideEffects(ctx: LinearizationContext) {
         when (field.accessPolicy) {
             // TODO: Handling a unique field on a shared receiver must be added here.
@@ -518,6 +555,11 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
 
 data class FieldAccessPermissions(override val inner: ExpEmbedding, val field: FieldEmbedding, val perm: PermExp) :
     OnlyToBuiltinTypeExpEmbedding, UnaryDirectResultExpEmbedding, DefaultUniqueness() {
+
+    override val endingPath: Lazy<Path?> = lazy {
+        inner.endingPath.value?.addField(field)
+    }
+
     // We consider access permissions to have type Boolean, though this is a bit questionable.
     override val type: TypeEmbedding = buildType { boolean() }
 
@@ -589,5 +631,12 @@ data class Declare(val variable: VariableEmbedding, val initializer: ExpEmbeddin
     override val debugExtraSubtrees: List<TreeView>
         get() = listOfNotNull(variable.debugTreeView, variable.type.debugTreeView, initializer?.debugTreeView)
 
+    override fun children(): Sequence<ExpEmbedding> {
+        return if (initializer == null) {
+            sequenceOf(variable)
+        } else {
+            sequenceOf(variable, initializer)
+        }
+    }
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitDeclare(this)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.expression
 
+import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.asPosition
 import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
 import org.jetbrains.kotlin.formver.core.conversion.Path
@@ -525,26 +526,53 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
     }
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
+
         when (field.accessPolicy) {
             // TODO: Handling a unique field on a shared receiver must be added here.
-            AccessPolicy.BY_RECEIVER_UNIQUENESS if false -> {
-                // We write to a shared var field. Since this value could change at any time, the result can not be
-                // used for reasoning. Hence, we want to ignore that statement.
-                // If there are side effects involved, we assign the results to throw away variables.
-                receiver.toViperUnusedResult(ctx)
-                newValue.toViperUnusedResult(ctx)
+            AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+                val permissionManager = PermissionManager(this)
+                if (permissionManager.isShared()) {
+                    // We write to a shared var field. Since this value could change at any time, the result can not be
+                    // used for reasoning. Hence, we want to ignore that statement.
+                    // If there are side effects involved, we assign the results to throw away variables.
+                    receiver.toViperUnusedResult(ctx)
+                    newValue.toViperUnusedResult(ctx)
+                } else {
+                    // The receiver is unique
+                    permissionManager.addUniqueUnfolds(ctx)
+                    ctx.addStatement {
+                        Stmt.FieldAssign(
+                            Exp.FieldAccess(receiver.toViper(ctx), field.toViper()),
+                            newValue.toViper(ctx)
+                        )
+                    }
+                    permissionManager.addUniqueFolds(ctx)
+                }
             }
-            else -> {
-                val receiverViper = receiver.toViper(ctx)
-                val newValueViper = newValue.withType(field.type).toViper(ctx)
+
+            AccessPolicy.ALWAYS_WRITEABLE -> {
+                // Nothing needs to be done, because it is always writeable (special field)
                 ctx.addStatement {
                     Stmt.FieldAssign(
-                        Exp.FieldAccess(receiverViper, field.toViper()),
-                        newValueViper,
-                        ctx.source.asPosition
+                        Exp.FieldAccess(receiver.toViper(ctx), field.toViper()),
+                        newValue.toViper(ctx)
                     )
                 }
+            }
 
+            AccessPolicy.MANUAL -> {
+                // Manual permission management.
+                // TODO: Handle this.
+                ctx.addStatement {
+                    Stmt.FieldAssign(
+                        Exp.FieldAccess(receiver.toViper(ctx), field.toViper()),
+                        newValue.toViper(ctx)
+                    )
+                }
+            }
+
+            AccessPolicy.ALWAYS_READABLE -> {
+                throw SnaktInternalException(ctx.source, "Trying to write to an immutable field")
             }
         }
     }
@@ -613,6 +641,7 @@ data class Assign(val lhs: VariableEmbedding, val rhs: ExpEmbedding) : UnitResul
         val manager = PermissionManager(this)
         manager.addUniqueUnfolds(ctx)
         rhs.withType(lhs.type).toViperStoringIn(LinearizationVariableEmbedding(lhs.name, lhs.type), ctx)
+        manager.addUniqueFolds(ctx)
     }
 
     context(nameResolver: NameResolver)
@@ -634,6 +663,7 @@ data class Declare(val variable: VariableEmbedding, val initializer: ExpEmbeddin
             manager.addUniqueUnfolds(ctx)
             initializer.withType(variable.type)
                 .toViperStoringIn(LinearizationVariableEmbedding(variable.name, variable.type), ctx)
+            manager.addUniqueFolds(ctx)
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -120,9 +120,8 @@ sealed interface ExpEmbedding : DebugPrintable {
 abstract class DefaultUniqueness : ExpEmbedding {
     override var uniquenessBefore: UniquenessTrie? = null
     override var uniquenessAfter: UniquenessTrie? = null
-
-    override val containingPaths: Lazy<Set<Path>> =
-        lazy { (children().flatMap { it.containingPaths.value } + listOfNotNull(endingPath.value)).toSet() }
+    override val containingPaths: Lazy<Set<Path>>
+        get() = lazy { children().flatMap { it.containingPaths.value }.toSet() }
 }
 
 sealed class ToViperBuiltinMisuseError(msg: String) : RuntimeException(msg)
@@ -334,6 +333,12 @@ sealed interface PassthroughExpEmbedding : ExpEmbedding {
             inner.endingPath.value
         }
 
+    override val containingPaths: Lazy<Set<Path>>
+        get() = lazy {
+            inner.containingPaths.value
+        }
+
+
     override fun toViper(ctx: LinearizationContext): Exp = withPassthroughHook(ctx) { inner.toViper(this) }
 
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp = withPassthroughHook(ctx) {
@@ -392,11 +397,17 @@ data class PrimitiveFieldAccess(override val inner: ExpEmbedding, val field: Fie
         get() = this.field.type
 
     override val endingPath: Lazy<Path?> = lazy {
+        // only UserFieldEmbeddings are support, because it must have a backlink to the corresponding fir element.
         when (field) {
             is UserFieldEmbedding -> inner.endingPath.value?.addField(field)
             else -> null
         }
     }
+
+    override val containingPaths: Lazy<Set<Path>> = lazy {
+        setOfNotNull(endingPath.value)
+    }
+
     override fun toViper(ctx: LinearizationContext): Exp =
         Exp.FieldAccess(inner.toViper(ctx), field.toViper(), ctx.source.asPosition)
 
@@ -412,11 +423,16 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
     override val type: TypeEmbedding = field.type
 
     override val endingPath: Lazy<Path?> = lazy {
+        // only UserFieldEmbeddings are support, because it must have a backlink to the corresponding fir element.
         when (field) {
             is UserFieldEmbedding -> receiver.endingPath.value?.addField(field)
             else -> null
         }
     }
+    override val containingPaths: Lazy<Set<Path>> = lazy {
+        setOfNotNull(endingPath.value)
+    }
+
 
     override fun toViper(ctx: LinearizationContext): Exp {
         if (field.accessPolicy == AccessPolicy.ALWAYS_WRITEABLE) {
@@ -524,15 +540,19 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
 
     override val endingPath: Lazy<Path?> = lazy {
         when (field) {
+            // only UserFieldEmbeddings are support, because it must have a backlink to the corresponding fir element.
             is UserFieldEmbedding -> receiver.endingPath.value?.addField(field)
             else -> null
         }
     }
+    override val containingPaths: Lazy<Set<Path>> = lazy {
+        setOfNotNull(endingPath.value)
+    }
+
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
 
         when (field.accessPolicy) {
-            // TODO: Handling a unique field on a shared receiver must be added here.
             AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
                 val permissionManager = SharedPermissionManager.create(this)
                 val havoc = permissionManager?.isShared ?: true
@@ -599,10 +619,15 @@ data class FieldAccessPermissions(override val inner: ExpEmbedding, val field: F
 
     override val endingPath: Lazy<Path?> = lazy {
         when (field) {
+            // only UserFieldEmbeddings are support, because it must have a backlink to the corresponding fir element.
             is UserFieldEmbedding -> inner.endingPath.value?.addField(field)
             else -> null
         }
     }
+    override val containingPaths: Lazy<Set<Path>> = lazy {
+        setOfNotNull(endingPath.value)
+    }
+
 
     // We consider access permissions to have type Boolean, though this is a bit questionable.
     override val type: TypeEmbedding = buildType { boolean() }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.core.embeddings.expression
 
 import org.jetbrains.kotlin.formver.core.asPosition
 import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
+import org.jetbrains.kotlin.formver.core.conversion.Path
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
@@ -18,6 +19,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.core.embeddings.types.injectionOr
 import org.jetbrains.kotlin.formver.core.linearization.LinearizationContext
+import org.jetbrains.kotlin.formver.core.linearization.PermissionManager
 import org.jetbrains.kotlin.formver.core.linearization.UnfoldPolicy
 import org.jetbrains.kotlin.formver.core.linearization.pureToViper
 import org.jetbrains.kotlin.formver.core.purity.PurityContext
@@ -424,26 +426,59 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
     }
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
-        ctx.addStatement {
-            when (field.accessPolicy) {
-                // TODO: Handling a unique field on a shared receiver must be added here.
-                AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
-                    receiver.toViperUnusedResult(ctx)
-                    field.type.havocMethod.toMethodCall(emptyList(), listOf(result.toLocalVarUse()))
-                }
+        when (field.accessPolicy) {
+            AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+                // Mutable fields
 
-                else -> {
-                    val receiverViper = receiver.toViper(ctx)
-                    // If the field access is not replaced with havoc,
-                    // we might need to unfold some predicate to access it.
-                    if (field.unfoldToAccess) {
-                        val receiverWrapper = ExpWrapper(receiverViper, receiver.type)
-                        unfoldHierarchy(receiverWrapper, ctx)
+                val permissionManager = PermissionManager(this)
+                if (permissionManager.isShared()) {
+                    // Since receiver is shared, we havoc it.
+                    receiver.toViper(ctx)
+                    val stmt = field.type.havocMethod.toMethodCall(emptyList(), listOf(result.toLocalVarUse()))
+                    ctx.addStatement { stmt }
+                } else {
+                    // receiver is unique
+                    PrimitiveFieldAccess(receiver, field).toViperStoringIn(result, ctx)
+                }
+            }
+
+            AccessPolicy.ALWAYS_READABLE -> {
+                // Immutable fields
+                // Issue, the receiver could become havocd, and then we unfold the wrong predicate.
+                // might be solved with some smart lookahead in the
+                val receiverViper = receiver.toViper(ctx)
+                val permissionManager = PermissionManager(this)
+                val inner = if (receiverViper is Exp.LocalVar) {
+                    val localVar = LinearizationVariableEmbedding(receiverViper.name, receiver.type)
+                    permissionManager.addSharedUnfold(ctx, localVar)
+                    localVar.toViper(ctx)
+                } else {
+                    val anon = ctx.freshAnonVar(receiver.type)
+                    val anonViper = anon.toViper(ctx)
+                    ctx.addStatement {
+                        Stmt.assign(anonViper, receiverViper, source.asPosition)
                     }
+                    anonViper
+                }
+                ctx.addStatement {
                     Stmt.assign(
-                        result.toLocalVarUse(), Exp.FieldAccess(receiverViper, field.toViper(), ctx.source.asPosition)
+                        result.toViper(ctx),
+                        Exp.FieldAccess(inner, field.toViper(), ctx.source.asPosition),
+                        source.asPosition
                     )
                 }
+            }
+
+            AccessPolicy.ALWAYS_WRITEABLE -> {
+                // Special fields. Nothing to do
+                PrimitiveFieldAccess(receiver, field).toViperStoringIn(result, ctx)
+            }
+
+            AccessPolicy.MANUAL -> {
+                Stmt.assign(
+                    result.toLocalVarUse(),
+                    Exp.FieldAccess(receiver.toViper(ctx), field.toViper(), ctx.source.asPosition)
+                )
             }
         }
     }
@@ -466,13 +501,6 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
             ?.pureToViper(toBuiltin = true, ctx.source) as? Exp.PredicateAccess
             ?: error("Attempt to unfold a predicate of ${name.debugMangled}.")
 
-    private fun unfoldHierarchy(receiverWrapper: ExpEmbedding, ctx: LinearizationContext) {
-        val hierarchyPath = (receiver.type.pretype as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field)
-        hierarchyPath?.forEach { classType ->
-            val predAcc = classType.predicateAccess(receiverWrapper, ctx)
-            predAcc.let { ctx.addStatement { Stmt.Unfold(it) } }
-        }
-    }
 
     override fun toViperUnusedResult(ctx: LinearizationContext) {
         receiver.toViperUnusedResult(ctx)
@@ -499,20 +527,15 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
     override fun toViperSideEffects(ctx: LinearizationContext) {
         when (field.accessPolicy) {
             // TODO: Handling a unique field on a shared receiver must be added here.
-            AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+            AccessPolicy.BY_RECEIVER_UNIQUENESS if false -> {
                 // We write to a shared var field. Since this value could change at any time, the result can not be
                 // used for reasoning. Hence, we want to ignore that statement.
                 // If there are side effects involved, we assign the results to throw away variables.
                 receiver.toViperUnusedResult(ctx)
                 newValue.toViperUnusedResult(ctx)
             }
-
             else -> {
                 val receiverViper = receiver.toViper(ctx)
-                if (field.unfoldToAccess) {
-                    val receiverWrapper = ExpWrapper(receiverViper, receiver.type)
-                    unfoldHierarchy(receiverWrapper, ctx)
-                }
                 val newValueViper = newValue.withType(field.type).toViper(ctx)
                 ctx.addStatement {
                     Stmt.FieldAssign(
@@ -523,14 +546,6 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
                 }
 
             }
-        }
-    }
-
-    private fun unfoldHierarchy(receiverWrapper: ExpEmbedding, ctx: LinearizationContext) {
-        val hierarchyPath = (receiver.type.pretype as? ClassTypeEmbedding)?.details?.hierarchyUnfoldPath(field)
-        hierarchyPath?.forEach { classType ->
-            val predAcc = classType.predicateAccess(receiverWrapper, ctx)
-            predAcc.let { ctx.addStatement { Stmt.Unfold(it) } }
         }
     }
 
@@ -603,6 +618,8 @@ data class Assign(val lhs: VariableEmbedding, val rhs: ExpEmbedding) : UnitResul
     override val type: TypeEmbedding = lhs.type
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
+        val manager = PermissionManager(this)
+        manager.addUniqueUnfolds(ctx)
         rhs.withType(lhs.type).toViperStoringIn(LinearizationVariableEmbedding(lhs.name, lhs.type), ctx)
     }
 
@@ -620,8 +637,12 @@ data class Declare(val variable: VariableEmbedding, val initializer: ExpEmbeddin
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addDeclaration(variable.toLocalVarDecl(ctx.source.asPosition))
-        initializer?.withType(variable.type)
-            ?.toViperStoringIn(LinearizationVariableEmbedding(variable.name, variable.type), ctx)
+        if (initializer != null) {
+            val manager = PermissionManager(this)
+            manager.addUniqueUnfolds(ctx)
+            initializer.withType(variable.type)
+                .toViperStoringIn(LinearizationVariableEmbedding(variable.name, variable.type), ctx)
+        }
     }
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.formver.core.linearization.UnfoldPolicy
 import org.jetbrains.kotlin.formver.core.linearization.pureToViper
 import org.jetbrains.kotlin.formver.core.purity.PurityContext
 import org.jetbrains.kotlin.formver.names.SimpleNameResolver
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -38,6 +39,16 @@ sealed interface ExpEmbedding : DebugPrintable {
      */
     val sourceRole: SourceRole?
         get() = null
+
+    /**
+     * Uniqueness tree before the `ExpEmbedding` is executed.
+     */
+    var uniquenessBefore: UniquenessTrie?
+
+    /**
+     * Uniqueness tree after the `ExpEmbedding` is executed.
+     */
+    var uniquenessAfter: UniquenessTrie?
 
     /**
      * Convert this `ExpEmbedding` into a Viper `Exp` of type `Ref`, using the provided context for auxiliary statements and declarations.
@@ -88,6 +99,11 @@ sealed interface ExpEmbedding : DebugPrintable {
     fun children(): Sequence<ExpEmbedding> = emptySequence()
     fun <R> accept(v: ExpVisitor<R>): R
     fun isValid(ctx: PurityContext): Boolean = true
+}
+
+abstract class DefaultUniqueness : ExpEmbedding {
+    override var uniquenessBefore: UniquenessTrie? = null
+    override var uniquenessAfter: UniquenessTrie? = null
 }
 
 sealed class ToViperBuiltinMisuseError(msg: String) : RuntimeException(msg)
@@ -347,7 +363,7 @@ fun List<ExpEmbedding>.toViper(ctx: LinearizationContext): List<Exp> = map { it.
  */
 data class PrimitiveFieldAccess(override val inner: ExpEmbedding, val field: FieldEmbedding) :
     UnaryDirectResultExpEmbedding,
-    DefaultToBuiltinExpEmbedding {
+    DefaultToBuiltinExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding
         get() = this.field.type
 
@@ -362,7 +378,7 @@ data class PrimitiveFieldAccess(override val inner: ExpEmbedding, val field: Fie
 }
 
 data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : DefaultMaybeStoringInExpEmbedding,
-    DefaultToBuiltinExpEmbedding {
+    DefaultToBuiltinExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding = field.type
     override fun toViper(ctx: LinearizationContext): Exp {
         if (field.accessPolicy == AccessPolicy.ALWAYS_WRITEABLE) {
@@ -442,7 +458,7 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
  * Represents a combination of `Assign` + `FieldAccess`.
  */
 data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbedding, val newValue: ExpEmbedding) :
-    UnitResultExpEmbedding {
+    UnitResultExpEmbedding, DefaultUniqueness() {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         when (field.accessPolicy) {
             // TODO: Handling a unique field on a shared receiver must be added here.
@@ -501,7 +517,7 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
 }
 
 data class FieldAccessPermissions(override val inner: ExpEmbedding, val field: FieldEmbedding, val perm: PermExp) :
-    OnlyToBuiltinTypeExpEmbedding, UnaryDirectResultExpEmbedding {
+    OnlyToBuiltinTypeExpEmbedding, UnaryDirectResultExpEmbedding, DefaultUniqueness() {
     // We consider access permissions to have type Boolean, though this is a bit questionable.
     override val type: TypeEmbedding = buildType { boolean() }
 
@@ -523,7 +539,7 @@ data class PredicateAccessPermissions(
     val args: List<ExpEmbedding>,
     val perm: PermExp
 ) :
-    OnlyToBuiltinTypeExpEmbedding {
+    OnlyToBuiltinTypeExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding = buildType { boolean() }
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
         Exp.PredicateAccess(predicateName, args.map { it.toViper(ctx) }, perm, ctx.source.asPosition)
@@ -541,7 +557,7 @@ data class PredicateAccessPermissions(
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitPredicateAccessPermissions(this)
 }
 
-data class Assign(val lhs: VariableEmbedding, val rhs: ExpEmbedding) : UnitResultExpEmbedding {
+data class Assign(val lhs: VariableEmbedding, val rhs: ExpEmbedding) : UnitResultExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding = lhs.type
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
@@ -557,7 +573,7 @@ data class Assign(val lhs: VariableEmbedding, val rhs: ExpEmbedding) : UnitResul
 }
 
 data class Declare(val variable: VariableEmbedding, val initializer: ExpEmbedding?) : UnitResultExpEmbedding,
-    DefaultDebugTreeViewImplementation {
+    DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override val type: TypeEmbedding = buildType { unit() }
 
     override fun toViperSideEffects(ctx: LinearizationContext) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -15,14 +15,12 @@ import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.core.embeddings.asInfo
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.*
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.properties.UserFieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.core.embeddings.types.injectionOr
-import org.jetbrains.kotlin.formver.core.linearization.LinearizationContext
-import org.jetbrains.kotlin.formver.core.linearization.PermissionManager
-import org.jetbrains.kotlin.formver.core.linearization.UnfoldPolicy
-import org.jetbrains.kotlin.formver.core.linearization.pureToViper
+import org.jetbrains.kotlin.formver.core.linearization.*
 import org.jetbrains.kotlin.formver.core.purity.PurityContext
 import org.jetbrains.kotlin.formver.names.SimpleNameResolver
 import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
@@ -394,9 +392,11 @@ data class PrimitiveFieldAccess(override val inner: ExpEmbedding, val field: Fie
         get() = this.field.type
 
     override val endingPath: Lazy<Path?> = lazy {
-        inner.endingPath.value?.addField(field)
+        when (field) {
+            is UserFieldEmbedding -> inner.endingPath.value?.addField(field)
+            else -> null
+        }
     }
-
     override fun toViper(ctx: LinearizationContext): Exp =
         Exp.FieldAccess(inner.toViper(ctx), field.toViper(), ctx.source.asPosition)
 
@@ -412,7 +412,10 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
     override val type: TypeEmbedding = field.type
 
     override val endingPath: Lazy<Path?> = lazy {
-        receiver.endingPath.value?.addField(field)
+        when (field) {
+            is UserFieldEmbedding -> receiver.endingPath.value?.addField(field)
+            else -> null
+        }
     }
 
     override fun toViper(ctx: LinearizationContext): Exp {
@@ -431,9 +434,11 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
             AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
                 // Mutable fields
 
-                val permissionManager = PermissionManager(this)
-                if (permissionManager.isShared()) {
-                    // Since receiver is shared, we havoc it.
+                val permissionManager = SharedPermissionManager.create(this)
+                val havoc = permissionManager?.isShared
+                    ?: true // permission Manager is null iff there is no path ending here. We assume that it is shared then.
+                if (havoc) {
+                    // Since the receiver is shared, it must call havoc.
                     receiver.toViper(ctx)
                     val stmt = field.type.havocMethod.toMethodCall(emptyList(), listOf(result.toLocalVarUse()))
                     ctx.addStatement { stmt }
@@ -445,21 +450,17 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
 
             AccessPolicy.ALWAYS_READABLE -> {
                 // Immutable fields
-                // Issue, the receiver could become havocd, and then we unfold the wrong predicate.
-                // might be solved with some smart lookahead in the
                 val receiverViper = receiver.toViper(ctx)
-                val permissionManager = PermissionManager(this)
+                val permissionManager = SharedPermissionManager.create(this)
                 val inner = if (receiverViper is Exp.LocalVar) {
+                    // One level deeper there was a havoc call. Hence the result is stored in a local variable.
+                    // We need to unfold the predicate of the path but with the local variable as target.
                     val localVar = LinearizationVariableEmbedding(receiverViper.name, receiver.type)
-                    permissionManager.addSharedUnfold(ctx, localVar)
+                    permissionManager?.unfold(ctx, localVar)
                     localVar.toViper(ctx)
                 } else {
-                    val anon = ctx.freshAnonVar(receiver.type)
-                    val anonViper = anon.toViper(ctx)
-                    ctx.addStatement {
-                        Stmt.assign(anonViper, receiverViper, source.asPosition)
-                    }
-                    anonViper
+                    permissionManager?.unfold(ctx)
+                    receiverViper
                 }
                 ctx.addStatement {
                     Stmt.assign(
@@ -522,7 +523,10 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
     UnitResultExpEmbedding, DefaultUniqueness() {
 
     override val endingPath: Lazy<Path?> = lazy {
-        receiver.endingPath.value?.addField(field)
+        when (field) {
+            is UserFieldEmbedding -> receiver.endingPath.value?.addField(field)
+            else -> null
+        }
     }
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
@@ -530,8 +534,9 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
         when (field.accessPolicy) {
             // TODO: Handling a unique field on a shared receiver must be added here.
             AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
-                val permissionManager = PermissionManager(this)
-                if (permissionManager.isShared()) {
+                val permissionManager = SharedPermissionManager.create(this)
+                val havoc = permissionManager?.isShared ?: true
+                if (havoc) {
                     // We write to a shared var field. Since this value could change at any time, the result can not be
                     // used for reasoning. Hence, we want to ignore that statement.
                     // If there are side effects involved, we assign the results to throw away variables.
@@ -539,14 +544,15 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
                     newValue.toViperUnusedResult(ctx)
                 } else {
                     // The receiver is unique
-                    permissionManager.addUniqueUnfolds(ctx)
+                    val permissionManager = UniquePermissionManager.create(this)
+                    permissionManager?.unfold(ctx)
                     ctx.addStatement {
                         Stmt.FieldAssign(
                             Exp.FieldAccess(receiver.toViper(ctx), field.toViper()),
                             newValue.toViper(ctx)
                         )
                     }
-                    permissionManager.addUniqueFolds(ctx)
+                    permissionManager?.fold(ctx)
                 }
             }
 
@@ -592,7 +598,10 @@ data class FieldAccessPermissions(override val inner: ExpEmbedding, val field: F
     OnlyToBuiltinTypeExpEmbedding, UnaryDirectResultExpEmbedding, DefaultUniqueness() {
 
     override val endingPath: Lazy<Path?> = lazy {
-        inner.endingPath.value?.addField(field)
+        when (field) {
+            is UserFieldEmbedding -> inner.endingPath.value?.addField(field)
+            else -> null
+        }
     }
 
     // We consider access permissions to have type Boolean, though this is a bit questionable.
@@ -638,10 +647,10 @@ data class Assign(val lhs: VariableEmbedding, val rhs: ExpEmbedding) : UnitResul
     override val type: TypeEmbedding = lhs.type
 
     override fun toViperSideEffects(ctx: LinearizationContext) {
-        val manager = PermissionManager(this)
-        manager.addUniqueUnfolds(ctx)
+        val manager = UniquePermissionManager.create(this)
+        manager?.unfold(ctx)
         rhs.withType(lhs.type).toViperStoringIn(LinearizationVariableEmbedding(lhs.name, lhs.type), ctx)
-        manager.addUniqueFolds(ctx)
+        manager?.fold(ctx)
     }
 
     context(nameResolver: NameResolver)
@@ -659,11 +668,11 @@ data class Declare(val variable: VariableEmbedding, val initializer: ExpEmbeddin
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addDeclaration(variable.toLocalVarDecl(ctx.source.asPosition))
         if (initializer != null) {
-            val manager = PermissionManager(this)
-            manager.addUniqueUnfolds(ctx)
+            val manager = UniquePermissionManager.create(this)
+            manager?.unfold(ctx)
             initializer.withType(variable.type)
                 .toViperStoringIn(LinearizationVariableEmbedding(variable.name, variable.type), ctx)
-            manager.addUniqueFolds(ctx)
+            manager?.fold(ctx)
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ForAllEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ForAllEmbedding.kt
@@ -20,7 +20,7 @@ class ForAllEmbedding(
     val variable: VariableEmbedding,
     conditions: List<ExpEmbedding>,
     val triggerExpressions: List<ExpEmbedding> = emptyList(),
-) : OnlyToBuiltinTypeExpEmbedding {
+) : OnlyToBuiltinTypeExpEmbedding, DefaultUniqueness() {
 
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp {
         val conjunction = subexpressions.map { it.toViperBuiltinType(ctx) }.toConjunction()

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Invariant.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Invariant.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
-data class Old(override val inner: ExpEmbedding) : UnaryDirectResultExpEmbedding {
+data class Old(override val inner: ExpEmbedding) : UnaryDirectResultExpEmbedding, DefaultUniqueness() {
     override val type: TypeEmbedding = inner.type
     override fun toViper(ctx: LinearizationContext): Exp = Exp.Old(inner.toViper(ctx), ctx.source.asPosition)
     override fun toViperBuiltinType(ctx: LinearizationContext): Exp =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/LambdaExp.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/LambdaExp.kt
@@ -26,7 +26,7 @@ class LambdaExp(
     private val parentCtx: MethodConversionContext,
     override val labelName: String,
 ) : CallableEmbedding, StoredResultExpEmbedding,
-    FunctionSignature by signature {
+    FunctionSignature by signature, DefaultUniqueness() {
     override val type: TypeEmbedding
         get() = callableType.asTypeEmbedding()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Literal.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Literal.kt
@@ -36,7 +36,7 @@ interface LiteralEmbedding : NullaryDirectResultExpEmbedding {
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitLiteralEmbedding(this)
 }
 
-data object UnitLit : LiteralEmbedding, UnitResultExpEmbedding {
+data object UnitLit : LiteralEmbedding, UnitResultExpEmbedding, DefaultUniqueness() {
     override fun toViper(ctx: LinearizationContext): Exp =
         super<UnitResultExpEmbedding>.toViper(ctx)
 
@@ -51,7 +51,7 @@ data object UnitLit : LiteralEmbedding, UnitResultExpEmbedding {
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitUnitLit(this)
 }
 
-data class IntLit(override val value: Int) : LiteralEmbedding {
+data class IntLit(override val value: Int) : LiteralEmbedding, DefaultUniqueness() {
     override val type = buildType { int() }
 
     override val debugName = "Int"
@@ -60,7 +60,7 @@ data class IntLit(override val value: Int) : LiteralEmbedding {
 data class BooleanLit(
     override val value: Boolean,
     override val sourceRole: SourceRole? = null
-) : LiteralEmbedding {
+) : LiteralEmbedding, DefaultUniqueness() {
 
     override val type = buildType { boolean() }
 
@@ -69,7 +69,7 @@ data class BooleanLit(
 
 data class CharLit(
     override val value: Char,
-) : LiteralEmbedding {
+) : LiteralEmbedding, DefaultUniqueness() {
     override val type = buildType { char() }
 
     override val debugName: String = "Char"
@@ -77,13 +77,13 @@ data class CharLit(
 
 data class StringLit(
     override val value: String,
-) : LiteralEmbedding {
+) : LiteralEmbedding, DefaultUniqueness() {
     override val type = buildType { string() }
 
     override val debugName: String = "String"
 }
 
-data object NullLit : LiteralEmbedding {
+data object NullLit : LiteralEmbedding, DefaultUniqueness() {
     override val value = null
 
     override val type = buildType { isNullable = true; nothing() }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Meta.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Meta.kt
@@ -19,8 +19,7 @@ import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
-data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceElement) : PassthroughExpEmbedding,
-    DefaultUniqueness() {
+data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceElement) : PassthroughExpEmbedding {
     override fun <R> withPassthroughHook(ctx: LinearizationContext, action: LinearizationContext.() -> R): R =
         ctx.withPosition(source, action)
 
@@ -36,7 +35,6 @@ data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceEl
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 
     override val endingPath: Lazy<Path?> = inner.endingPath
-    override val containingPaths: Lazy<Set<Path>> = inner.containingPaths
     override var uniquenessBefore: UniquenessTrie? = inner.uniquenessBefore
     override var uniquenessAfter: UniquenessTrie? = inner.uniquenessAfter
 }
@@ -64,6 +62,7 @@ fun ExpEmbedding.withPosition(source: KtSourceElement?): ExpEmbedding =
  */
 data class SharingContext(override val inner: ExpEmbedding) : PassthroughExpEmbedding, DefaultUniqueness() {
     var sharedExp: Exp? = null
+    override val containingPaths: Lazy<Set<Path>> = inner.containingPaths
 
     override fun <R> withPassthroughHook(ctx: LinearizationContext, action: LinearizationContext.() -> R): R =
         ctx.action().also { sharedExp = null }
@@ -86,6 +85,7 @@ data class SharingContext(override val inner: ExpEmbedding) : PassthroughExpEmbe
         )
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitSharingContext(this)
+
 }
 
 /**

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Meta.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Meta.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.core.embeddings.expression
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.core.conversion.Path
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.NamedBranchingNode
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.PlaintextLeaf
@@ -14,10 +15,12 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.withDesigna
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.core.linearization.pureToViper
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
-data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceElement) : PassthroughExpEmbedding {
+data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceElement) : PassthroughExpEmbedding,
+    DefaultUniqueness() {
     override fun <R> withPassthroughHook(ctx: LinearizationContext, action: LinearizationContext.() -> R): R =
         ctx.withPosition(source, action)
 
@@ -31,6 +34,11 @@ data class WithPosition(override val inner: ExpEmbedding, val source: KtSourceEl
         get() = inner.debugTreeView
 
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
+
+    override val endingPath: Lazy<Path?> = inner.endingPath
+    override val containingPaths: Lazy<Set<Path>> = inner.containingPaths
+    override var uniquenessBefore: UniquenessTrie? = inner.uniquenessBefore
+    override var uniquenessAfter: UniquenessTrie? = inner.uniquenessAfter
 }
 
 fun ExpEmbedding.withPosition(source: KtSourceElement?): ExpEmbedding =
@@ -54,7 +62,7 @@ fun ExpEmbedding.withPosition(source: KtSourceElement?): ExpEmbedding =
  *
  * This class should be used via the `share` function below. Do not do anything funny, or it will not work.
  */
-data class SharingContext(override val inner: ExpEmbedding) : PassthroughExpEmbedding {
+data class SharingContext(override val inner: ExpEmbedding) : PassthroughExpEmbedding, DefaultUniqueness() {
     var sharedExp: Exp? = null
 
     override fun <R> withPassthroughHook(ctx: LinearizationContext, action: LinearizationContext.() -> R): R =
@@ -90,7 +98,8 @@ data class SharingContext(override val inner: ExpEmbedding) : PassthroughExpEmbe
  * quite easily by using a fresh variable every time, but that would add unreasonable bloat to many programs.
  * TODO: fix this.
  */
-data class Shared(val inner: ExpEmbedding) : StoredResultExpEmbedding, DefaultToBuiltinExpEmbedding {
+data class Shared(val inner: ExpEmbedding) : StoredResultExpEmbedding, DefaultToBuiltinExpEmbedding,
+    DefaultUniqueness() {
     private var _context: SharingContext? = null
     val context: SharingContext
         get() = checkNotNull(_context) { "Context of shared used before initialisation is complete." }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/OperatorExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/OperatorExpEmbedding.kt
@@ -78,7 +78,7 @@ class BinaryOperatorExpEmbeddingTemplate(
         right: ExpEmbedding,
         sourceRole: SourceRole? = null
     ): BinaryOperatorExpEmbedding =
-        object : BinaryOperatorExpEmbedding {
+        object : BinaryOperatorExpEmbedding, DefaultUniqueness() {
             override val refsOperation: InjectionImageFunction = this@BinaryOperatorExpEmbeddingTemplate.refsOperation
             override val type = this@BinaryOperatorExpEmbeddingTemplate.type
             override val left = left
@@ -93,7 +93,7 @@ class UnaryOperatorExpEmbeddingTemplate(
 ) :
     OperatorExpEmbeddingTemplate {
     operator fun invoke(inner: ExpEmbedding, sourceRole: SourceRole? = null): UnaryOperatorExpEmbedding =
-        object : UnaryOperatorExpEmbedding {
+        object : UnaryOperatorExpEmbedding, DefaultUniqueness() {
             override val refsOperation: InjectionImageFunction = this@UnaryOperatorExpEmbeddingTemplate.refsOperation
             override val type = this@UnaryOperatorExpEmbeddingTemplate.type
             override val inner = inner

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/SequentialLogicOperatorEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/SequentialLogicOperatorEmbedding.kt
@@ -19,41 +19,69 @@ sealed class SequentialLogicOperatorEmbedding : BinaryDirectResultExpEmbedding, 
     override val type
         get() = buildType { boolean() }
 
-    protected abstract val ifReplacement: ExpEmbedding
+    abstract fun addIfReplacement(ctx: LinearizationContext, result: VariableEmbedding)
     protected abstract val expressionReplacement: ExpEmbedding
 
-    private fun operatorReplacement(ctx: LinearizationContext) = when (ctx.logicOperatorPolicy) {
-        LogicOperatorPolicy.CONVERT_TO_IF -> ifReplacement
-        LogicOperatorPolicy.CONVERT_TO_EXPRESSION -> expressionReplacement
+
+    fun toViperHelper(ctx: LinearizationContext): ExpEmbedding {
+        when (ctx.logicOperatorPolicy) {
+            LogicOperatorPolicy.CONVERT_TO_IF -> {
+                val result = ctx.freshAnonVar(buildType { boolean() })
+                addIfReplacement(ctx, result)
+                return result
+            }
+
+            LogicOperatorPolicy.CONVERT_TO_EXPRESSION -> {
+                return expressionReplacement
+            }
+        }
     }
 
-    override fun toViper(ctx: LinearizationContext): Exp =
-        operatorReplacement(ctx).toViper(ctx)
 
-    override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
-        operatorReplacement(ctx).toViperBuiltinType(ctx)
+    override fun toViper(ctx: LinearizationContext): Exp = toViperHelper(ctx).toViper(ctx)
+
+    override fun toViperBuiltinType(ctx: LinearizationContext): Exp = toViperHelper(ctx).toViperBuiltinType(ctx)
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
-        operatorReplacement(ctx).toViperStoringIn(result, ctx)
+        when (ctx.logicOperatorPolicy) {
+            LogicOperatorPolicy.CONVERT_TO_IF -> {
+                addIfReplacement(ctx, result)
+            }
+
+            LogicOperatorPolicy.CONVERT_TO_EXPRESSION -> {
+                expressionReplacement.toViperStoringIn(result, ctx)
+            }
+        }
     }
 }
 
 class SequentialAnd(override val left: ExpEmbedding, override val right: ExpEmbedding) :
     SequentialLogicOperatorEmbedding() {
-    override val ifReplacement
-        get() = If(left, right, BooleanLit(false), buildType { boolean() })
+
     override val expressionReplacement
         get() = OperatorExpEmbeddings.And(left, right)
+
+    override fun addIfReplacement(
+        ctx: LinearizationContext,
+        result: VariableEmbedding
+    ) {
+        ctx.addBranch(left, right, BooleanLit(false), buildType { boolean() }, result)
+    }
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitSequentialAnd(this)
 }
 
 class SequentialOr(override val left: ExpEmbedding, override val right: ExpEmbedding) :
     SequentialLogicOperatorEmbedding() {
-    override val ifReplacement
-        get() = If(left, BooleanLit(true), right, buildType { boolean() })
     override val expressionReplacement
         get() = OperatorExpEmbeddings.Or(left, right)
+
+    override fun addIfReplacement(
+        ctx: LinearizationContext,
+        result: VariableEmbedding
+    ) {
+        ctx.addBranch(left, BooleanLit(true), right, buildType { boolean() }, result)
+    }
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitSequentialOr(this)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/SequentialLogicOperatorEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/SequentialLogicOperatorEmbedding.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Exp
  * In pure contexts these operators can be written as simple binary operators.
  * However, regularly their semantics is different: evaluate the first argument and then maybe the second one (not necessarily)
  */
-sealed class SequentialLogicOperatorEmbedding : BinaryDirectResultExpEmbedding {
+sealed class SequentialLogicOperatorEmbedding : BinaryDirectResultExpEmbedding, DefaultUniqueness() {
     override val type
         get() = buildType { boolean() }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
@@ -20,12 +20,13 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
  * We will eventually want to solve this somehow, but there are still open design questions there, so for now this wrapper will
  * do the job.
  */
-data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : NullaryDirectResultExpEmbedding {
+data class ExpWrapper(val value: Exp, override val type: TypeEmbedding) : NullaryDirectResultExpEmbedding,
+    DefaultUniqueness() {
     override fun toViper(ctx: LinearizationContext): Exp = value
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitExpWrapper(this)
 }
 
-data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation {
+data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override val type: TypeEmbedding = buildType { nothing() }
     override fun toViperUnusedResult(ctx: LinearizationContext) {
         ctx.addStatement { Stmt.Inhale(Exp.BoolLit(false, ctx.source.asPosition), ctx.source.asPosition) }
@@ -37,7 +38,8 @@ data object ErrorExp : NoResultExpEmbedding, DefaultDebugTreeViewImplementation 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitErrorExp(this)
 }
 
-data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
+data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation,
+    DefaultUniqueness() {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addStatement { Stmt.Assert(exp.toViperBuiltinType(ctx), ctx.source.asPosition) }
     }
@@ -59,7 +61,8 @@ data class Assert(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugT
  * This can cause all kinds of issues with statement ordering, so it's more of a solution for porting legacy stuff than something
  * we should be adding more of going forward.
  */
-data class InhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation {
+data class InhaleDirect(val exp: ExpEmbedding) : UnitResultExpEmbedding, DefaultDebugTreeViewImplementation,
+    DefaultUniqueness() {
     override fun toViperSideEffects(ctx: LinearizationContext) {
         ctx.addStatement { Stmt.Inhale(exp.toViperBuiltinType(ctx), ctx.source.asPosition) }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
@@ -24,7 +24,7 @@ data class Is(
     override val inner: ExpEmbedding, val comparisonType: RuntimeTypeHolder,
     override val sourceRole: SourceRole? = null,
 ) :
-    UnaryDirectResultExpEmbedding {
+    UnaryDirectResultExpEmbedding, DefaultUniqueness() {
     override val type = buildType { boolean() }
 
     override fun toViper(ctx: LinearizationContext) =
@@ -51,7 +51,8 @@ data class Is(
  * ExpEmbedding to change the TypeEmbedding of an inner ExpEmbedding.
  * This is needed since most of our invariants require type and hence can be made more precise via Cast.
  */
-data class Cast(override val inner: ExpEmbedding, override val type: TypeEmbedding) : UnaryDirectResultExpEmbedding {
+data class Cast(override val inner: ExpEmbedding, override val type: TypeEmbedding) : UnaryDirectResultExpEmbedding,
+    DefaultUniqueness() {
     // TODO: Do we want to assert `inner isOf type` here before making a cast itself?
     override fun toViper(ctx: LinearizationContext) = inner.toViper(ctx)
     override fun ignoringCasts(): ExpEmbedding = inner.ignoringCasts()
@@ -76,7 +77,7 @@ fun ExpEmbedding.withType(init: TypeBuilder.() -> PretypeBuilder): ExpEmbedding 
  * This is also why we insist the result is stored; this is a little stronger than necessary, but that does not harm correctness.
  */
 data class SafeCast(val exp: ExpEmbedding, val targetType: TypeEmbedding) : StoredResultExpEmbedding,
-    DefaultDebugTreeViewImplementation {
+    DefaultDebugTreeViewImplementation, DefaultUniqueness() {
     override val type: TypeEmbedding
         get() = targetType.getNullable()
 
@@ -129,7 +130,7 @@ private data class InhaleInvariantsForExp(
     override val exp: ExpEmbedding,
     override val invariants: List<TypeInvariantEmbedding>
 ) :
-    StoredResultExpEmbedding, InhaleInvariants {
+    StoredResultExpEmbedding, InhaleInvariants, DefaultUniqueness() {
 
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
         exp.toViperStoringIn(result, ctx)
@@ -143,7 +144,7 @@ private data class InhaleInvariantsForVariable(
     override val exp: ExpEmbedding,
     override val invariants: List<TypeInvariantEmbedding>,
 ) :
-    InhaleInvariants, OnlyToViperExpEmbedding {
+    InhaleInvariants, OnlyToViperExpEmbedding, DefaultUniqueness() {
 
     override fun toViper(ctx: LinearizationContext): Exp {
         val variable = exp.underlyingVariable ?: error("Use of InhaleInvariantsForVariable for non-variable")

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.formver.core.embeddings.expression
 
 import org.jetbrains.kotlin.formver.core.asPosition
+import org.jetbrains.kotlin.formver.core.conversion.Path
+import org.jetbrains.kotlin.formver.core.conversion.PathCast
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
@@ -15,6 +17,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.withDesigna
 import org.jetbrains.kotlin.formver.core.embeddings.types.*
 import org.jetbrains.kotlin.formver.core.linearization.LinearizationContext
 import org.jetbrains.kotlin.formver.core.linearization.pureToViper
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
@@ -58,6 +61,13 @@ data class Cast(override val inner: ExpEmbedding, override val type: TypeEmbeddi
     override fun ignoringCasts(): ExpEmbedding = inner.ignoringCasts()
     override fun ignoringCastsAndMetaNodes(): ExpEmbedding = inner.ignoringCastsAndMetaNodes()
 
+    override val containingPaths: Lazy<Set<Path>>
+        get() = lazy { setOfNotNull(endingPath.value) }
+    override val endingPath: Lazy<Path?>
+        get() = lazy { PathCast(inner.endingPath.value!!, type) }
+    override var uniquenessBefore: UniquenessTrie? = inner.uniquenessBefore
+    override var uniquenessAfter: UniquenessTrie? = inner.uniquenessAfter
+
     context(nameResolver: NameResolver)
     override val debugExtraSubtrees: List<TreeView>
         get() = listOf(type.debugTreeView.withDesignation("target"))
@@ -88,6 +98,11 @@ data class SafeCast(val exp: ExpEmbedding, val targetType: TypeEmbedding) : Stor
         conditional.toViperStoringIn(result, ctx)
     }
 
+    override val containingPaths: Lazy<Set<Path>>
+        get() = lazy { setOfNotNull(endingPath.value) }
+    override val endingPath: Lazy<Path?>
+        get() = lazy { exp.endingPath.value?.let { PathCast(it, type) } }
+
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
         get() = listOf(exp)
 
@@ -105,6 +120,9 @@ interface InhaleInvariants : ExpEmbedding, DefaultDebugTreeViewImplementation {
 
     override val type: TypeEmbedding
         get() = exp.type
+
+    override val endingPath: Lazy<Path?>
+        get() = exp.endingPath
 
     override val debugAnonymousSubexpressions: List<ExpEmbedding>
         get() = listOf(exp)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
@@ -64,7 +64,7 @@ data class Cast(override val inner: ExpEmbedding, override val type: TypeEmbeddi
     override val containingPaths: Lazy<Set<Path>>
         get() = lazy { setOfNotNull(endingPath.value) }
     override val endingPath: Lazy<Path?>
-        get() = lazy { PathCast(inner.endingPath.value!!, type) }
+        get() = lazy { inner.endingPath.value?.let { PathCast(it, type) } }
     override var uniquenessBefore: UniquenessTrie? = inner.uniquenessBefore
     override var uniquenessAfter: UniquenessTrie? = inner.uniquenessAfter
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
@@ -94,8 +94,7 @@ data class SafeCast(val exp: ExpEmbedding, val targetType: TypeEmbedding) : Stor
     override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
         val expViper = exp.toViper(ctx)
         val expWrapped = ExpWrapper(expViper, exp.type)
-        val conditional = If(Is(expWrapped, targetType), expWrapped, NullLit, type)
-        conditional.toViperStoringIn(result, ctx)
+        ctx.addBranch(Is(expWrapped, targetType), expWrapped, NullLit, type, result)
     }
 
     override val containingPaths: Lazy<Set<Path>>

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
@@ -92,16 +92,17 @@ class PlaceholderVariableEmbedding(
     override val type: TypeEmbedding,
     override val isUnique: Boolean = false,
     override val isBorrowed: Boolean = false,
-) : VariableEmbedding
+) : VariableEmbedding, DefaultUniqueness()
 
 /**
  * Embedding of an anonymous variable.
  */
-class AnonymousVariableEmbedding(n: Int, override val type: TypeEmbedding) : VariableEmbedding {
+class AnonymousVariableEmbedding(n: Int, override val type: TypeEmbedding) : VariableEmbedding, DefaultUniqueness() {
     override val name: SymbolicName = AnonymousName(n)
 }
 
-class AnonymousBuiltinVariableEmbedding(n: Int, override val type: TypeEmbedding) : VariableEmbedding {
+class AnonymousBuiltinVariableEmbedding(n: Int, override val type: TypeEmbedding) : VariableEmbedding,
+    DefaultUniqueness() {
     override val name: SymbolicName = AnonymousBuiltinName(n)
     private val injection: Injection? = type.injectionOrNull
     override fun toViper(ctx: LinearizationContext): Exp {
@@ -128,7 +129,7 @@ class FirVariableEmbedding(
     val symbol: FirBasedSymbol<*>,
     override val isUnique: Boolean = false,
     override val isBorrowed: Boolean = false,
-) : VariableEmbedding {
+) : VariableEmbedding, DefaultUniqueness() {
     override val sourceRole: SourceRole
         get() = symbol.asSourceRole
 }
@@ -139,7 +140,7 @@ class FirVariableEmbedding(
  * This can still correspond to an earlier variable, but it no longer carries any interesting information.
  */
 class LinearizationVariableEmbedding(override val name: SymbolicName, override val type: TypeEmbedding) :
-    VariableEmbedding
+    VariableEmbedding, DefaultUniqueness()
 
 val ExpEmbedding.underlyingVariable
     get() = this.ignoringCastsAndMetaNodes() as? VariableEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
@@ -8,6 +8,8 @@ package org.jetbrains.kotlin.formver.core.embeddings.expression
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.formver.core.asPosition
 import org.jetbrains.kotlin.formver.core.asSourceRole
+import org.jetbrains.kotlin.formver.core.conversion.Path
+import org.jetbrains.kotlin.formver.core.conversion.PathRoot
 import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.core.domains.Injection
 import org.jetbrains.kotlin.formver.core.domains.viperType
@@ -132,6 +134,8 @@ class FirVariableEmbedding(
 ) : VariableEmbedding, DefaultUniqueness() {
     override val sourceRole: SourceRole
         get() = symbol.asSourceRole
+
+    override val endingPath: Lazy<Path?> = lazy { PathRoot(this) }
 }
 
 /**

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
@@ -56,6 +56,14 @@ interface LinearizationContext {
         result: VariableEmbedding?
     )
 
+    fun addBranchWithFolding(
+        condition: ExpEmbedding,
+        thenBranch: ExpEmbedding,
+        elseBranch: ExpEmbedding,
+        type: TypeEmbedding,
+        result: VariableEmbedding?
+    )
+
     fun addModifier(mod: StmtModifier)
 
     fun resolveVariableName(name: SymbolicName): SymbolicName

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -74,11 +74,11 @@ data class Linearizer(
     }
 
     override fun addReturn(returnExp: ExpEmbedding, target: ReturnTarget) {
-        val permissionManager = PermissionManager(returnExp)
-        permissionManager.addUniqueUnfolds(this)
+        val permissionManager = UniquePermissionManager.create(returnExp)
+        permissionManager?.unfold(this)
         returnExp.withType(target.variable.type)
             .toViperStoringIn(target.variable, this)
-        permissionManager.addUniqueFolds(this)
+        permissionManager?.fold(this)
         addStatement { target.label.toLink().toViperGoto(this) }
     }
 
@@ -90,10 +90,10 @@ data class Linearizer(
         result: VariableEmbedding?
     ) =
         addStatement {
-            val conditionPermissionManager = PermissionManager(condition)
-            conditionPermissionManager.addUniqueUnfolds(this)
+            val permissionManager = UniquePermissionManager.create(condition)
+            permissionManager?.unfold(this)
             val condViper = condition.toViperBuiltinType(this)
-            conditionPermissionManager.addUniqueFolds(this)
+            permissionManager?.fold(this)
             val thenViper = asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, this) }
             val elseViper = asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, this) }
             Stmt.If(condViper, thenViper, elseViper, source.asPosition)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -87,7 +87,10 @@ data class Linearizer(
         result: VariableEmbedding?
     ) =
         addStatement {
+            val conditionPermissionManager = PermissionManager(condition)
+            conditionPermissionManager.addUniqueUnfolds(this)
             val condViper = condition.toViperBuiltinType(this)
+            conditionPermissionManager.addUniqueFolds(this)
             val thenViper = asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, this) }
             val elseViper = asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, this) }
             Stmt.If(condViper, thenViper, elseViper, source.asPosition)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -74,8 +74,11 @@ data class Linearizer(
     }
 
     override fun addReturn(returnExp: ExpEmbedding, target: ReturnTarget) {
+        val permissionManager = PermissionManager(returnExp)
+        permissionManager.addUniqueUnfolds(this)
         returnExp.withType(target.variable.type)
             .toViperStoringIn(target.variable, this)
+        permissionManager.addUniqueFolds(this)
         addStatement { target.label.toLink().toViperGoto(this) }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -90,10 +90,7 @@ data class Linearizer(
         result: VariableEmbedding?
     ) =
         addStatement {
-            val permissionManager = UniquePermissionManager.create(condition)
-            permissionManager?.unfold(this)
             val condViper = condition.toViperBuiltinType(this)
-            permissionManager?.fold(this)
             val thenViper = asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, this) }
             val elseViper = asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, this) }
             Stmt.If(condViper, thenViper, elseViper, source.asPosition)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -82,6 +82,23 @@ data class Linearizer(
         addStatement { target.label.toLink().toViperGoto(this) }
     }
 
+    override fun addBranchWithFolding(
+        condition: ExpEmbedding,
+        thenBranch: ExpEmbedding,
+        elseBranch: ExpEmbedding,
+        type: TypeEmbedding,
+        result: VariableEmbedding?
+    ) =
+        addStatement {
+            val permissionManager = UniquePermissionManager.create(condition)
+            permissionManager?.unfold(this)
+            val condViper = condition.toViperBuiltinType(this)
+            permissionManager?.fold(this)
+            val thenViper = asBlock { thenBranch.withType(type).toViperMaybeStoringIn(result, this) }
+            val elseViper = asBlock { elseBranch.withType(type).toViperMaybeStoringIn(result, this) }
+            Stmt.If(condViper, thenViper, elseViper, source.asPosition)
+        }
+
     override fun addBranch(
         condition: ExpEmbedding,
         thenBranch: ExpEmbedding,

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
@@ -3,12 +3,15 @@ package org.jetbrains.kotlin.formver.core.linearization
 import org.jetbrains.kotlin.formver.core.conversion.Path
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.PredicateAccessPermissions
+import org.jetbrains.kotlin.formver.core.embeddings.expression.While
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeInvariantEmbedding
 import org.jetbrains.kotlin.formver.uniqueness.BorrowLevel
 import org.jetbrains.kotlin.formver.uniqueness.UniqueLevel
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.uniqueness.UniquenessType
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
+import org.jetbrains.kotlin.formver.uniqueness.Path as FirPath
 
 fun UniquenessType.isMoved(): Boolean = this == UniquenessType.Moved
 fun UniquenessType.isShared(): Boolean = this is UniquenessType.Active && uniqueLevel == UniqueLevel.Shared
@@ -101,9 +104,12 @@ class PermissionManager(val exp: ExpEmbedding) {
     fun getUniqueFolds(ctx: LinearizationContext): List<Exp.PredicateAccess> = toFold.map {
         toUniquePredicates(it, ctx)
     }
-
-    fun isUnique(path: Path): Boolean = exp.uniquenessAfter!!.ensure(path.firPath).parentsJoin.isUnique()
-    fun isShared(path: Path): Boolean = exp.uniquenessAfter!!.ensure(path.firPath).parentsJoin.isShared()
+    fun isUnique(path: FirPath, trie: UniquenessTrie): Boolean = trie.ensure(path).parentsJoin.isUnique()
+    fun isShared(path: FirPath, trie: UniquenessTrie): Boolean = trie.ensure(path).parentsJoin.isShared()
+    fun isUnique(path: Path, trie: UniquenessTrie): Boolean = isUnique(path.firPath, trie)
+    fun isShared(path: Path, trie: UniquenessTrie): Boolean = isShared(path.firPath, trie)
+    fun isUnique(path: Path): Boolean = isUnique(path, exp.uniquenessAfter!!)
+    fun isShared(path: Path): Boolean = isShared(path, exp.uniquenessAfter!!)
 
     fun isShared(): Boolean {
         val path = exp.endingPath.value!!
@@ -123,4 +129,47 @@ class PermissionManager(val exp: ExpEmbedding) {
         }
     }
 
+    fun extractWhileInvariants(ctx: LinearizationContext): List<ExpEmbedding> {
+        check(exp is While) { "Invariants can only be extracted from a while loop." }
+
+        val paths = exp.containingPaths.value
+        val tries = listOf(
+            exp.uniquenessBefore!!,
+            exp.uniquenessAfter!!,
+            exp.body.uniquenessAfter!!,
+            exp.body.uniquenessBefore!!
+        )
+
+        fun isUnique(path: Path) = tries.all { isUnique(path, it) }
+        fun isMoved(path: Path) = tries.all { it.ensure(path.firPath).childrenJoin.isMoved() }
+        fun isShared(path: Path) = tries.all { isShared(path, it) }
+        val resultUnique = mutableSetOf<Path>()
+        val resultShared = mutableSetOf<Path>()
+        for (path in paths) {
+
+            for (prefix in path.traverse()) {
+
+                if (isMoved(prefix)) continue
+                if (isUnique(prefix)) {
+                    resultUnique.add(prefix)
+                    break
+                }
+
+                if (isShared(prefix)) {
+                    resultShared.add(prefix)
+                }
+            }
+
+        }
+
+        val uniquePredicates = resultUnique.mapNotNull {
+            val predicate = it.type.uniquePredicateAccessInvariant()
+            predicate?.fillHole(it.expEmbedding)
+        }
+        val sharedPredicates = resultShared.mapNotNull {
+            val predicate = it.type.sharedPredicateAccessInvariant()
+            predicate?.fillHole(it.expEmbedding)
+        }
+        return uniquePredicates + sharedPredicates
+    }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
@@ -1,0 +1,110 @@
+package org.jetbrains.kotlin.formver.core.linearization
+
+import org.jetbrains.kotlin.formver.common.SnaktInternalException
+import org.jetbrains.kotlin.formver.core.conversion.Path
+import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.PredicateAccessPermissions
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeInvariantEmbedding
+import org.jetbrains.kotlin.formver.uniqueness.BorrowLevel
+import org.jetbrains.kotlin.formver.uniqueness.UniqueLevel
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessType
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
+
+fun UniquenessType.isMoved(): Boolean = this == UniquenessType.Moved
+fun UniquenessType.isShared(): Boolean = this is UniquenessType.Active && uniqueLevel == UniqueLevel.Shared
+fun UniquenessType.isUnique(): Boolean = this is UniquenessType.Active && uniqueLevel == UniqueLevel.Unique
+fun UniquenessType.isGlobal(): Boolean = this is UniquenessType.Active && borrowLevel == BorrowLevel.Global
+fun UniquenessType.isLocal(): Boolean = this is UniquenessType.Active && borrowLevel == BorrowLevel.Local
+
+
+class PermissionManager(val exp: ExpEmbedding) {
+
+    private fun toUniquePredicates(path: Path, ctx: LinearizationContext): Exp.PredicateAccess {
+        val predicate = path.type.uniquePredicateAccessInvariant()!!
+        return buildPredicate(path.expEmbedding, predicate, ctx)
+    }
+
+    private fun toSharedPredicates(path: Path, ctx: LinearizationContext): Exp.PredicateAccess {
+        val predicate = path.type.sharedPredicateAccessInvariant()!!
+        return buildPredicate(path.expEmbedding, predicate, ctx)
+    }
+
+    private fun toSharedPredicates(unfoldTarget: ExpEmbedding, ctx: LinearizationContext): Exp.PredicateAccess {
+        val predicate = unfoldTarget.type.sharedPredicateAccessInvariant()!!
+        predicate.fillHole(unfoldTarget)
+        return buildPredicate(unfoldTarget, predicate, ctx)
+    }
+
+    private fun buildPredicate(
+        unfoldTarget: ExpEmbedding,
+        predicate: TypeInvariantEmbedding,
+        ctx: LinearizationContext
+    ): Exp.PredicateAccess {
+        val predicateApplied = (predicate.fillHole(unfoldTarget) as? PredicateAccessPermissions)
+        val viperPredicate = predicateApplied?.toViperBuiltinType(ctx) as Exp.PredicateAccess
+        return viperPredicate
+    }
+
+    fun getUniqueUnfolds(ctx: LinearizationContext): List<Exp.PredicateAccess> {
+        if (exp.uniquenessBefore == null || exp.uniquenessAfter == null) throw SnaktInternalException(
+            null,
+            "No Uniqueness information provided"
+        )
+
+
+        val usedPaths = exp.containingPaths.value
+        val toUnfold = mutableListOf<Path>()
+        for (path in usedPaths) {
+            val prefix = path.pathWithoutLast() ?: continue
+
+            val childrenType = exp.uniquenessBefore!!.ensure(prefix.firPath).childrenJoin
+            val parentsType = exp.uniquenessAfter!!.ensure(prefix.firPath).parentsJoin
+
+            // if partially moved: continue (already unfolded)
+            if (childrenType.isMoved()) continue
+
+            // it is unique, so we need to unfold
+            if (parentsType.isUnique()) {
+                toUnfold.add(prefix)
+            }
+        }
+        // We need to unfold a first before a.field
+        toUnfold.sortBy { it.length }
+
+        return toUnfold.map { toUniquePredicates(it, ctx) }
+    }
+
+    fun isUnique(path: Path): Boolean = exp.uniquenessAfter!!.ensure(path.firPath).parentsJoin.isUnique()
+    fun isShared(path: Path): Boolean = exp.uniquenessAfter!!.ensure(path.firPath).parentsJoin.isShared()
+
+    fun isShared(): Boolean {
+        val path = exp.endingPath.value!!
+        val pathToConsider = path.pathWithoutLast()!!
+        return isShared(pathToConsider)
+    }
+
+    fun addUniqueUnfolds(ctx: LinearizationContext) {
+        getUniqueUnfolds(ctx).forEach { ctx.addStatement { Stmt.Unfold(it) } }
+    }
+
+
+    fun addSharedUnfold(ctx: LinearizationContext) {
+        val usedPaths = exp.containingPaths.value
+        val path = usedPaths.first()
+        val pathToConsider = path.pathWithoutLast()!!
+
+        if (isShared(pathToConsider)) {
+            val predicate = toSharedPredicates(pathToConsider, ctx)
+            ctx.addStatement { Stmt.Unfold(predicate) }
+        }
+    }
+
+    fun addSharedUnfold(ctx: LinearizationContext, unfoldTarget: ExpEmbedding) {
+        if (isShared()) {
+            val predicate = toSharedPredicates(unfoldTarget, ctx)
+            ctx.addStatement { Stmt.Unfold(predicate) }
+        }
+    }
+
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
@@ -66,7 +66,11 @@ sealed interface Folder {
  * There is a limited amount of `ExpEmbeddings` that can be used to create this object. There is not an exact definition,
  * but it should only be used with `ExpEmbeddings` which correspond to statements.
  */
-class UniquePermissionManager private constructor(before: UniquenessTrie, after: UniquenessTrie, paths: Set<Path>) :
+class UniquePermissionManager private constructor(
+    val before: UniquenessTrie,
+    val after: UniquenessTrie,
+    val paths: Set<Path>
+) :
     PredicateBuilder, Folder, Helper {
 
     companion object {
@@ -133,7 +137,7 @@ class UniquePermissionManager private constructor(before: UniquenessTrie, after:
  * there are not enough information available to determine the necessary folds.
  *
  */
-class SharedPermissionManager(before: UniquenessTrie, path: PathElement) :
+class SharedPermissionManager private constructor(val before: UniquenessTrie, val path: PathElement) :
     PredicateBuilder,
     Folder, Helper {
 
@@ -141,11 +145,11 @@ class SharedPermissionManager(before: UniquenessTrie, path: PathElement) :
 
     companion object {
         fun create(exp: ExpEmbedding): SharedPermissionManager? {
-            val before = exp.uniquenessBefore ?: return null
+            val beforeTrie = exp.uniquenessBefore ?: return null
             val usedPath = exp.endingPath.value ?: return null
             if (usedPath.length <= 1) return null
             return SharedPermissionManager(
-                before,
+                beforeTrie,
                 usedPath as PathElement
             ) //cast will always succeed, because of length > 1
         }
@@ -159,11 +163,14 @@ class SharedPermissionManager(before: UniquenessTrie, path: PathElement) :
     val isShared = isShared(prefixPath, before)
 
 
-    fun predicate(path: Path, target: ExpEmbedding, ctx: LinearizationContext) =
+    fun predicate(target: ExpEmbedding, ctx: LinearizationContext) =
         prefixPath.type.sharedPredicateAccessInvariant()?.run { buildPredicate(target, this, ctx) }
 
     override fun unfold(ctx: LinearizationContext) {
-        buildSharedPredicate(prefixPath, ctx)?.let { ctx.addStatement { Stmt.Unfold(it) } }
+        // If the receiver is unique, we must use the unique predicate. Because otherwise we leak privileges
+        if (isShared(prefixPath, before)) {
+            buildSharedPredicate(prefixPath, ctx)?.let { ctx.addStatement { Stmt.Unfold(it) } }
+        }
     }
 
     /**
@@ -172,7 +179,10 @@ class SharedPermissionManager(before: UniquenessTrie, path: PathElement) :
      * on the local variable (``target``)
      */
     fun unfold(ctx: LinearizationContext, target: ExpEmbedding) {
-        predicate(prefixPath, target, ctx)?.let { ctx.addStatement { Stmt.Unfold(it) } }
+        // If the receiver is unique, we must use the unique predicate. Because otherwise we leak privileges
+        if (isShared(prefixPath, before)) {
+            predicate(target, ctx)?.let { ctx.addStatement { Stmt.Unfold(it) } }
+        }
     }
 
     override fun fold(ctx: LinearizationContext) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
@@ -84,7 +84,7 @@ class UniquePermissionManager private constructor(before: UniquenessTrie, after:
     val toFold: List<Path>
 
     init {
-        val pathsToConsider = paths.mapNotNull { it.pathWithoutLast() }.toSet()
+        val pathsToConsider = paths.flatMap { path -> path.traverse().mapNotNull { it.pathWithoutLast() } }.toSet()
         val toUnfold = mutableListOf<Path>()
         val toFold = mutableListOf<Path>()
 
@@ -110,8 +110,8 @@ class UniquePermissionManager private constructor(before: UniquenessTrie, after:
         toUnfold.sortBy { it.length }
         // We need to fold `a.field` before `first`
         toFold.sortByDescending { it.length }
-        this.toUnfold = toUnfold
-        this.toFold = toFold
+        this.toUnfold = toUnfold.toList()
+        this.toFold = toFold.toList()
     }
 
     fun uniquePredicates(list: List<Path>, ctx: LinearizationContext): List<Exp.PredicateAccess> =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.formver.core.linearization
 
-import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.conversion.Path
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.PredicateAccessPermissions
@@ -19,6 +18,56 @@ fun UniquenessType.isLocal(): Boolean = this is UniquenessType.Active && borrowL
 
 
 class PermissionManager(val exp: ExpEmbedding) {
+
+
+    val toUnfold: List<Path>
+    val toFold: List<Path>
+
+    init {
+        if (exp.uniquenessBefore == null || exp.uniquenessAfter == null) {
+            toUnfold = emptyList()
+            toFold = emptyList()
+
+        } else {
+            val usedPaths = exp.containingPaths.value
+
+            val pathsToConsider = usedPaths.mapNotNull { it.pathWithoutLast() }.toSet()
+
+            val toUnfold = mutableListOf<Path>()
+            val toFold = mutableListOf<Path>()
+
+            for (path in pathsToConsider) {
+
+                val childrenTypeBefore = exp.uniquenessBefore!!.ensure(path.firPath).childrenJoin
+                val parentsTypeBefore = exp.uniquenessBefore!!.ensure(path.firPath).parentsJoin
+
+                // if partially moved: continue (already unfolded)
+                if (childrenTypeBefore.isMoved()) continue
+
+                // it is unique, so we need to unfold
+                if (parentsTypeBefore.isUnique()) {
+                    toUnfold.add(path)
+                }
+            }
+
+            for (path in pathsToConsider) {
+                val childrenTypeAfter = exp.uniquenessAfter!!.ensure(path.firPath).childrenJoin
+                val parentsTypeAfter = exp.uniquenessAfter!!.ensure(path.firPath).parentsJoin
+                // is is moved
+                if (childrenTypeAfter.isMoved()) continue
+
+                if (parentsTypeAfter.isUnique()) {
+                    toFold.add(path)
+                }
+            }
+            // We need to unfold `first` before `a.field`
+            toUnfold.sortBy { it.length }
+            // We need to fold `a.field` before `first`
+            toFold.sortByDescending { it.length }
+            this.toUnfold = toUnfold
+            this.toFold = toFold
+        }
+    }
 
     private fun toUniquePredicates(path: Path, ctx: LinearizationContext): Exp.PredicateAccess {
         val predicate = path.type.uniquePredicateAccessInvariant()!!
@@ -46,33 +95,11 @@ class PermissionManager(val exp: ExpEmbedding) {
         return viperPredicate
     }
 
-    fun getUniqueUnfolds(ctx: LinearizationContext): List<Exp.PredicateAccess> {
-        if (exp.uniquenessBefore == null || exp.uniquenessAfter == null) throw SnaktInternalException(
-            null,
-            "No Uniqueness information provided"
-        )
+    fun getUniqueUnfolds(ctx: LinearizationContext): List<Exp.PredicateAccess> =
+        toUnfold.map { toUniquePredicates(it, ctx) }
 
-
-        val usedPaths = exp.containingPaths.value
-        val toUnfold = mutableListOf<Path>()
-        for (path in usedPaths) {
-            val prefix = path.pathWithoutLast() ?: continue
-
-            val childrenType = exp.uniquenessBefore!!.ensure(prefix.firPath).childrenJoin
-            val parentsType = exp.uniquenessAfter!!.ensure(prefix.firPath).parentsJoin
-
-            // if partially moved: continue (already unfolded)
-            if (childrenType.isMoved()) continue
-
-            // it is unique, so we need to unfold
-            if (parentsType.isUnique()) {
-                toUnfold.add(prefix)
-            }
-        }
-        // We need to unfold a first before a.field
-        toUnfold.sortBy { it.length }
-
-        return toUnfold.map { toUniquePredicates(it, ctx) }
+    fun getUniqueFolds(ctx: LinearizationContext): List<Exp.PredicateAccess> = toFold.map {
+        toUniquePredicates(it, ctx)
     }
 
     fun isUnique(path: Path): Boolean = exp.uniquenessAfter!!.ensure(path.firPath).parentsJoin.isUnique()
@@ -84,21 +111,10 @@ class PermissionManager(val exp: ExpEmbedding) {
         return isShared(pathToConsider)
     }
 
-    fun addUniqueUnfolds(ctx: LinearizationContext) {
+    fun addUniqueUnfolds(ctx: LinearizationContext) =
         getUniqueUnfolds(ctx).forEach { ctx.addStatement { Stmt.Unfold(it) } }
-    }
 
-
-    fun addSharedUnfold(ctx: LinearizationContext) {
-        val usedPaths = exp.containingPaths.value
-        val path = usedPaths.first()
-        val pathToConsider = path.pathWithoutLast()!!
-
-        if (isShared(pathToConsider)) {
-            val predicate = toSharedPredicates(pathToConsider, ctx)
-            ctx.addStatement { Stmt.Unfold(predicate) }
-        }
-    }
+    fun addUniqueFolds(ctx: LinearizationContext) = getUniqueFolds(ctx).forEach { ctx.addStatement { Stmt.Fold(it) } }
 
     fun addSharedUnfold(ctx: LinearizationContext, unfoldTarget: ExpEmbedding) {
         if (isShared()) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PermissionManager.kt
@@ -1,11 +1,11 @@
 package org.jetbrains.kotlin.formver.core.linearization
 
 import org.jetbrains.kotlin.formver.core.conversion.Path
+import org.jetbrains.kotlin.formver.core.conversion.PathElement
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.PredicateAccessPermissions
 import org.jetbrains.kotlin.formver.core.embeddings.expression.While
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeInvariantEmbedding
-import org.jetbrains.kotlin.formver.uniqueness.BorrowLevel
 import org.jetbrains.kotlin.formver.uniqueness.UniqueLevel
 import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.uniqueness.UniquenessType
@@ -13,163 +13,238 @@ import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 import org.jetbrains.kotlin.formver.uniqueness.Path as FirPath
 
-fun UniquenessType.isMoved(): Boolean = this == UniquenessType.Moved
-fun UniquenessType.isShared(): Boolean = this is UniquenessType.Active && uniqueLevel == UniqueLevel.Shared
-fun UniquenessType.isUnique(): Boolean = this is UniquenessType.Active && uniqueLevel == UniqueLevel.Unique
-fun UniquenessType.isGlobal(): Boolean = this is UniquenessType.Active && borrowLevel == BorrowLevel.Global
-fun UniquenessType.isLocal(): Boolean = this is UniquenessType.Active && borrowLevel == BorrowLevel.Local
+
+sealed interface Helper {
+    fun UniquenessType.isMoved(): Boolean = this == UniquenessType.Moved
+    fun UniquenessType.isShared(): Boolean = this is UniquenessType.Active && uniqueLevel == UniqueLevel.Shared
+    fun UniquenessType.isUnique(): Boolean = this is UniquenessType.Active && uniqueLevel == UniqueLevel.Unique
+    fun isUnique(path: FirPath, trie: UniquenessTrie): Boolean = trie.ensure(path).parentsJoin.isUnique()
+    fun isShared(path: FirPath, trie: UniquenessTrie): Boolean = trie.ensure(path).parentsJoin.isShared()
+    fun isMoved(path: FirPath, trie: UniquenessTrie): Boolean = trie.ensure(path).childrenJoin.isMoved()
+    fun isUnique(path: Path, trie: UniquenessTrie): Boolean = isUnique(path.firPath, trie)
+    fun isShared(path: Path, trie: UniquenessTrie): Boolean = isShared(path.firPath, trie)
+    fun isMoved(path: Path, trie: UniquenessTrie): Boolean = isMoved(path.firPath, trie)
+
+}
 
 
-class PermissionManager(val exp: ExpEmbedding) {
+sealed interface PredicateBuilder {
+    fun buildPredicate(
+        unfoldTarget: ExpEmbedding,
+        predicate: TypeInvariantEmbedding,
+        ctx: LinearizationContext
+    ): Exp.PredicateAccess? {
+        val predicateApplied = (predicate.fillHole(unfoldTarget) as? PredicateAccessPermissions)
+        val viperPredicate = predicateApplied?.toViperBuiltinType(ctx) as? Exp.PredicateAccess
+        return viperPredicate
+    }
+
+    fun buildUniquePredicate(
+        path: Path,
+        ctx: LinearizationContext
+    ): Exp.PredicateAccess? =
+        path.expEmbedding.type.uniquePredicateAccessInvariant()?.run { buildPredicate(path.expEmbedding, this, ctx) }
+
+    fun buildSharedPredicate(
+        path: Path,
+        ctx: LinearizationContext
+    ): Exp.PredicateAccess? =
+        path.expEmbedding.type.sharedPredicateAccessInvariant()?.run { buildPredicate(path.expEmbedding, this, ctx) }
+
+}
+
+sealed interface Folder {
+    fun unfold(ctx: LinearizationContext)
+    fun fold(ctx: LinearizationContext)
+}
+
+/**
+ * The `UniquePermissionManager` figures out which unfolds and folds are needed around a statement.
+ * The object can only be created through the `create` function. The creation can fail (null is returned). This happens when
+ * there are not enough information available to determine the necessary folds.
+ *
+ * There is a limited amount of `ExpEmbeddings` that can be used to create this object. There is not an exact definition,
+ * but it should only be used with `ExpEmbeddings` which correspond to statements.
+ */
+class UniquePermissionManager private constructor(before: UniquenessTrie, after: UniquenessTrie, paths: Set<Path>) :
+    PredicateBuilder, Folder, Helper {
+
+    companion object {
+        fun create(exp: ExpEmbedding): UniquePermissionManager? {
+            val before = exp.uniquenessBefore ?: return null
+            val after = exp.uniquenessAfter ?: return null
+            val paths = exp.containingPaths.value
+            return UniquePermissionManager(before, after, paths)
+        }
+
+    }
 
 
     val toUnfold: List<Path>
     val toFold: List<Path>
 
     init {
-        if (exp.uniquenessBefore == null || exp.uniquenessAfter == null) {
-            toUnfold = emptyList()
-            toFold = emptyList()
+        val pathsToConsider = paths.mapNotNull { it.pathWithoutLast() }.toSet()
+        val toUnfold = mutableListOf<Path>()
+        val toFold = mutableListOf<Path>()
 
-        } else {
-            val usedPaths = exp.containingPaths.value
+        for (path in pathsToConsider) {
+            // if partially moved: continue (already unfolded)
+            if (isMoved(path, before)) continue
 
-            val pathsToConsider = usedPaths.mapNotNull { it.pathWithoutLast() }.toSet()
-
-            val toUnfold = mutableListOf<Path>()
-            val toFold = mutableListOf<Path>()
-
-            for (path in pathsToConsider) {
-
-                val childrenTypeBefore = exp.uniquenessBefore!!.ensure(path.firPath).childrenJoin
-                val parentsTypeBefore = exp.uniquenessBefore!!.ensure(path.firPath).parentsJoin
-
-                // if partially moved: continue (already unfolded)
-                if (childrenTypeBefore.isMoved()) continue
-
-                // it is unique, so we need to unfold
-                if (parentsTypeBefore.isUnique()) {
-                    toUnfold.add(path)
-                }
+            // it is unique, so we need to unfold
+            if (isUnique(path, before)) {
+                toUnfold.add(path)
             }
+        }
 
-            for (path in pathsToConsider) {
-                val childrenTypeAfter = exp.uniquenessAfter!!.ensure(path.firPath).childrenJoin
-                val parentsTypeAfter = exp.uniquenessAfter!!.ensure(path.firPath).parentsJoin
-                // is is moved
-                if (childrenTypeAfter.isMoved()) continue
+        for (path in pathsToConsider) {
+            // is is moved, we can not fold it back
+            if (isMoved(path, after)) continue
 
-                if (parentsTypeAfter.isUnique()) {
-                    toFold.add(path)
-                }
+            if (isUnique(path, after)) {
+                toFold.add(path)
             }
-            // We need to unfold `first` before `a.field`
-            toUnfold.sortBy { it.length }
-            // We need to fold `a.field` before `first`
-            toFold.sortByDescending { it.length }
-            this.toUnfold = toUnfold
-            this.toFold = toFold
+        }
+        // We need to unfold `first` before `a.field`
+        toUnfold.sortBy { it.length }
+        // We need to fold `a.field` before `first`
+        toFold.sortByDescending { it.length }
+        this.toUnfold = toUnfold
+        this.toFold = toFold
+    }
+
+    fun uniquePredicates(list: List<Path>, ctx: LinearizationContext): List<Exp.PredicateAccess> =
+        list.mapNotNull { buildUniquePredicate(it, ctx) }
+
+
+    override fun unfold(ctx: LinearizationContext) {
+        uniquePredicates(toUnfold, ctx).forEach { ctx.addStatement { Stmt.Unfold(it) } }
+    }
+
+    override fun fold(ctx: LinearizationContext) {
+        uniquePredicates(toFold, ctx).forEach { ctx.addStatement { Stmt.Fold(it) } }
+    }
+}
+
+/**
+ * The `SharedPermissionManager` figures out which unfolds and folds are needed around an access.
+ * The object can only be created through the `create` function. The creation can fail (null is returned). This happens when
+ * there are not enough information available to determine the necessary folds.
+ *
+ */
+class SharedPermissionManager(before: UniquenessTrie, path: PathElement) :
+    PredicateBuilder,
+    Folder, Helper {
+
+    val prefixPath = path.pathWithoutLast()
+
+    companion object {
+        fun create(exp: ExpEmbedding): SharedPermissionManager? {
+            val before = exp.uniquenessBefore ?: return null
+            val usedPath = exp.endingPath.value ?: return null
+            if (usedPath.length <= 1) return null
+            return SharedPermissionManager(
+                before,
+                usedPath as PathElement
+            ) //cast will always succeed, because of length > 1
         }
     }
 
-    private fun toUniquePredicates(path: Path, ctx: LinearizationContext): Exp.PredicateAccess {
-        val predicate = path.type.uniquePredicateAccessInvariant()!!
-        return buildPredicate(path.expEmbedding, predicate, ctx)
+
+    /**
+     * True iff the last receiver is shared.
+     * E.g. if tha path is x.y.z, it is true if y is shared
+     */
+    val isShared = isShared(prefixPath, before)
+
+
+    fun predicate(path: Path, target: ExpEmbedding, ctx: LinearizationContext) =
+        prefixPath.type.sharedPredicateAccessInvariant()?.run { buildPredicate(target, this, ctx) }
+
+    override fun unfold(ctx: LinearizationContext) {
+        buildSharedPredicate(prefixPath, ctx)?.let { ctx.addStatement { Stmt.Unfold(it) } }
     }
 
-    private fun toSharedPredicates(path: Path, ctx: LinearizationContext): Exp.PredicateAccess {
-        val predicate = path.type.sharedPredicateAccessInvariant()!!
-        return buildPredicate(path.expEmbedding, predicate, ctx)
+    /**
+     * The predicate will be unfolded for the target.
+     * This is used when previous access was translated into a havoc call. Hence, the path is broken and restarts
+     * on the local variable (``target``)
+     */
+    fun unfold(ctx: LinearizationContext, target: ExpEmbedding) {
+        predicate(prefixPath, target, ctx)?.let { ctx.addStatement { Stmt.Unfold(it) } }
     }
 
-    private fun toSharedPredicates(unfoldTarget: ExpEmbedding, ctx: LinearizationContext): Exp.PredicateAccess {
-        val predicate = unfoldTarget.type.sharedPredicateAccessInvariant()!!
-        predicate.fillHole(unfoldTarget)
-        return buildPredicate(unfoldTarget, predicate, ctx)
+    override fun fold(ctx: LinearizationContext) {
+        buildSharedPredicate(prefixPath, ctx)?.let { ctx.addStatement { Stmt.Fold(it) } }
     }
 
-    private fun buildPredicate(
-        unfoldTarget: ExpEmbedding,
-        predicate: TypeInvariantEmbedding,
-        ctx: LinearizationContext
-    ): Exp.PredicateAccess {
-        val predicateApplied = (predicate.fillHole(unfoldTarget) as? PredicateAccessPermissions)
-        val viperPredicate = predicateApplied?.toViperBuiltinType(ctx) as Exp.PredicateAccess
-        return viperPredicate
-    }
+}
 
-    fun getUniqueUnfolds(ctx: LinearizationContext): List<Exp.PredicateAccess> =
-        toUnfold.map { toUniquePredicates(it, ctx) }
+/**
+ * The `WhilePermissionManager` figures out the necessary invariants for a while loop.
+ * The object can only be created through the `create` function. The creation can fail (null is returned). This happens when
+ * there are not enough information available to determine the necessary folds.
+ *
+ */
+class WhilePermissionManager private constructor(
+    val before: UniquenessTrie,
+    val after: UniquenessTrie,
+    val beforeBody: UniquenessTrie,
+    val afterBody: UniquenessTrie,
+    val paths: Set<Path>
+) : PredicateBuilder, Helper {
 
-    fun getUniqueFolds(ctx: LinearizationContext): List<Exp.PredicateAccess> = toFold.map {
-        toUniquePredicates(it, ctx)
-    }
-    fun isUnique(path: FirPath, trie: UniquenessTrie): Boolean = trie.ensure(path).parentsJoin.isUnique()
-    fun isShared(path: FirPath, trie: UniquenessTrie): Boolean = trie.ensure(path).parentsJoin.isShared()
-    fun isUnique(path: Path, trie: UniquenessTrie): Boolean = isUnique(path.firPath, trie)
-    fun isShared(path: Path, trie: UniquenessTrie): Boolean = isShared(path.firPath, trie)
-    fun isUnique(path: Path): Boolean = isUnique(path, exp.uniquenessAfter!!)
-    fun isShared(path: Path): Boolean = isShared(path, exp.uniquenessAfter!!)
-
-    fun isShared(): Boolean {
-        val path = exp.endingPath.value!!
-        val pathToConsider = path.pathWithoutLast()!!
-        return isShared(pathToConsider)
-    }
-
-    fun addUniqueUnfolds(ctx: LinearizationContext) =
-        getUniqueUnfolds(ctx).forEach { ctx.addStatement { Stmt.Unfold(it) } }
-
-    fun addUniqueFolds(ctx: LinearizationContext) = getUniqueFolds(ctx).forEach { ctx.addStatement { Stmt.Fold(it) } }
-
-    fun addSharedUnfold(ctx: LinearizationContext, unfoldTarget: ExpEmbedding) {
-        if (isShared()) {
-            val predicate = toSharedPredicates(unfoldTarget, ctx)
-            ctx.addStatement { Stmt.Unfold(predicate) }
+    companion object {
+        fun create(exp: While): WhilePermissionManager? {
+            val before = exp.uniquenessBefore ?: return null
+            val after = exp.uniquenessAfter ?: return null
+            val beforeBody = exp.body.uniquenessBefore ?: return null
+            val afterBody = exp.body.uniquenessAfter ?: return null
+            val paths = exp.containingPaths.value
+            return WhilePermissionManager(before, after, beforeBody, afterBody, paths)
         }
     }
 
-    fun extractWhileInvariants(ctx: LinearizationContext): List<ExpEmbedding> {
-        check(exp is While) { "Invariants can only be extracted from a while loop." }
 
-        val paths = exp.containingPaths.value
-        val tries = listOf(
-            exp.uniquenessBefore!!,
-            exp.uniquenessAfter!!,
-            exp.body.uniquenessAfter!!,
-            exp.body.uniquenessBefore!!
+    fun extractWhileInvariants(): List<ExpEmbedding> {
+
+        val uniqueness = listOf(
+            before,
+            beforeBody,
+            afterBody,
+            after,
         )
 
-        fun isUnique(path: Path) = tries.all { isUnique(path, it) }
-        fun isMoved(path: Path) = tries.all { it.ensure(path.firPath).childrenJoin.isMoved() }
-        fun isShared(path: Path) = tries.all { isShared(path, it) }
+        fun isUnique(path: FirPath) = uniqueness.all { isUnique(path, it) }
+        fun isMoved(path: FirPath) = uniqueness.all { isMoved(path, it) }
+        fun isShared(path: FirPath) = uniqueness.all { isShared(path, it) }
+
         val resultUnique = mutableSetOf<Path>()
         val resultShared = mutableSetOf<Path>()
         for (path in paths) {
-
             for (prefix in path.traverse()) {
+                val firPrefix = prefix.firPath ?: continue
 
-                if (isMoved(prefix)) continue
-                if (isUnique(prefix)) {
+                if (isMoved(firPrefix)) continue
+                if (isUnique(firPrefix)) {
                     resultUnique.add(prefix)
                     break
                 }
 
-                if (isShared(prefix)) {
+                if (isShared(firPrefix)) {
                     resultShared.add(prefix)
                 }
             }
 
         }
 
-        val uniquePredicates = resultUnique.mapNotNull {
-            val predicate = it.type.uniquePredicateAccessInvariant()
-            predicate?.fillHole(it.expEmbedding)
-        }
-        val sharedPredicates = resultShared.mapNotNull {
-            val predicate = it.type.sharedPredicateAccessInvariant()
-            predicate?.fillHole(it.expEmbedding)
-        }
+        val uniquePredicates =
+            resultUnique.mapNotNull { it.expEmbedding.type.uniquePredicateAccessInvariant()?.fillHole(it.expEmbedding) }
+        val sharedPredicates =
+            resultShared.mapNotNull { it.expEmbedding.type.sharedPredicateAccessInvariant()?.fillHole(it.expEmbedding) }
         return uniquePredicates + sharedPredicates
     }
+
+
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureLinearizer.kt
@@ -105,6 +105,14 @@ data class PureLinearizer(
         }
     }
 
+    override fun addBranchWithFolding(
+        condition: ExpEmbedding,
+        thenBranch: ExpEmbedding,
+        elseBranch: ExpEmbedding,
+        type: TypeEmbedding,
+        result: VariableEmbedding?
+    ) = addBranch(condition, thenBranch, elseBranch, type, result)
+
     override fun addModifier(mod: StmtModifier) {
         throw PureLinearizerMisuseException("addModifier")
     }

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -366,6 +366,24 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
       public void testFieldRead() {
         runTest("formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.kt");
       }
+
+      @Test
+      @TestMetadata("methodCalls.kt")
+      public void testMethodCalls() {
+        runTest("formver.compiler-plugin/testData/diagnostics/conversion/permissions/methodCalls.kt");
+      }
+
+      @Test
+      @TestMetadata("return.kt")
+      public void testReturn() {
+        runTest("formver.compiler-plugin/testData/diagnostics/conversion/permissions/return.kt");
+      }
+
+      @Test
+      @TestMetadata("while.kt")
+      public void testWhile() {
+        runTest("formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.kt");
+      }
     }
 
     @Nested

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -347,6 +347,22 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/conversion/permissions")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Permissions {
+      @Test
+      public void testAllFilesPresentInPermissions() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/conversion/permissions"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("fieldRead.kt")
+      public void testFieldRead() {
+        runTest("formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/conversion/pure_functions")
     @TestDataPath("$PROJECT_ROOT")
     public class Pure_functions {

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -356,6 +356,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
       }
 
       @Test
+      @TestMetadata("branch.kt")
+      public void testBranch() {
+        runTest("formver.compiler-plugin/testData/diagnostics/conversion/permissions/branch.kt");
+      }
+
+      @Test
       @TestMetadata("fieldRead.kt")
       public void testFieldRead() {
         runTest("formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.kt");

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
@@ -69,18 +69,23 @@ method f$testCascadingFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$fa: Ref
   var anon$0: Ref
   var l0$fb: Ref
-  var l0$ga: Ref
   var anon$1: Ref
+  var l0$ga: Ref
+  var anon$2: Ref
   var l0$gb: Ref
+  var anon$3: Ref
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := p$rf.bf$f
   unfold acc(p$c$PrimitiveFields$shared(anon$0), wildcard)
   l0$fa := anon$0.bf$a
+  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
+  anon$1 := p$rf.bf$f
   l0$fb := havoc$T$Int()
-  anon$1 := havoc$T$PrimitiveFields()
-  unfold acc(p$c$PrimitiveFields$shared(anon$1), wildcard)
-  l0$ga := anon$1.bf$a
+  anon$2 := havoc$T$PrimitiveFields()
+  unfold acc(p$c$PrimitiveFields$shared(anon$2), wildcard)
+  l0$ga := anon$2.bf$a
+  anon$3 := havoc$T$PrimitiveFields()
   l0$gb := havoc$T$Int()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
@@ -18,12 +18,15 @@ method f$testPrimitiveFieldGetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
+  unfold acc(p$c$PrimitiveFields$unique(p$pf), write)
   l0$sharedVal := p$pf.bf$sharedVal
-  l0$sharedVar := havoc$T$Int()
-  unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
+  fold acc(p$c$PrimitiveFields$unique(p$pf), write)
+  unfold acc(p$c$PrimitiveFields$unique(p$pf), write)
+  l0$sharedVar := p$pf.bf$sharedVar
+  fold acc(p$c$PrimitiveFields$unique(p$pf), write)
+  unfold acc(p$c$PrimitiveFields$unique(p$pf), write)
   l0$uniqueVal := p$pf.bf$uniqueVal
-  l0$uniqueVar := havoc$T$Int()
+  l0$uniqueVar := p$pf.bf$uniqueVar
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -77,12 +80,15 @@ method f$testReferenceFieldGetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
+  unfold acc(p$c$ReferenceFields$unique(p$rf), write)
   l0$sharedVal := p$rf.bf$sharedVal
-  l0$sharedVar := havoc$T$PrimitiveFields()
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
+  fold acc(p$c$ReferenceFields$unique(p$rf), write)
+  unfold acc(p$c$ReferenceFields$unique(p$rf), write)
+  l0$sharedVar := p$rf.bf$sharedVar
+  fold acc(p$c$ReferenceFields$unique(p$rf), write)
+  unfold acc(p$c$ReferenceFields$unique(p$rf), write)
   l0$uniqueVal := p$rf.bf$uniqueVal
-  l0$uniqueVar := havoc$T$PrimitiveFields()
+  l0$uniqueVar := p$rf.bf$uniqueVar
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
@@ -10,6 +10,12 @@ method f$testPrimitiveFieldSetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
+  unfold acc(p$c$PrimitiveFields$unique(p$pf), write)
+  p$pf.bf$shared := df$rt$intToRef(1)
+  fold acc(p$c$PrimitiveFields$unique(p$pf), write)
+  unfold acc(p$c$PrimitiveFields$unique(p$pf), write)
+  p$pf.bf$unique := df$rt$intToRef(2)
+  fold acc(p$c$PrimitiveFields$unique(p$pf), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -52,10 +58,16 @@ method f$testReferenceFieldSetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var anon$0: Ref
   var anon$1: Ref
   inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
+  unfold acc(p$c$ReferenceFields$unique(p$rf), write)
   anon$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(5),
     df$rt$intToRef(6))
+  p$rf.bf$shared := anon$0
+  fold acc(p$c$ReferenceFields$unique(p$rf), write)
+  unfold acc(p$c$ReferenceFields$unique(p$rf), write)
   anon$1 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(7),
     df$rt$intToRef(8))
+  p$rf.bf$unique := anon$1
+  fold acc(p$c$ReferenceFields$unique(p$rf), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
@@ -10,7 +10,6 @@ method f$c$Foo$getY$TF$T$Foo$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$y
   goto lbl$ret$0
   label lbl$ret$0
@@ -32,10 +31,7 @@ method f$c$Bar$sum$TF$T$Bar$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var anon$1: Ref
   inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Bar$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   anon$0 := this$dispatch.bf$x
-  unfold acc(p$c$Bar$shared(this$dispatch), wildcard)
   anon$1 := this$dispatch.bf$z
   ret$0 := sp$plusInts(anon$0, anon$1)
   goto lbl$ret$0
@@ -164,8 +160,6 @@ method f$accessSuperSuperField$TF$T$Baz$T$Int(p$baz: Ref)
 {
   inhale acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Baz$shared(p$baz), wildcard)
-  unfold acc(p$c$Bar$shared(p$baz), wildcard)
-  unfold acc(p$c$Foo$shared(p$baz), wildcard)
   ret$0 := p$baz.bf$x
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
@@ -29,7 +29,6 @@ method f$createB$TF$T$Unit() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$fieldOverride), df$rt$c$FieldB())
   inhale acc(p$c$FieldB$shared(l0$fieldOverride), wildcard)
   unfold acc(p$c$B$shared(l0$b), wildcard)
-  unfold acc(p$c$A$shared(l0$b), wildcard)
   l0$fieldNotOverride := l0$b.bf$fieldNotOverride
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -111,7 +110,6 @@ method f$createY$TF$T$Unit() returns (ret$0: Ref)
   var l0$ya: Ref
   l0$y := con$c$Y$T$Int$T$Y(df$rt$intToRef(10))
   unfold acc(p$c$Y$shared(l0$y), wildcard)
-  unfold acc(p$c$X$shared(l0$y), wildcard)
   l0$ya := l0$y.bf$a
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
@@ -13,7 +13,6 @@ method f$testManualPermissionFieldGetter$TF$T$ManualPermissionFields$T$Unit(p$mp
   inhale acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   unfold acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   l0$a := p$mpf.bf$a
-  l0$b := p$mpf.bf$b
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
@@ -7,7 +7,6 @@ method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$x
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
@@ -64,8 +64,6 @@ method f$accessSuperTypeProperty$TF$T$C$T$Unit(p$c: Ref)
   var l0$temp: Ref
   inhale acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$C$shared(p$c), wildcard)
-  unfold acc(p$c$B$shared(p$c), wildcard)
-  unfold acc(p$c$A$shared(p$c), wildcard)
   l0$temp := p$c.bf$a
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
@@ -1,4 +1,4 @@
-/safe_call.kt:(142,154): info: Generated Viper text for testSafeCall:
+/safe_call.kt:(141,153): info: Generated Viper text for testSafeCall:
 field bf$x: Ref
 
 method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
@@ -22,7 +22,7 @@ method f$testSafeCall$TF$NT$Foo$NT$Unit(p$foo: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-/safe_call.kt:(217,240): info: Generated Viper text for testSafeCallNonNullable:
+/safe_call.kt:(216,239): info: Generated Viper text for testSafeCallNonNullable:
 field bf$x: Ref
 
 method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
@@ -46,7 +46,7 @@ method f$testSafeCallNonNullable$TF$T$Foo$NT$Unit(p$foo: Ref)
   label lbl$ret$0
 }
 
-/safe_call.kt:(267,287): info: Generated Viper text for testSafeCallProperty:
+/safe_call.kt:(266,286): info: Generated Viper text for testSafeCallProperty:
 field bf$x: Ref
 
 method f$testSafeCallProperty$TF$NT$Foo$NT$Int(p$foo: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.kt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.kt
@@ -1,5 +1,4 @@
 // NEVER_VALIDATE
-
 import org.jetbrains.kotlin.formver.plugin.NeverConvert
 
 class Foo {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/branch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/branch.fir.diag.txt
@@ -118,11 +118,8 @@ method f$movedOverBranch$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$si
   if (anon$0 == anon$1) {
     p$a.bf$um := l0$x
-    fold acc(p$c$A$unique(p$a), write)
   } else {
-    p$a.bf$um := l0$x
-    fold acc(p$c$A$unique(p$a), write)
-  }
+    p$a.bf$um := l0$x}
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -152,7 +149,6 @@ method f$movedOverBranchWithoutMovingBack$TF$T$A$T$Unit(p$a: Ref)
   anon$1 := p$a.bf$si
   if (anon$0 == anon$1) {
     p$a.bf$um := l0$x
-    fold acc(p$c$A$unique(p$a), write)
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/branch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/branch.fir.diag.txt
@@ -1,0 +1,233 @@
+/branch.kt:(704,716): info: Generated Viper text for simpleBranch:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$simpleBranch$TF$T$A$T$Int(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$ui
+  anon$1 := p$a.bf$si
+  fold acc(p$c$A$unique(p$a), write)
+  if (anon$0 == anon$1) {
+    ret$0 := df$rt$intToRef(1)
+    goto lbl$ret$0
+  } else {
+    ret$0 := df$rt$intToRef(2)
+    goto lbl$ret$0
+  }
+  label lbl$ret$0
+}
+
+/branch.kt:(824,847): info: Generated Viper text for simpleBranchWithoutElse:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$simpleBranchWithoutElse$TF$T$A$T$Int(p$a: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$ui
+  anon$1 := p$a.bf$si
+  fold acc(p$c$A$unique(p$a), write)
+  if (anon$0 == anon$1) {
+    ret$0 := df$rt$intToRef(1)
+    goto lbl$ret$0
+  }
+  ret$0 := df$rt$intToRef(2)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/branch.kt:(938,970): info: Generated Viper text for simpleBranchWithOutsideCondition:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$simpleBranchWithOutsideCondition$TF$T$A$T$Int(p$a: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var l0$b: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$ui
+  anon$1 := p$a.bf$si
+  l0$b := df$rt$boolToRef(anon$0 == anon$1)
+  fold acc(p$c$A$unique(p$a), write)
+  if (df$rt$boolFromRef(l0$b)) {
+    ret$0 := df$rt$intToRef(1)
+    goto lbl$ret$0
+  } else {
+    ret$0 := df$rt$intToRef(2)
+    goto lbl$ret$0
+  }
+  label lbl$ret$0
+}
+
+/branch.kt:(1094,1109): info: Generated Viper text for movedOverBranch:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$movedOverBranch$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$x := p$a.bf$um
+  anon$0 := p$a.bf$ui
+  anon$1 := p$a.bf$si
+  if (anon$0 == anon$1) {
+    p$a.bf$um := l0$x
+    fold acc(p$c$A$unique(p$a), write)
+  } else {
+    p$a.bf$um := l0$x
+    fold acc(p$c$A$unique(p$a), write)
+  }
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/branch.kt:(1236,1268): info: Generated Viper text for movedOverBranchWithoutMovingBack:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$movedOverBranchWithoutMovingBack$TF$T$A$T$Unit(p$a: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$x := p$a.bf$um
+  anon$0 := p$a.bf$ui
+  anon$1 := p$a.bf$si
+  if (anon$0 == anon$1) {
+    p$a.bf$um := l0$x
+    fold acc(p$c$A$unique(p$a), write)
+  }
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/branch.kt:(1366,1379): info: Generated Viper text for deepCondition:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$deepCondition$TF$T$A$T$Int(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  var anon$2: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$2 := p$a.bf$si
+  if (anon$1 == anon$2) {
+    var anon$3: Ref
+    var anon$4: Ref
+    var anon$5: Ref
+    var anon$6: Ref
+    anon$4 := p$a.bf$um
+    anon$3 := anon$4.bf$um
+    anon$6 := p$a.bf$si
+    anon$5 := havoc$T$C()
+    anon$0 := df$rt$boolToRef(anon$3 == anon$5)
+  } else {
+    anon$0 := df$rt$boolToRef(false)}
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
+  if (df$rt$boolFromRef(anon$0)) {
+    ret$0 := df$rt$intToRef(2)
+    goto lbl$ret$0
+  }
+  ret$0 := df$rt$intToRef(1)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/branch.kt:(1494,1502): info: Generated Viper text for nullTest:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$nullTest$TF$T$D$T$Int(p$d: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$d), df$rt$c$D())
+  requires acc(p$c$D$unique(p$d), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+  var anon$0: Ref
+  inhale acc(p$c$D$shared(p$d), wildcard)
+  unfold acc(p$c$D$unique(p$d), write)
+  anon$0 := p$d.bf$um
+  fold acc(p$c$D$unique(p$d), write)
+  if (anon$0 == df$rt$nullValue()) {
+    ret$0 := df$rt$intToRef(1)
+    goto lbl$ret$0
+  } else {
+    ret$0 := df$rt$intToRef(2)
+    goto lbl$ret$0
+  }
+  label lbl$ret$0
+}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/branch.kt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/branch.kt
@@ -1,0 +1,91 @@
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+
+class A(
+    @Unique var um: B,  // unique-mutable
+    @Unique val ui: B,  // unique-immutable
+    var sm: B,          // shared-mutable
+    val si: B,          // shared-immutable
+)
+
+
+class B(
+    @Unique var um: C,  // unique-mutable
+    @Unique val ui: C,  // unique-immutable
+    var sm: C,          // shared-mutable
+    val si: C,          // shared-immutable
+)
+
+
+class C(
+    @Unique var um: Any,  // unique-mutable
+    @Unique val ui: Any,  // unique-immutable
+    var sm: Any,          // shared-mutable
+    val si: Any,          // shared-immutable
+)
+
+class D(
+    @Unique var um: A?
+)
+
+fun <!VIPER_TEXT!>simpleBranch<!>(@Unique a : A) : Int {
+    if (a.ui == a.si) {
+        return 1
+    } else {
+        return 2
+    }
+}
+
+fun <!VIPER_TEXT!>simpleBranchWithoutElse<!>(@Unique a : A) : Int {
+    if (a.ui == a.si) {
+        return 1
+    }
+    return 2
+}
+
+fun <!VIPER_TEXT!>simpleBranchWithOutsideCondition<!>(@Unique a : A) : Int {
+    val b = (a.ui == a.si)
+    if (b) {
+        return 1
+    } else {
+        return 2
+    }
+}
+
+fun <!VIPER_TEXT!>movedOverBranch<!>(@Unique a: A) {
+    @Unique val x = a.um
+
+    if (a.ui == a.si) {
+        a.um = x
+    } else {
+        a.um = x
+    }
+}
+
+fun <!VIPER_TEXT!>movedOverBranchWithoutMovingBack<!>(@Unique a: A)  {
+    @Unique val x = a.um
+
+    if (a.ui == a.si) {
+        a.um = x
+    }
+}
+
+fun <!VIPER_TEXT!>deepCondition<!>(@Unique a : A) : Int {
+
+    if (a.um == a.si && a.um.um == a.si.um) {
+        return 2
+    }
+    return 1
+}
+
+
+fun <!VIPER_TEXT!>nullTest<!>(@Unique d : D) : Int {
+
+    if (d.um == null) {
+        return 1
+    } else {
+        return 2
+    }
+
+
+}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.fir.diag.txt
@@ -60,6 +60,7 @@ method f$sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale acc(p$c$A$shared(p$a), wildcard)
   unfold acc(p$c$A$unique(p$a), write)
   l0$x := p$a.bf$sm
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -82,6 +83,7 @@ method f$si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale acc(p$c$A$shared(p$a), wildcard)
   unfold acc(p$c$A$unique(p$a), write)
   l0$x := p$a.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -157,6 +159,8 @@ method f$um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$unique(p$a.bf$um), write)
   anon$0 := p$a.bf$um
   l0$x := anon$0.bf$sm
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -182,6 +186,8 @@ method f$um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$unique(p$a.bf$um), write)
   anon$0 := p$a.bf$um
   l0$x := anon$0.bf$si
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -257,6 +263,8 @@ method f$ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$unique(p$a.bf$ui), write)
   anon$0 := p$a.bf$ui
   l0$x := anon$0.bf$sm
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -282,6 +290,8 @@ method f$ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$unique(p$a.bf$ui), write)
   anon$0 := p$a.bf$ui
   l0$x := anon$0.bf$si
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -355,6 +365,7 @@ method f$sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$A$unique(p$a), write)
   anon$0 := p$a.bf$sm
   l0$x := havoc$T$C()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -380,6 +391,7 @@ method f$sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := p$a.bf$sm
   unfold acc(p$c$B$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -453,6 +465,7 @@ method f$si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$A$unique(p$a), write)
   anon$0 := p$a.bf$si
   l0$x := havoc$T$C()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -478,6 +491,7 @@ method f$si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := p$a.bf$si
   unfold acc(p$c$B$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -562,6 +576,9 @@ method f$um_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$um
   anon$0 := anon$1.bf$um
   l0$x := anon$0.bf$sm
+  fold acc(p$c$C$unique(p$a.bf$um.bf$um), write)
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -590,6 +607,9 @@ method f$um_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$um
   anon$0 := anon$1.bf$um
   l0$x := anon$0.bf$si
+  fold acc(p$c$C$unique(p$a.bf$um.bf$um), write)
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -674,6 +694,9 @@ method f$um_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$um
   anon$0 := anon$1.bf$ui
   l0$x := anon$0.bf$sm
+  fold acc(p$c$C$unique(p$a.bf$um.bf$ui), write)
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -702,6 +725,9 @@ method f$um_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$um
   anon$0 := anon$1.bf$ui
   l0$x := anon$0.bf$si
+  fold acc(p$c$C$unique(p$a.bf$um.bf$ui), write)
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -784,6 +810,8 @@ method f$um_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$um
   anon$0 := anon$1.bf$sm
   l0$x := havoc$T$Any()
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -812,6 +840,8 @@ method f$um_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$sm
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -894,6 +924,8 @@ method f$um_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$um
   anon$0 := anon$1.bf$si
   l0$x := havoc$T$Any()
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -922,6 +954,8 @@ method f$um_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$si
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1006,6 +1040,9 @@ method f$ui_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$ui
   anon$0 := anon$1.bf$um
   l0$x := anon$0.bf$sm
+  fold acc(p$c$C$unique(p$a.bf$ui.bf$um), write)
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1034,6 +1071,9 @@ method f$ui_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$ui
   anon$0 := anon$1.bf$um
   l0$x := anon$0.bf$si
+  fold acc(p$c$C$unique(p$a.bf$ui.bf$um), write)
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1118,6 +1158,9 @@ method f$ui_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$ui
   anon$0 := anon$1.bf$ui
   l0$x := anon$0.bf$sm
+  fold acc(p$c$C$unique(p$a.bf$ui.bf$ui), write)
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1146,6 +1189,9 @@ method f$ui_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$ui
   anon$0 := anon$1.bf$ui
   l0$x := anon$0.bf$si
+  fold acc(p$c$C$unique(p$a.bf$ui.bf$ui), write)
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1228,6 +1274,8 @@ method f$ui_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$ui
   anon$0 := anon$1.bf$sm
   l0$x := havoc$T$Any()
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1256,6 +1304,8 @@ method f$ui_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$sm
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1338,6 +1388,8 @@ method f$ui_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$ui
   anon$0 := anon$1.bf$si
   l0$x := havoc$T$Any()
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1366,6 +1418,8 @@ method f$ui_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$si
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$B$unique(p$a.bf$ui), write)
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1445,6 +1499,7 @@ method f$sm_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$sm
   anon$0 := havoc$T$C()
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1472,6 +1527,7 @@ method f$sm_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := havoc$T$C()
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1554,6 +1610,7 @@ method f$sm_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$ui
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1582,6 +1639,7 @@ method f$sm_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$ui
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1661,6 +1719,7 @@ method f$sm_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$sm
   anon$0 := havoc$T$C()
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1688,6 +1747,7 @@ method f$sm_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := havoc$T$C()
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1770,6 +1830,7 @@ method f$sm_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$si
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1798,6 +1859,7 @@ method f$sm_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$si
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1877,6 +1939,7 @@ method f$si_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$si
   anon$0 := havoc$T$C()
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1904,6 +1967,7 @@ method f$si_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := havoc$T$C()
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -1986,6 +2050,7 @@ method f$si_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$ui
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -2014,6 +2079,7 @@ method f$si_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$ui
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -2093,6 +2159,7 @@ method f$si_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := p$a.bf$si
   anon$0 := havoc$T$C()
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -2120,6 +2187,7 @@ method f$si_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := havoc$T$C()
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -2202,6 +2270,7 @@ method f$si_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   unfold acc(p$c$B$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$si
   l0$x := havoc$T$Any()
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -2230,6 +2299,7 @@ method f$si_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := anon$1.bf$si
   unfold acc(p$c$C$shared(anon$0), wildcard)
   l0$x := anon$0.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.fir.diag.txt
@@ -1,0 +1,2235 @@
+/fieldRead.kt:(670,672): info: Generated Viper text for um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$x := p$a.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(713,715): info: Generated Viper text for ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$x := p$a.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(756,758): info: Generated Viper text for sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$x := p$a.bf$sm
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(799,801): info: Generated Viper text for si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$x := p$a.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(842,847): info: Generated Viper text for um_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$0 := p$a.bf$um
+  l0$x := anon$0.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(891,896): info: Generated Viper text for um_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$0 := p$a.bf$um
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(940,945): info: Generated Viper text for um_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$0 := p$a.bf$um
+  l0$x := anon$0.bf$sm
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(989,994): info: Generated Viper text for um_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$0 := p$a.bf$um
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1038,1043): info: Generated Viper text for ui_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$0 := p$a.bf$ui
+  l0$x := anon$0.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1087,1092): info: Generated Viper text for ui_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$0 := p$a.bf$ui
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1136,1141): info: Generated Viper text for ui_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$0 := p$a.bf$ui
+  l0$x := anon$0.bf$sm
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1185,1190): info: Generated Viper text for ui_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$0 := p$a.bf$ui
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1234,1239): info: Generated Viper text for sm_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$sm
+  l0$x := havoc$T$C()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1283,1288): info: Generated Viper text for sm_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1332,1337): info: Generated Viper text for sm_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$sm
+  l0$x := havoc$T$C()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1381,1386): info: Generated Viper text for sm_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1430,1435): info: Generated Viper text for si_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$si
+  l0$x := havoc$T$C()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1479,1484): info: Generated Viper text for si_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1528,1533): info: Generated Viper text for si_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$si
+  l0$x := havoc$T$C()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1577,1582): info: Generated Viper text for si_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$0 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1627,1635): info: Generated Viper text for um_um_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_um_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1682,1690): info: Generated Viper text for um_um_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_um_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1737,1745): info: Generated Viper text for um_um_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$sm
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1792,1800): info: Generated Viper text for um_um_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1847,1855): info: Generated Viper text for um_ui_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_ui_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$ui), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1902,1910): info: Generated Viper text for um_ui_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_ui_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$ui), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(1957,1965): info: Generated Viper text for um_ui_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$ui), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$sm
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2012,2020): info: Generated Viper text for um_ui_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  unfold acc(p$c$C$unique(p$a.bf$um.bf$ui), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2067,2075): info: Generated Viper text for um_sm_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_sm_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$sm
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2122,2130): info: Generated Viper text for um_sm_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_sm_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$sm
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2177,2185): info: Generated Viper text for um_sm_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$sm
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2232,2240): info: Generated Viper text for um_sm_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$sm
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2287,2295): info: Generated Viper text for um_si_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_si_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2342,2350): info: Generated Viper text for um_si_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_si_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2397,2405): info: Generated Viper text for um_si_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2452,2460): info: Generated Viper text for um_si_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$um_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$1 := p$a.bf$um
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2508,2516): info: Generated Viper text for ui_um_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_um_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$um), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2563,2571): info: Generated Viper text for ui_um_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_um_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$um), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2618,2626): info: Generated Viper text for ui_um_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$um), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$sm
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2673,2681): info: Generated Viper text for ui_um_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$um), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$um
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2728,2736): info: Generated Viper text for ui_ui_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_ui_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2783,2791): info: Generated Viper text for ui_ui_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_ui_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2838,2846): info: Generated Viper text for ui_ui_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$sm
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2893,2901): info: Generated Viper text for ui_ui_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  unfold acc(p$c$C$unique(p$a.bf$ui.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$ui
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(2948,2956): info: Generated Viper text for ui_sm_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_sm_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$sm
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3003,3011): info: Generated Viper text for ui_sm_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_sm_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$sm
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3058,3066): info: Generated Viper text for ui_sm_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$sm
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3113,3121): info: Generated Viper text for ui_sm_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$sm
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3168,3176): info: Generated Viper text for ui_si_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_si_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3223,3231): info: Generated Viper text for ui_si_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_si_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3278,3286): info: Generated Viper text for ui_si_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3333,3341): info: Generated Viper text for ui_si_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$ui_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$ui), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3389,3397): info: Generated Viper text for sm_um_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_um_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3444,3452): info: Generated Viper text for sm_um_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_um_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3499,3507): info: Generated Viper text for sm_um_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3554,3562): info: Generated Viper text for sm_um_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3609,3617): info: Generated Viper text for sm_ui_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_ui_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3664,3672): info: Generated Viper text for sm_ui_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_ui_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3719,3727): info: Generated Viper text for sm_ui_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3774,3782): info: Generated Viper text for sm_ui_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3829,3837): info: Generated Viper text for sm_sm_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_sm_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3884,3892): info: Generated Viper text for sm_sm_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_sm_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3939,3947): info: Generated Viper text for sm_sm_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(3994,4002): info: Generated Viper text for sm_sm_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4049,4057): info: Generated Viper text for sm_si_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_si_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4104,4112): info: Generated Viper text for sm_si_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_si_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4159,4167): info: Generated Viper text for sm_si_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4214,4222): info: Generated Viper text for sm_si_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$sm_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$sm
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4270,4278): info: Generated Viper text for si_um_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_um_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4325,4333): info: Generated Viper text for si_um_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_um_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4380,4388): info: Generated Viper text for si_um_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_um_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4435,4443): info: Generated Viper text for si_um_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_um_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4490,4498): info: Generated Viper text for si_ui_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_ui_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4545,4553): info: Generated Viper text for si_ui_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_ui_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4600,4608): info: Generated Viper text for si_ui_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_ui_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4655,4663): info: Generated Viper text for si_ui_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_ui_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$ui
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4710,4718): info: Generated Viper text for si_sm_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_sm_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4765,4773): info: Generated Viper text for si_sm_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_sm_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4820,4828): info: Generated Viper text for si_sm_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_sm_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4875,4883): info: Generated Viper text for si_sm_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_sm_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  anon$0 := havoc$T$C()
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4930,4938): info: Generated Viper text for si_si_um:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_si_um$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(4985,4993): info: Generated Viper text for si_si_ui:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_si_ui$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$ui
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(5040,5048): info: Generated Viper text for si_si_sm:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_si_sm$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  l0$x := havoc$T$Any()
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/fieldRead.kt:(5095,5103): info: Generated Viper text for si_si_si:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$si_si_si$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$si
+  unfold acc(p$c$B$shared(anon$1), wildcard)
+  anon$0 := anon$1.bf$si
+  unfold acc(p$c$C$shared(anon$0), wildcard)
+  l0$x := anon$0.bf$si
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.kt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/fieldRead.kt
@@ -1,0 +1,366 @@
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+
+class A(
+    @Unique var um: B,  // unique-mutable
+    @Unique val ui: B,  // unique-immutable
+    var sm: B,          // shared-mutable
+    val si: B,          // shared-immutable
+)
+
+
+class B(
+    @Unique var um: C,  // unique-mutable
+    @Unique val ui: C,  // unique-immutable
+    var sm: C,          // shared-mutable
+    val si: C,          // shared-immutable
+)
+
+
+class C(
+    @Unique var um: Any,  // unique-mutable
+    @Unique val ui: Any,  // unique-immutable
+    var sm: Any,          // shared-mutable
+    val si: Any,          // shared-immutable
+)
+
+
+fun <!VIPER_TEXT!>um<!>(@Unique a: A) {
+    var x = a.um
+}
+
+fun <!VIPER_TEXT!>ui<!>(@Unique a: A) {
+    var x = a.ui
+}
+
+fun <!VIPER_TEXT!>sm<!>(@Unique a: A) {
+    var x = a.sm
+}
+
+fun <!VIPER_TEXT!>si<!>(@Unique a: A) {
+    var x = a.si
+}
+
+fun <!VIPER_TEXT!>um_um<!>(@Unique a: A) {
+    var x = a.um.um
+}
+
+fun <!VIPER_TEXT!>um_ui<!>(@Unique a: A) {
+    var x = a.um.ui
+}
+
+fun <!VIPER_TEXT!>um_sm<!>(@Unique a: A) {
+    var x = a.um.sm
+}
+
+fun <!VIPER_TEXT!>um_si<!>(@Unique a: A) {
+    var x = a.um.si
+}
+
+fun <!VIPER_TEXT!>ui_um<!>(@Unique a: A) {
+    var x = a.ui.um
+}
+
+fun <!VIPER_TEXT!>ui_ui<!>(@Unique a: A) {
+    var x = a.ui.ui
+}
+
+fun <!VIPER_TEXT!>ui_sm<!>(@Unique a: A) {
+    var x = a.ui.sm
+}
+
+fun <!VIPER_TEXT!>ui_si<!>(@Unique a: A) {
+    var x = a.ui.si
+}
+
+fun <!VIPER_TEXT!>sm_um<!>(@Unique a: A) {
+    var x = a.sm.um
+}
+
+fun <!VIPER_TEXT!>sm_ui<!>(@Unique a: A) {
+    var x = a.sm.ui
+}
+
+fun <!VIPER_TEXT!>sm_sm<!>(@Unique a: A) {
+    var x = a.sm.sm
+}
+
+fun <!VIPER_TEXT!>sm_si<!>(@Unique a: A) {
+    var x = a.sm.si
+}
+
+fun <!VIPER_TEXT!>si_um<!>(@Unique a: A) {
+    var x = a.si.um
+}
+
+fun <!VIPER_TEXT!>si_ui<!>(@Unique a: A) {
+    var x = a.si.ui
+}
+
+fun <!VIPER_TEXT!>si_sm<!>(@Unique a: A) {
+    var x = a.si.sm
+}
+
+fun <!VIPER_TEXT!>si_si<!>(@Unique a: A) {
+    var x = a.si.si
+}
+
+
+fun <!VIPER_TEXT!>um_um_um<!>(@Unique a: A) {
+    var x = a.um.um.um
+}
+
+fun <!VIPER_TEXT!>um_um_ui<!>(@Unique a: A) {
+    var x = a.um.um.ui
+}
+
+fun <!VIPER_TEXT!>um_um_sm<!>(@Unique a: A) {
+    var x = a.um.um.sm
+}
+
+fun <!VIPER_TEXT!>um_um_si<!>(@Unique a: A) {
+    var x = a.um.um.si
+}
+
+fun <!VIPER_TEXT!>um_ui_um<!>(@Unique a: A) {
+    var x = a.um.ui.um
+}
+
+fun <!VIPER_TEXT!>um_ui_ui<!>(@Unique a: A) {
+    var x = a.um.ui.ui
+}
+
+fun <!VIPER_TEXT!>um_ui_sm<!>(@Unique a: A) {
+    var x = a.um.ui.sm
+}
+
+fun <!VIPER_TEXT!>um_ui_si<!>(@Unique a: A) {
+    var x = a.um.ui.si
+}
+
+fun <!VIPER_TEXT!>um_sm_um<!>(@Unique a: A) {
+    var x = a.um.sm.um
+}
+
+fun <!VIPER_TEXT!>um_sm_ui<!>(@Unique a: A) {
+    var x = a.um.sm.ui
+}
+
+fun <!VIPER_TEXT!>um_sm_sm<!>(@Unique a: A) {
+    var x = a.um.sm.sm
+}
+
+fun <!VIPER_TEXT!>um_sm_si<!>(@Unique a: A) {
+    var x = a.um.sm.si
+}
+
+fun <!VIPER_TEXT!>um_si_um<!>(@Unique a: A) {
+    var x = a.um.si.um
+}
+
+fun <!VIPER_TEXT!>um_si_ui<!>(@Unique a: A) {
+    var x = a.um.si.ui
+}
+
+fun <!VIPER_TEXT!>um_si_sm<!>(@Unique a: A) {
+    var x = a.um.si.sm
+}
+
+fun <!VIPER_TEXT!>um_si_si<!>(@Unique a: A) {
+    var x = a.um.si.si
+}
+
+
+fun <!VIPER_TEXT!>ui_um_um<!>(@Unique a: A) {
+    var x = a.ui.um.um
+}
+
+fun <!VIPER_TEXT!>ui_um_ui<!>(@Unique a: A) {
+    var x = a.ui.um.ui
+}
+
+fun <!VIPER_TEXT!>ui_um_sm<!>(@Unique a: A) {
+    var x = a.ui.um.sm
+}
+
+fun <!VIPER_TEXT!>ui_um_si<!>(@Unique a: A) {
+    var x = a.ui.um.si
+}
+
+fun <!VIPER_TEXT!>ui_ui_um<!>(@Unique a: A) {
+    var x = a.ui.ui.um
+}
+
+fun <!VIPER_TEXT!>ui_ui_ui<!>(@Unique a: A) {
+    var x = a.ui.ui.ui
+}
+
+fun <!VIPER_TEXT!>ui_ui_sm<!>(@Unique a: A) {
+    var x = a.ui.ui.sm
+}
+
+fun <!VIPER_TEXT!>ui_ui_si<!>(@Unique a: A) {
+    var x = a.ui.ui.si
+}
+
+fun <!VIPER_TEXT!>ui_sm_um<!>(@Unique a: A) {
+    var x = a.ui.sm.um
+}
+
+fun <!VIPER_TEXT!>ui_sm_ui<!>(@Unique a: A) {
+    var x = a.ui.sm.ui
+}
+
+fun <!VIPER_TEXT!>ui_sm_sm<!>(@Unique a: A) {
+    var x = a.ui.sm.sm
+}
+
+fun <!VIPER_TEXT!>ui_sm_si<!>(@Unique a: A) {
+    var x = a.ui.sm.si
+}
+
+fun <!VIPER_TEXT!>ui_si_um<!>(@Unique a: A) {
+    var x = a.ui.si.um
+}
+
+fun <!VIPER_TEXT!>ui_si_ui<!>(@Unique a: A) {
+    var x = a.ui.si.ui
+}
+
+fun <!VIPER_TEXT!>ui_si_sm<!>(@Unique a: A) {
+    var x = a.ui.si.sm
+}
+
+fun <!VIPER_TEXT!>ui_si_si<!>(@Unique a: A) {
+    var x = a.ui.si.si
+}
+
+
+fun <!VIPER_TEXT!>sm_um_um<!>(@Unique a: A) {
+    var x = a.sm.um.um
+}
+
+fun <!VIPER_TEXT!>sm_um_ui<!>(@Unique a: A) {
+    var x = a.sm.um.ui
+}
+
+fun <!VIPER_TEXT!>sm_um_sm<!>(@Unique a: A) {
+    var x = a.sm.um.sm
+}
+
+fun <!VIPER_TEXT!>sm_um_si<!>(@Unique a: A) {
+    var x = a.sm.um.si
+}
+
+fun <!VIPER_TEXT!>sm_ui_um<!>(@Unique a: A) {
+    var x = a.sm.ui.um
+}
+
+fun <!VIPER_TEXT!>sm_ui_ui<!>(@Unique a: A) {
+    var x = a.sm.ui.ui
+}
+
+fun <!VIPER_TEXT!>sm_ui_sm<!>(@Unique a: A) {
+    var x = a.sm.ui.sm
+}
+
+fun <!VIPER_TEXT!>sm_ui_si<!>(@Unique a: A) {
+    var x = a.sm.ui.si
+}
+
+fun <!VIPER_TEXT!>sm_sm_um<!>(@Unique a: A) {
+    var x = a.sm.sm.um
+}
+
+fun <!VIPER_TEXT!>sm_sm_ui<!>(@Unique a: A) {
+    var x = a.sm.sm.ui
+}
+
+fun <!VIPER_TEXT!>sm_sm_sm<!>(@Unique a: A) {
+    var x = a.sm.sm.sm
+}
+
+fun <!VIPER_TEXT!>sm_sm_si<!>(@Unique a: A) {
+    var x = a.sm.sm.si
+}
+
+fun <!VIPER_TEXT!>sm_si_um<!>(@Unique a: A) {
+    var x = a.sm.si.um
+}
+
+fun <!VIPER_TEXT!>sm_si_ui<!>(@Unique a: A) {
+    var x = a.sm.si.ui
+}
+
+fun <!VIPER_TEXT!>sm_si_sm<!>(@Unique a: A) {
+    var x = a.sm.si.sm
+}
+
+fun <!VIPER_TEXT!>sm_si_si<!>(@Unique a: A) {
+    var x = a.sm.si.si
+}
+
+
+fun <!VIPER_TEXT!>si_um_um<!>(@Unique a: A) {
+    var x = a.si.um.um
+}
+
+fun <!VIPER_TEXT!>si_um_ui<!>(@Unique a: A) {
+    var x = a.si.um.ui
+}
+
+fun <!VIPER_TEXT!>si_um_sm<!>(@Unique a: A) {
+    var x = a.si.um.sm
+}
+
+fun <!VIPER_TEXT!>si_um_si<!>(@Unique a: A) {
+    var x = a.si.um.si
+}
+
+fun <!VIPER_TEXT!>si_ui_um<!>(@Unique a: A) {
+    var x = a.si.ui.um
+}
+
+fun <!VIPER_TEXT!>si_ui_ui<!>(@Unique a: A) {
+    var x = a.si.ui.ui
+}
+
+fun <!VIPER_TEXT!>si_ui_sm<!>(@Unique a: A) {
+    var x = a.si.ui.sm
+}
+
+fun <!VIPER_TEXT!>si_ui_si<!>(@Unique a: A) {
+    var x = a.si.ui.si
+}
+
+fun <!VIPER_TEXT!>si_sm_um<!>(@Unique a: A) {
+    var x = a.si.sm.um
+}
+
+fun <!VIPER_TEXT!>si_sm_ui<!>(@Unique a: A) {
+    var x = a.si.sm.ui
+}
+
+fun <!VIPER_TEXT!>si_sm_sm<!>(@Unique a: A) {
+    var x = a.si.sm.sm
+}
+
+fun <!VIPER_TEXT!>si_sm_si<!>(@Unique a: A) {
+    var x = a.si.sm.si
+}
+
+fun <!VIPER_TEXT!>si_si_um<!>(@Unique a: A) {
+    var x = a.si.si.um
+}
+
+fun <!VIPER_TEXT!>si_si_ui<!>(@Unique a: A) {
+    var x = a.si.si.ui
+}
+
+fun <!VIPER_TEXT!>si_si_sm<!>(@Unique a: A) {
+    var x = a.si.si.sm
+}
+
+fun <!VIPER_TEXT!>si_si_si<!>(@Unique a: A) {
+    var x = a.si.si.si
+}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/methodCalls.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/methodCalls.fir.diag.txt
@@ -1,0 +1,381 @@
+/methodCalls.kt:(672,679): info: Generated Viper text for consume:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consume$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  requires acc(p$c$C$unique(p$c), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$C$shared(p$c), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(701,708): info: Generated Viper text for consume:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consume$TF$T$B$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$B$shared(p$b), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(730,736): info: Generated Viper text for shared:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$shared$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$C$shared(p$c), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(750,756): info: Generated Viper text for borrow:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$B$shared(p$b), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(780,790): info: Generated Viper text for consumeTwo:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consumeTwo$TF$T$B$T$B$T$Unit(p$b1: Ref, p$b2: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b1), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b1), write)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b2), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b2), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$B$shared(p$b1), wildcard)
+  inhale acc(p$c$B$shared(p$b2), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(829,854): info: Generated Viper text for testUniqueFieldFoldUnfold:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consume$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testUniqueFieldFoldUnfold$TF$T$A$T$Unit(p$a: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$um
+  anon$0 := f$consume$TF$T$B$T$Unit(anon$1)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(897,914): info: Generated Viper text for testBorrowedField:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testBorrowedField$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  var anon$2: Ref
+  var anon$3: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$um
+  anon$0 := f$borrow$TF$T$B$T$Unit(anon$1)
+  fold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$3 := p$a.bf$um
+  anon$2 := f$borrow$TF$T$B$T$Unit(anon$3)
+  fold acc(p$c$A$unique(p$a), write)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(972,988): info: Generated Viper text for testNestedUnique:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consume$TF$T$C$T$Unit(p$c: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  requires acc(p$c$C$unique(p$c), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testNestedUnique$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$b: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$b := p$a.bf$um
+  unfold acc(p$c$B$unique(l0$b), write)
+  anon$1 := l0$b.bf$um
+  anon$0 := f$consume$TF$T$C$T$Unit(anon$1)
+  p$a.bf$um := l0$b
+  fold acc(p$c$A$unique(p$a), write)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(1069,1086): info: Generated Viper text for testMultipleCalls:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testMultipleCalls$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  var anon$2: Ref
+  var anon$3: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$ui
+  anon$0 := f$borrow$TF$T$B$T$Unit(anon$1)
+  fold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$3 := p$a.bf$ui
+  anon$2 := f$borrow$TF$T$B$T$Unit(anon$3)
+  fold acc(p$c$A$unique(p$a), write)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(1145,1161): info: Generated Viper text for testNestedBorrow:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testNestedBorrow$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  var l0$c: Ref
+  var anon$2: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$um
+  anon$0 := f$borrow$TF$T$B$T$Unit(anon$1)
+  fold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
+  anon$2 := p$a.bf$um
+  l0$c := anon$2.bf$um
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(1240,1255): info: Generated Viper text for testMixedAccess:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$consume$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testMixedAccess$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  var anon$2: Ref
+  var anon$3: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$um
+  anon$0 := f$borrow$TF$T$B$T$Unit(anon$1)
+  fold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$3 := p$a.bf$um
+  anon$2 := f$consume$TF$T$B$T$Unit(anon$3)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(1314,1321): info: Generated Viper text for testTwo:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consumeTwo$TF$T$B$T$B$T$Unit(p$b1: Ref, p$b2: Ref)
+  returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b1), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b1), write)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b2), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b2), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testTwo$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  var anon$2: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$um
+  anon$2 := p$a.bf$ui
+  anon$0 := f$consumeTwo$TF$T$B$T$B$T$Unit(anon$1, anon$2)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/methodCalls.kt:(1372,1387): info: Generated Viper text for testSharedField:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$shared$TF$T$C$T$Unit(p$c: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$testSharedField$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$b: Ref
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$b := p$a.bf$um
+  unfold acc(p$c$B$unique(l0$b), write)
+  anon$1 := l0$b.bf$sm
+  anon$0 := f$shared$TF$T$C$T$Unit(anon$1)
+  fold acc(p$c$B$unique(l0$b), write)
+  p$a.bf$um := l0$b
+  fold acc(p$c$A$unique(p$a), write)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/methodCalls.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/methodCalls.fir.diag.txt
@@ -1,4 +1,4 @@
-/methodCalls.kt:(672,679): info: Generated Viper text for consume:
+/methodCalls.kt:(670,677): info: Generated Viper text for consume:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -17,7 +17,7 @@ method f$consume$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(701,708): info: Generated Viper text for consume:
+/methodCalls.kt:(699,706): info: Generated Viper text for consume:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -36,7 +36,7 @@ method f$consume$TF$T$B$T$Unit(p$b: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(730,736): info: Generated Viper text for shared:
+/methodCalls.kt:(728,734): info: Generated Viper text for shared:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -54,7 +54,7 @@ method f$shared$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(750,756): info: Generated Viper text for borrow:
+/methodCalls.kt:(748,754): info: Generated Viper text for borrow:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -72,7 +72,7 @@ method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(780,790): info: Generated Viper text for consumeTwo:
+/methodCalls.kt:(778,788): info: Generated Viper text for consumeTwo:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -95,7 +95,7 @@ method f$consumeTwo$TF$T$B$T$B$T$Unit(p$b1: Ref, p$b2: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(829,854): info: Generated Viper text for testUniqueFieldFoldUnfold:
+/methodCalls.kt:(827,852): info: Generated Viper text for testUniqueFieldFoldUnfold:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -126,7 +126,7 @@ method f$testUniqueFieldFoldUnfold$TF$T$A$T$Unit(p$a: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(897,914): info: Generated Viper text for testBorrowedField:
+/methodCalls.kt:(895,912): info: Generated Viper text for testBorrowedField:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -162,7 +162,7 @@ method f$testBorrowedField$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(972,988): info: Generated Viper text for testNestedUnique:
+/methodCalls.kt:(970,986): info: Generated Viper text for testNestedUnique:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -192,12 +192,11 @@ method f$testNestedUnique$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$1 := l0$b.bf$um
   anon$0 := f$consume$TF$T$C$T$Unit(anon$1)
   p$a.bf$um := l0$b
-  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(1069,1086): info: Generated Viper text for testMultipleCalls:
+/methodCalls.kt:(1067,1084): info: Generated Viper text for testMultipleCalls:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -233,7 +232,7 @@ method f$testMultipleCalls$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(1145,1161): info: Generated Viper text for testNestedBorrow:
+/methodCalls.kt:(1143,1159): info: Generated Viper text for testNestedBorrow:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -269,7 +268,7 @@ method f$testNestedBorrow$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(1240,1255): info: Generated Viper text for testMixedAccess:
+/methodCalls.kt:(1238,1253): info: Generated Viper text for testMixedAccess:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -310,7 +309,7 @@ method f$testMixedAccess$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(1314,1321): info: Generated Viper text for testTwo:
+/methodCalls.kt:(1312,1319): info: Generated Viper text for testTwo:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -345,7 +344,7 @@ method f$testTwo$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/methodCalls.kt:(1372,1387): info: Generated Viper text for testSharedField:
+/methodCalls.kt:(1370,1385): info: Generated Viper text for testSharedField:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -375,7 +374,6 @@ method f$testSharedField$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   anon$0 := f$shared$TF$T$C$T$Unit(anon$1)
   fold acc(p$c$B$unique(l0$b), write)
   p$a.bf$um := l0$b
-  fold acc(p$c$A$unique(p$a), write)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/methodCalls.kt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/methodCalls.kt
@@ -1,0 +1,77 @@
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+
+class A(
+    @Unique var um: B,  // unique-mutable
+    @Unique val ui: B,  // unique-immutable
+    var sm: B,          // shared-mutable
+    val si: B,          // shared-immutable
+)
+
+
+class B(
+    @Unique var um: C,  // unique-mutable
+    @Unique val ui: C,  // unique-immutable
+    var sm: C,          // shared-mutable
+    val si: C,          // shared-immutable
+)
+
+
+class C(
+    @Unique var um: Any,  // unique-mutable
+    @Unique val ui: Any,  // unique-immutable
+    var sm: Any,          // shared-mutable
+    val si: Any,          // shared-immutable
+)
+
+
+fun <!VIPER_TEXT!>consume<!>(@Unique c: C) {}
+fun <!VIPER_TEXT!>consume<!>(@Unique b: B) {}
+fun <!VIPER_TEXT!>shared<!>(c: C) {}
+fun <!VIPER_TEXT!>borrow<!>(@Borrowed b: B) {}
+fun <!VIPER_TEXT!>consumeTwo<!>(@Unique b1: B, @Unique b2: B) {}
+
+fun <!VIPER_TEXT!>testUniqueFieldFoldUnfold<!>(@Unique a: A) {
+
+    consume(a.um)
+}
+
+fun <!VIPER_TEXT!>testBorrowedField<!>(@Unique a: A) {
+    borrow(a.um)
+    borrow(a.um)
+}
+
+fun <!VIPER_TEXT!>testNestedUnique<!>(@Unique a: A) {
+    @Unique val b = a.um
+    consume(b.um)
+    a.um = b
+}
+
+
+fun <!VIPER_TEXT!>testMultipleCalls<!>(@Unique a: A) {
+    borrow(a.ui)
+    borrow(a.ui)
+}
+
+
+fun <!VIPER_TEXT!>testNestedBorrow<!>(@Unique a: A) {
+    borrow(a.um)
+    @Unique @Borrowed val c = a.um.um
+}
+
+fun <!VIPER_TEXT!>testMixedAccess<!>(@Unique a: A) {
+    borrow(a.um)
+    consume(a.um)
+}
+
+fun <!VIPER_TEXT!>testTwo<!>(@Unique a: A) {
+    consumeTwo(a.um, a.ui)
+}
+
+fun <!VIPER_TEXT!>testSharedField<!>(@Unique a: A) {
+    @Unique val b = a.um
+    shared(b.sm)
+    a.um = b
+}
+
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/return.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/return.fir.diag.txt
@@ -14,7 +14,9 @@ method f$simpleReturnUM$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
   ensures acc(p$c$B$shared(ret$0), wildcard)
 {
   inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
   ret$0 := p$a.bf$um
+  fold acc(p$c$A$unique(p$a), write)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -35,7 +37,9 @@ method f$simpleReturnUI$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
   ensures acc(p$c$B$shared(ret$0), wildcard)
 {
   inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
   ret$0 := p$a.bf$ui
+  fold acc(p$c$A$unique(p$a), write)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -56,7 +60,9 @@ method f$simpleReturnSM$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
   ensures acc(p$c$B$shared(ret$0), wildcard)
 {
   inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
   ret$0 := p$a.bf$sm
+  fold acc(p$c$A$unique(p$a), write)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -77,7 +83,9 @@ method f$simpleReturnSI$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
   ensures acc(p$c$B$shared(ret$0), wildcard)
 {
   inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
   ret$0 := p$a.bf$si
+  fold acc(p$c$A$unique(p$a), write)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -99,8 +107,12 @@ method f$deepReturnUMSI$TF$T$A$T$C(p$a: Ref) returns (ret$0: Ref)
 {
   var anon$0: Ref
   inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$B$unique(p$a.bf$um), write)
   anon$0 := p$a.bf$um
   ret$0 := anon$0.bf$si
+  fold acc(p$c$B$unique(p$a.bf$um), write)
+  fold acc(p$c$A$unique(p$a), write)
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/return.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/return.fir.diag.txt
@@ -1,0 +1,106 @@
+/return.kt:(669,683): info: Generated Viper text for simpleReturnUM:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$simpleReturnUM$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$B())
+  ensures acc(p$c$B$shared(ret$0), wildcard)
+{
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  ret$0 := p$a.bf$um
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/return.kt:(726,740): info: Generated Viper text for simpleReturnUI:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$simpleReturnUI$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$B())
+  ensures acc(p$c$B$shared(ret$0), wildcard)
+{
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  ret$0 := p$a.bf$ui
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/return.kt:(784,798): info: Generated Viper text for simpleReturnSM:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$simpleReturnSM$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$B())
+  ensures acc(p$c$B$shared(ret$0), wildcard)
+{
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  ret$0 := p$a.bf$sm
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/return.kt:(842,856): info: Generated Viper text for simpleReturnSI:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$simpleReturnSI$TF$T$A$T$B(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$B())
+  ensures acc(p$c$B$shared(ret$0), wildcard)
+{
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  ret$0 := p$a.bf$si
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/return.kt:(900,914): info: Generated Viper text for deepReturnUMSI:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$deepReturnUMSI$TF$T$A$T$C(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$C())
+  ensures acc(p$c$C$shared(ret$0), wildcard)
+{
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  anon$0 := p$a.bf$um
+  ret$0 := anon$0.bf$si
+  goto lbl$ret$0
+  label lbl$ret$0
+}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/return.kt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/return.kt
@@ -1,0 +1,45 @@
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+
+class A(
+    @Unique var um: B,  // unique-mutable
+    @Unique val ui: B,  // unique-immutable
+    var sm: B,          // shared-mutable
+    val si: B,          // shared-immutable
+)
+
+
+class B(
+    @Unique var um: C,  // unique-mutable
+    @Unique val ui: C,  // unique-immutable
+    var sm: C,          // shared-mutable
+    val si: C,          // shared-immutable
+)
+
+
+class C(
+    @Unique var um: Any,  // unique-mutable
+    @Unique val ui: Any,  // unique-immutable
+    var sm: Any,          // shared-mutable
+    val si: Any,          // shared-immutable
+)
+
+fun <!VIPER_TEXT!>simpleReturnUM<!>(@Unique a: A) : B{
+    return a.um
+}
+
+fun <!VIPER_TEXT!>simpleReturnUI<!>(@Unique a: A) : B {
+    return a.ui
+}
+
+fun <!VIPER_TEXT!>simpleReturnSM<!>(@Unique a: A) : B {
+    return a.sm
+}
+
+fun <!VIPER_TEXT!>simpleReturnSI<!>(@Unique a: A) : B {
+    return a.si
+}
+
+fun <!VIPER_TEXT!>deepReturnUMSI<!>(@Unique a: A) : C {
+    return a.um.si
+}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.fir.diag.txt
@@ -1,0 +1,317 @@
+/while.kt:(752,763): info: Generated Viper text for simpleWrite:
+field bf$something: Ref
+
+method con$pkg$kotlin$c$Any$T$Any() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$anyType())
+
+
+method f$consume$TF$T$Simple$T$Unit(p$a: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$Simple())
+  requires acc(p$c$Simple$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$nonDet$TF$T$Boolean() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+
+
+method f$simpleWrite$TF$T$Simple$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$Simple())
+  requires acc(p$c$Simple$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$2: Ref
+  inhale acc(p$c$Simple$shared(p$a), wildcard)
+  label lbl$continue$0
+    invariant acc(p$c$Simple$shared(p$a), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$Simple())
+    invariant acc(p$c$Simple$unique(p$a), write)
+  anon$0 := f$nonDet$TF$T$Boolean()
+  if (df$rt$boolFromRef(anon$0)) {
+    var anon$1: Ref
+    unfold acc(p$c$Simple$unique(p$a), write)
+    anon$1 := con$pkg$kotlin$c$Any$T$Any()
+    p$a.bf$something := anon$1
+    fold acc(p$c$Simple$unique(p$a), write)
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+  assert acc(p$c$Simple$shared(p$a), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$Simple())
+  anon$2 := f$consume$TF$T$Simple$T$Unit(p$a)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(887,893): info: Generated Viper text for nonDet:
+method f$nonDet$TF$T$Boolean() returns (ret$0: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
+{
+  ret$0 := df$rt$boolToRef(true)
+  goto lbl$ret$0
+  label lbl$ret$0
+}
+
+/while.kt:(931,938): info: Generated Viper text for consume:
+field bf$something: Ref
+
+method f$consume$TF$T$Simple$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$Simple())
+  requires acc(p$c$Simple$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$Simple$shared(p$a), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(965,972): info: Generated Viper text for consume:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consume$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(994,1000): info: Generated Viper text for borrow:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b), write)
+  ensures acc(p$c$B$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$B$shared(p$b), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(1034,1040): info: Generated Viper text for simple:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$consume$TF$T$A$T$Unit(p$a: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$nonDet$TF$T$Boolean() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+
+
+method f$simple$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  label lbl$continue$0
+    invariant acc(p$c$A$shared(p$a), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  anon$0 := f$nonDet$TF$T$Boolean()
+  if (df$rt$boolFromRef(anon$0)) {
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+  assert acc(p$c$A$shared(p$a), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  anon$1 := f$consume$TF$T$A$T$Unit(p$a)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(1112,1134): info: Generated Viper text for partiallyMovedOverLoop:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$nonDet$TF$T$Boolean() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+
+
+method f$partiallyMovedOverLoop$TF$T$A$T$Unit(p$a: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var l0$x: Ref
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  unfold acc(p$c$A$unique(p$a), write)
+  l0$x := p$a.bf$um
+  label lbl$continue$0
+    invariant acc(p$c$B$shared(l0$x), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$c$B())
+    invariant acc(p$c$A$shared(p$a), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+    invariant acc(p$c$B$shared(p$a.bf$sm), wildcard)
+    invariant acc(p$c$B$shared(p$a.bf$si), wildcard)
+  anon$0 := f$nonDet$TF$T$Boolean()
+  if (df$rt$boolFromRef(anon$0)) {
+    var anon$1: Ref
+    var anon$2: Ref
+    anon$1 := p$a.bf$sm
+    anon$2 := p$a.bf$si
+    if (anon$1 == anon$2) {
+    }
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+  assert acc(p$c$B$shared(l0$x), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$c$B())
+  assert acc(p$c$A$shared(p$a), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(1324,1336): info: Generated Viper text for BorrowInLoop:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$BorrowInLoop$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  label lbl$continue$0
+    invariant acc(p$c$A$shared(p$a), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+    invariant acc(p$c$A$unique(p$a), write)
+  anon$0 := f$nonDet$TF$T$Boolean()
+  if (df$rt$boolFromRef(anon$0)) {
+    var anon$1: Ref
+    var anon$2: Ref
+    unfold acc(p$c$A$unique(p$a), write)
+    anon$1 := p$a.bf$sm
+    anon$2 := p$a.bf$si
+    fold acc(p$c$A$unique(p$a), write)
+    if (anon$1 == anon$2) {
+      var anon$3: Ref
+      var anon$4: Ref
+      unfold acc(p$c$A$unique(p$a), write)
+      anon$4 := p$a.bf$um
+      anon$3 := f$borrow$TF$T$B$T$Unit(anon$4)
+      fold acc(p$c$A$unique(p$a), write)
+    }
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+  assert acc(p$c$A$shared(p$a), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b), write)
+  ensures acc(p$c$B$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$nonDet$TF$T$Boolean() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+
+
+/while.kt:(1543,1551): info: Generated Viper text for Optional:
+field bf$data: Ref
+
+field bf$next: Ref
+
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$Optional$TF$T$Node$T$Unit(p$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
+  requires acc(p$c$Node$unique(p$n), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  inhale acc(p$c$Node$shared(p$n), wildcard)
+  label lbl$continue$0
+    invariant acc(p$c$Node$shared(p$n), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
+    invariant acc(p$c$Node$unique(p$n), write)
+  unfold acc(p$c$Node$unique(p$n), write)
+  anon$1 := f$nonDet$TF$T$Boolean()
+  if (df$rt$boolFromRef(anon$1)) {
+    var anon$2: Ref
+    anon$2 := p$n.bf$next
+    anon$0 := sp$notBool(df$rt$boolToRef(anon$2 == df$rt$nullValue()))
+  } else {
+    anon$0 := df$rt$boolToRef(false)}
+  fold acc(p$c$Node$unique(p$n), write)
+  if (df$rt$boolFromRef(anon$0)) {
+    var anon$3: Ref
+    var anon$4: Ref
+    unfold acc(p$c$Node$unique(p$n), write)
+    anon$4 := p$n.bf$data
+    anon$3 := f$borrow$TF$T$B$T$Unit(anon$4)
+    fold acc(p$c$Node$unique(p$n), write)
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+  assert acc(p$c$Node$shared(p$n), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b), write)
+  ensures acc(p$c$B$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$nonDet$TF$T$Boolean() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+
+
+/while.kt:(1628,1634): error: Argument type mismatch: actual type is 'A', but 'B' was expected.

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.fir.diag.txt
@@ -105,7 +105,27 @@ method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/while.kt:(1034,1040): info: Generated Viper text for simple:
+/while.kt:(1032,1038): info: Generated Viper text for borrow:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$borrow$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(1072,1078): info: Generated Viper text for simple:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -147,7 +167,7 @@ method f$simple$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/while.kt:(1112,1134): info: Generated Viper text for partiallyMovedOverLoop:
+/while.kt:(1150,1172): info: Generated Viper text for partiallyMovedOverLoop:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -197,7 +217,7 @@ method f$partiallyMovedOverLoop$TF$T$A$T$Unit(p$a: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-/while.kt:(1324,1336): info: Generated Viper text for BorrowInLoop:
+/while.kt:(1362,1374): info: Generated Viper text for borrowInLoop:
 field bf$si: Ref
 
 field bf$sm: Ref
@@ -206,7 +226,14 @@ field bf$ui: Ref
 
 field bf$um: Ref
 
-method f$BorrowInLoop$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
+  requires acc(p$c$B$unique(p$b), write)
+  ensures acc(p$c$B$unique(p$b), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$borrowInLoop$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
   requires acc(p$c$A$unique(p$a), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -242,18 +269,48 @@ method f$BorrowInLoop$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
-  requires acc(p$c$B$unique(p$b), write)
-  ensures acc(p$c$B$unique(p$b), write)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
-
-
 method f$nonDet$TF$T$Boolean() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 
-/while.kt:(1543,1551): info: Generated Viper text for Optional:
+/while.kt:(1512,1530): info: Generated Viper text for unfoldForCondition:
+field bf$si: Ref
+
+field bf$sm: Ref
+
+field bf$ui: Ref
+
+field bf$um: Ref
+
+method f$unfoldForCondition$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+{
+  var anon$0: Ref
+  var anon$1: Ref
+  var anon$2: Ref
+  inhale acc(p$c$A$shared(p$a), wildcard)
+  label lbl$continue$0
+    invariant acc(p$c$A$shared(p$a), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+    invariant acc(p$c$A$unique(p$a), write)
+  unfold acc(p$c$A$unique(p$a), write)
+  anon$1 := p$a.bf$um
+  anon$2 := p$a.bf$ui
+  anon$0 := df$rt$boolToRef(anon$1 == anon$2)
+  fold acc(p$c$A$unique(p$a), write)
+  if (df$rt$boolFromRef(anon$0)) {
+    goto lbl$continue$0
+  }
+  label lbl$break$0
+  assert acc(p$c$A$shared(p$a), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  label lbl$ret$0
+  inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
+}
+
+/while.kt:(1657,1665): info: Generated Viper text for optional:
 field bf$data: Ref
 
 field bf$next: Ref
@@ -266,7 +323,18 @@ field bf$ui: Ref
 
 field bf$um: Ref
 
-method f$Optional$TF$T$Node$T$Unit(p$n: Ref) returns (ret$0: Ref)
+method f$borrow$TF$T$A$T$Unit(p$a: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$unique(p$a), write)
+  ensures acc(p$c$A$unique(p$a), write)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+
+
+method f$nonDet$TF$T$Boolean() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+
+
+method f$optional$TF$T$Node$T$Unit(p$n: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
   requires acc(p$c$Node$unique(p$n), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -292,7 +360,7 @@ method f$Optional$TF$T$Node$T$Unit(p$n: Ref) returns (ret$0: Ref)
     var anon$4: Ref
     unfold acc(p$c$Node$unique(p$n), write)
     anon$4 := p$n.bf$data
-    anon$3 := f$borrow$TF$T$B$T$Unit(anon$4)
+    anon$3 := f$borrow$TF$T$A$T$Unit(anon$4)
     fold acc(p$c$Node$unique(p$n), write)
     goto lbl$continue$0
   }
@@ -302,16 +370,3 @@ method f$Optional$TF$T$Node$T$Unit(p$n: Ref) returns (ret$0: Ref)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
-
-method f$borrow$TF$T$B$T$Unit(p$b: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$B())
-  requires acc(p$c$B$unique(p$b), write)
-  ensures acc(p$c$B$unique(p$b), write)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
-
-
-method f$nonDet$TF$T$Boolean() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
-
-
-/while.kt:(1628,1634): error: Argument type mismatch: actual type is 'A', but 'B' was expected.

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.kt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.kt
@@ -85,6 +85,12 @@ fun <!VIPER_TEXT!>borrowInLoop<!>(@Unique a: A) {
     }
 }
 
+fun <!VIPER_TEXT!>unfoldForCondition<!>(@Unique a: A) {
+
+    while (a.um == a.ui) {
+    }
+}
+
 class Node(
     @Unique var next: Node?,
     @Unique var data: A,

--- a/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.kt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/permissions/while.kt
@@ -1,0 +1,98 @@
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+
+class A(
+    @Unique var um: B,  // unique-mutable
+    @Unique val ui: B,  // unique-immutable
+    var sm: B,          // shared-mutable
+    val si: B,          // shared-immutable
+)
+
+
+class B(
+    @Unique var um: C,  // unique-mutable
+    @Unique val ui: C,  // unique-immutable
+    var sm: C,          // shared-mutable
+    val si: C,          // shared-immutable
+)
+
+
+class C(
+    @Unique var um: Any,  // unique-mutable
+    @Unique val ui: Any,  // unique-immutable
+    var sm: Any,          // shared-mutable
+    val si: Any,          // shared-immutable
+)
+
+class D(
+    @Unique var um: A?
+)
+
+class Simple(
+    @Unique var something: Any
+)
+
+fun <!VIPER_TEXT!>simpleWrite<!>(@Unique a: Simple) {
+
+    while (nonDet()) {
+        // unique(a)
+        a.something = Any()
+    }
+
+    consume(a)
+}
+
+fun <!VIPER_TEXT!>nonDet<!>() : Boolean {
+    return true
+}
+
+fun <!VIPER_TEXT!>consume<!>(@Unique a: Simple) {}
+fun <!VIPER_TEXT!>consume<!>(@Unique a: A) {}
+fun <!VIPER_TEXT!>borrow<!>(@Unique @Borrowed b: B) {}
+fun <!VIPER_TEXT!>borrow<!>(@Unique @Borrowed a: A) {}
+
+
+fun <!VIPER_TEXT!>simple<!>(@Unique a: A) {
+
+    while (nonDet()) {
+
+    }
+
+    consume(a)
+}
+
+
+fun <!VIPER_TEXT!>partiallyMovedOverLoop<!>(@Unique a: A) {
+    @Unique val x = a.um
+
+    while (nonDet()) {
+        // shared(a.sm)
+        // shared(a.si)
+        // unique(a.um)
+        if (a.sm == a.si) {
+
+        }
+    }
+}
+
+fun <!VIPER_TEXT!>borrowInLoop<!>(@Unique a: A) {
+
+    while (nonDet()) {
+        // unique(a)
+        if (a.sm == a.si) {
+            borrow(a.um)
+        }
+    }
+}
+
+class Node(
+    @Unique var next: Node?,
+    @Unique var data: A,
+)
+
+fun <!VIPER_TEXT!>optional<!>(@Unique n: Node) {
+
+    while (nonDet() && n.next != null) {
+        borrow(n.data)
+    }
+}


### PR DESCRIPTION
This PR targets #72 

# Overview of Changes

## Uniqueness Information
When a program is registered for verification, we call the uniqueness checker. This also means that the verification plugin is now dependent on the uniqueness plugin.
The uniqueness information is collected in a `UniquenessInformation` object, which using dfs maps the in/out flows from the cfg nodes to the corresponding firEmbeddings.
The uniqueness information is added to the `MethodConverter` for the next step.


## Fir to ExpEmbedding
### New Properties on ExpEmbedding
For every `ExpEmbedding` we want to have access to the uniqueness information before and after the execution of it. Two mutable fields were added on the `ExpEmbedding`. Generally having immutable fields would make more sense, however this would require to change all the classes and add them to the constructor, which would make the construction less clean.
We use the abstract class `DefaultUniqueness` to initialize both fields to null. 

>Question: Is this the best way to do it? Should we change it to immutable properties and add the values during construction?

### Fir to ExpEmbedding translation
The `StmtConversionVisitor` was updated to also set the uniqueness information for each generated `ExpEmbedding`.

## Permission Manager
The permission management can be divided into three parts: The management of unique predicates, shared predicates and the invariant extraction.  For each of those parts a separate object was created.
The task of the permission manager is to figure out what needs to be unfolded/folded.

All the permission managers have a private constructor, they can be created via the `create` method. The creation can fail, if we do not have enough information available. Since currently there are some code structures that are not yet supported by the uniqueness checker, we do not always have the necessary information (flow before/after) available. With the failing construction we can "soft fail". 

>Question: We could also remove the PermissionManager objects and move the logic into the `ExpEmbedding`. I think with the `PermissionManager` we have the logic a bit more separated and the `ExpEmbedding` remain rather simple. But I am not sure, if that is the best way to do it?

>Question: Also about handling cases where there is not enough information available. In an ideal world this would never happen. There are two points of failure: missing uniqueness information, missing path information (see below).  What should be de default for such situation behaviour there?  Just unfold nothing (likely result in a viper error, but should not introduce unsoundness)?

### Path Abstraction
The added `Path` classes are used to associate the `ExpEmbedding` paths with the fir Paths and add some utilities that can be used by the `PermissionManager`.  On each `ExpEmbedding` there were two new properties added:
- `endingPath`: Is the path that ends in the current `ExpEmbedding`. This path may be extended if the current `ExpEmbedding` becomes the receiver of a `FieldAccess`. 
- `containingPaths`: This is used to collect paths for larger statements such as assignments. All the paths contained in the assignment are collected there.  Usually only the final path is added here and not all the prefixes. So if the statement is `a.b = x.y.z + 1`, the collection would consist of `Path(a.b), Path(x.y.z)`. This does not mean however that two paths never share a prefix. For the statement `x.y = x.y.z + 1` both `Path(x.y)` and `Path(x.y.z)` are included.

>Question: At the moment these are implemented as lazy fields. I am not sure if this is the best way to do it. I used lazy fields, because we do not always need them, so calculating them might be wasteful. We could also implement a visitor that extracts the paths, but this visitor might make unnecessary passes. E.g. extract the paths on the statement level (for unique predicates) and afterwards again on field access level (for shared predicates). 

### Linearizer
On the `Linearizer` I added a new method `addBranchWithFolding`. This method should add a branch, and does the necessary folding on the `condition`. This was necessary, because:
- The unique predicates must be unfolded on "statement" level. Because for example for an assignment, a used field only becomes moved once the read value is assigned. For example: `b = tree.left + tree.right` , on the `FieldAccess` level both the access to `left` and `right` look the same and would conclude that `unique(tree)` must be unfolded. However, we can only unfold `unique(tree)` once.
- For branches this means that we need to look at the whole condition and do the necessary uniqueness folding before and after the whole condition. We can not do this on the `If` `ExpEmbedding` level, because this would involve using the linearizer to add statements, which we can not do, in pure settings. Therefore we moved the unfolding into the linearizer and created a new method (`addBranchWithGolding`). 

>Question: I think a better way to do this, would be to use `unfoldPolicy` to decided if we should add unfold statements or not. Is that correct? 

Because of the added uniqueness unfolds on the branch level it was necessary to update `SequentialLogicOperatorEmbedding`. When translation conditions that could short-circuit, a `If` `ExpEmbedding` was created and translated to viper. However if we do it like this, some unique predicates might become unfolded twice. Because multiple nested `If`s are created. I changed it, such that the `SequentialLogicOperatorEmbedding`, use the linearization context to add their branches.


## Limitations
Currently there are quite some parts that are not supported:
- Generally all member functions. It is unclear, if `this` should be considered unique of shared. Currently, the permission Managers just ignore those statements. Hence, nothing is unfolded.
> Question: Is this a reasonable default, or should we assume that is uniqe/shared? Or just leave it for now until we figure out how the uniqueness checker should handle this situations?
- Selecting the correct predicate for classes that inherit. At the moment just the predicate of the actual type is unfolded/folded.
- Return, Casts, Safe Calls, Elvis Operator: the uniqueness checker provides no information on these statements.
- The `Unfolding Strategy` of the `Linearizer` is not taken into account.
- The Invariant extraction needs some more work.  
