### PR TITLE
Propagate access dependencies for ternary expressions in pure functions

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -72,14 +72,16 @@ class SsaConverter(
     ) {
         val ssaName = head.updateLatestName(name)
         varExp.propagateAccessInvariants(ssaName)
+        val propagatedInvariants = accessInvariants[ssaName]
         if (newVarAccessInvariants.isNotEmpty()) {
-            val propagatedInvariants = accessInvariants[ssaName]
             if (propagatedInvariants == null || propagatedInvariants.isEmpty()) {
                 accessInvariants[ssaName] = mapOf(Exp.BoolLit(true) to newVarAccessInvariants)
             } else {
                 val withNewInvariants = propagatedInvariants.mapValues { (_, value) -> value + newVarAccessInvariants }
                 accessInvariants[ssaName] = withNewInvariants
             }
+        } else if (propagatedInvariants == null || propagatedInvariants.isEmpty()) {
+            accessInvariants[ssaName] = mapOf(Exp.BoolLit(true) to emptyList())
         }
         addGuardedAssignment(ssaName, varExp.withAccessInvariants(ssaName))
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.formver.core.names.SsaVariableName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toConjunction
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
 class SsaConverter(
@@ -15,7 +16,7 @@ class SsaConverter(
     private var head: SsaBlockNode = SsaBlockNode(SsaStartNode(), Exp.BoolLit(true))
     private val ssaAssignments: MutableList<Pair<SsaVariableName, Exp>> = mutableListOf()
     private val returnExpressions: MutableList<Pair<Exp, Exp>> = mutableListOf()
-    private val accessInvariants: MutableMap<SsaVariableName, List<Exp.PredicateAccess>> = mutableMapOf()
+    private val accessInvariants: MutableMap<SsaVariableName, Map<Exp, List<Exp.PredicateAccess>>> = mutableMapOf()
 
     // Produce new ssa names for a source variable name
     private val ssaNameProducers: MutableMap<SymbolicName, FreshEntityProducer<SsaVariableName, SymbolicName>> =
@@ -70,8 +71,16 @@ class SsaConverter(
         newVarAccessInvariants: List<Exp.PredicateAccess> = emptyList()
     ) {
         val ssaName = head.updateLatestName(name)
-        accessInvariants[ssaName] = newVarAccessInvariants
         varExp.propagateAccessInvariants(ssaName)
+        if (newVarAccessInvariants.isNotEmpty()) {
+            val propagatedInvariants = accessInvariants[ssaName]
+            if (propagatedInvariants == null || propagatedInvariants.isEmpty()) {
+                accessInvariants[ssaName] = mapOf(Exp.BoolLit(true) to newVarAccessInvariants)
+            } else {
+                val withNewInvariants = propagatedInvariants.mapValues { (_, value) -> value + newVarAccessInvariants }
+                accessInvariants[ssaName] = withNewInvariants
+            }
+        }
         addGuardedAssignment(ssaName, varExp.withAccessInvariants(ssaName))
     }
 
@@ -113,35 +122,87 @@ class SsaConverter(
 
     private fun Exp.withAccessInvariants(name: SsaVariableName): Exp =
         when (this) {
-            is Exp.FieldAccess, is Exp.FuncApp, is Exp.DomainFuncApp -> accessInvariants[name]?.foldRight(this) { invariant, acc ->
-                Exp.Unfolding(invariant, acc)
-            } ?: this
+            is Exp.FieldAccess, is Exp.FuncApp, is Exp.DomainFuncApp -> {
+                val accesses = accessInvariants[name]
+                when {
+                    accesses == null || accesses.isEmpty() -> this
+                    accesses.size == 1 -> {
+                        val toUnfold = accesses.values.first()
+                        if (toUnfold.isEmpty()) {
+                            this
+                        } else {
+                            toUnfold.foldRight(this) { access, acc ->
+                                Exp.Unfolding(access, acc)
+                            }
+                        }
+                    }
+
+                    else -> {
+                        val asExpressions = accesses.mapValues { (_, predicates) ->
+                            predicates.foldRight<Exp.PredicateAccess, Exp>(this) { access, acc ->
+                                Exp.Unfolding(access, acc)
+                            }
+                        }
+                        val defaultExpression = this.type.defaultExpression() ?: throw SnaktInternalException(
+                            source,
+                            "Tried to assign a variable without a default expression"
+                        )
+                        asExpressions.entries.fold(defaultExpression) { acc, entry ->
+                            Exp.TernaryExp(entry.key, entry.value, acc)
+                        }
+                    }
+                }
+            }
 
             else -> this
         }
 
-    private fun mergeAccessInvariants(from: List<SymbolicName>, newName: SsaVariableName) {
-        val mergedInvariants = from.mapNotNull { accessInvariants[it] }.flatten() + accessInvariants[newName].orEmpty()
-        accessInvariants[newName] = mergedInvariants.distinct()
+    private fun mergeAccessInvariants(from: SymbolicName, newName: SsaVariableName) {
+        val fromInvariants = accessInvariants[from] ?: emptyMap()
+        val toInvariants = accessInvariants[newName] ?: emptyMap()
+        accessInvariants[newName] = fromInvariants.mergeWith(toInvariants)
+    }
+
+    private fun Map<Exp, List<Exp.PredicateAccess>>.mergeWith(
+        other: Map<Exp, List<Exp.PredicateAccess>>
+    ): Map<Exp, List<Exp.PredicateAccess>> {
+        return (this.keys + other.keys).associateWith { key ->
+            ((this[key] ?: emptyList()) + (other[key] ?: emptyList())).distinct()
+        }
     }
 
     private fun Exp.propagateAccessInvariants(to: SsaVariableName) {
-        var from: Exp? = null
-        when (this) {
-            is Exp.LocalVar -> from = this
-            is Exp.FieldAccess -> from = this.rcv
-            is Exp.FuncApp -> this.args.forEach { it.propagateAccessInvariants(to) }
+        val sourceExp = when (this) {
+            is Exp.LocalVar -> this
+            is Exp.FieldAccess -> this.rcv
+            is Exp.FuncApp -> {
+                this.args.forEach { it.propagateAccessInvariants(to) }
+                return
+            }
+
             is Exp.DomainFuncApp -> {
                 this.args.forEach { it.propagateAccessInvariants(to) }
+                return
             }
-            // TODO: Determine how to handle the access invariants of a Ternary
-            else -> {}
+
+            is Exp.TernaryExp -> {
+                val leftInvariants = accessInvariants[(this.thenExp as? Exp.LocalVar)?.name] ?: emptyMap()
+                val rightInvariants = accessInvariants[(this.elseExp as? Exp.LocalVar)?.name] ?: emptyMap()
+                val leftAmended = leftInvariants.mapKeys { (condition, _) ->
+                    listOf(condition, this.condExp).toConjunction()
+                }
+                val rightAmended = rightInvariants.mapKeys { (condition, _) ->
+                    listOf(condition, Exp.Not(this.condExp)).toConjunction()
+                }
+                accessInvariants[to] = leftAmended.mergeWith(rightAmended)
+                return
+            }
+
+            else -> return
         }
-        if (from == null) return
-        if (from !is Exp.LocalVar) throw SnaktInternalException(
-            source,
-            "Access sources must be local variables $from"
-        )
-        mergeAccessInvariants(listOf(from.name), to)
+        if (sourceExp !is Exp.LocalVar) {
+            throw SnaktInternalException(source, "Access sources must be local variables $sourceExp")
+        }
+        mergeAccessInvariants(sourceExp.name, to)
     }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -16,6 +16,8 @@ class SsaConverter(
     private var head: SsaBlockNode = SsaBlockNode(SsaStartNode(), Exp.BoolLit(true))
     private val ssaAssignments: MutableList<Pair<SsaVariableName, Exp>> = mutableListOf()
     private val returnExpressions: MutableList<Pair<Exp, Exp>> = mutableListOf()
+
+    // An entry in this map means that to accessing the let-bound variable SSAVariableName under condition Exp requires predicates in the List<Exp.PredicateAccess> unfolded
     private val accessInvariants: MutableMap<SsaVariableName, Map<Exp, List<Exp.PredicateAccess>>> = mutableMapOf()
 
     // Produce new ssa names for a source variable name
@@ -73,15 +75,11 @@ class SsaConverter(
         val ssaName = head.updateLatestName(name)
         varExp.propagateAccessInvariants(ssaName)
         val propagatedInvariants = accessInvariants[ssaName]
-        if (newVarAccessInvariants.isNotEmpty()) {
-            if (propagatedInvariants == null || propagatedInvariants.isEmpty()) {
-                accessInvariants[ssaName] = mapOf(Exp.BoolLit(true) to newVarAccessInvariants)
-            } else {
-                val withNewInvariants = propagatedInvariants.mapValues { (_, value) -> value + newVarAccessInvariants }
-                accessInvariants[ssaName] = withNewInvariants
-            }
-        } else if (propagatedInvariants == null || propagatedInvariants.isEmpty()) {
-            accessInvariants[ssaName] = mapOf(Exp.BoolLit(true) to emptyList())
+        if (propagatedInvariants == null || propagatedInvariants.isEmpty()) {
+            accessInvariants[ssaName] = mapOf(Exp.BoolLit(true) to newVarAccessInvariants)
+        } else if (newVarAccessInvariants.isNotEmpty()) {
+            val withNewInvariants = propagatedInvariants.mapValues { (_, value) -> value + newVarAccessInvariants }
+            accessInvariants[ssaName] = withNewInvariants
         }
         addGuardedAssignment(ssaName, varExp.withAccessInvariants(ssaName))
     }
@@ -130,32 +128,20 @@ class SsaConverter(
                     accesses == null || accesses.isEmpty() -> this
                     accesses.size == 1 -> {
                         val toUnfold = accesses.values.first()
-                        if (toUnfold.isEmpty()) {
-                            this
-                        } else {
-                            toUnfold.foldRight(this) { access, acc ->
-                                Exp.Unfolding(access, acc)
-                            }
-                        }
+                        toUnfold.asUnfoldingIn(this)
                     }
-
                     else -> {
-                        val asExpressions = accesses.mapValues { (_, predicates) ->
-                            predicates.foldRight<Exp.PredicateAccess, Exp>(this) { access, acc ->
-                                Exp.Unfolding(access, acc)
-                            }
-                        }
                         val defaultExpression = this.type.defaultExpression() ?: throw SnaktInternalException(
                             source,
                             "Tried to assign a variable without a default expression"
                         )
+                        val asExpressions = accesses.mapValues { (_, predicates) -> predicates.asUnfoldingIn(this) }
                         asExpressions.entries.fold(defaultExpression) { acc, entry ->
                             Exp.TernaryExp(entry.key, entry.value, acc)
                         }
                     }
                 }
             }
-
             else -> this
         }
 
@@ -181,12 +167,10 @@ class SsaConverter(
                 this.args.forEach { it.propagateAccessInvariants(to) }
                 return
             }
-
             is Exp.DomainFuncApp -> {
                 this.args.forEach { it.propagateAccessInvariants(to) }
                 return
             }
-
             is Exp.TernaryExp -> {
                 val leftInvariants = accessInvariants[(this.thenExp as? Exp.LocalVar)?.name] ?: emptyMap()
                 val rightInvariants = accessInvariants[(this.elseExp as? Exp.LocalVar)?.name] ?: emptyMap()
@@ -199,12 +183,14 @@ class SsaConverter(
                 accessInvariants[to] = leftAmended.mergeWith(rightAmended)
                 return
             }
-
             else -> return
         }
         if (sourceExp !is Exp.LocalVar) {
-            throw SnaktInternalException(source, "Access sources must be local variables $sourceExp")
+            throw SnaktInternalException(source, "Access sources must be local variables, but received $sourceExp")
         }
         mergeAccessInvariants(sourceExp.name, to)
     }
+
+    private fun List<Exp.PredicateAccess>.asUnfoldingIn(exp: Exp): Exp =
+        foldRight(exp) { access, acc -> Exp.Unfolding(access, acc) }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -18,7 +18,7 @@ class SsaConverter(
     private val returnExpressions: MutableList<Pair<Exp, Exp>> = mutableListOf()
 
     // An entry in this map means that to accessing the let-bound variable SSAVariableName under condition Exp requires predicates in the List<Exp.PredicateAccess> unfolded
-    private val accessInvariants: MutableMap<SsaVariableName, Map<Exp, List<Exp.PredicateAccess>>> = mutableMapOf()
+    private val accessDependencies: MutableMap<SsaVariableName, Map<Exp, List<Exp.PredicateAccess>>> = mutableMapOf()
 
     // Produce new ssa names for a source variable name
     private val ssaNameProducers: MutableMap<SymbolicName, FreshEntityProducer<SsaVariableName, SymbolicName>> =
@@ -70,18 +70,19 @@ class SsaConverter(
     fun addAssignment(
         name: SymbolicName,
         varExp: Exp,
-        newVarAccessInvariants: List<Exp.PredicateAccess> = emptyList()
+        newVarAccessDependencies: List<Exp.PredicateAccess> = emptyList()
     ) {
         val ssaName = head.updateLatestName(name)
-        varExp.propagateAccessInvariants(ssaName)
-        val propagatedInvariants = accessInvariants[ssaName]
-        if (propagatedInvariants == null || propagatedInvariants.isEmpty()) {
-            accessInvariants[ssaName] = mapOf(Exp.BoolLit(true) to newVarAccessInvariants)
-        } else if (newVarAccessInvariants.isNotEmpty()) {
-            val withNewInvariants = propagatedInvariants.mapValues { (_, value) -> value + newVarAccessInvariants }
-            accessInvariants[ssaName] = withNewInvariants
+        varExp.propagateAccessDependencies(ssaName)
+        val propagatedDependencies = accessDependencies[ssaName]
+        if (propagatedDependencies == null || propagatedDependencies.isEmpty()) {
+            accessDependencies[ssaName] = mapOf(Exp.BoolLit(true) to newVarAccessDependencies)
+        } else if (newVarAccessDependencies.isNotEmpty()) {
+            val withNewDependencies =
+                propagatedDependencies.mapValues { (_, value) -> value + newVarAccessDependencies }
+            accessDependencies[ssaName] = withNewDependencies
         }
-        addGuardedAssignment(ssaName, varExp.withAccessInvariants(ssaName))
+        addGuardedAssignment(ssaName, varExp.withAccessDependencies(ssaName))
     }
 
     fun addPhiAssignment(condition: Exp, left: SsaVariableName, right: SsaVariableName, name: SsaVariableName) {
@@ -96,8 +97,8 @@ class SsaConverter(
             Exp.LocalVar(left, Type.Ref),
             Exp.LocalVar(right, Type.Ref)
         )
-        phiExpression.propagateAccessInvariants(name)
-        addGuardedAssignment(name, phiExpression.withAccessInvariants(name))
+        phiExpression.propagateAccessDependencies(name)
+        addGuardedAssignment(name, phiExpression.withAccessDependencies(name))
     }
 
     fun addReturn(returnExp: Exp) {
@@ -120,16 +121,17 @@ class SsaConverter(
         }
     }
 
-    private fun Exp.withAccessInvariants(name: SsaVariableName): Exp =
+    private fun Exp.withAccessDependencies(name: SsaVariableName): Exp =
         when (this) {
             is Exp.FieldAccess, is Exp.FuncApp, is Exp.DomainFuncApp -> {
-                val accesses = accessInvariants[name]
+                val accesses = accessDependencies[name]
                 when {
                     accesses == null || accesses.isEmpty() -> this
                     accesses.size == 1 -> {
                         val toUnfold = accesses.values.first()
                         toUnfold.asUnfoldingIn(this)
                     }
+
                     else -> {
                         val defaultExpression = this.type.defaultExpression() ?: throw SnaktInternalException(
                             source,
@@ -142,13 +144,14 @@ class SsaConverter(
                     }
                 }
             }
+
             else -> this
         }
 
-    private fun mergeAccessInvariants(from: SymbolicName, newName: SsaVariableName) {
-        val fromInvariants = accessInvariants[from] ?: emptyMap()
-        val toInvariants = accessInvariants[newName] ?: emptyMap()
-        accessInvariants[newName] = fromInvariants.mergeWith(toInvariants)
+    private fun mergeAccessDependencies(from: SymbolicName, newName: SsaVariableName) {
+        val fromDependencies = accessDependencies[from] ?: emptyMap()
+        val toDependencies = accessDependencies[newName] ?: emptyMap()
+        accessDependencies[newName] = fromDependencies.mergeWith(toDependencies)
     }
 
     private fun Map<Exp, List<Exp.PredicateAccess>>.mergeWith(
@@ -159,36 +162,39 @@ class SsaConverter(
         }
     }
 
-    private fun Exp.propagateAccessInvariants(to: SsaVariableName) {
+    private fun Exp.propagateAccessDependencies(to: SsaVariableName) {
         val sourceExp = when (this) {
             is Exp.LocalVar -> this
             is Exp.FieldAccess -> this.rcv
             is Exp.FuncApp -> {
-                this.args.forEach { it.propagateAccessInvariants(to) }
+                this.args.forEach { it.propagateAccessDependencies(to) }
                 return
             }
+
             is Exp.DomainFuncApp -> {
-                this.args.forEach { it.propagateAccessInvariants(to) }
+                this.args.forEach { it.propagateAccessDependencies(to) }
                 return
             }
+
             is Exp.TernaryExp -> {
-                val leftInvariants = accessInvariants[(this.thenExp as? Exp.LocalVar)?.name] ?: emptyMap()
-                val rightInvariants = accessInvariants[(this.elseExp as? Exp.LocalVar)?.name] ?: emptyMap()
+                val leftInvariants = accessDependencies[(this.thenExp as? Exp.LocalVar)?.name] ?: emptyMap()
+                val rightInvariants = accessDependencies[(this.elseExp as? Exp.LocalVar)?.name] ?: emptyMap()
                 val leftAmended = leftInvariants.mapKeys { (condition, _) ->
                     listOf(condition, this.condExp).toConjunction()
                 }
                 val rightAmended = rightInvariants.mapKeys { (condition, _) ->
                     listOf(condition, Exp.Not(this.condExp)).toConjunction()
                 }
-                accessInvariants[to] = leftAmended.mergeWith(rightAmended)
+                accessDependencies[to] = leftAmended.mergeWith(rightAmended)
                 return
             }
+
             else -> return
         }
         if (sourceExp !is Exp.LocalVar) {
             throw SnaktInternalException(source, "Access sources must be local variables, but received $sourceExp")
         }
-        mergeAccessInvariants(sourceExp.name, to)
+        mergeAccessDependencies(sourceExp.name, to)
     }
 
     private fun List<Exp.PredicateAccess>.asUnfoldingIn(exp: Exp): Exp =

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
@@ -239,6 +239,12 @@ public class FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated ext
       }
 
       @Test
+      @TestMetadata("heap_dependent_specifications.kt")
+      public void testHeap_dependent_specifications() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt");
+      }
+
+      @Test
       @TestMetadata("pure_function_rely_on_branch.kt")
       public void testPure_function_rely_on_branch() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.kt");

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -60,8 +60,10 @@ function f$getSafeNextNextValue$TF$T$Node$T$Int(p$node: Ref): Ref
         ((anon$3$0 != df$rt$nullValue() ? anon$4$0 : df$rt$nullValue())) in
         (let anon$5$0 ==
           ((anon$2$0 != df$rt$nullValue() ?
-            (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
-              anon$2$0.bf$value) :
+            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+              (unfolding acc(p$c$Node$shared(anon$3$0), wildcard) in
+                (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
+                  anon$2$0.bf$value))) :
             null)) in
           (let anon$1$0 ==
             ((anon$2$0 != df$rt$nullValue() ? anon$5$0 : df$rt$nullValue())) in

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
@@ -64,14 +64,30 @@ function f$nestedBranching$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
                   null)) in
                 (let l0$result$7 ==
                   ((!df$rt$boolFromRef(p$a) ?
-                    sp$plusInts(df$rt$intToRef(6), l0$result$6) :
+                    (true && !df$rt$boolFromRef(p$b) ?
+                      sp$plusInts(df$rt$intToRef(6), l0$result$6) :
+                      (true && df$rt$boolFromRef(p$b) ?
+                        sp$plusInts(df$rt$intToRef(6), l0$result$6) :
+                        null)) :
                     null)) in
                   (let l0$result$8 ==
                     ((df$rt$boolFromRef(p$b) ? l0$result$2 : l0$result$3)) in
                     (let l0$result$9 ==
                       ((df$rt$boolFromRef(p$a) ? l0$result$8 : l0$result$7)) in
                       (let l0$result$10 ==
-                        (sp$plusInts(df$rt$intToRef(7), l0$result$9)) in
+                        ((true && !df$rt$boolFromRef(p$b) &&
+                        !df$rt$boolFromRef(p$a) ?
+                          sp$plusInts(df$rt$intToRef(7), l0$result$9) :
+                          (true && df$rt$boolFromRef(p$b) &&
+                          !df$rt$boolFromRef(p$a) ?
+                            sp$plusInts(df$rt$intToRef(7), l0$result$9) :
+                            (true && !df$rt$boolFromRef(p$b) &&
+                            df$rt$boolFromRef(p$a) ?
+                              sp$plusInts(df$rt$intToRef(7), l0$result$9) :
+                              (true && df$rt$boolFromRef(p$b) &&
+                              df$rt$boolFromRef(p$a) ?
+                                sp$plusInts(df$rt$intToRef(7), l0$result$9) :
+                                null))))) in
                         l0$result$10)))))))))))
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
@@ -120,7 +120,11 @@ function f$blockConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
           null)) in
         (let anon$0$0 ==
           ((df$rt$boolFromRef(p$a) ?
-            sp$plusInts(l2$y$0, df$rt$intToRef(1)) :
+            (true && !df$rt$boolFromRef(p$b) ?
+              sp$plusInts(l2$y$0, df$rt$intToRef(1)) :
+              (true && df$rt$boolFromRef(p$b) ?
+                sp$plusInts(l2$y$0, df$rt$intToRef(1)) :
+                null)) :
             null)) in
           (let anon$3$0 ==
             ((!df$rt$boolFromRef(p$a) ? df$rt$intToRef(30) : null)) in

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -184,3 +184,314 @@ function f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(p$node: Ref): Ref
                             anon$7$0)) in
                           sp$andBools(l0$leftValid$0, l0$rightValid$0)))))))))))))
 }
