### PR TITLE
Add early returns

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.formver.core.names.SsaVariableName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toDisjunction
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
 class SsaConverter(
@@ -42,7 +43,7 @@ class SsaConverter(
             thenResultHead.returns && head.returns -> Exp.BoolLit(false)
             thenResultHead.returns -> head.fullBranchingCondition
             head.returns -> thenResultHead.fullBranchingCondition
-            else -> splitPoint.fullBranchingCondition
+            else -> listOf(thenResultHead.fullBranchingCondition, head.fullBranchingCondition).toDisjunction()
         }
         head = SsaBlockNode(joinNode, branchCondition)
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -38,7 +38,13 @@ class SsaConverter(
             condition,
             this
         )
-        head = SsaBlockNode(joinNode, splitPoint.fullBranchingCondition)
+        val branchCondition = when {
+            thenResultHead.returns && head.returns -> Exp.BoolLit(false)
+            thenResultHead.returns -> head.fullBranchingCondition
+            head.returns -> thenResultHead.fullBranchingCondition
+            else -> splitPoint.fullBranchingCondition
+        }
+        head = SsaBlockNode(joinNode, branchCondition)
     }
 
     fun constructExpression(): Exp {
@@ -92,6 +98,7 @@ class SsaConverter(
     }
 
     fun addReturn(returnExp: Exp) {
+        head.returns = true
         returnExpressions.add(head.fullBranchingCondition to returnExp)
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
@@ -23,9 +23,10 @@ class SsaStartNode() : SsaNode {
 
 class SsaBlockNode(
     private val predecessor: SsaNode,
-    val fullBranchingCondition: Exp
+    val fullBranchingCondition: Exp,
 ) : SsaNode {
     val latestName: MutableMap<SymbolicName, SsaVariableName> = mutableMapOf()
+    var returns: Boolean = false
 
     fun generateBranchingBlockNodeFromThisNode(condition: Exp): SsaBlockNode =
         SsaBlockNode(

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
@@ -239,6 +239,12 @@ public class FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated ext
       }
 
       @Test
+      @TestMetadata("heap_dependent_specifications.kt")
+      public void testHeap_dependent_specifications() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt");
+      }
+
+      @Test
       @TestMetadata("pure_function_rely_on_branch.kt")
       public void testPure_function_rely_on_branch() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.kt");

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -200,18 +200,25 @@ function f$containsValue$TF$T$Node$T$Int$T$Boolean(p$node: Ref, p$target: Ref): 
   (let anon$0$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$value)) in
     (let l0$nextNode$0 ==
-      ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+      ((!(df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target)) ?
+        (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+          p$node.bf$next) :
+        null)) in
       (let anon$2$0 ==
-        ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+        ((!(l0$nextNode$0 == df$rt$nullValue()) &&
+        !(df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target)) ?
           (unfolding acc(p$c$Node$shared(p$node), wildcard) in
             f$containsValue$TF$T$Node$T$Int$T$Boolean(l0$nextNode$0, p$target)) :
           null)) in
         (let anon$3$0 ==
-          ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+          ((!!(l0$nextNode$0 == df$rt$nullValue()) &&
+          !(df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target)) ?
             df$rt$boolToRef(false) :
             null)) in
           (let anon$1$0 ==
-            ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$2$0 : anon$3$0)) in
+            ((!(df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target)) ?
+              (!(l0$nextNode$0 == df$rt$nullValue()) ? anon$2$0 : anon$3$0) :
+              null)) in
             (df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target) ?
               df$rt$boolToRef(true) :
               anon$1$0))))))

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -32,9 +32,18 @@ function f$getSafeNextValue$TF$T$Node$T$Int(p$node: Ref): Ref
             anon$2$0.bf$value)) :
         null)) in
       (let anon$1$0 ==
-        ((anon$2$0 != df$rt$nullValue() ? anon$3$0 : df$rt$nullValue())) in
+        ((anon$2$0 != df$rt$nullValue() || !(anon$2$0 != df$rt$nullValue()) ?
+          (anon$2$0 != df$rt$nullValue() ? anon$3$0 : df$rt$nullValue()) :
+          null)) in
         (let anon$0$0 ==
-          ((anon$1$0 != df$rt$nullValue() ? anon$1$0 : df$rt$intToRef(-1))) in
+          ((anon$1$0 != df$rt$nullValue() &&
+          (anon$2$0 != df$rt$nullValue() ||
+          !(anon$2$0 != df$rt$nullValue())) ||
+          !(anon$1$0 != df$rt$nullValue()) &&
+          (anon$2$0 != df$rt$nullValue() ||
+          !(anon$2$0 != df$rt$nullValue())) ?
+            (anon$1$0 != df$rt$nullValue() ? anon$1$0 : df$rt$intToRef(-1)) :
+            null)) in
           anon$0$0))))
 }
 
