### PR TITLE
Deduplicate body conversion setup in ProgramConverter

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -105,22 +105,7 @@ class ProgramConverter(
         if (declaration.symbol.isPure(session)) {
             embedPureUserFunction(declaration.symbol, signature)
         } else {
-            val returnTarget = returnTargetProducer.getFresh(signature.callableType.returnType)
-            val paramResolver =
-                RootParameterResolver(
-                    this@ProgramConverter,
-                    signature,
-                    signature.symbol.valueParameterSymbols,
-                    signature.labelName,
-                    returnTarget,
-                )
-            val stmtCtx =
-                MethodConverter(
-                    this@ProgramConverter,
-                    signature,
-                    paramResolver,
-                    scopeIndexProducer.getFresh(),
-                ).statementCtxt()
+            val (returnTarget, stmtCtx) = createBodyConversionContext(signature)
             embedUserFunction(declaration.symbol, signature).apply {
                 body = stmtCtx.convertMethodWithBody(declaration, signature, returnTarget)
             }
@@ -139,23 +124,28 @@ class ProgramConverter(
         functions[signature.name] = new
         val declaration = symbol.fir as? FirSimpleFunction
         if (declaration?.body != null) {
-            val returnTarget = returnTargetProducer.getFresh(signature.callableType.returnType)
-            val paramResolver = RootParameterResolver(
-                this@ProgramConverter,
-                signature,
-                signature.symbol.valueParameterSymbols,
-                signature.labelName,
-                returnTarget,
-            )
-            val stmtCtx = MethodConverter(
-                this@ProgramConverter,
-                signature,
-                paramResolver,
-                scopeIndexProducer.getFresh(),
-            ).statementCtxt()
+            val (_, stmtCtx) = createBodyConversionContext(signature)
             new.body = stmtCtx.convertFunctionWithBody(declaration)
         }
         return new
+    }
+
+    private fun createBodyConversionContext(signature: FullNamedFunctionSignature): Pair<ReturnTarget, StmtConversionContext> {
+        val returnTarget = returnTargetProducer.getFresh(signature.callableType.returnType)
+        val paramResolver = RootParameterResolver(
+            this@ProgramConverter,
+            signature,
+            signature.symbol.valueParameterSymbols,
+            signature.labelName,
+            returnTarget,
+        )
+        val stmtCtx = MethodConverter(
+            this@ProgramConverter,
+            signature,
+            paramResolver,
+            scopeIndexProducer.getFresh(),
+        ).statementCtxt()
+        return Pair(returnTarget, stmtCtx)
     }
 
     fun embedUserFunction(symbol: FirFunctionSymbol<*>, signature: FullNamedFunctionSignature): UserFunctionEmbedding {


### PR DESCRIPTION
## Summary
- Extracts `createBodyConversionContext` helper to eliminate duplicated creation of `ReturnTarget`, `RootParameterResolver`, and `StmtConversionContext` between `registerForVerification` (non-pure branch) and `embedPureUserFunction`.
- Net reduction of ~10 lines; both call sites now delegate to the shared helper.

## Test plan
- [x] `./gradlew :formver.compiler-plugin:compileKotlin` passes
- [x] `./gradlew :formver.compiler-plugin:test --tests "*Pure*"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)