+
+/heap_dependent_specifications.kt:(1405,1413): info: Generated Viper text for testNode:
+field bf$next: Ref
+
+field bf$value: Ref
+
+function f$testNode$TF$T$Node$T$Node$T$Int(p$nodeLeft: Ref, p$nodeRight: Ref): Ref
+  requires acc(p$c$Node$shared(p$nodeLeft), wildcard)
+  requires acc(p$c$Node$shared(p$nodeRight), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(p$nodeLeft), df$rt$c$Node())
+  requires df$rt$isSubtype(df$rt$typeOf(p$nodeRight), df$rt$c$Node())
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
+{
+  (let l0$node$0 ==
+    (p$nodeLeft) in
+    (let anon$0$0 ==
+      ((unfolding acc(p$c$Node$shared(p$nodeLeft), wildcard) in
+        p$nodeLeft.bf$next)) in
+      (let anon$1$0 ==
+        ((!(anon$0$0 == df$rt$nullValue()) ?
+          (unfolding acc(p$c$Node$shared(p$nodeLeft), wildcard) in
+            p$nodeLeft.bf$next) :
+          null)) in
+        (let l0$node$1 ==
+          ((!(anon$0$0 == df$rt$nullValue()) ? anon$1$0 : null)) in
+          (let anon$2$0 ==
+            ((!!(anon$0$0 == df$rt$nullValue()) ?
+              (unfolding acc(p$c$Node$shared(p$nodeRight), wildcard) in
+                p$nodeRight.bf$next) :
+              null)) in
+            (let anon$3$0 ==
+              ((!(anon$2$0 == df$rt$nullValue()) &&
+              !!(anon$0$0 == df$rt$nullValue()) ?
+                (unfolding acc(p$c$Node$shared(p$nodeRight), wildcard) in
+                  p$nodeRight.bf$next) :
+                null)) in
+              (let l0$node$2 ==
+                ((!(anon$2$0 == df$rt$nullValue()) &&
+                !!(anon$0$0 == df$rt$nullValue()) ?
+                  anon$3$0 :
+                  null)) in
+                (let l0$node$3 ==
+                  ((!(anon$2$0 == df$rt$nullValue()) ?
+                    l0$node$2 :
+                    l0$node$0)) in
+                  (let l0$node$4 ==
+                    ((!(anon$0$0 == df$rt$nullValue()) ?
+                      l0$node$1 :
+                      l0$node$3)) in
+                    (let anon$4$0 ==
+                      ((true && !!(anon$2$0 == df$rt$nullValue()) &&
+                      !!(anon$0$0 == df$rt$nullValue()) ?
+                        (unfolding acc(p$c$Node$shared(l0$node$4), wildcard) in
+                          l0$node$4.bf$value) :
+                        (true && !(anon$2$0 == df$rt$nullValue()) &&
+                        !!(anon$0$0 == df$rt$nullValue()) ?
+                          (unfolding acc(p$c$Node$shared(p$nodeRight), wildcard) in
+                            (unfolding acc(p$c$Node$shared(l0$node$4), wildcard) in
+                              l0$node$4.bf$value)) :
+                          (true && !(anon$0$0 == df$rt$nullValue()) ?
+                            (unfolding acc(p$c$Node$shared(p$nodeLeft), wildcard) in
+                              (unfolding acc(p$c$Node$shared(l0$node$4), wildcard) in
+                                l0$node$4.bf$value)) :
+                            null)))) in
+                      anon$4$0))))))))))
+}
+
+/heap_dependent_specifications.kt:(1666,1688): info: Generated Viper text for testSequentialBranches:
+field bf$next: Ref
+
+field bf$value: Ref
+
+function f$testSequentialBranches$TF$T$Node$T$Node$T$Int(p$nodeA: Ref, p$nodeB: Ref): Ref
+  requires acc(p$c$Node$shared(p$nodeA), wildcard)
+  requires acc(p$c$Node$shared(p$nodeB), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(p$nodeA), df$rt$c$Node())
+  requires df$rt$isSubtype(df$rt$typeOf(p$nodeB), df$rt$c$Node())
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
+{
+  (let l0$node$0 ==
+    (p$nodeA) in
+    (let anon$0$0 ==
+      ((unfolding acc(p$c$Node$shared(p$nodeA), wildcard) in
+        p$nodeA.bf$value)) in
+      (let l0$node$1 ==
+        ((df$rt$intFromRef(anon$0$0) > 0 ? p$nodeB : null)) in
+        (let l0$node$2 ==
+          ((df$rt$intFromRef(anon$0$0) > 0 ? l0$node$1 : l0$node$0)) in
+          (let anon$1$0 ==
+            ((true && !(df$rt$intFromRef(anon$0$0) > 0) ?
+              (unfolding acc(p$c$Node$shared(l0$node$2), wildcard) in
+                l0$node$2.bf$next) :
+              (true && df$rt$intFromRef(anon$0$0) > 0 ?
+                (unfolding acc(p$c$Node$shared(l0$node$2), wildcard) in
+                  l0$node$2.bf$next) :
+                null))) in
+            (let l0$node$3 ==
+              ((!(anon$1$0 == df$rt$nullValue()) ?
+                (df$rt$intFromRef(anon$0$0) > 0 ? l0$node$1 : l0$node$0) :
+                null)) in
+              (let anon$2$0 ==
+                ((!(anon$1$0 == df$rt$nullValue()) ?
+                  (true && !(df$rt$intFromRef(anon$0$0) > 0) ?
+                    (unfolding acc(p$c$Node$shared(l0$node$3), wildcard) in
+                      l0$node$3.bf$next) :
+                    (true && df$rt$intFromRef(anon$0$0) > 0 ?
+                      (unfolding acc(p$c$Node$shared(l0$node$3), wildcard) in
+                        l0$node$3.bf$next) :
+                      null)) :
+                  null)) in
+                (let l0$node$4 ==
+                  ((!(anon$1$0 == df$rt$nullValue()) ? anon$2$0 : null)) in
+                  (let l0$node$5 ==
+                    ((df$rt$intFromRef(anon$0$0) > 0 ?
+                      l0$node$1 :
+                      l0$node$0)) in
+                    (let l0$node$6 ==
+                      ((!(anon$1$0 == df$rt$nullValue()) ?
+                        l0$node$4 :
+                        l0$node$5)) in
+                      (let anon$3$0 ==
+                        ((true && !(df$rt$intFromRef(anon$0$0) > 0) &&
+                        !!(anon$1$0 == df$rt$nullValue()) ?
+                          (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                            l0$node$6.bf$value) :
+                          (true && df$rt$intFromRef(anon$0$0) > 0 &&
+                          !!(anon$1$0 == df$rt$nullValue()) ?
+                            (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                              l0$node$6.bf$value) :
+                            (true && !(df$rt$intFromRef(anon$0$0) > 0) &&
+                            !(anon$1$0 == df$rt$nullValue()) ?
+                              (unfolding acc(p$c$Node$shared(l0$node$3), wildcard) in
+                                (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                                  l0$node$6.bf$value)) :
+                              (true && df$rt$intFromRef(anon$0$0) > 0 &&
+                              !(anon$1$0 == df$rt$nullValue()) ?
+                                (unfolding acc(p$c$Node$shared(l0$node$3), wildcard) in
+                                  (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                                    l0$node$6.bf$value)) :
+                                null))))) in
+                        anon$3$0)))))))))))
+}
+
+/heap_dependent_specifications.kt:(1906,1926): info: Generated Viper text for testNestedConditions:
+field bf$next: Ref
+
+field bf$value: Ref
+
+function f$testNestedConditions$TF$T$Node$T$Node$T$Int(p$nodeA: Ref, p$nodeB: Ref): Ref
+  requires acc(p$c$Node$shared(p$nodeA), wildcard)
+  requires acc(p$c$Node$shared(p$nodeB), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(p$nodeA), df$rt$c$Node())
+  requires df$rt$isSubtype(df$rt$typeOf(p$nodeB), df$rt$c$Node())
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
+{
+  (let l0$node$0 ==
+    (p$nodeA) in
+    (let anon$0$0 ==
+      ((unfolding acc(p$c$Node$shared(p$nodeA), wildcard) in
+        p$nodeA.bf$next)) in
+      (let anon$2$0 ==
+        ((!(anon$0$0 == df$rt$nullValue()) ?
+          (unfolding acc(p$c$Node$shared(p$nodeA), wildcard) in
+            p$nodeA.bf$next) :
+          null)) in
+        (let anon$1$0 ==
+          ((!(anon$0$0 == df$rt$nullValue()) ?
+            (unfolding acc(p$c$Node$shared(p$nodeA), wildcard) in
+              (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
+                anon$2$0.bf$next)) :
+            null)) in
+          (let anon$4$0 ==
+            ((!(anon$1$0 == df$rt$nullValue()) &&
+            !(anon$0$0 == df$rt$nullValue()) ?
+              (unfolding acc(p$c$Node$shared(p$nodeA), wildcard) in
+                p$nodeA.bf$next) :
+              null)) in
+            (let anon$3$0 ==
+              ((!(anon$1$0 == df$rt$nullValue()) &&
+              !(anon$0$0 == df$rt$nullValue()) ?
+                (unfolding acc(p$c$Node$shared(p$nodeA), wildcard) in
+                  (unfolding acc(p$c$Node$shared(anon$4$0), wildcard) in
+                    anon$4$0.bf$next)) :
+                null)) in
+              (let l0$node$1 ==
+                ((!(anon$1$0 == df$rt$nullValue()) &&
+                !(anon$0$0 == df$rt$nullValue()) ?
+                  anon$3$0 :
+                  null)) in
+                (let l0$node$2 ==
+                  ((!!(anon$1$0 == df$rt$nullValue()) &&
+                  !(anon$0$0 == df$rt$nullValue()) ?
+                    p$nodeB :
+                    null)) in
+                  (let anon$5$0 ==
+                    ((!!(anon$0$0 == df$rt$nullValue()) ?
+                      (unfolding acc(p$c$Node$shared(p$nodeB), wildcard) in
+                        p$nodeB.bf$next) :
+                      null)) in
+                    (let anon$6$0 ==
+                      ((!(anon$5$0 == df$rt$nullValue()) &&
+                      !!(anon$0$0 == df$rt$nullValue()) ?
+                        (unfolding acc(p$c$Node$shared(p$nodeB), wildcard) in
+                          p$nodeB.bf$next) :
+                        null)) in
+                      (let l0$node$3 ==
+                        ((!(anon$5$0 == df$rt$nullValue()) &&
+                        !!(anon$0$0 == df$rt$nullValue()) ?
+                          anon$6$0 :
+                          null)) in
+                        (let l0$node$4 ==
+                          ((!(anon$1$0 == df$rt$nullValue()) ?
+                            l0$node$1 :
+                            l0$node$2)) in
+                          (let l0$node$5 ==
+                            ((!(anon$5$0 == df$rt$nullValue()) ?
+                              l0$node$3 :
+                              l0$node$0)) in
+                            (let l0$node$6 ==
+                              ((!(anon$0$0 == df$rt$nullValue()) ?
+                                l0$node$4 :
+                                l0$node$5)) in
+                              (let anon$7$0 ==
+                                ((true && !!(anon$5$0 == df$rt$nullValue()) &&
+                                !!(anon$0$0 == df$rt$nullValue()) ?
+                                  (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                                    l0$node$6.bf$value) :
+                                  (true && !(anon$5$0 == df$rt$nullValue()) &&
+                                  !!(anon$0$0 == df$rt$nullValue()) ?
+                                    (unfolding acc(p$c$Node$shared(p$nodeB), wildcard) in
+                                      (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                                        l0$node$6.bf$value)) :
+                                    (true &&
+                                    !!(anon$1$0 == df$rt$nullValue()) &&
+                                    !(anon$0$0 == df$rt$nullValue()) ?
+                                      (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                                        l0$node$6.bf$value) :
+                                      (true &&
+                                      !(anon$1$0 == df$rt$nullValue()) &&
+                                      !(anon$0$0 == df$rt$nullValue()) ?
+                                        (unfolding acc(p$c$Node$shared(p$nodeA), wildcard) in
+                                          (unfolding acc(p$c$Node$shared(anon$4$0), wildcard) in
+                                            (unfolding acc(p$c$Node$shared(l0$node$6), wildcard) in
+                                              l0$node$6.bf$value))) :
+                                        null))))) in
+                                anon$7$0)))))))))))))))
+}
+
+/heap_dependent_specifications.kt:(2280,2300): info: Generated Viper text for testMultipleVarMerge:
+field bf$next: Ref
+
+field bf$value: Ref
+
+function f$testMultipleVarMerge$TF$T$Node$T$Node$T$Int(p$left: Ref, p$right: Ref): Ref
+  requires acc(p$c$Node$shared(p$left), wildcard)
+  requires acc(p$c$Node$shared(p$right), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$c$Node())
+  requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$c$Node())
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
+{
+  (let l0$n1$0 ==
+    (p$left) in
+    (let l0$n2$0 ==
+      (p$right) in
+      (let anon$0$0 ==
+        ((unfolding acc(p$c$Node$shared(p$left), wildcard) in
+          p$left.bf$value)) in
+        (let anon$1$0 ==
+          ((unfolding acc(p$c$Node$shared(p$right), wildcard) in
+            p$right.bf$value)) in
+          (let l0$n1$1 ==
+            ((df$rt$intFromRef(anon$0$0) > df$rt$intFromRef(anon$1$0) ?
+              p$right :
+              null)) in
+            (let l0$n2$1 ==
+              ((df$rt$intFromRef(anon$0$0) > df$rt$intFromRef(anon$1$0) ?
+                p$left :
+                null)) in
+              (let l0$n1$2 ==
+                ((df$rt$intFromRef(anon$0$0) > df$rt$intFromRef(anon$1$0) ?
+                  l0$n1$1 :
+                  l0$n1$0)) in
+                (let anon$2$0 ==
+                  ((true &&
+                  !(df$rt$intFromRef(anon$0$0) > df$rt$intFromRef(anon$1$0)) ?
+                    (unfolding acc(p$c$Node$shared(l0$n1$2), wildcard) in
+                      l0$n1$2.bf$value) :
+                    (true &&
+                    df$rt$intFromRef(anon$0$0) > df$rt$intFromRef(anon$1$0) ?
+                      (unfolding acc(p$c$Node$shared(l0$n1$2), wildcard) in
+                        l0$n1$2.bf$value) :
+                      null))) in
+                  (let l0$n2$2 ==
+                    ((df$rt$intFromRef(anon$0$0) >
+                    df$rt$intFromRef(anon$1$0) ?
+                      l0$n2$1 :
+                      l0$n2$0)) in
+                    (let anon$3$0 ==
+                      ((true &&
+                      !(df$rt$intFromRef(anon$0$0) >
+                      df$rt$intFromRef(anon$1$0)) ?
+                        (unfolding acc(p$c$Node$shared(l0$n2$2), wildcard) in
+                          l0$n2$2.bf$value) :
+                        (true &&
+                        df$rt$intFromRef(anon$0$0) >
+                        df$rt$intFromRef(anon$1$0) ?
+                          (unfolding acc(p$c$Node$shared(l0$n2$2), wildcard) in
+                            l0$n2$2.bf$value) :
+                          null))) in
+                      sp$plusInts(anon$2$0, anon$3$0)))))))))))
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt
@@ -68,3 +68,48 @@ fun <!VIPER_TEXT!>testNode<!>(nodeLeft: Node, nodeRight: Node): Int {
     }
     return node.value
 }
