### PR TITLE
Fix consumption of nested unique properties

### DIFF
--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -593,6 +593,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("consume_deeply_nested.kt")
+    public void testConsume_deeply_nested() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_deeply_nested.kt");
+    }
+
+    @Test
     @TestMetadata("consume_local.kt")
     public void testConsume_local() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.kt");
@@ -635,9 +641,9 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
-    @TestMetadata("share_properties.kt")
-    public void testShare_properties() {
-      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_properties.kt");
+    @TestMetadata("share_property.kt")
+    public void testShare_property() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_property.kt");
     }
 
     @Test

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/assign_property.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/assign_property.fir.diag.txt
@@ -1,5 +1,5 @@
-/assign_property.kt:(409,410): error: Assignment uniqueness mismatch: expected 'unique global', actual 'shared global'.
+/assign_property.kt:(403,404): error: Assignment uniqueness mismatch: expected 'unique global', actual 'shared global'.
 
-/assign_property.kt:(506,507): error: Assignment uniqueness mismatch: expected 'unique global', actual 'shared local'.
+/assign_property.kt:(500,501): error: Assignment uniqueness mismatch: expected 'unique global', actual 'shared local'.
 
-/assign_property.kt:(727,728): error: Assignment uniqueness mismatch: expected 'unique global', actual 'unique local'.
+/assign_property.kt:(721,722): error: Assignment uniqueness mismatch: expected 'unique global', actual 'unique local'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/assign_property.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/assign_property.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
 class A {
-    @Unique var x = Object()
-    @Unique var w = Object()
+    @Unique var x = Any()
+    @Unique var w = Any()
 }
 
 class B {

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrow_property.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrow_property.fir.diag.txt
@@ -1,3 +1,3 @@
-/borrow_property.kt:(853,854): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
+/borrow_property.kt:(847,848): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
 
-/borrow_property.kt:(931,932): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.
+/borrow_property.kt:(925,926): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrow_property.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/borrow_property.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
 class A {
-    @Unique var x = Object()
-    @Unique var w = Object()
+    @Unique var x = Any()
+    @Unique var w = Any()
 }
 
 class B {

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_deeply_nested.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_deeply_nested.fir.diag.txt
@@ -1,0 +1,1 @@
+/consume_deeply_nested.kt:(420,421): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_deeply_nested.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_deeply_nested.kt
@@ -1,0 +1,20 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class A(
+    @Unique var um: A,  // unique-mutable
+    @Unique val ui: A,  // unique-immutable
+    var sm: A,          // shared-mutable
+    val si: A,          // shared-immutable
+)
+
+fun consume(@Unique x: Any) {}
+
+fun `consume nested unique after moving back`(@Unique a: A) {
+    @Unique val b = a.um
+    consume(b.um)
+    a.um = b
+
+    consume(<!UNIQUENESS_VIOLATION!>a<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.fir.diag.txt
@@ -1,9 +1,9 @@
-/consume_property.kt:(368,373): error: Argument uniqueness mismatch: expected 'unique global', actual 'shared global'.
+/consume_property.kt:(362,367): error: Argument uniqueness mismatch: expected 'unique global', actual 'shared global'.
 
-/consume_property.kt:(443,448): error: Argument uniqueness mismatch: expected 'unique global', actual 'shared local'.
+/consume_property.kt:(437,442): error: Argument uniqueness mismatch: expected 'unique global', actual 'shared local'.
 
-/consume_property.kt:(604,609): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
+/consume_property.kt:(598,603): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
 
-/consume_property.kt:(841,842): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
+/consume_property.kt:(835,836): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
 
-/consume_property.kt:(921,922): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.
+/consume_property.kt:(915,916): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
 class A {
-    @Unique var x = Object()
-    @Unique var w = Object()
+    @Unique var x = Any()
+    @Unique var w = Any()
 }
 
 class B {

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/pass_property_argument.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/pass_property_argument.fir.diag.txt
@@ -1,1 +1,1 @@
-/pass_property_argument.kt:(655,656): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
+/pass_property_argument.kt:(649,650): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/pass_property_argument.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/pass_property_argument.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
 class A {
-    @Unique var x = Object()
-    @Unique var w = Object()
+    @Unique var x = Any()
+    @Unique var w = Any()
 }
 
 class B {

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return_property.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return_property.fir.diag.txt
@@ -1,3 +1,3 @@
-/return_property.kt:(364,367): error: Return uniqueness mismatch: cannot return a 'shared local' value
+/return_property.kt:(358,361): error: Return uniqueness mismatch: cannot return a 'shared local' value
 
-/return_property.kt:(525,528): error: Return uniqueness mismatch: cannot return a 'unique local' value
+/return_property.kt:(519,522): error: Return uniqueness mismatch: cannot return a 'unique local' value

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return_property.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return_property.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
 class A {
-    @Unique var x = Object()
-    @Unique var w = Object()
+    @Unique var x = Any()
+    @Unique var w = Any()
 }
 
 class B {

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_properties.fir.diag.txt
@@ -1,9 +1,0 @@
-/share_properties.kt:(433,438): error: Argument uniqueness mismatch: expected 'shared global', actual 'shared local'.
-
-/share_properties.kt:(586,591): error: Argument uniqueness mismatch: expected 'shared global', actual 'unique local'.
-
-/share_properties.kt:(808,809): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
-
-/share_properties.kt:(884,885): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.
-
-/share_properties.kt:(1018,1019): error: Assignment uniqueness mismatch: expected 'unique global', actual 'shared global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_property.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_property.fir.diag.txt
@@ -1,0 +1,9 @@
+/share_property.kt:(427,432): error: Argument uniqueness mismatch: expected 'shared global', actual 'shared local'.
+
+/share_property.kt:(580,585): error: Argument uniqueness mismatch: expected 'shared global', actual 'unique local'.
+
+/share_property.kt:(802,803): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
+
+/share_property.kt:(878,879): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.
+
+/share_property.kt:(1012,1013): error: Assignment uniqueness mismatch: expected 'unique global', actual 'shared global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_property.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/share_property.kt
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
 class A {
-    @Unique var x = Object()
-    @Unique var w = Object()
+    @Unique var x = Any()
+    @Unique var w = Any()
 }
 
 class B {

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
@@ -30,16 +30,19 @@ class UniquenessTypeAssigner(
         val result = data.copy()
         val receiverPath = receiver.receiverPath
         val valuePaths = value.valuePaths
-
-        if (receiverPath != null) {
-            result[receiverPath] = resolver.resolveUniquenessType(receiverPath.last())
+        val receiverResult = receiverPath?.let {
+            result.ensure(it).also{
+                it.children.clear()
+            }
         }
 
         for (valuePath in valuePaths) {
-            val valueType = data[valuePath]
+            val valueData = data.ensure(valuePath)
+            val valueType = valueData.type
+            receiverResult?.join(valueData)
 
             if (valueType is UniquenessType.Active && valueType.uniqueLevel == UniqueLevel.Unique) {
-                result[valuePath] = UniquenessType.Moved
+                result.ensure(valuePath).type = UniquenessType.Moved
             }
         }
 
@@ -78,11 +81,11 @@ class UniquenessTypeAssigner(
                 if (parameterType.borrowLevel == BorrowLevel.Global) {
                     when (parameterType.uniqueLevel) {
                         UniqueLevel.Unique -> {
-                            result[argumentPath] = UniquenessType.Moved
+                            result.ensure(argumentPath).type = UniquenessType.Moved
                         }
 
                         UniqueLevel.Shared -> {
-                            result[argumentPath] = UniquenessType.Active(UniqueLevel.Shared, BorrowLevel.Global)
+                            result.ensure(argumentPath).type = UniquenessType.Active(UniqueLevel.Shared, BorrowLevel.Global)
                         }
                     }
                 }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
@@ -105,21 +105,22 @@ class UniquenessTypeChecker(
         onError: (UniquenessType, UniquenessType) -> Unit
     ) {
         for (valuePath in value.valuePaths) {
-            val valueType = data.ensure(valuePath).parentsJoin
-            val expectedType = resolver.resolveUniquenessType(valuePath.last())
+            val valueData = data.ensure(valuePath)
+            val valueActualType = valueData.parentsJoin
+            val valueExpectedType = resolver.resolveUniquenessType(valuePath.last())
 
-            if (valueType is UniquenessType.Active &&
-                valueType.uniqueLevel == UniqueLevel.Unique &&
-                !data.isInvariant(valuePath)) {
+            if (valueActualType is UniquenessType.Active &&
+                valueActualType.uniqueLevel == UniqueLevel.Unique &&
+                !valueData.isInvariant()) {
                 val valuePartialType = data.childrenJoin
 
                 when (valuePartialType) {
                     is UniquenessType.Moved ->
-                        return onError(valueType, valuePartialType)
+                        return onError(valueActualType, valuePartialType)
 
                     is UniquenessType.Active -> {
-                        if (valuePartialType.uniqueLevel > expectedType.uniqueLevel) {
-                            return onError(valueType, valuePartialType)
+                        if (valuePartialType.uniqueLevel > valueExpectedType.uniqueLevel) {
+                            return onError(valueActualType, valuePartialType)
                         }
                     }
                 }
@@ -159,7 +160,7 @@ class UniquenessTypeChecker(
                 //  {@see UniquenessGraphAnalyzer.visitFunctionCallEnterNode}
                 if (parameterType.uniqueLevel == UniqueLevel.Unique) {
                     currentData = currentData.copy()
-                    currentData[argumentPath] = UniquenessType.Moved
+                    currentData.ensure(argumentPath).type = UniquenessType.Moved
                 }
             }
         }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessTrie.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessTrie.kt
@@ -22,8 +22,8 @@ import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 class UniquenessTrie(
     val resolver: UniquenessResolver,
     var type: UniquenessType = UniquenessType.Active(UniqueLevel.Unique, BorrowLevel.Global),
-    private val children: MutableMap<FirBasedSymbol<*>, UniquenessTrie> = mutableMapOf(),
-    private val parent: UniquenessTrie? = null
+    val children: MutableMap<FirBasedSymbol<*>, UniquenessTrie> = mutableMapOf(),
+    val parent: UniquenessTrie? = null
 ) {
     /**
      * Represents the least upper bound (LUB) of uniqueness levels for the path from the current node * to the root of
@@ -51,18 +51,16 @@ class UniquenessTrie(
         val actual = type
         val default = resolver.resolveUniquenessType(symbol)
 
-        return actual == default &&
-                children.all { (symbol, store) ->
-                    store.isInvariant(symbol)
-                }
+        return actual == default && isInvariant()
     }
 
     /**
-     * @return true if the subpaths of `symbol` are invariant with respect to their default specification, `false`
-     * otherwise.
+     * @return true if the subpaths of invariant with respect to their default specification, `false` otherwise.
      */
-    fun isInvariant(path: Path): Boolean {
-        return path.isEmpty() || ensure(path).isInvariant(path.first())
+    fun isInvariant(): Boolean {
+        return children.all { (head, child) ->
+            child.isInvariant(head)
+        }
     }
 
     /**
@@ -86,42 +84,6 @@ class UniquenessTrie(
         }
 
         return child.ensure(path.subList(1, path.size))
-    }
-
-    /**
-     * Retrieves the uniqueness type for a given path.
-     *
-     * @param path The path to retrieve the uniqueness type for.
-     * @return The uniqueness type for the given path, or null if not found.
-     */
-    operator fun get(path: Path): UniquenessType =
-        ensure(path).type
-
-    /**
-     * Aggregates the uniqueness types of multiple paths into a single type.
-     *
-     * @param paths The list of paths of which type should be aggregated.
-     * @return The aggregated uniqueness type.
-     */
-    fun aggregate(paths: List<Path>): UniquenessType {
-        if (paths.isEmpty()) {
-            return UniquenessType.Active(UniqueLevel.Shared, BorrowLevel.Global)
-        } else {
-            return paths.fold(
-                UniquenessType.Active(UniqueLevel.Unique, BorrowLevel.Global) as UniquenessType
-            ) { result, path -> result.join(get(path)) }
-        }
-    }
-
-    /**
-     * Sets the uniqueness type for a given path.
-     *
-     * @param path The path to set the uniqueness type for.
-     * @return The updated UniquenessStore.
-     */
-    operator fun set(path: Path, value: UniquenessType) {
-        val store = ensure(path)
-        store.type = value
     }
 
     private fun copyWithParent(newParent: UniquenessTrie?): UniquenessTrie {


### PR DESCRIPTION
This pull request fixes the rerooting within the uniqueness trie of an assigned path onto the uniqueness trie of the assignee. In addition to this, it also adds the following fixes:

- Cleans the interface of `UniquenessTrie`, removing the `get` and `set` functions because their semantics were a bit confusing. Now, for getting the type of a path `p` from a uniqueness trie `u`, it is necessary to directly fetch it with `u.ensure(p).type`, and for setting the type to `t`: `u.ensure(p).type = t`.
- Adds a test `consume_deeply_nested` for testing the partial consumption of a unique 3-level nested data structure.
- Fixes an inconsistency with the naming of `share_properties`, renaming it to `share_property` for consistency with the other tests.
- Uses the `Any` instead of `Object` constructors in the tests.