### PR TITLE
Support casts in uniqueness checker

### DIFF
--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.fir.diag.txt
@@ -11,3 +11,5 @@
 /consume_local.kt:(996,997): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
 
 /consume_local.kt:(1122,1123): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
+
+/consume_local.kt:(1321,1322): error: Argument uniqueness mismatch: expected 'unique global', actual 'moved'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.fir.diag.txt
@@ -8,8 +8,8 @@
 
 /consume_local.kt:(705,706): error: Argument uniqueness mismatch: expected 'unique global', actual 'shared local'.
 
-/consume_local.kt:(996,997): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
+/consume_local.kt:(995,996): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
 
-/consume_local.kt:(1122,1123): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
+/consume_local.kt:(1121,1122): error: Argument uniqueness mismatch: expected 'unique global', actual 'unique local'.
 
-/consume_local.kt:(1321,1322): error: Argument uniqueness mismatch: expected 'unique global', actual 'moved'.
+/consume_local.kt:(1320,1321): error: Argument uniqueness mismatch: expected 'unique global', actual 'moved'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.kt
@@ -65,3 +65,8 @@ fun `consume unique after storing type check`(@Unique a: Any) {
     val ok = a is A
     consume(a)
 }
+
+fun `consume unique after safe cast`(@Unique a: Any) {
+    val maybe = a as? A
+    consume(<!UNIQUENESS_VIOLATION!>a<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.kt
@@ -60,3 +60,8 @@ fun `consume after after borrowing unique-borrowed as unique`(@Unique @Borrowed 
     borrowUnique(a)
     consume(<!UNIQUENESS_VIOLATION!>a<!>)
 }
+
+fun `consume unique after storing type check`(@Unique a: Any) {
+    val ok = a is A
+    consume(a)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_local.kt
@@ -51,7 +51,7 @@ fun `consume after borrowing unique as unique`(@Unique a: A) {
     consume(a)
 }
 
-fun `consume after borrowing unique-borrowed `(@Unique @Borrowed a: A) {
+fun `consume after borrowing unique-borrowed`(@Unique @Borrowed a: A) {
     borrow(a)
     consume(<!UNIQUENESS_VIOLATION!>a<!>)
 }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.fir.diag.txt
@@ -8,4 +8,8 @@
 
 /consume_property.kt:(915,916): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.
 
-/consume_property.kt:(1342,1349): error: Argument uniqueness mismatch: expected 'unique global', actual 'shared global'.
+/consume_property.kt:(1295,1299): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
+
+/consume_property.kt:(1431,1435): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
+
+/consume_property.kt:(1586,1590): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.fir.diag.txt
@@ -7,3 +7,5 @@
 /consume_property.kt:(835,836): error: Argument uniqueness mismatch: partial type 'moved' is inconsistent with parent type 'unique global'.
 
 /consume_property.kt:(915,916): error: Argument uniqueness mismatch: partial type 'shared global' is inconsistent with parent type 'unique global'.
+
+/consume_property.kt:(1342,1349): error: Argument uniqueness mismatch: expected 'unique global', actual 'shared global'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.kt
@@ -73,3 +73,10 @@ fun `consume unique parent after cast to not-null`(@Unique node: Node) {
     @Unique val local = node.next as Node
     consume(<!UNIQUENESS_VIOLATION!>node<!>)
 }
+
+fun `consume unique parent after smart-cast`(@Unique node: Node?) {
+    if (node != null) {
+        @Unique val local = node.next
+        consume(<!UNIQUENESS_VIOLATION!>node<!>)
+    }
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/consume_property.kt
@@ -57,3 +57,19 @@ fun `consume unique parent after assigning subproperty to unique`(@Unique x: B, 
     x.y = y
     consume(x.y)
 }
+
+// Consuming subproperty after smart-cast
+
+class Node(
+    @Unique val next : Node?
+)
+
+fun `consume unique parent after cast`(@Unique node: Any) {
+    @Unique val local = (node as Node).next
+    consume(<!UNIQUENESS_VIOLATION!>node<!>)
+}
+
+fun `consume unique parent after cast to not-null`(@Unique node: Node) {
+    @Unique val local = node.next as Node
+    consume(<!UNIQUENESS_VIOLATION!>node<!>)
+}

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/FunctionCallResolver.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/FunctionCallResolver.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.kotlin.formver.uniqueness
+
+import org.jetbrains.kotlin.fir.declarations.FirFunction
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+
+@OptIn(SymbolInternals::class)
+internal fun FirFunctionCall.resolveFunction(): FirFunction? {
+    val callableSymbol = toResolvedCallableSymbol()
+        ?: error("Unresolved callable symbol for function call: $this")
+
+    return callableSymbol.fir as? FirFunction
+        ?: error("Expected function callee for $this, got ${callableSymbol::class.simpleName}")
+}

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.expressions.FirCheckNotNullCall
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirSmartCastExpression
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
@@ -88,6 +89,10 @@ object ValuePathCollector : FirVisitor<List<Path>, Unit>() {
 
     override fun visitSmartCastExpression(smartCastExpression: FirSmartCastExpression, data: Unit): List<Path> {
         return smartCastExpression.originalExpression.accept(this, data)
+    }
+
+    override fun visitCheckNotNullCall(checkNotNullCall: FirCheckNotNullCall, data: Unit): List<Path> {
+        return checkNotNullCall.argumentList.arguments.singleOrNull()?.accept(this, data) ?: emptyList()
     }
 }
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.expressions.FirCheckNotNullCall
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirSmartCastExpression
+import org.jetbrains.kotlin.fir.expressions.FirTypeOperatorCall
+import org.jetbrains.kotlin.fir.expressions.FirWrappedExpression
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
@@ -91,8 +93,8 @@ object ValuePathCollector : FirVisitor<List<Path>, Unit>() {
         return smartCastExpression.originalExpression.accept(this, data)
     }
 
-    override fun visitCheckNotNullCall(checkNotNullCall: FirCheckNotNullCall, data: Unit): List<Path> {
-        return checkNotNullCall.argumentList.arguments.singleOrNull()?.accept(this, data) ?: emptyList()
+    override fun visitTypeOperatorCall(typeOperatorCall: FirTypeOperatorCall, data: Unit): List<Path> {
+        return typeOperatorCall.argumentList.arguments.singleOrNull()?.accept(this, data) ?: emptyList()
     }
 }
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
@@ -53,6 +53,15 @@ object ReceiverPathExtractor : FirVisitor<Path?, Unit>() {
             return parent + callee
         }
     }
+
+    override fun visitSmartCastExpression(smartCastExpression: FirSmartCastExpression, data: Unit): Path? {
+        return smartCastExpression.originalExpression.accept(this, data)
+    }
+
+    override fun visitTypeOperatorCall(typeOperatorCall: FirTypeOperatorCall, data: Unit): Path? {
+        return typeOperatorCall.argumentList.arguments.singleOrNull()?.accept(this, data)
+    }
+
 }
 
 val FirElement.receiverPath

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
@@ -7,16 +7,18 @@ package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.FirProperty
-import org.jetbrains.kotlin.fir.expressions.FirCheckNotNullCall
+import org.jetbrains.kotlin.fir.expressions.FirOperation
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirSmartCastExpression
 import org.jetbrains.kotlin.fir.expressions.FirTypeOperatorCall
-import org.jetbrains.kotlin.fir.expressions.FirWrappedExpression
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 
 typealias Path = List<FirBasedSymbol<*>>
+
+private fun FirTypeOperatorCall.isCast(): Boolean =
+    operation == FirOperation.AS || operation == FirOperation.SAFE_AS
 
 /**
  * A visitor for extracting an atomic receiving path from a [org.jetbrains.kotlin.fir.expressions.FirExpression].
@@ -59,6 +61,8 @@ object ReceiverPathExtractor : FirVisitor<Path?, Unit>() {
     }
 
     override fun visitTypeOperatorCall(typeOperatorCall: FirTypeOperatorCall, data: Unit): Path? {
+        if (!typeOperatorCall.isCast()) return null
+
         return typeOperatorCall.argumentList.arguments.singleOrNull()?.accept(this, data)
     }
 
@@ -103,6 +107,8 @@ object ValuePathCollector : FirVisitor<List<Path>, Unit>() {
     }
 
     override fun visitTypeOperatorCall(typeOperatorCall: FirTypeOperatorCall, data: Unit): List<Path> {
+        if (!typeOperatorCall.isCast()) return emptyList()
+
         return typeOperatorCall.argumentList.arguments.singleOrNull()?.accept(this, data) ?: emptyList()
     }
 }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/Path.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.uniqueness
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
+import org.jetbrains.kotlin.fir.expressions.FirSmartCastExpression
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
@@ -83,6 +84,10 @@ object ValuePathCollector : FirVisitor<List<Path>, Unit>() {
         } else {
             return emptyList()
         }
+    }
+
+    override fun visitSmartCastExpression(smartCastExpression: FirSmartCastExpression, data: Unit): List<Path> {
+        return smartCastExpression.originalExpression.accept(this, data)
     }
 }
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.expressions.arguments
 import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
@@ -67,7 +68,7 @@ class UniquenessTypeAssigner(
     override fun visitFunctionCallEnterNode(node: FunctionCallEnterNode, data: UniquenessTrie): UniquenessTrie {
         val functionCall = node.fir
         val callableSymbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
-            ?: throw IllegalStateException("Unable to resolve ${functionCall}")
+            ?: return data
         val callableDeclaration = callableSymbol.fir
         val result = data.copy()
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
@@ -6,16 +6,12 @@
 package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirElement
-import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.expressions.arguments
-import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraphVisitor
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.FunctionCallEnterNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.VariableAssignmentNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.VariableDeclarationNode
-import org.jetbrains.kotlin.fir.symbols.SymbolInternals
-import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 
 /**
  * Visitor assigning uniqueness types to paths after the execution of a [CFGNode].
@@ -64,18 +60,15 @@ class UniquenessTypeAssigner(
         return evaluateDefinition(receiver, value, data)
     }
 
-    @OptIn(SymbolInternals::class)
     override fun visitFunctionCallEnterNode(node: FunctionCallEnterNode, data: UniquenessTrie): UniquenessTrie {
         val functionCall = node.fir
-        val callableSymbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
-            ?: return data
-        val callableDeclaration = callableSymbol.fir
+        val function = functionCall.resolveFunction() ?: return data
         val result = data.copy()
 
         // TODO: If possible, it would be good to compute the outflow for the argument before reaching the
         //  [FunctionCallEnterNode]. This would allow us to provide more precise flow information to the checker.
         //  {@see UniquenessGraphChecker.visitFunctionCallEnterNode}
-        for ((argument, parameter) in functionCall.arguments.zip(callableDeclaration.valueParameters)) {
+        for ((argument, parameter) in functionCall.arguments.zip(function.valueParameters)) {
             for (argumentPath in argument.valuePaths) {
                 val parameterType = resolver.resolveUniquenessType(parameter.symbol)
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphAnalyzer.kt
@@ -111,7 +111,6 @@ class UniquenessGraphAnalyzer(
         return result
     }
 
-    @OptIn(SymbolInternals::class)
     override fun transfer(node: CFGNode<*>, inFlow: UniquenessTrie): UniquenessTrie =
         node.accept(typeAssigner, inFlow)
 }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
@@ -7,11 +7,9 @@ package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
 import org.jetbrains.kotlin.fir.expressions.arguments
-import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraph
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraphVisitor
@@ -20,8 +18,6 @@ import org.jetbrains.kotlin.fir.resolve.dfa.cfg.JumpNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ThrowExceptionNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.VariableAssignmentNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.VariableDeclarationNode
-import org.jetbrains.kotlin.fir.symbols.SymbolInternals
-import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.formver.common.ErrorCollector
 
 /**
@@ -129,15 +125,12 @@ class UniquenessTypeChecker(
         }
     }
 
-    @OptIn(SymbolInternals::class)
     override fun visitFunctionCallEnterNode(node: FunctionCallEnterNode, data: UniquenessTrie) {
         val functionCall = node.fir
-        val callableSymbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
-            ?: return
-        val callableDeclaration = callableSymbol.fir
+        val function = functionCall.resolveFunction() ?: return
         var currentData = data
 
-        for ((argument, parameter) in functionCall.arguments.zip(callableDeclaration.valueParameters)) {
+        for ((argument, parameter) in functionCall.arguments.zip(function.valueParameters)) {
             val argumentPaths = argument.valuePaths
 
             for (argumentPath in argumentPaths) {

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
@@ -113,7 +113,7 @@ class UniquenessTypeChecker(
             if (valueActualType is UniquenessType.Active &&
                 valueActualType.uniqueLevel == UniqueLevel.Unique &&
                 !valueData.isInvariant()) {
-                val valuePartialType = data.childrenJoin
+                val valuePartialType = valueData.childrenJoin
 
                 when (valuePartialType) {
                     is UniquenessType.Moved ->

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessGraphChecker.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.uniqueness
 
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
 import org.jetbrains.kotlin.fir.expressions.arguments
@@ -132,7 +133,7 @@ class UniquenessTypeChecker(
     override fun visitFunctionCallEnterNode(node: FunctionCallEnterNode, data: UniquenessTrie) {
         val functionCall = node.fir
         val callableSymbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
-            ?: throw IllegalStateException("Unable to resolve ${functionCall}")
+            ?: return
         val callableDeclaration = callableSymbol.fir
         var currentData = data
 


### PR DESCRIPTION
This PR adds support for extracting paths from cast and smartcast expressions.
In addition to this, it also adds the following fixes:
- Refactor the logic for resolving function declarations from `UniquenessGraphAnalyzer` and `UniquenessGraphChecker`.
- Fixes a bug where the whole flow UniquenessTrie was checked for invariance as opposed to just the subtree of the leaked variable.