+
+@Pure
+@AlwaysVerify
+fun <!VIPER_TEXT!>testSequentialBranches<!>(nodeA: Node, nodeB: Node): Int {
+    var node = nodeA
+    if (nodeA.value > 0) {
+        node = nodeB
+    }
+    if (node.next != null) {
+        node = node.next
+    }
+    return node.value
+}
+
+@Pure
+@AlwaysVerify
+fun <!VIPER_TEXT!>testNestedConditions<!>(nodeA: Node, nodeB: Node): Int {
+    var node = nodeA
+
+    if (nodeA.next != null) {
+        if (nodeA.next.next != null) {
+            node = nodeA.next.next
+        } else {
+            node = nodeB
+        }
+    } else {
+        if (nodeB.next != null) {
+            node = nodeB.next
+        }
+    }
+    return node.value
+}
+
+@Pure
+@AlwaysVerify
+fun <!VIPER_TEXT!>testMultipleVarMerge<!>(left: Node, right: Node): Int {
+    var n1 = left
+    var n2 = right
+
+    if (left.value > right.value) {
+        n1 = right
+        n2 = left
+    }
+    return n1.value + n2.value
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt
@@ -56,3 +56,15 @@ fun <!VIPER_TEXT!>isLocallyValidBST<!>(node: TreeNode): Boolean {
     }
     return leftValid && rightValid
 }
+
+@Pure
+@AlwaysVerify
+fun <!VIPER_TEXT!>testNode<!>(nodeLeft: Node, nodeRight: Node): Int {
+    var node = nodeLeft
+    if (nodeLeft.next != null) {
+        node = nodeLeft.next
+    } else if (nodeRight.next != null) {
+        node = nodeRight.next
+    }
+    return node.value
+}


### PR DESCRIPTION
In this PR we introduce conditional heap-dependent expressions in pure functions. Namely, we extend the already existing model, which passed access dependencies unconditionally, and extend it by a condition. On field access or function usage, instead of encoding an expression as an unconditional access, we create a ternary expression unfolding predicates depending on the condition under which what predicates have to be unfolded. To validate our implementation we have created various test cases