@@ -57,18 +66,46 @@ function f$getSafeNextNextValue$TF$T$Node$T$Int(p$node: Ref): Ref
             anon$3$0.bf$next)) :
         null)) in
       (let anon$2$0 ==
-        ((anon$3$0 != df$rt$nullValue() ? anon$4$0 : df$rt$nullValue())) in
+        ((anon$3$0 != df$rt$nullValue() || !(anon$3$0 != df$rt$nullValue()) ?
+          (anon$3$0 != df$rt$nullValue() ? anon$4$0 : df$rt$nullValue()) :
+          null)) in
         (let anon$5$0 ==
-          ((anon$2$0 != df$rt$nullValue() ?
+          ((anon$2$0 != df$rt$nullValue() &&
+          (anon$3$0 != df$rt$nullValue() ||
+          !(anon$3$0 != df$rt$nullValue())) ?
             (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
               anon$2$0.bf$value) :
             null)) in
           (let anon$1$0 ==
-            ((anon$2$0 != df$rt$nullValue() ? anon$5$0 : df$rt$nullValue())) in
+            ((anon$2$0 != df$rt$nullValue() &&
+            (anon$3$0 != df$rt$nullValue() ||
+            !(anon$3$0 != df$rt$nullValue())) ||
+            !(anon$2$0 != df$rt$nullValue()) &&
+            (anon$3$0 != df$rt$nullValue() ||
+            !(anon$3$0 != df$rt$nullValue())) ?
+              (anon$2$0 != df$rt$nullValue() ?
+                anon$5$0 :
+                df$rt$nullValue()) :
+              null)) in
             (let anon$0$0 ==
-              ((anon$1$0 != df$rt$nullValue() ?
-                anon$1$0 :
-                df$rt$intToRef(0))) in
+              ((anon$1$0 != df$rt$nullValue() &&
+              (anon$2$0 != df$rt$nullValue() &&
+              (anon$3$0 != df$rt$nullValue() ||
+              !(anon$3$0 != df$rt$nullValue())) ||
+              !(anon$2$0 != df$rt$nullValue()) &&
+              (anon$3$0 != df$rt$nullValue() ||
+              !(anon$3$0 != df$rt$nullValue()))) ||
+              !(anon$1$0 != df$rt$nullValue()) &&
+              (anon$2$0 != df$rt$nullValue() &&
+              (anon$3$0 != df$rt$nullValue() ||
+              !(anon$3$0 != df$rt$nullValue())) ||
+              !(anon$2$0 != df$rt$nullValue()) &&
+              (anon$3$0 != df$rt$nullValue() ||
+              !(anon$3$0 != df$rt$nullValue()))) ?
+                (anon$1$0 != df$rt$nullValue() ?
+                  anon$1$0 :
+                  df$rt$intToRef(0)) :
+                null)) in
               anon$0$0))))))
 }
 
@@ -108,9 +145,12 @@ function f$sumFirstTwoNodes$TF$T$Node$T$Int(p$node: Ref): Ref
                 p$node.bf$value) :
               null)) in
             (let anon$0$0 ==
-              ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                anon$1$0 :
-                anon$4$0)) in
+              ((!(l0$nextNode$0 == df$rt$nullValue()) ||
+              !!(l0$nextNode$0 == df$rt$nullValue()) ?
+                (!(l0$nextNode$0 == df$rt$nullValue()) ?
+                  anon$1$0 :
+                  anon$4$0) :
+                null)) in
               anon$0$0))))))
 }
 
@@ -149,7 +189,10 @@ function f$length$TF$T$Node$T$Int(p$node: Ref): Ref
             sp$plusInts(df$rt$intToRef(1), f$length$TF$T$Node$T$Int(l0$nextNode$0))) :
           null)) in
         (let anon$0$0 ==
-          ((l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0)) in
+          ((l0$nextNode$0 == df$rt$nullValue() ||
+          !(l0$nextNode$0 == df$rt$nullValue()) ?
+            (l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0) :
+            null)) in
           anon$0$0))))
 }
 
@@ -182,7 +225,10 @@ function f$sumAllNodes$TF$T$Node$T$Int(p$node: Ref): Ref
                 sp$plusInts(anon$3$0, f$sumAllNodes$TF$T$Node$T$Int(l0$nextNode$0)))) :
             null)) in
           (let anon$0$0 ==
-            ((l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0)) in
+            ((l0$nextNode$0 == df$rt$nullValue() ||
+            !(l0$nextNode$0 == df$rt$nullValue()) ?
+              (l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0) :
+              null)) in
             anon$0$0)))))
 }
 
