### PR TITLE
Enhance CFG renderer with flow addition

### DIFF
--- a/formver.common/src/org/jetbrains/kotlin/formver/common/PluginConfiguration.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/PluginConfiguration.kt
@@ -12,6 +12,7 @@ data class PluginConfiguration(
     val conversionSelection: TargetsSelection,
     val verificationSelection: TargetsSelection,
     val checkUniqueness: Boolean,
+    val dumpUniquenessCFG: Boolean,
 ) {
     init {
         require(conversionSelection >= verificationSelection) {

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
@@ -40,9 +40,10 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
         )
         // TODO: provide configuration to enable uniqueness checks
         val checkUniqueness = false
+        val dumpUniquenessCFG = false
         val config = PluginConfiguration(
             logLevel, errorStyle, behaviour, conversionSelection, verificationSelection,
-            checkUniqueness
+            checkUniqueness, dumpUniquenessCFG
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
     }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/Diagnostics.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/Diagnostics.kt
@@ -6,11 +6,14 @@
 package org.jetbrains.kotlin.formver.plugin.compiler
 
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.diagnostics.AbstractSourceElementPositioningStrategy
-import org.jetbrains.kotlin.diagnostics.DiagnosticFactory2DelegateProvider
-import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
-import org.jetbrains.kotlin.diagnostics.Severity
-import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
+import org.jetbrains.kotlin.diagnostics.*
+
+context(container: KtDiagnosticsContainer)
+inline fun <reified P : PsiElement, A> info1(
+    positioningStrategy: AbstractSourceElementPositioningStrategy = SourceElementPositioningStrategies.DEFAULT
+): DiagnosticFactory1DelegateProvider<A> {
+    return DiagnosticFactory1DelegateProvider(Severity.INFO, positioningStrategy, P::class, container)
+}
 
 context(container: KtDiagnosticsContainer)
 inline fun <reified P : PsiElement, A, B> info2(

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
@@ -71,5 +71,11 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             "{0}",
             CommonRenderers.STRING,
         )
+
+        map.put(
+            PluginErrors.UNIQUENESS_CFG,
+            "\n{0}",
+            CommonRenderers.STRING,
+        )
     }
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
@@ -6,11 +6,7 @@
 package org.jetbrains.kotlin.formver.plugin.compiler
 
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
-import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
-import org.jetbrains.kotlin.diagnostics.error1
-import org.jetbrains.kotlin.diagnostics.warning1
-import org.jetbrains.kotlin.diagnostics.warning2
+import org.jetbrains.kotlin.diagnostics.*
 
 object PluginErrors : KtDiagnosticsContainer() {
     val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
@@ -25,6 +21,7 @@ object PluginErrors : KtDiagnosticsContainer() {
     val PURITY_VIOLATION by error1<PsiElement, String>()
 
     val UNIQUENESS_VIOLATION by error1<PsiElement, String>()
+    val UNIQUENESS_CFG by info1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
 
     override fun getRendererFactory() = FormalVerificationPluginErrorMessages
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/UniquenessDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/UniquenessDeclarationChecker.kt
@@ -15,10 +15,8 @@ import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.resolve.dfa.controlFlowGraph
 import org.jetbrains.kotlin.formver.common.ErrorCollector
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
-import org.jetbrains.kotlin.formver.uniqueness.UniquenessCheckException
-import org.jetbrains.kotlin.formver.uniqueness.UniquenessGraphChecker
-import org.jetbrains.kotlin.formver.uniqueness.UniquenessResolver
-import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
+import org.jetbrains.kotlin.formver.uniqueness.*
+import org.jetbrains.kotlin.formver.uniqueness.utils.render
 
 class UniquenessDeclarationChecker(private val session: FirSession, private val config: PluginConfiguration) :
 
@@ -33,6 +31,17 @@ class UniquenessDeclarationChecker(private val session: FirSession, private val 
             val graph = declaration.controlFlowGraphReference?.controlFlowGraph
                 ?: error("Control flow graph is null for declaration: ${declaration.name}")
             val resolver = UniquenessResolver(session)
+            if (config.dumpUniquenessCFG) {
+                val initial = UniquenessTrie(resolver)
+                val facts = UniquenessGraphAnalyzer(resolver, initial).analyze(graph)
+                val dot = graph.render(facts)
+                reporter.reportOn(
+                    declaration.source,
+                    PluginErrors.UNIQUENESS_CFG,
+                    dot
+                )
+
+            }
             val initial = UniquenessTrie(resolver)
             val graphChecker = UniquenessGraphChecker(session, initial, errorCollector)
             graphChecker.check(graph)

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -11,10 +11,11 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.common.*
 import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.ALWAYS_VALIDATE
+import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DUMP_UNIQUENESS_CFG
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.FULL_VIPER_DUMP
+import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.NEVER_VALIDATE
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.RENDER_PREDICATES
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.REPLACE_STDLIB_EXTENSIONS
-import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.NEVER_VALIDATE
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.UNIQUE_CHECK_ONLY
 import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
@@ -45,6 +46,7 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
         val conversionOnly = (System.getProperty("formver.conversionOnly")?.toBoolean() ?: false)
                 || NEVER_VALIDATE in module.directives
         val uniquenessOnly = UNIQUE_CHECK_ONLY in module.directives
+        val dumpUniquenessCFG = DUMP_UNIQUENESS_CFG in module.directives
         val verificationSelection = when {
             conversionOnly -> TargetsSelection.NO_TARGETS
             ALWAYS_VALIDATE in module.directives -> TargetsSelection.ALL_TARGETS
@@ -62,7 +64,8 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
             UnsupportedFeatureBehaviour.THROW_EXCEPTION,
             conversionSelection = conversionSelection,
             verificationSelection = verificationSelection,
-            checkUniqueness = checkUniqueness
+            checkUniqueness = checkUniqueness,
+            dumpUniquenessCFG = dumpUniquenessCFG,
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
     }
@@ -83,6 +86,10 @@ object FormVerDirectives : SimpleDirectivesContainer() {
 
     val UNIQUE_CHECK_ONLY by directive(
         description = "Do uniqueness checking"
+    )
+
+    val DUMP_UNIQUENESS_CFG by directive(
+        description = "dumps the CFG augmented with flow information"
     )
 
     val REPLACE_STDLIB_EXTENSIONS by directive(

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginDiagnosticsTestGenerated.java
@@ -611,6 +611,12 @@ public class FirLightTreeFormVerPluginDiagnosticsTestGenerated extends AbstractF
     }
 
     @Test
+    @TestMetadata("dump_cfg.kt")
+    public void testDump_cfg() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/dump_cfg.kt");
+    }
+
+    @Test
     @TestMetadata("pass_local_argument.kt")
     public void testPass_local_argument() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/pass_local_argument.kt");

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/dump_cfg.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/dump_cfg.fir.diag.txt
@@ -1,0 +1,124 @@
+/dump_cfg.kt:(229,235): info:
+digraph nonDet {
+    graph [nodesep=3]
+    node [shape=box penwidth=2]
+    edge [penwidth=2]
+
+    subgraph cluster_0 {
+        color=red
+        0 [label=< <TABLE BORDER="0"><TR><TD>Enter function nonDet</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Initial:<BR/>null<BR/></TD></TR></TABLE> > style="filled" fillcolor=red];
+        subgraph cluster_1 {
+            color=blue
+            1 [label="Enter block"];
+            2 [label="Const: Boolean(true)"];
+            3 [label="Jump: ^nonDet Boolean(true)"];
+            4 [label="Stub" style="filled" fillcolor=gray];
+            5 [label="Exit block" style="filled" fillcolor=gray];
+        }
+        6 [label=< <TABLE BORDER="0"><TR><TD>Exit function nonDet</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Final:<BR/>null<BR/></TD></TR></TABLE> > style="filled" fillcolor=red];
+    }
+    0 -> {1};
+    1 -> {2};
+    2 -> {3};
+    3 -> {6};
+    3 -> {4} [style=dotted];
+    4 -> {5} [style=dotted];
+    5 -> {6} [style=dotted];
+
+}
+
+
+/dump_cfg.kt:(273,277): info:
+digraph test {
+    graph [nodesep=3]
+    node [shape=box penwidth=2]
+    edge [penwidth=2]
+
+    subgraph cluster_0 {
+        color=red
+        0 [label=< <TABLE BORDER="0"><TR><TD>Enter function test</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Initial:<BR/>null<BR/></TD></TR></TABLE> > style="filled" fillcolor=red];
+        subgraph cluster_1 {
+            color=blue
+            1 [label=< <TABLE BORDER="0"><TR><TD>Enter block</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Before:<BR/>null<BR/><BR/>After:<BR/>a unique global<BR/>    first unique global<BR/>    second unique global<BR/></TD></TR></TABLE> >];
+            subgraph cluster_2 {
+                color=blue
+                2 [label="Enter when"];
+                subgraph cluster_3 {
+                    color=blue
+                    3 [label="Enter when branch condition "];
+                    subgraph cluster_4 {
+                        color=blue
+                        4 [label="Function call arguments enter"];
+                        5 [label="Function call arguments exit"];
+                    }
+                    6 [label="Function call enter: R|/nonDet|()"];
+                    7 [label="Function call exit: R|/nonDet|()" style="filled" fillcolor=yellow];
+                    8 [label="Exit when branch condition"];
+                }
+                subgraph cluster_5 {
+                    color=blue
+                    9 [label="Enter when branch condition else"];
+                    10 [label="Exit when branch condition"];
+                }
+                11 [label="Enter when branch result"];
+                subgraph cluster_6 {
+                    color=blue
+                    12 [label="Enter block"];
+                    13 [label="Access variable R|<local>/a|"];
+                    14 [label="Access variable R|/A.second|"];
+                    15 [label=< <TABLE BORDER="0"><TR><TD>Variable declaration: lvar y: R|B|</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Before:<BR/>a unique global<BR/>    first unique global<BR/>    second unique global<BR/><BR/>After:<BR/>a unique global<BR/>    first unique global<BR/>    second moved<BR/>y unique global<BR/></TD></TR></TABLE> >];
+                    16 [label="Exit block"];
+                }
+                17 [label="Exit when branch result"];
+                18 [label="Enter when branch result"];
+                subgraph cluster_7 {
+                    color=blue
+                    19 [label="Enter block"];
+                    20 [label="Access variable R|<local>/a|"];
+                    21 [label="Access variable R|/A.first|"];
+                    22 [label=< <TABLE BORDER="0"><TR><TD>Variable declaration: lvar x: R|B|</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Before:<BR/>a unique global<BR/>    first unique global<BR/>    second unique global<BR/><BR/>After:<BR/>x shared global<BR/>a unique global<BR/>    first moved<BR/></TD></TR></TABLE> >];
+                    23 [label="Exit block"];
+                }
+                24 [label="Exit when branch result"];
+                25 [label=< <TABLE BORDER="0"><TR><TD>Exit when</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Merge:<BR/>x shared global<BR/>a unique global<BR/>    first moved<BR/>    second moved<BR/>y unique global<BR/></TD></TR></TABLE> >];
+            }
+            26 [label="Access variable R|<local>/a|"];
+            27 [label="Jump: ^test R|<local>/a|"];
+            28 [label="Stub" style="filled" fillcolor=gray];
+            29 [label="Exit block" style="filled" fillcolor=gray];
+        }
+        30 [label=< <TABLE BORDER="0"><TR><TD>Exit function test</TD></TR><TR><TD ALIGN="LEFT" BALIGN="LEFT">Final:<BR/>x shared global<BR/>a unique global<BR/>    first moved<BR/>    second moved<BR/>y unique global<BR/></TD></TR></TABLE> > style="filled" fillcolor=red];
+    }
+    0 -> {1};
+    1 -> {2};
+    2 -> {3};
+    3 -> {4};
+    4 -> {5};
+    5 -> {6};
+    6 -> {7};
+    7 -> {8};
+    8 -> {9 18};
+    9 -> {10};
+    10 -> {11};
+    11 -> {12};
+    12 -> {13};
+    13 -> {14};
+    14 -> {15};
+    15 -> {16};
+    16 -> {17};
+    17 -> {25};
+    18 -> {19};
+    19 -> {20};
+    20 -> {21};
+    21 -> {22};
+    22 -> {23};
+    23 -> {24};
+    24 -> {25};
+    25 -> {26};
+    26 -> {27};
+    27 -> {30};
+    27 -> {28} [style=dotted];
+    28 -> {29} [style=dotted];
+    29 -> {30} [style=dotted];
+
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/dump_cfg.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/dump_cfg.kt
@@ -1,0 +1,29 @@
+// UNIQUE_CHECK_ONLY
+// DUMP_UNIQUENESS_CFG
+
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class A(
+    @Unique var first: B,
+    @Unique var second: B,
+)
+
+
+class B()
+
+fun <!UNIQUENESS_CFG!>nonDet<!>() : Boolean {
+    return true
+}
+
+fun <!UNIQUENESS_CFG!>test<!>(@Unique a: A) : A{
+
+    if (nonDet()) {
+        var x = a.first
+    } else {
+        @Unique var y = a.second
+    }
+
+    return a
+
+}

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessTrie.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessTrie.kt
@@ -127,6 +127,9 @@ class UniquenessTrie(
     }
 
     private fun toString(prefix: String): String {
+        if (children.isEmpty()) {
+            return "$prefix : $type\n"
+        }
         val builder = StringBuilder()
         val prefix = "$prefix : $type"
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessTrie.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessTrie.kt
@@ -6,6 +6,9 @@
 package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirLocalPropertySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularPropertySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 
 /**
  * Stores unique context for each path in a trie structure.
@@ -156,5 +159,27 @@ class UniquenessTrie(
         result = 31 * result + children.hashCode()
 
         return result
+    }
+
+
+    fun render(): String? {
+
+        fun FirBasedSymbol<*>.render(): String = when (this) {
+            is FirValueParameterSymbol,
+            is FirRegularPropertySymbol,
+            is FirLocalPropertySymbol -> name.asString()
+
+            else -> toString()
+        }
+
+        if (children.isNotEmpty()) {
+            return children.flatMap { (child, data) ->
+                val first = "${child.render()} ${data.type}"
+                val second = data.render()?.prependIndent("    ")
+                listOfNotNull(first, second)
+            }.joinToString("\n")
+
+        }
+        return null
     }
 }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/utils/CFGRenderer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/utils/CFGRenderer.kt
@@ -44,7 +44,6 @@ fun render(node: CFGNode<*>, facts: FlowFacts<UniquenessTrie>): String {
     }
 }
 
-@Suppress("unused") // Can be used from the debugger
 fun ControlFlowGraph.render(facts: FlowFacts<UniquenessTrie>): String {
     val options = ControlFlowGraphRenderOptions(
         data = { data: CFGNode<*> -> render(data, facts) },

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/utils/CFGRenderer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/utils/CFGRenderer.kt
@@ -1,23 +1,47 @@
 package org.jetbrains.kotlin.formver.uniqueness.utils
 
-import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
-import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraph
-import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraphRenderOptions
-import org.jetbrains.kotlin.fir.resolve.dfa.cfg.renderTo
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.*
 import org.jetbrains.kotlin.formver.uniqueness.FlowFacts
 import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 
 
+/**
+ * This method creates the uniqueness-related content for each CFG Node. To not overload the graph with data, not everything is displayed.
+ * In these cases some flow information is added:
+ * - The flow changed when executing the node: In and Out flow are displayed
+ * - On the border of the function the flow is displayed
+ * - On nodes that join multiple flows the flow is displayed
+ */
 fun render(node: CFGNode<*>, facts: FlowFacts<UniquenessTrie>): String {
     val flowBefore = facts.flowBefore(node)
     val flowAfter = facts.flowAfter(node)
-    val builder = StringBuilder()
-
-    builder.appendLine("Before:")
-    builder.appendLine(flowBefore.render())
-    builder.appendLine("After:")
-    builder.appendLine(flowAfter.render())
-    return builder.toString()
+    return buildString {
+        when {
+            // flows differ
+            flowBefore != flowAfter -> {
+                appendLine("Before:")
+                appendLine(flowBefore.render())
+                appendLine()
+                appendLine("After:")
+                appendLine(flowAfter.render())
+            }
+            // function boundary start
+            node is FunctionEnterNode -> {
+                appendLine("Initial:")
+                appendLine(flowBefore.render())
+            }
+            // function boundary end
+            node is FunctionExitNode -> {
+                appendLine("Final:")
+                appendLine(flowAfter.render())
+            }
+            // joining node
+            node.previousNodes.count() > 1 -> {
+                appendLine("Merge:")
+                appendLine(flowAfter.render())
+            }
+        }
+    }
 }
 
 @Suppress("unused") // Can be used from the debugger

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/utils/CFGRenderer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/utils/CFGRenderer.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.kotlin.formver.uniqueness.utils
+
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraph
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraphRenderOptions
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.renderTo
+import org.jetbrains.kotlin.formver.uniqueness.FlowFacts
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
+
+
+fun render(node: CFGNode<*>, facts: FlowFacts<UniquenessTrie>): String {
+    val flowBefore = facts.flowBefore(node)
+    val flowAfter = facts.flowAfter(node)
+    val builder = StringBuilder()
+
+    builder.appendLine("Before:")
+    builder.appendLine(flowBefore.render())
+    builder.appendLine("After:")
+    builder.appendLine(flowAfter.render())
+    return builder.toString()
+}
+
+@Suppress("unused") // Can be used from the debugger
+fun ControlFlowGraph.render(facts: FlowFacts<UniquenessTrie>): String {
+    val options = ControlFlowGraphRenderOptions(
+        data = { data: CFGNode<*> -> render(data, facts) },
+    )
+    return buildString {
+        renderTo(this, options)
+    }
+}


### PR DESCRIPTION
This pull request enhances the rendering and debugging utilities for uniqueness analysis within the Kotlin Formver compiler plugin. These improvements are designed to make the internal state of the analysis more transparent and easier to verify during development.

## Key Changes
- CFG Rendering: Introduced a new utility to render Control Flow Graphs (CFG) alongside their associated uniqueness facts.
- Trie Visualization: Enhanced the UniquenessTrie class with a custom render method to improve symbol display and structural clarity.

## How to Use
### From the Compiler
To visualize the analysis state, use a debugger to set a breakpoint at a location where both the CFG and flow facts are in scope.

Execute the following command in the evaluator:
`graph.render(facts)`

This will output a Graphviz (DOT) string that can be rendered into a visual diagram.

### From Testing
Annotated the file you want to dump with `// DUMP_UNIQUENESS_CFG`
The graph is added to the corresponding `.diag` file.

## Technical Notes
Type Representation: The types displayed correspond to the nodes within the Trie. Note that "in-head" joining may be required to resolve the actual resulting type at a specific point.

Delta-based Display: To reduce visual noise, types are only displayed if there is a difference between `flowBefore` and `flowAfter`.

Function Boundaries: For clarity, types are always displayed at function boundaries, regardless of whether the flow facts have changed.
## Example
```kotlin
class A {
    @Unique var x = Object()
    @Unique var w = Object()
}

class B {
    @Unique var y = A()
}

fun test(@Unique b1: B, @Unique b2: B) {
    if (b1.y == b2.y) {
        @Unique var b1tmp = b1.y
        b2.y = b1.y
        b1.y = b1tmp
    } else {
        @Unique var stored = b1.y.w
        borrow(b1.y.x)
        b1.y.w = stored
    }
}



fun borrow(@Borrowed a: Object) {}
```
![graphviz (1)](https://github.com/user-attachments/assets/6fe49828-a174-4639-a539-2977f6471ef0)



