### PR TITLE
Type Domain Name Style

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/RuntimeTypeDomain.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/domains/RuntimeTypeDomain.kt
@@ -291,10 +291,10 @@ class RuntimeTypeDomain(val classes: List<ClassTypeEmbedding>) : BuiltinDomain(R
         nullValue, unitValue, isSubtype, typeOf, nullable
     ) + allInjections.flatMap { listOf(it.toRef, it.fromRef) }
     override val axioms: List<DomainAxiom> = AxiomListBuilder.build(this) {
-        axiom("subtype_reflexive") {
+        axiom("subtypeReflexive") {
             Exp.forall(t) { t -> t subtype t }
         }
-        axiom("subtype_transitive") {
+        axiom("subtypeTransitive") {
             Exp.forall(t1, t2, t3) { t1, t2, t3 ->
                 assumption {
                     compoundTrigger {
@@ -313,7 +313,7 @@ class RuntimeTypeDomain(val classes: List<ClassTypeEmbedding>) : BuiltinDomain(R
                 t1 subtype t3
             }
         }
-        axiom("subtype_antisymmetric") {
+        axiom("subtypeAntisymmetric") {
             Exp.forall(t1, t2) { t1, t2 ->
                 assumption {
                     compoundTrigger {
@@ -324,23 +324,23 @@ class RuntimeTypeDomain(val classes: List<ClassTypeEmbedding>) : BuiltinDomain(R
                 t1 eq t2
             }
         }
-        axiom("nullable_idempotent") {
+        axiom("nullableIdempotent") {
             Exp.forall(t) { t ->
                 simpleTrigger { nullable(nullable(t)) } eq nullable(t)
             }
         }
-        axiom("nullable_supertype") {
+        axiom("nullableSupertype") {
             Exp.forall(t) { t ->
                 t subtype simpleTrigger { nullable(t) }
             }
         }
-        axiom("nullable_preserves_subtype") {
+        axiom("nullablePreservesSubtype") {
             Exp.forall(t1, t2) { t1, t2 ->
                 assumption { t1 subtype t2 }
                 simpleTrigger { nullable(t1) subtype nullable(t2) }
             }
         }
-        axiom("nullable_any_supertype") {
+        axiom("nullableAnySupertype") {
             Exp.forall(t) { t ->
                 t subtype nullable(anyType())
             }
@@ -348,17 +348,17 @@ class RuntimeTypeDomain(val classes: List<ClassTypeEmbedding>) : BuiltinDomain(R
         nonNullableTypes.forEach {
             axiom { it() subtype anyType() }
         }
-        axiom("supertype_of_nothing") {
+        axiom("supertypeOfNothing") {
             Exp.forall(t) { t ->
                 nothingType() subtype t
             }
         }
-        axiom("any_not_nullable_type_level") {
+        axiom("anyNotNullableTypeLevel") {
             Exp.forall(t) { t ->
                 !isSubtype(nullable(t), anyType())
             }
         }
-        axiom("null_smartcast_value_level") {
+        axiom("nullSmartcastValueLevel") {
             Exp.forall(r, t) { r, t ->
                 assumption {
                     simpleTrigger { r isOf nullable(t) }
@@ -366,12 +366,12 @@ class RuntimeTypeDomain(val classes: List<ClassTypeEmbedding>) : BuiltinDomain(R
                 (r eq nullValue()) or (r isOf t)
             }
         }
-        axiom("nothing_empty") {
+        axiom("nothingEmpty") {
             Exp.forall(r) { r ->
                 !(r isOf nothingType())
             }
         }
-        axiom("null_smartcast_type_level") {
+        axiom("nullSmartcastTypeLevel") {
             Exp.forall(t1, t2) { t1, t2 ->
                 assumption {
                     compoundTrigger {
@@ -382,16 +382,16 @@ class RuntimeTypeDomain(val classes: List<ClassTypeEmbedding>) : BuiltinDomain(R
                 t1 subtype t2
             }
         }
-        axiom("type_of_null") {
+        axiom("typeOfNull") {
             nullValue() isOf nullable(nothingType())
         }
-        axiom("any_not_nullable_value_level") {
+        axiom("anyNotNullableValueLevel") {
             !(nullValue() isOf anyType())
         }
-        axiom("type_of_unit") {
+        axiom("typeOfUnit") {
             unitValue() isOf unitType()
         }
-        axiom("uniqueness_of_unit") {
+        axiom("uniquenessOfUnit") {
             Exp.forall(r) { r ->
                 assumption {
                     simpleTrigger { r isOf unitType() }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
@@ -52,11 +52,11 @@ domain d$rt  {
 
   function df$rt$stringFromRef(r: Ref): Seq[Int]
 
-  axiom rt$subtype_reflexive {
+  axiom rt$subtypeReflexive {
     (forall t: d$rt ::df$rt$isSubtype(t, t))
   }
 
-  axiom rt$subtype_transitive {
+  axiom rt$subtypeTransitive {
     (forall t1: d$rt, t2: d$rt, t3: d$rt ::
       { df$rt$isSubtype(t1, t2), df$rt$isSubtype(t2, t3) }
       { df$rt$isSubtype(t1, t2), df$rt$isSubtype(t1, t3) }
@@ -65,32 +65,32 @@ domain d$rt  {
       df$rt$isSubtype(t1, t3))
   }
 
-  axiom rt$subtype_antisymmetric {
+  axiom rt$subtypeAntisymmetric {
     (forall t1: d$rt, t2: d$rt ::
       { df$rt$isSubtype(t1, t2), df$rt$isSubtype(t2, t1) }
       df$rt$isSubtype(t1, t2) && df$rt$isSubtype(t2, t1) ==> t1 == t2)
   }
 
-  axiom rt$nullable_idempotent {
+  axiom rt$nullableIdempotent {
     (forall t: d$rt ::
       { df$rt$nullable(df$rt$nullable(t)) }
       df$rt$nullable(df$rt$nullable(t)) == df$rt$nullable(t))
   }
 
-  axiom rt$nullable_supertype {
+  axiom rt$nullableSupertype {
     (forall t: d$rt ::
       { df$rt$nullable(t) }
       df$rt$isSubtype(t, df$rt$nullable(t)))
   }
 
-  axiom rt$nullable_preserves_subtype {
+  axiom rt$nullablePreservesSubtype {
     (forall t1: d$rt, t2: d$rt ::
       { df$rt$isSubtype(df$rt$nullable(t1), df$rt$nullable(t2)) }
       df$rt$isSubtype(t1, t2) ==>
       df$rt$isSubtype(df$rt$nullable(t1), df$rt$nullable(t2)))
   }
 
-  axiom rt$nullable_any_supertype {
+  axiom rt$nullableAnySupertype {
     (forall t: d$rt ::df$rt$isSubtype(t, df$rt$nullable(df$rt$anyType())))
   }
 
@@ -130,26 +130,26 @@ domain d$rt  {
     df$rt$isSubtype(df$rt$c$Foo(), df$rt$anyType())
   }
 
-  axiom rt$supertype_of_nothing {
+  axiom rt$supertypeOfNothing {
     (forall t: d$rt ::df$rt$isSubtype(df$rt$nothingType(), t))
   }
 
-  axiom rt$any_not_nullable_type_level {
+  axiom rt$anyNotNullableTypeLevel {
     (forall t: d$rt ::!df$rt$isSubtype(df$rt$nullable(t), df$rt$anyType()))
   }
 
-  axiom rt$null_smartcast_value_level {
+  axiom rt$nullSmartcastValueLevel {
     (forall r: Ref, t: d$rt ::
       { df$rt$isSubtype(df$rt$typeOf(r), df$rt$nullable(t)) }
       df$rt$isSubtype(df$rt$typeOf(r), df$rt$nullable(t)) ==>
       r == df$rt$nullValue() || df$rt$isSubtype(df$rt$typeOf(r), t))
   }
 
-  axiom rt$nothing_empty {
+  axiom rt$nothingEmpty {
     (forall r: Ref ::!df$rt$isSubtype(df$rt$typeOf(r), df$rt$nothingType()))
   }
 
-  axiom rt$null_smartcast_type_level {
+  axiom rt$nullSmartcastTypeLevel {
     (forall t1: d$rt, t2: d$rt ::
       { df$rt$isSubtype(t1, df$rt$anyType()), df$rt$isSubtype(t1, df$rt$nullable(t2)) }
       df$rt$isSubtype(t1, df$rt$anyType()) &&
@@ -157,19 +157,19 @@ domain d$rt  {
       df$rt$isSubtype(t1, t2))
   }
 
-  axiom rt$type_of_null {
+  axiom rt$typeOfNull {
     df$rt$isSubtype(df$rt$typeOf(df$rt$nullValue()), df$rt$nullable(df$rt$nothingType()))
   }
 
-  axiom rt$any_not_nullable_value_level {
+  axiom rt$anyNotNullableValueLevel {
     !df$rt$isSubtype(df$rt$typeOf(df$rt$nullValue()), df$rt$anyType())
   }
 
-  axiom rt$type_of_unit {
+  axiom rt$typeOfUnit {
     df$rt$isSubtype(df$rt$typeOf(df$rt$unitValue()), df$rt$unitType())
   }
 
-  axiom rt$uniqueness_of_unit {
+  axiom rt$uniquenessOfUnit {
     (forall r: Ref ::
       { df$rt$isSubtype(df$rt$typeOf(r), df$rt$unitType()) }
       df$rt$isSubtype(df$rt$typeOf(r), df$rt$unitType()) ==>
@@ -437,3 +437,4 @@ method f$f$TF$T$Unit() returns (ret$0: Ref)
 
 method havoc$T$Int() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
@@ -47,11 +47,11 @@ domain d$rt  {
 
   function df$rt$stringFromRef(r: Ref): Seq[Int]
 
-  axiom rt$subtype_reflexive {
+  axiom rt$subtypeReflexive {
     (forall t: d$rt ::df$rt$isSubtype(t, t))
   }
 
-  axiom rt$subtype_transitive {
+  axiom rt$subtypeTransitive {
     (forall t1: d$rt, t2: d$rt, t3: d$rt ::
       { df$rt$isSubtype(t1, t2), df$rt$isSubtype(t2, t3) }
       { df$rt$isSubtype(t1, t2), df$rt$isSubtype(t1, t3) }
@@ -60,32 +60,32 @@ domain d$rt  {
       df$rt$isSubtype(t1, t3))
   }
 
-  axiom rt$subtype_antisymmetric {
+  axiom rt$subtypeAntisymmetric {
     (forall t1: d$rt, t2: d$rt ::
       { df$rt$isSubtype(t1, t2), df$rt$isSubtype(t2, t1) }
       df$rt$isSubtype(t1, t2) && df$rt$isSubtype(t2, t1) ==> t1 == t2)
   }
 
-  axiom rt$nullable_idempotent {
+  axiom rt$nullableIdempotent {
     (forall t: d$rt ::
       { df$rt$nullable(df$rt$nullable(t)) }
       df$rt$nullable(df$rt$nullable(t)) == df$rt$nullable(t))
   }
 
-  axiom rt$nullable_supertype {
+  axiom rt$nullableSupertype {
     (forall t: d$rt ::
       { df$rt$nullable(t) }
       df$rt$isSubtype(t, df$rt$nullable(t)))
   }
 
-  axiom rt$nullable_preserves_subtype {
+  axiom rt$nullablePreservesSubtype {
     (forall t1: d$rt, t2: d$rt ::
       { df$rt$isSubtype(df$rt$nullable(t1), df$rt$nullable(t2)) }
       df$rt$isSubtype(t1, t2) ==>
       df$rt$isSubtype(df$rt$nullable(t1), df$rt$nullable(t2)))
   }
 
-  axiom rt$nullable_any_supertype {
+  axiom rt$nullableAnySupertype {
     (forall t: d$rt ::df$rt$isSubtype(t, df$rt$nullable(df$rt$anyType())))
   }
 
@@ -129,26 +129,26 @@ domain d$rt  {
     df$rt$isSubtype(df$rt$c$B(), df$rt$anyType())
   }
 
-  axiom rt$supertype_of_nothing {
+  axiom rt$supertypeOfNothing {
     (forall t: d$rt ::df$rt$isSubtype(df$rt$nothingType(), t))
   }
 
-  axiom rt$any_not_nullable_type_level {
+  axiom rt$anyNotNullableTypeLevel {
     (forall t: d$rt ::!df$rt$isSubtype(df$rt$nullable(t), df$rt$anyType()))
   }
 
-  axiom rt$null_smartcast_value_level {
+  axiom rt$nullSmartcastValueLevel {
     (forall r: Ref, t: d$rt ::
       { df$rt$isSubtype(df$rt$typeOf(r), df$rt$nullable(t)) }
       df$rt$isSubtype(df$rt$typeOf(r), df$rt$nullable(t)) ==>
       r == df$rt$nullValue() || df$rt$isSubtype(df$rt$typeOf(r), t))
   }
 
-  axiom rt$nothing_empty {
+  axiom rt$nothingEmpty {
     (forall r: Ref ::!df$rt$isSubtype(df$rt$typeOf(r), df$rt$nothingType()))
   }
 
-  axiom rt$null_smartcast_type_level {
+  axiom rt$nullSmartcastTypeLevel {
     (forall t1: d$rt, t2: d$rt ::
       { df$rt$isSubtype(t1, df$rt$anyType()), df$rt$isSubtype(t1, df$rt$nullable(t2)) }
       df$rt$isSubtype(t1, df$rt$anyType()) &&
@@ -156,19 +156,19 @@ domain d$rt  {
       df$rt$isSubtype(t1, t2))
   }
 
-  axiom rt$type_of_null {
+  axiom rt$typeOfNull {
     df$rt$isSubtype(df$rt$typeOf(df$rt$nullValue()), df$rt$nullable(df$rt$nothingType()))
   }
 
-  axiom rt$any_not_nullable_value_level {
+  axiom rt$anyNotNullableValueLevel {
     !df$rt$isSubtype(df$rt$typeOf(df$rt$nullValue()), df$rt$anyType())
   }
 
-  axiom rt$type_of_unit {
+  axiom rt$typeOfUnit {
     df$rt$isSubtype(df$rt$typeOf(df$rt$unitValue()), df$rt$unitType())
   }
 
-  axiom rt$uniqueness_of_unit {
+  axiom rt$uniquenessOfUnit {
     (forall r: Ref ::
       { df$rt$isSubtype(df$rt$typeOf(r), df$rt$unitType()) }
       df$rt$isSubtype(df$rt$typeOf(r), df$rt$unitType()) ==>


### PR DESCRIPTION
This PR updates the axiom names to use camelCase like the domain functions. We do this, because it will allow us to have a better short name resolver.

Before:
```
// function uses camelCase
function df$rt$stringFromRef(r: Ref): Seq[Int]

// axiom does not
axiom rt$subtype_reflexive {
    (forall t: d$rt ::df$rt$isSubtype(t, t))
}
```

Now:
```
function df$rt$stringFromRef(r: Ref): Seq[Int]

axiom rt$subtypeReflexive {
    (forall t: d$rt ::df$rt$isSubtype(t, t))
}
```