@@ -216,7 +262,10 @@ function f$containsValue$TF$T$Node$T$Int$T$Boolean(p$node: Ref, p$target: Ref): 
             df$rt$boolToRef(false) :
             null)) in
           (let anon$1$0 ==
-            ((!(df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target)) ?
+            ((!(l0$nextNode$0 == df$rt$nullValue()) &&
+            !(df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target)) ||
+            !!(l0$nextNode$0 == df$rt$nullValue()) &&
+            !(df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target)) ?
               (!(l0$nextNode$0 == df$rt$nullValue()) ? anon$2$0 : anon$3$0) :
               null)) in
             (df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target) ?
@@ -248,9 +297,12 @@ function f$aliasAndReassign$TF$T$Node$T$Int(p$node: Ref): Ref
                 l0$alias2$0.bf$value)) :
             null)) in
           (let l0$fallbackValue$2 ==
-            ((!(l0$alias2$0 == df$rt$nullValue()) ?
-              l0$fallbackValue$1 :
-              l0$fallbackValue$0)) in
+            ((!(l0$alias2$0 == df$rt$nullValue()) ||
+            !!(l0$alias2$0 == df$rt$nullValue()) ?
+              (!(l0$alias2$0 == df$rt$nullValue()) ?
+                l0$fallbackValue$1 :
+                l0$fallbackValue$0) :
+              null)) in
             l0$fallbackValue$2)))))
 }
 
@@ -293,11 +345,21 @@ function f$useIdentityFunction$TF$T$Node$T$Int(p$node: Ref): Ref
           l0$sameNode$0.bf$value) :
         null)) in
       (let anon$1$0 ==
-        ((l0$sameNode$0 != df$rt$nullValue() ?
-          anon$2$0 :
-          df$rt$nullValue())) in
+        ((l0$sameNode$0 != df$rt$nullValue() ||
+        !(l0$sameNode$0 != df$rt$nullValue()) ?
+          (l0$sameNode$0 != df$rt$nullValue() ?
+            anon$2$0 :
+            df$rt$nullValue()) :
+          null)) in
         (let anon$0$0 ==
-          ((anon$1$0 != df$rt$nullValue() ? anon$1$0 : df$rt$intToRef(0))) in
+          ((anon$1$0 != df$rt$nullValue() &&
+          (l0$sameNode$0 != df$rt$nullValue() ||
+          !(l0$sameNode$0 != df$rt$nullValue())) ||
+          !(anon$1$0 != df$rt$nullValue()) &&
+          (l0$sameNode$0 != df$rt$nullValue() ||
+          !(l0$sameNode$0 != df$rt$nullValue())) ?
+            (anon$1$0 != df$rt$nullValue() ? anon$1$0 : df$rt$intToRef(0)) :
+            null)) in
           anon$0$0))))
 }
 
@@ -325,7 +387,10 @@ function f$getNextValueUsingId$TF$T$Node$T$Int(p$node: Ref): Ref
                 l0$nextNode$0.bf$value)) :
             null)) in
           (let anon$1$0 ==
-            ((l0$nextNode$0 == df$rt$nullValue() ? anon$2$0 : anon$3$0)) in
+            ((l0$nextNode$0 == df$rt$nullValue() ||
+            !(l0$nextNode$0 == df$rt$nullValue()) ?
+              (l0$nextNode$0 == df$rt$nullValue() ? anon$2$0 : anon$3$0) :
+              null)) in
             anon$1$0)))))
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
@@ -6,7 +6,9 @@ function f$noAssignmentInBlocks$TF$T$Boolean$T$Int(p$a: Ref): Ref
   (let l0$result$0 ==
     (df$rt$intToRef(0)) in
     (let l0$result$1 ==
-      (sp$plusInts(l0$result$0, df$rt$intToRef(1))) in
+      ((df$rt$boolFromRef(p$a) || !df$rt$boolFromRef(p$a) ?
+        sp$plusInts(l0$result$0, df$rt$intToRef(1)) :
+        null)) in
       l0$result$1))
 }
 
@@ -26,7 +28,9 @@ function f$simpleBranching$TF$T$Boolean$T$Int(p$a: Ref): Ref
           sp$plusInts(l0$result$0, df$rt$intToRef(2)) :
           null)) in
         (let l0$result$3 ==
-          ((df$rt$boolFromRef(p$a) ? l0$result$1 : l0$result$2)) in
+          ((df$rt$boolFromRef(p$a) || !df$rt$boolFromRef(p$a) ?
+            (df$rt$boolFromRef(p$a) ? l0$result$1 : l0$result$2) :
+            null)) in
           l0$result$3))))
 }
 
@@ -59,19 +63,38 @@ function f$nestedBranching$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
                 sp$plusInts(df$rt$intToRef(5), l0$result$0) :
                 null)) in
               (let l0$result$6 ==
-                ((!df$rt$boolFromRef(p$a) ?
+                ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ||
+                !df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
                   (df$rt$boolFromRef(p$b) ? l0$result$4 : l0$result$5) :
                   null)) in
                 (let l0$result$7 ==
-                  ((!df$rt$boolFromRef(p$a) ?
+                  ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ||
+                  !df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
                     sp$plusInts(df$rt$intToRef(6), l0$result$6) :
                     null)) in
                   (let l0$result$8 ==
-                    ((df$rt$boolFromRef(p$b) ? l0$result$2 : l0$result$3)) in
+                    ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                    !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                    (df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ||
+                    !df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a)) ?
+                      (df$rt$boolFromRef(p$b) ? l0$result$2 : l0$result$3) :
+                      null)) in
                     (let l0$result$9 ==
-                      ((df$rt$boolFromRef(p$a) ? l0$result$8 : l0$result$7)) in
+                      ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                      !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                      (df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ||
+                      !df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a)) ?
+                        (df$rt$boolFromRef(p$a) ?
+                          l0$result$8 :
+                          l0$result$7) :
+                        null)) in
                       (let l0$result$10 ==
-                        (sp$plusInts(df$rt$intToRef(7), l0$result$9)) in
+                        ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                        !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                        (df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ||
+                        !df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a)) ?
+                          sp$plusInts(df$rt$intToRef(7), l0$result$9) :
+                          null)) in
                         l0$result$10)))))))))))
 }
 
@@ -92,9 +115,17 @@ function f$whenExpressionSimple$TF$T$Int$T$Int(p$x: Ref): Ref
             df$rt$intToRef(30) :
             null)) in
           (let l0$y$3 ==
-            ((df$rt$intFromRef(anon$0$0) == 2 ? l0$y$0 : l0$y$2)) in
+            ((df$rt$intFromRef(anon$0$0) == 1 ||
+            !(df$rt$intFromRef(anon$0$0) == 2) &&
+            !(df$rt$intFromRef(anon$0$0) == 1) ?
+              (df$rt$intFromRef(anon$0$0) == 2 ? l0$y$0 : l0$y$2) :
+              null)) in
             (let l0$y$4 ==
-              ((df$rt$intFromRef(anon$0$0) == 1 ? l0$y$1 : l0$y$3)) in
+              ((df$rt$intFromRef(anon$0$0) == 1 ||
+              !(df$rt$intFromRef(anon$0$0) == 2) &&
+              !(df$rt$intFromRef(anon$0$0) == 1) ?
+                (df$rt$intFromRef(anon$0$0) == 1 ? l0$y$1 : l0$y$3) :
+                null)) in
               (df$rt$intFromRef(anon$0$0) == 2 &&
               !(df$rt$intFromRef(anon$0$0) == 1) ?
                 df$rt$intToRef(20) :
@@ -143,13 +174,19 @@ function f$stringEqualityBranching$TF$T$String$T$Boolean(p$input: Ref): Ref
           df$rt$boolToRef(false) :
           null)) in
         (let l0$isValid$3 ==
-          ((!(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+          ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) &&
+          !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ||
+          !(df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114)) &&
+          !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
             (df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) ?
               l0$isValid$1 :
               l0$isValid$2) :
             null)) in
           (let l0$isValid$4 ==
-            ((!(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+            ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) &&
+            !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ||
+            !(df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114)) &&
+            !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
               (df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
                 l0$isValid$0 :
                 l0$isValid$3) :
@@ -170,8 +207,11 @@ function f$sequentialIfWithMutation$TF$T$Int(): Ref
       (let l0$x$2 ==
         ((!(df$rt$intFromRef(l0$x$0) > 5) ? df$rt$intToRef(20) : null)) in
         (let l0$x$3 ==
-          ((df$rt$intFromRef(l0$x$0) > 5 ? l0$x$1 : l0$x$2)) in
-          (df$rt$intFromRef(l0$x$3) == 2 ?
+          ((df$rt$intFromRef(l0$x$0) > 5 || !(df$rt$intFromRef(l0$x$0) > 5) ?
+            (df$rt$intFromRef(l0$x$0) > 5 ? l0$x$1 : l0$x$2) :
+            null)) in
+          (df$rt$intFromRef(l0$x$3) == 2 &&
+          (df$rt$intFromRef(l0$x$0) > 5 || !(df$rt$intFromRef(l0$x$0) > 5)) ?
             df$rt$intToRef(100) :
             df$rt$intToRef(0))))))
 }
@@ -193,7 +233,9 @@ function f$complexBooleanReturn$TF$T$Int$T$Boolean(p$x: Ref): Ref
           df$rt$boolToRef(true) :
           null)) in
         (let l0$result$3 ==
-          ((!(df$rt$intFromRef(p$x) > 100) ?
+          ((df$rt$intFromRef(p$x) > 50 && !(df$rt$intFromRef(p$x) > 100) ||
+          !(df$rt$intFromRef(p$x) < 0) &&
+          (!(df$rt$intFromRef(p$x) > 50) && !(df$rt$intFromRef(p$x) > 100)) ?
             (df$rt$intFromRef(p$x) > 50 ? l0$result$1 : l0$result$2) :
             null)) in
           (df$rt$intFromRef(p$x) > 100 ?
@@ -203,7 +245,10 @@ function f$complexBooleanReturn$TF$T$Int$T$Boolean(p$x: Ref): Ref
             !(df$rt$intFromRef(p$x) > 100)) ?
               df$rt$boolToRef(false) :
               (df$rt$boolFromRef(l0$result$3) &&
-              !(df$rt$intFromRef(p$x) > 100) ?
+              (df$rt$intFromRef(p$x) > 50 && !(df$rt$intFromRef(p$x) > 100) ||
+              !(df$rt$intFromRef(p$x) < 0) &&
+              (!(df$rt$intFromRef(p$x) > 50) &&
+              !(df$rt$intFromRef(p$x) > 100))) ?
                 df$rt$boolToRef(false) :
                 df$rt$boolToRef(true))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
@@ -143,13 +143,17 @@ function f$stringEqualityBranching$TF$T$String$T$Boolean(p$input: Ref): Ref
           df$rt$boolToRef(false) :
           null)) in
         (let l0$isValid$3 ==
-          ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) ?
-            l0$isValid$1 :
-            l0$isValid$2)) in
+          ((!(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+            (df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) ?
+              l0$isValid$1 :
+              l0$isValid$2) :
+            null)) in
           (let l0$isValid$4 ==
-            ((df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
-              l0$isValid$0 :
-              l0$isValid$3)) in
+            ((!(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+              (df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
+                l0$isValid$0 :
+                l0$isValid$3) :
+              null)) in
             (df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
               df$rt$boolToRef(true) :
               l0$isValid$4))))))
@@ -178,18 +182,28 @@ function f$complexBooleanReturn$TF$T$Int$T$Boolean(p$x: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$result$0 ==
-    (df$rt$boolToRef(false)) in
+    ((!(df$rt$intFromRef(p$x) > 100) ? df$rt$boolToRef(false) : null)) in
     (let l0$result$1 ==
-      ((df$rt$intFromRef(p$x) > 50 ? df$rt$boolToRef(true) : null)) in
+      ((df$rt$intFromRef(p$x) > 50 && !(df$rt$intFromRef(p$x) > 100) ?
+        df$rt$boolToRef(true) :
+        null)) in
       (let l0$result$2 ==
-        ((!(df$rt$intFromRef(p$x) > 50) ? df$rt$boolToRef(true) : null)) in
+        ((!(df$rt$intFromRef(p$x) < 0) &&
+        (!(df$rt$intFromRef(p$x) > 50) && !(df$rt$intFromRef(p$x) > 100)) ?
+          df$rt$boolToRef(true) :
+          null)) in
         (let l0$result$3 ==
-          ((df$rt$intFromRef(p$x) > 50 ? l0$result$1 : l0$result$2)) in
+          ((!(df$rt$intFromRef(p$x) > 100) ?
+            (df$rt$intFromRef(p$x) > 50 ? l0$result$1 : l0$result$2) :
+            null)) in
           (df$rt$intFromRef(p$x) > 100 ?
             df$rt$boolToRef(true) :
-            (df$rt$intFromRef(p$x) < 0 && !(df$rt$intFromRef(p$x) > 50) ?
+            (df$rt$intFromRef(p$x) < 0 &&
+            (!(df$rt$intFromRef(p$x) > 50) &&
+            !(df$rt$intFromRef(p$x) > 100)) ?
               df$rt$boolToRef(false) :
-              (df$rt$boolFromRef(l0$result$3) ?
+              (df$rt$boolFromRef(l0$result$3) &&
+              !(df$rt$intFromRef(p$x) > 100) ?
                 df$rt$boolToRef(false) :
                 df$rt$boolToRef(true))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
@@ -79,7 +79,8 @@ function f$nestedConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
         df$rt$intToRef(3) :
         null)) in
       (let anon$0$0 ==
-        ((df$rt$boolFromRef(p$a) ?
+        ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+        !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
           (df$rt$boolFromRef(p$b) ? anon$1$0 : anon$2$0) :
           null)) in
         (let anon$4$0 ==
@@ -91,11 +92,17 @@ function f$nestedConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
               df$rt$intToRef(1) :
               null)) in
             (let anon$3$0 ==
-              ((!df$rt$boolFromRef(p$a) ?
+              ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ||
+              !df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
                 (df$rt$boolFromRef(p$b) ? anon$4$0 : anon$5$0) :
                 null)) in
               (let l0$x$0 ==
-                ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0)) in
+                ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+                (df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ||
+                !df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a)) ?
+                  (df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0) :
+                  null)) in
                 l0$x$0)))))))
 }
 
@@ -115,17 +122,23 @@ function f$blockConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
         df$rt$intToRef(20) :
         null)) in
       (let l2$y$0 ==
-        ((df$rt$boolFromRef(p$a) ?
+        ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+        !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
           (df$rt$boolFromRef(p$b) ? anon$1$0 : anon$2$0) :
           null)) in
         (let anon$0$0 ==
-          ((df$rt$boolFromRef(p$a) ?
+          ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+          !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
             sp$plusInts(l2$y$0, df$rt$intToRef(1)) :
             null)) in
           (let anon$3$0 ==
             ((!df$rt$boolFromRef(p$a) ? df$rt$intToRef(30) : null)) in
             (let l0$x$0 ==
-              ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0)) in
+              ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+              !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ||
+              !df$rt$boolFromRef(p$a) ?
+                (df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0) :
+                null)) in
               l0$x$0))))))
 }
 
@@ -146,7 +159,8 @@ function f$whenAssignment$TF$T$Int$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
           df$rt$intToRef(3) :
           null)) in
         (let anon$1$0 ==
-          ((df$rt$intFromRef(anon$0$0) == 1 ?
+          ((df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ||
+          !df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
             (df$rt$boolFromRef(p$b) ? anon$2$0 : anon$3$0) :
             null)) in
           (let anon$5$0 ==
@@ -160,10 +174,22 @@ function f$whenAssignment$TF$T$Int$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
                 df$rt$intToRef(5) :
                 null)) in
               (let anon$4$0 ==
-                ((!(df$rt$intFromRef(anon$0$0) == 1) ?
+                ((df$rt$intFromRef(anon$0$0) == 2 &&
+                !(df$rt$intFromRef(anon$0$0) == 1) ||
+                !(df$rt$intFromRef(anon$0$0) == 2) &&
+                !(df$rt$intFromRef(anon$0$0) == 1) ?
                   (df$rt$intFromRef(anon$0$0) == 2 ? anon$5$0 : anon$6$0) :
                   null)) in
                 (let l0$x$0 ==
-                  ((df$rt$intFromRef(anon$0$0) == 1 ? anon$1$0 : anon$4$0)) in
+                  ((df$rt$boolFromRef(p$b) &&
+                  df$rt$intFromRef(anon$0$0) == 1 ||
+                  !df$rt$boolFromRef(p$b) &&
+                  df$rt$intFromRef(anon$0$0) == 1 ||
+                  (df$rt$intFromRef(anon$0$0) == 2 &&
+                  !(df$rt$intFromRef(anon$0$0) == 1) ||
+                  !(df$rt$intFromRef(anon$0$0) == 2) &&
+                  !(df$rt$intFromRef(anon$0$0) == 1)) ?
+                    (df$rt$intFromRef(anon$0$0) == 1 ? anon$1$0 : anon$4$0) :
+                    null)) in
                   l0$x$0))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -29,24 +29,41 @@ function f$isAlternating$TF$T$Node$T$Boolean$T$Boolean(p$node: Ref, p$expectsPos
               sp$ltInts(anon$3$0, df$rt$intToRef(0))) :
             null)) in
           (let l0$isCurrentValid$0 ==
-            ((df$rt$boolFromRef(p$expectsPositive) ? anon$0$0 : anon$2$0)) in
+            ((df$rt$boolFromRef(p$expectsPositive) ||
+            !df$rt$boolFromRef(p$expectsPositive) ?
+              (df$rt$boolFromRef(p$expectsPositive) ? anon$0$0 : anon$2$0) :
+              null)) in
             (let l0$nextNode$0 ==
-              ((unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                p$node.bf$next)) in
+              ((df$rt$boolFromRef(p$expectsPositive) ||
+              !df$rt$boolFromRef(p$expectsPositive) ?
+                (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                  p$node.bf$next) :
+                null)) in
               (let anon$5$0 ==
-                ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                ((!(l0$nextNode$0 == df$rt$nullValue()) &&
+                (df$rt$boolFromRef(p$expectsPositive) ||
+                !df$rt$boolFromRef(p$expectsPositive)) ?
                   (unfolding acc(p$c$Node$shared(p$node), wildcard) in
                     f$isAlternating$TF$T$Node$T$Boolean$T$Boolean(l0$nextNode$0,
                     sp$notBool(p$expectsPositive))) :
                   null)) in
                 (let anon$6$0 ==
-                  ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+                  ((!!(l0$nextNode$0 == df$rt$nullValue()) &&
+                  (df$rt$boolFromRef(p$expectsPositive) ||
+                  !df$rt$boolFromRef(p$expectsPositive)) ?
                     df$rt$boolToRef(true) :
                     null)) in
                   (let anon$4$0 ==
-                    ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                      anon$5$0 :
-                      anon$6$0)) in
+                    ((!(l0$nextNode$0 == df$rt$nullValue()) &&
+                    (df$rt$boolFromRef(p$expectsPositive) ||
+                    !df$rt$boolFromRef(p$expectsPositive)) ||
+                    !!(l0$nextNode$0 == df$rt$nullValue()) &&
+                    (df$rt$boolFromRef(p$expectsPositive) ||
+                    !df$rt$boolFromRef(p$expectsPositive)) ?
+                      (!(l0$nextNode$0 == df$rt$nullValue()) ?
+                        anon$5$0 :
+                        anon$6$0) :
+                      null)) in
                     sp$andBools(l0$isCurrentValid$0, anon$4$0))))))))))
 }
 
@@ -98,7 +115,10 @@ function f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(p$node: Ref): Ref
                       sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(l0$nextNode$0))))) :
                 null)) in
               (let anon$1$0 ==
-                ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                ((df$rt$intFromRef(anon$2$0) < 0 &&
+                !(l0$nextNode$0 == df$rt$nullValue()) ||
+                !(df$rt$intFromRef(anon$2$0) < 0) &&
+                !(l0$nextNode$0 == df$rt$nullValue()) ?
                   (df$rt$intFromRef(anon$2$0) < 0 ? anon$3$0 : anon$4$0) :
                   null)) in
                 (let anon$7$0 ==
@@ -106,9 +126,15 @@ function f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(p$node: Ref): Ref
                     df$rt$boolToRef(true) :
                     null)) in
                   (let anon$0$0 ==
-                    ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                      anon$1$0 :
-                      anon$7$0)) in
+                    ((df$rt$intFromRef(anon$2$0) < 0 &&
+                    !(l0$nextNode$0 == df$rt$nullValue()) ||
+                    !(df$rt$intFromRef(anon$2$0) < 0) &&
+                    !(l0$nextNode$0 == df$rt$nullValue()) ||
+                    !!(l0$nextNode$0 == df$rt$nullValue()) ?
+                      (!(l0$nextNode$0 == df$rt$nullValue()) ?
+                        anon$1$0 :
+                        anon$7$0) :
+                      null)) in
                     anon$0$0)))))))))
 }
 
@@ -150,37 +176,58 @@ function f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(p$node: Ref): Ref
               df$rt$boolToRef(true) :
               null)) in
             (let l0$leftValid$0 ==
-              ((!(l0$leftNode$0 == df$rt$nullValue()) ?
-                anon$0$0 :
-                anon$3$0)) in
+              ((!(l0$leftNode$0 == df$rt$nullValue()) ||
+              !!(l0$leftNode$0 == df$rt$nullValue()) ?
+                (!(l0$leftNode$0 == df$rt$nullValue()) ?
+                  anon$0$0 :
+                  anon$3$0) :
+                null)) in
               (let l0$rightNode$0 ==
-                ((unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                  p$node.bf$right)) in
+                ((!(l0$leftNode$0 == df$rt$nullValue()) ||
+                !!(l0$leftNode$0 == df$rt$nullValue()) ?
+                  (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
+                    p$node.bf$right) :
+                  null)) in
                 (let anon$5$0 ==
-                  ((!(l0$rightNode$0 == df$rt$nullValue()) ?
+                  ((!(l0$rightNode$0 == df$rt$nullValue()) &&
+                  (!(l0$leftNode$0 == df$rt$nullValue()) ||
+                  !!(l0$leftNode$0 == df$rt$nullValue())) ?
                     (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
                       (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
                         l0$rightNode$0.bf$value)) :
                     null)) in
                   (let anon$6$0 ==
-                    ((!(l0$rightNode$0 == df$rt$nullValue()) ?
+                    ((!(l0$rightNode$0 == df$rt$nullValue()) &&
+                    (!(l0$leftNode$0 == df$rt$nullValue()) ||
+                    !!(l0$leftNode$0 == df$rt$nullValue())) ?
                       (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
                         p$node.bf$value) :
                       null)) in
                     (let anon$4$0 ==
-                      ((!(l0$rightNode$0 == df$rt$nullValue()) ?
+                      ((!(l0$rightNode$0 == df$rt$nullValue()) &&
+                      (!(l0$leftNode$0 == df$rt$nullValue()) ||
+                      !!(l0$leftNode$0 == df$rt$nullValue())) ?
                         (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
                           (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
                             (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
                               sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(l0$rightNode$0))))) :
                         null)) in
                       (let anon$7$0 ==
-                        ((!!(l0$rightNode$0 == df$rt$nullValue()) ?
+                        ((!!(l0$rightNode$0 == df$rt$nullValue()) &&
+                        (!(l0$leftNode$0 == df$rt$nullValue()) ||
+                        !!(l0$leftNode$0 == df$rt$nullValue())) ?
                           df$rt$boolToRef(true) :
                           null)) in
                         (let l0$rightValid$0 ==
-                          ((!(l0$rightNode$0 == df$rt$nullValue()) ?
-                            anon$4$0 :
-                            anon$7$0)) in
+                          ((!(l0$rightNode$0 == df$rt$nullValue()) &&
+                          (!(l0$leftNode$0 == df$rt$nullValue()) ||
+                          !!(l0$leftNode$0 == df$rt$nullValue())) ||
+                          !!(l0$rightNode$0 == df$rt$nullValue()) &&
+                          (!(l0$leftNode$0 == df$rt$nullValue()) ||
+                          !!(l0$leftNode$0 == df$rt$nullValue())) ?
+                            (!(l0$rightNode$0 == df$rt$nullValue()) ?
+                              anon$4$0 :
+                              anon$7$0) :
+                            null)) in
                           sp$andBools(l0$leftValid$0, l0$rightValid$0)))))))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
@@ -9,7 +9,9 @@ function f$safeDivide$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
     (let l0$res$1 ==
       ((!(df$rt$intFromRef(p$y) == 0) ? sp$divInts(p$x, p$y) : null)) in
       (let l0$res$2 ==
-        ((!(df$rt$intFromRef(p$y) == 0) ? l0$res$1 : l0$res$0)) in
+        ((!(df$rt$intFromRef(p$y) == 0) || !!(df$rt$intFromRef(p$y) == 0) ?
+          (!(df$rt$intFromRef(p$y) == 0) ? l0$res$1 : l0$res$0) :
+          null)) in
         l0$res$2)))
 }
 
@@ -25,9 +27,12 @@ function f$getStringLength$TF$T$Any$T$Int(p$obj: Ref): Ref
         sp$stringLength(p$obj) :
         null)) in
       (let l0$len$2 ==
-        ((df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$stringType()) ?
-          l0$len$1 :
-          l0$len$0)) in
+        ((df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$stringType()) ||
+        !df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$stringType()) ?
+          (df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$stringType()) ?
+            l0$len$1 :
+            l0$len$0) :
+          null)) in
         l0$len$2)))
 }
 
@@ -45,9 +50,17 @@ function f$safeNestedDivide$TF$T$Int$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref, p$z: 
         sp$divInts(sp$divInts(p$x, p$y), p$z) :
         null)) in
       (let l0$res$2 ==
-        ((!(df$rt$intFromRef(p$z) == 0) ? l0$res$1 : l0$res$0)) in
+        ((!(df$rt$intFromRef(p$z) == 0) && !(df$rt$intFromRef(p$y) == 0) ||
+        !!(df$rt$intFromRef(p$z) == 0) && !(df$rt$intFromRef(p$y) == 0) ||
+        !!(df$rt$intFromRef(p$y) == 0) ?
+          (!(df$rt$intFromRef(p$z) == 0) ? l0$res$1 : l0$res$0) :
+          null)) in
         (let l0$res$3 ==
-          ((!(df$rt$intFromRef(p$y) == 0) ? l0$res$2 : l0$res$0)) in
+          ((!(df$rt$intFromRef(p$z) == 0) && !(df$rt$intFromRef(p$y) == 0) ||
+          !!(df$rt$intFromRef(p$z) == 0) && !(df$rt$intFromRef(p$y) == 0) ||
+          !!(df$rt$intFromRef(p$y) == 0) ?
+            (!(df$rt$intFromRef(p$y) == 0) ? l0$res$2 : l0$res$0) :
+            null)) in
           l0$res$3))))
 }
 
@@ -64,8 +77,11 @@ function f$safeInverseDifference$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
         sp$divInts(df$rt$intToRef(100), sp$minusInts(p$x, p$y)) :
         null)) in
       (let l0$res$2 ==
-        ((!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y)) ?
-          l0$res$1 :
-          l0$res$0)) in
+        ((!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y)) ||
+        !!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y)) ?
+          (!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y)) ?
+            l0$res$1 :
+            l0$res$0) :
+          null)) in
         l0$res$2)))
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -672,6 +672,13 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         fun List<Exp>.toConjunction(): Exp =
             if (isEmpty()) BoolLit(true)
             else reduce { l, r -> And(l, r) }
+
+        /**
+         * Take the disjunction of the given expressions.
+         */
+        fun List<Exp>.toDisjunction(): Exp =
+            if (isEmpty()) BoolLit(false)
+            else reduce { l, r -> Or(l, r) }
     }
 
     /**


### PR DESCRIPTION
This PR introduces the proper handling of early returns in pure functions by adding a returns value to the SSABlockNode, updating it to be true once a return is encountered and infering the full branching condition of a BlockNode after a join accordlingly.