### PR TITLE
Introduce NameType

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshNames.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshNames.kt
@@ -101,18 +101,19 @@ data class SpecialName(val baseName: String) : SymbolicName {
         get() = baseName
 }
 
-abstract class NumberedLabelName(override val mangledType: NameType, val originalN: Int) : SymbolicName {
+abstract class NumberedLabelName(val baseName: String, val originalN: Int) : SymbolicName {
+    override val mangledType = Label
 
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
-        get() = originalN.toString()
+        get() = "$baseName$$originalN"
 }
 
-data class ReturnLabelName(val scopeDepth: Int) : NumberedLabelName(Label.Return, scopeDepth)
-data class BreakLabelName(val n: Int) : NumberedLabelName(Label.Break, n)
-data class ContinueLabelName(val n: Int) : NumberedLabelName(Label.Continue, n)
-data class CatchLabelName(val n: Int) : NumberedLabelName(Label.Catch, n)
-data class TryExitLabelName(val n: Int) : NumberedLabelName(Label.TryExit, n)
+data class ReturnLabelName(val scopeDepth: Int) : NumberedLabelName("ret", scopeDepth)
+data class BreakLabelName(val n: Int) : NumberedLabelName("break", n)
+data class ContinueLabelName(val n: Int) : NumberedLabelName("cont", n)
+data class CatchLabelName(val n: Int) : NumberedLabelName("catch", n)
+data class TryExitLabelName(val n: Int) : NumberedLabelName("tryExit", n)
 
 
 data class PlaceholderArgumentName(val n: Int) : SymbolicName {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshNames.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshNames.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.formver.core.names
 
 import org.jetbrains.kotlin.formver.viper.NameResolver
+import org.jetbrains.kotlin.formver.viper.NameType
+import org.jetbrains.kotlin.formver.viper.NameType.Label
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.mangled
 
@@ -19,40 +21,44 @@ import org.jetbrains.kotlin.formver.viper.mangled
  * e.g. storage for the result of subexpressions.
  */
 data class AnonymousName(val n: Int) : SymbolicName {
-    override val mangledType: String
-        get() = "anon"
+    override val mangledType: NameType
+        get() = NameType.Variable
 
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
-        get() = n.toString()
+        get() = "anon$$n"
 }
 
 data class AnonymousBuiltinName(val n: Int) : SymbolicName {
 
-    override val mangledType: String
-        get() = $$"anon$builtin"
+    override val mangledType: NameType
+        get() = NameType.Variable
 
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
-        get() = n.toString()
+        get() = $$"anon$builtin$$$n"
 }
 
 /**
  * Name for return variable that should *only* be used in signatures of methods without a body.
  */
 data object PlaceholderReturnVariableName : SymbolicName {
+
+    override val mangledType: NameType
+        get() = NameType.Variable
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = "ret"
 }
 
 data class ReturnVariableName(val n: Int) : SymbolicName {
-    override val mangledType: String
-        get() = "ret"
+    override val mangledType: NameType
+        get() = NameType.Variable
 
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
-        get() = n.toString()
+        get() = "ret$$n"
 }
 
 /**
@@ -60,64 +66,76 @@ data class ReturnVariableName(val n: Int) : SymbolicName {
  * This variable will be translated into the special result variable in Viper
  */
 data object FunctionResultVariableName : SymbolicName {
+    override val mangledType: NameType
+        get() = NameType.Variable
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = "result"
 }
 
 data object DispatchReceiverName : SymbolicName {
+    override val mangledType: NameType
+        get() = NameType.Variable
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = $$"this$dispatch"
 }
 
 data object ExtensionReceiverName : SymbolicName {
+    override val mangledType: NameType
+        get() = NameType.Variable
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = $$"this$extension"
 }
 
 data class SpecialName(val baseName: String) : SymbolicName {
+    override val mangledType: NameType
+        get() = NameType.Special
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = baseName
-    override val mangledType: String
-        get() = "sp"
 }
 
-abstract class NumberedLabelName(val scope: String, val originalN: Int) : SymbolicName {
-    override val mangledType: String
-        get() = "lbl"
+abstract class NumberedLabelName(override val mangledType: NameType, val originalN: Int) : SymbolicName {
 
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = originalN.toString()
-
-    context(nameResolver: NameResolver)
-    override val mangledScope: String?
-        get() = scope
 }
 
-data class ReturnLabelName(val scopeDepth: Int) : NumberedLabelName("ret", scopeDepth)
-data class BreakLabelName(val n: Int) : NumberedLabelName("break", n)
-data class ContinueLabelName(val n: Int) : NumberedLabelName("continue", n)
-data class CatchLabelName(val n: Int) : NumberedLabelName("catch", n)
-data class TryExitLabelName(val n: Int) : NumberedLabelName("try_exit", n)
+data class ReturnLabelName(val scopeDepth: Int) : NumberedLabelName(Label.Return, scopeDepth)
+data class BreakLabelName(val n: Int) : NumberedLabelName(Label.Break, n)
+data class ContinueLabelName(val n: Int) : NumberedLabelName(Label.Continue, n)
+data class CatchLabelName(val n: Int) : NumberedLabelName(Label.Catch, n)
+data class TryExitLabelName(val n: Int) : NumberedLabelName(Label.TryExit, n)
 
 
 data class PlaceholderArgumentName(val n: Int) : SymbolicName {
+    override val mangledType: NameType
+        get() = NameType.Variable
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
-        get() = "arg$n"
+        get() = "arg$$n"
 }
 
 data class DomainFuncParameterName(val baseName: String) : SymbolicName {
+    override val mangledType: NameType
+        get() = NameType.Variable
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = baseName
 }
 
 data class SsaVariableName(val ssaIndex: Int, val baseName: SymbolicName) : SymbolicName {
+    override val mangledType: NameType
+        get() = NameType.Variable
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = "${baseName.mangled}$$ssaIndex"

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/KotlinName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/KotlinName.kt
@@ -9,10 +9,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.PretypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.asTypeEmbedding
-import org.jetbrains.kotlin.formver.viper.NameResolver
-import org.jetbrains.kotlin.formver.viper.SEPARATOR
-import org.jetbrains.kotlin.formver.viper.SymbolicName
-import org.jetbrains.kotlin.formver.viper.mangled
+import org.jetbrains.kotlin.formver.viper.*
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
@@ -30,13 +27,17 @@ data class SimpleKotlinName(val name: Name) : KotlinName {
         get() = name.asStringStripSpecialMarkers()
 }
 
-abstract class TypedKotlinName(override val mangledType: String, open val name: Name) : KotlinName {
+abstract class TypedKotlinName(override val mangledType: NameType, open val name: Name) : KotlinName {
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = name.asStringStripSpecialMarkers()
 }
 
-abstract class TypedKotlinNameWithType(override val mangledType: String, open val name: Name, val type: TypeEmbedding) :
+abstract class TypedKotlinNameWithType(
+    override val mangledType: NameType,
+    open val name: Name,
+    val type: TypeEmbedding
+) :
     KotlinName {
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
@@ -45,26 +46,26 @@ abstract class TypedKotlinNameWithType(override val mangledType: String, open va
 
 data class FunctionKotlinName(override val name: Name, val functionType: FunctionTypeEmbedding) :
     TypedKotlinNameWithType(
-        "f", name,
+        NameType.Function, name,
         functionType.asTypeEmbedding()
     )
 
 /**
  * This name will never occur in the viper output, but rather is used to lookup properties.
  */
-data class PropertyKotlinName(override val name: Name) : TypedKotlinName("pp", name)
-data class BackingFieldKotlinName(override val name: Name) : TypedKotlinName("bf", name)
-data class GetterKotlinName(override val name: Name) : TypedKotlinName("pg", name)
-data class SetterKotlinName(override val name: Name) : TypedKotlinName("ps", name)
+data class PropertyKotlinName(override val name: Name) : TypedKotlinName(NameType.Property, name)
+data class BackingFieldKotlinName(override val name: Name) : TypedKotlinName(NameType.BackingField, name)
+data class GetterKotlinName(override val name: Name) : TypedKotlinName(NameType.Getter, name)
+data class SetterKotlinName(override val name: Name) : TypedKotlinName(NameType.Setter, name)
 data class ExtensionSetterKotlinName(override val name: Name, val functionType: FunctionTypeEmbedding) :
-    TypedKotlinNameWithType("es", name, functionType.asTypeEmbedding())
+    TypedKotlinNameWithType(NameType.ExtensionSetter, name, functionType.asTypeEmbedding())
 
 data class ExtensionGetterKotlinName(override val name: Name, val functionType: FunctionTypeEmbedding) :
-    TypedKotlinNameWithType("eg", name, functionType.asTypeEmbedding())
+    TypedKotlinNameWithType(NameType.ExtensionGetter, name, functionType.asTypeEmbedding())
 
 data class ClassKotlinName(val name: FqName) : KotlinName {
-    override val mangledType: String
-        get() = "c"
+    override val mangledType: NameType
+        get() = NameType.Type.Class
 
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
@@ -74,8 +75,8 @@ data class ClassKotlinName(val name: FqName) : KotlinName {
 }
 
 data class ConstructorKotlinName(val type: FunctionTypeEmbedding) : KotlinName {
-    override val mangledType: String
-        get() = "con"
+    override val mangledType: NameType
+        get() = NameType.Constructor
 
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
@@ -88,38 +89,46 @@ data class PredicateKotlinName(val name: String) : KotlinName {
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = name
-    override val mangledType: String
-        get() = "p"
+    override val mangledType: NameType
+        get() = NameType.Predicate
 }
 
 data class HavocKotlinName(val type: TypeEmbedding) : KotlinName {
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = type.name.mangled
-    override val mangledType: String
-        get() = "havoc"
+    override val mangledType: NameType
+        get() = NameType.Havoc
 }
 
 data class PretypeName(val name: String) : KotlinName {
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = name
 }
 
 data class SetOfNames(val names: List<SymbolicName>) : KotlinName {
+    override val mangledType: NameType
+        get() = NameType.Type
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = names.joinToString(SEPARATOR) { it.mangled }
 }
 
 data class TypeName(val pretype: PretypeEmbedding, val nullable: Boolean) : KotlinName {
+
+    override val mangledType: NameType
+        get() = NameType.Type
+
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
-        get() = pretype.name.mangledBaseName
-    override val mangledType: String
-        get() = listOfNotNull(
-            if (nullable) "N" else null,
-            "T",
-            if (pretype is FunctionTypeEmbedding) "F" else null
-        ).joinToString("")
+        get() = buildString {
+            if (nullable) append("N")
+            if (pretype is FunctionTypeEmbedding) append("F")
+            if (isNotEmpty()) append(SEPARATOR)
+            append(pretype.name.mangledBaseName)
+        }
+
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
@@ -87,7 +87,7 @@ data object ParameterScope : NameScope {
 
     context(nameResolver: NameResolver)
     override val mangledScopeName: String
-        get() = "p"
+        get() = "par"
 }
 
 data object BadScope : NameScope {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedKotlinName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedKotlinName.kt
@@ -5,8 +5,9 @@
 
 package org.jetbrains.kotlin.formver.core.names
 
-import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.NameResolver
+import org.jetbrains.kotlin.formver.viper.NameType
+import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.name.FqName
 
 /**
@@ -20,8 +21,8 @@ data class ScopedKotlinName(val scope: NameScope, val name: KotlinName) : Symbol
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = name.mangledBaseName
-    override val mangledType: String?
-        get() = name.mangledType
+
+    override val mangledType: NameType? = name.mangledType
 }
 
 fun FqName.asViperString() = asString().replace('.', '_')

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
@@ -1,8 +1,9 @@
 package org.jetbrains.kotlin.formver.names
 
-import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.NameResolver
+import org.jetbrains.kotlin.formver.viper.NameType
 import org.jetbrains.kotlin.formver.viper.SEPARATOR
+import org.jetbrains.kotlin.formver.viper.SymbolicName
 
 /**
  * Resolves mangled names into Viper identifiers while maintaining uniqueness.
@@ -17,7 +18,10 @@ import org.jetbrains.kotlin.formver.viper.SEPARATOR
  *  3. Track used names to detect conflicts for future resolutions.
  */
 class SimpleNameResolver : NameResolver {
-    override fun resolve(name: SymbolicName): String =
-        listOfNotNull(name.mangledType, name.mangledScope, name.mangledBaseName).joinToString(SEPARATOR)
+    override fun resolve(name: SymbolicName): String = listOfNotNull(
+        name.mangledType.takeUnless { it is NameType.Variable },
+        name.mangledScope,
+        name.mangledBaseName
+    ).joinToString(SEPARATOR)
     override fun register(name: SymbolicName) {}
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/basic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/basic.fir.diag.txt
@@ -1,5 +1,5 @@
 /basic.kt:(23,33): info: Generated Viper text for returnUnit:
-method f$returnUnit$TF$T$Unit() returns (ret$0: Ref)
+method f$returnUnit$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -7,7 +7,7 @@ method f$returnUnit$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /basic.kt:(43,52): info: Generated Viper text for returnInt:
-method f$returnInt$TF$T$Int() returns (ret$0: Ref)
+method f$returnInt$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   ret$0 := df$rt$intToRef(0)
@@ -16,8 +16,9 @@ method f$returnInt$TF$T$Int() returns (ret$0: Ref)
 }
 
 /basic.kt:(77,94): info: Generated Viper text for takeIntReturnUnit:
-method f$takeIntReturnUnit$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$takeIntReturnUnit$t$F$t$Int$t$Unit(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -25,27 +26,28 @@ method f$takeIntReturnUnit$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 }
 
 /basic.kt:(140,156): info: Generated Viper text for takeIntReturnInt:
-method f$takeIntReturnInt$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$takeIntReturnInt$t$F$t$Int$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /basic.kt:(187,207): info: Generated Viper text for takeIntReturnIntExpr:
-method f$takeIntReturnIntExpr$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$takeIntReturnIntExpr$t$F$t$Int$t$Int(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /basic.kt:(229,247): info: Generated Viper text for withIntDeclaration:
-method f$withIntDeclaration$TF$T$Int() returns (ret$0: Ref)
+method f$withIntDeclaration$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$x: Ref
@@ -56,7 +58,7 @@ method f$withIntDeclaration$TF$T$Int() returns (ret$0: Ref)
 }
 
 /basic.kt:(290,303): info: Generated Viper text for intAssignment:
-method f$intAssignment$TF$T$Unit() returns (ret$0: Ref)
+method f$intAssignment$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
@@ -3,17 +3,17 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-method f$testPrimitiveFieldGetter$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
+method f$testPrimitiveFieldGetter$t$F$t$PrimitiveFields$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  l0$a := p$pf.bf$a
-  l0$b := havoc$T$Int()
+  inhale acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  unfold acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  l0$a := par$pf.bf$a
+  l0$b := havoc$t$Int()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -27,9 +27,9 @@ field bf$f: Ref
 
 field bf$g: Ref
 
-method f$testReferenceFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
+method f$testReferenceFieldGetter$t$F$t$ReferenceFields$t$Unit(par$rf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
@@ -38,16 +38,16 @@ method f$testReferenceFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$fb: Ref
   var l0$ga: Ref
   var l0$gb: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  l0$f := p$rf.bf$f
-  l0$g := havoc$T$PrimitiveFields()
-  unfold acc(p$c$PrimitiveFields$shared(l0$f), wildcard)
+  inhale acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  unfold acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  l0$f := par$rf.bf$f
+  l0$g := havoc$t$PrimitiveFields()
+  unfold acc(pred$c$PrimitiveFields$shared(l0$f), wildcard)
   l0$fa := l0$f.bf$a
-  l0$fb := havoc$T$Int()
-  unfold acc(p$c$PrimitiveFields$shared(l0$g), wildcard)
+  l0$fb := havoc$t$Int()
+  unfold acc(pred$c$PrimitiveFields$shared(l0$g), wildcard)
   l0$ga := l0$g.bf$a
-  l0$gb := havoc$T$Int()
+  l0$gb := havoc$t$Int()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -61,9 +61,9 @@ field bf$f: Ref
 
 field bf$g: Ref
 
-method f$testCascadingFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
+method f$testCascadingFieldGetter$t$F$t$ReferenceFields$t$Unit(par$rf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$fa: Ref
@@ -72,16 +72,16 @@ method f$testCascadingFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$ga: Ref
   var anon$1: Ref
   var l0$gb: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  anon$0 := p$rf.bf$f
-  unfold acc(p$c$PrimitiveFields$shared(anon$0), wildcard)
+  inhale acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  unfold acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  anon$0 := par$rf.bf$f
+  unfold acc(pred$c$PrimitiveFields$shared(anon$0), wildcard)
   l0$fa := anon$0.bf$a
-  l0$fb := havoc$T$Int()
-  anon$1 := havoc$T$PrimitiveFields()
-  unfold acc(p$c$PrimitiveFields$shared(anon$1), wildcard)
+  l0$fb := havoc$t$Int()
+  anon$1 := havoc$t$PrimitiveFields()
+  unfold acc(pred$c$PrimitiveFields$shared(anon$1), wildcard)
   l0$ga := anon$1.bf$a
-  l0$gb := havoc$T$Int()
+  l0$gb := havoc$t$Int()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
@@ -7,23 +7,23 @@ field bf$uniqueVal: Ref
 
 field bf$uniqueVar: Ref
 
-method f$testPrimitiveFieldGetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
+method f$testPrimitiveFieldGetterUnique$t$F$t$PrimitiveFields$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
-  requires acc(p$c$PrimitiveFields$unique(p$pf), write)
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveFields())
+  requires acc(pred$c$PrimitiveFields$unique(par$pf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  l0$sharedVal := p$pf.bf$sharedVal
-  l0$sharedVar := havoc$T$Int()
-  unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  l0$uniqueVal := p$pf.bf$uniqueVal
-  l0$uniqueVar := havoc$T$Int()
+  inhale acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  unfold acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  l0$sharedVal := par$pf.bf$sharedVal
+  l0$sharedVar := havoc$t$Int()
+  unfold acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  l0$uniqueVal := par$pf.bf$uniqueVal
+  l0$uniqueVar := havoc$t$Int()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -37,22 +37,22 @@ field bf$uniqueVal: Ref
 
 field bf$uniqueVar: Ref
 
-method f$testPrimitiveFieldGetterShared$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
+method f$testPrimitiveFieldGetterShared$t$F$t$PrimitiveFields$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  l0$sharedVal := p$pf.bf$sharedVal
-  l0$sharedVar := havoc$T$Int()
-  unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
-  l0$uniqueVal := p$pf.bf$uniqueVal
-  l0$uniqueVar := havoc$T$Int()
+  inhale acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  unfold acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  l0$sharedVal := par$pf.bf$sharedVal
+  l0$sharedVar := havoc$t$Int()
+  unfold acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
+  l0$uniqueVal := par$pf.bf$uniqueVal
+  l0$uniqueVar := havoc$t$Int()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -66,23 +66,23 @@ field bf$uniqueVal: Ref
 
 field bf$uniqueVar: Ref
 
-method f$testReferenceFieldGetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
+method f$testReferenceFieldGetterUnique$t$F$t$ReferenceFields$t$Unit(par$rf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
-  requires acc(p$c$ReferenceFields$unique(p$rf), write)
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceFields())
+  requires acc(pred$c$ReferenceFields$unique(par$rf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  l0$sharedVal := p$rf.bf$sharedVal
-  l0$sharedVar := havoc$T$PrimitiveFields()
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  l0$uniqueVal := p$rf.bf$uniqueVal
-  l0$uniqueVar := havoc$T$PrimitiveFields()
+  inhale acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  unfold acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  l0$sharedVal := par$rf.bf$sharedVal
+  l0$sharedVar := havoc$t$PrimitiveFields()
+  unfold acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  l0$uniqueVal := par$rf.bf$uniqueVal
+  l0$uniqueVar := havoc$t$PrimitiveFields()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -96,22 +96,22 @@ field bf$uniqueVal: Ref
 
 field bf$uniqueVar: Ref
 
-method f$testReferenceFieldGetterShared$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
+method f$testReferenceFieldGetterShared$t$F$t$ReferenceFields$t$Unit(par$rf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  l0$sharedVal := p$rf.bf$sharedVal
-  l0$sharedVar := havoc$T$PrimitiveFields()
-  unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  l0$uniqueVal := p$rf.bf$uniqueVal
-  l0$uniqueVar := havoc$T$PrimitiveFields()
+  inhale acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  unfold acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  l0$sharedVal := par$rf.bf$sharedVal
+  l0$sharedVar := havoc$t$PrimitiveFields()
+  unfold acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  l0$uniqueVal := par$rf.bf$uniqueVal
+  l0$uniqueVar := havoc$t$PrimitiveFields()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
@@ -3,13 +3,13 @@ field bf$shared: Ref
 
 field bf$unique: Ref
 
-method f$testPrimitiveFieldSetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
+method f$testPrimitiveFieldSetterUnique$t$F$t$PrimitiveFields$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
-  requires acc(p$c$PrimitiveFields$unique(p$pf), write)
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveFields())
+  requires acc(pred$c$PrimitiveFields$unique(par$pf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
+  inhale acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -19,12 +19,12 @@ field bf$shared: Ref
 
 field bf$unique: Ref
 
-method f$testPrimitiveFieldSetterShared$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
+method f$testPrimitiveFieldSetterShared$t$F$t$PrimitiveFields$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
+  inhale acc(pred$c$PrimitiveFields$shared(par$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -34,27 +34,28 @@ field bf$shared: Ref
 
 field bf$unique: Ref
 
-method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$unique: Ref)
+method con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(par$shared: Ref,
+  par$unique: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$shared), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$unique), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$shared), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$unique), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
-  ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
-  ensures acc(p$c$PrimitiveFields$unique(ret), write)
+  ensures acc(pred$c$PrimitiveFields$shared(ret), wildcard)
+  ensures acc(pred$c$PrimitiveFields$unique(ret), write)
 
 
-method f$testReferenceFieldSetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
+method f$testReferenceFieldSetterUnique$t$F$t$ReferenceFields$t$Unit(par$rf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
-  requires acc(p$c$ReferenceFields$unique(p$rf), write)
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceFields())
+  requires acc(pred$c$ReferenceFields$unique(par$rf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  anon$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(5),
+  inhale acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  anon$0 := con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(df$rt$intToRef(5),
     df$rt$intToRef(6))
-  anon$1 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(7),
+  anon$1 := con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(df$rt$intToRef(7),
     df$rt$intToRef(8))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -65,26 +66,27 @@ field bf$shared: Ref
 
 field bf$unique: Ref
 
-method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$unique: Ref)
+method con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(par$shared: Ref,
+  par$unique: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$shared), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$unique), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$shared), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$unique), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
-  ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
-  ensures acc(p$c$PrimitiveFields$unique(ret), write)
+  ensures acc(pred$c$PrimitiveFields$shared(ret), wildcard)
+  ensures acc(pred$c$PrimitiveFields$unique(ret), write)
 
 
-method f$testReferenceFieldSetterShared$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
+method f$testReferenceFieldSetterShared$t$F$t$ReferenceFields$t$Unit(par$rf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
-  anon$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(9),
+  inhale acc(pred$c$ReferenceFields$shared(par$rf), wildcard)
+  anon$0 := con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(df$rt$intToRef(9),
     df$rt$intToRef(10))
-  anon$1 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(11),
+  anon$1 := con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(df$rt$intToRef(11),
     df$rt$intToRef(12))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
@@ -5,12 +5,13 @@ field bf$x: Ref
 
 field bf$y: Ref
 
-method f$c$Foo$getY$TF$T$Foo$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
+method f$c$Foo$getY$t$F$t$Foo$t$Int(this$dispatch: Ref)
+  returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Foo$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$y
   goto lbl$ret$0
   label lbl$ret$0
@@ -25,17 +26,17 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$c$Bar$sum$TF$T$Bar$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
+method f$c$Bar$sum$t$F$t$Bar$t$Int(this$dispatch: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Bar$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Bar$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$Bar$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$Foo$shared(this$dispatch), wildcard)
   anon$0 := this$dispatch.bf$x
-  unfold acc(p$c$Bar$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$Bar$shared(this$dispatch), wildcard)
   anon$1 := this$dispatch.bf$z
   ret$0 := sp$plusInts(anon$0, anon$1)
   goto lbl$ret$0
@@ -51,17 +52,17 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$c$Foo$getY$TF$T$Foo$T$Int(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$getY$t$F$t$Foo$t$Int(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$callSuperMethod$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+method f$callSuperMethod$t$F$t$Bar$t$Int(par$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
-  ret$0 := f$c$Foo$getY$TF$T$Foo$T$Int(p$bar)
+  inhale acc(pred$c$Bar$shared(par$bar), wildcard)
+  ret$0 := f$c$Foo$getY$t$F$t$Foo$t$Int(par$bar)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -75,13 +76,13 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$accessSuperField$TF$T$Bar$T$Boolean(p$bar: Ref)
+method f$accessSuperField$t$F$t$Bar$t$Boolean(par$bar: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+  requires df$rt$isSubtype(df$rt$typeOf(par$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
-  ret$0 := havoc$T$Boolean()
+  inhale acc(pred$c$Bar$shared(par$bar), wildcard)
+  ret$0 := havoc$t$Boolean()
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -95,13 +96,13 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$accessNewField$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+method f$accessNewField$t$F$t$Bar$t$Int(par$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
-  unfold acc(p$c$Bar$shared(p$bar), wildcard)
-  ret$0 := p$bar.bf$z
+  inhale acc(pred$c$Bar$shared(par$bar), wildcard)
+  unfold acc(pred$c$Bar$shared(par$bar), wildcard)
+  ret$0 := par$bar.bf$z
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -115,17 +116,17 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$c$Bar$sum$TF$T$Bar$T$Int(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Bar$sum$t$F$t$Bar$t$Int(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$callNewMethod$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+method f$callNewMethod$t$F$t$Bar$t$Int(par$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
-  ret$0 := f$c$Bar$sum$TF$T$Bar$T$Int(p$bar)
+  inhale acc(pred$c$Bar$shared(par$bar), wildcard)
+  ret$0 := f$c$Bar$sum$t$F$t$Bar$t$Int(par$bar)
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -139,11 +140,11 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$setSuperField$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+method f$setSuperField$t$F$t$Bar$t$Unit(par$bar: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
+  inhale acc(pred$c$Bar$shared(par$bar), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -157,16 +158,16 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$accessSuperSuperField$TF$T$Baz$T$Int(p$baz: Ref)
+method f$accessSuperSuperField$t$F$t$Baz$t$Int(par$baz: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$baz), df$rt$c$Baz())
+  requires df$rt$isSubtype(df$rt$typeOf(par$baz), df$rt$c$Baz())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Baz$shared(p$baz), wildcard)
-  unfold acc(p$c$Baz$shared(p$baz), wildcard)
-  unfold acc(p$c$Bar$shared(p$baz), wildcard)
-  unfold acc(p$c$Foo$shared(p$baz), wildcard)
-  ret$0 := p$baz.bf$x
+  inhale acc(pred$c$Baz$shared(par$baz), wildcard)
+  unfold acc(pred$c$Baz$shared(par$baz), wildcard)
+  unfold acc(pred$c$Bar$shared(par$baz), wildcard)
+  unfold acc(pred$c$Foo$shared(par$baz), wildcard)
+  ret$0 := par$baz.bf$x
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
@@ -1,20 +1,20 @@
 /inheritance_fields.kt:(227,234): info: Generated Viper text for createB:
 field bf$fieldNotOverride: Ref
 
-method con$c$B$T$FieldB$T$B(p$fieldOverride: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$fieldOverride), df$rt$c$FieldB())
+method con$c$B$t$FieldB$t$B(par$fieldOverride: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$fieldOverride), df$rt$c$FieldB())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$B())
-  ensures acc(p$c$B$shared(ret), wildcard)
-  ensures acc(p$c$B$unique(ret), write)
+  ensures acc(pred$c$B$shared(ret), wildcard)
+  ensures acc(pred$c$B$unique(ret), write)
 
 
-method con$c$FieldB$T$FieldB() returns (ret: Ref)
+method con$c$FieldB$t$FieldB() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FieldB())
-  ensures acc(p$c$FieldB$shared(ret), wildcard)
-  ensures acc(p$c$FieldB$unique(ret), write)
+  ensures acc(pred$c$FieldB$shared(ret), wildcard)
+  ensures acc(pred$c$FieldB$unique(ret), write)
 
 
-method f$createB$TF$T$Unit() returns (ret$0: Ref)
+method f$createB$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$fieldB: Ref
@@ -22,50 +22,50 @@ method f$createB$TF$T$Unit() returns (ret$0: Ref)
   var l0$fieldOverride: Ref
   var anon$0: Ref
   var l0$fieldNotOverride: Ref
-  l0$fieldB := con$c$FieldB$T$FieldB()
-  l0$b := con$c$B$T$FieldB$T$B(l0$fieldB)
-  anon$0 := pg$public$fieldOverride(l0$b)
+  l0$fieldB := con$c$FieldB$t$FieldB()
+  l0$b := con$c$B$t$FieldB$t$B(l0$fieldB)
+  anon$0 := g$public$fieldOverride(l0$b)
   l0$fieldOverride := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$fieldOverride), df$rt$c$FieldB())
-  inhale acc(p$c$FieldB$shared(l0$fieldOverride), wildcard)
-  unfold acc(p$c$B$shared(l0$b), wildcard)
-  unfold acc(p$c$A$shared(l0$b), wildcard)
+  inhale acc(pred$c$FieldB$shared(l0$fieldOverride), wildcard)
+  unfold acc(pred$c$B$shared(l0$b), wildcard)
+  unfold acc(pred$c$A$shared(l0$b), wildcard)
   l0$fieldNotOverride := l0$b.bf$fieldNotOverride
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$fieldOverride(this$dispatch: Ref) returns (ret: Ref)
+method g$public$fieldOverride(this$dispatch: Ref) returns (ret: Ref)
 
 
 /inheritance_fields.kt:(699,715): info: Generated Viper text for createBFsAndNoBF:
 field bf$x: Ref
 
-method con$c$FirstBackingFieldClass$T$FirstBackingFieldClass()
+method con$c$FirstBackingFieldClass$t$FirstBackingFieldClass()
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FirstBackingFieldClass())
-  ensures acc(p$c$FirstBackingFieldClass$shared(ret), wildcard)
-  ensures acc(p$c$FirstBackingFieldClass$unique(ret), write)
+  ensures acc(pred$c$FirstBackingFieldClass$shared(ret), wildcard)
+  ensures acc(pred$c$FirstBackingFieldClass$unique(ret), write)
 
 
-method con$c$NoBackingFieldClass$T$NoBackingFieldClass() returns (ret: Ref)
+method con$c$NoBackingFieldClass$t$NoBackingFieldClass() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoBackingFieldClass())
-  ensures acc(p$c$NoBackingFieldClass$shared(ret), wildcard)
-  ensures acc(p$c$NoBackingFieldClass$unique(ret), write)
+  ensures acc(pred$c$NoBackingFieldClass$shared(ret), wildcard)
+  ensures acc(pred$c$NoBackingFieldClass$unique(ret), write)
 
 
-method con$c$SecondBackingFieldClass$T$Int$T$SecondBackingFieldClass(p$x: Ref)
+method con$c$SecondBackingFieldClass$t$Int$t$SecondBackingFieldClass(par$x: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$SecondBackingFieldClass())
-  ensures acc(p$c$SecondBackingFieldClass$shared(ret), wildcard)
-  ensures acc(p$c$SecondBackingFieldClass$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$SecondBackingFieldClass$shared(ret), wildcard) in
+  ensures acc(pred$c$SecondBackingFieldClass$shared(ret), wildcard)
+  ensures acc(pred$c$SecondBackingFieldClass$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$SecondBackingFieldClass$shared(ret), wildcard) in
       ret.bf$x)) ==
-    df$rt$intFromRef(p$x)
+    df$rt$intFromRef(par$x)
 
 
-method f$createBFsAndNoBF$TF$T$Unit() returns (ret$0: Ref)
+method f$createBFsAndNoBF$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$fbf: Ref
@@ -76,42 +76,42 @@ method f$createBFsAndNoBF$TF$T$Unit() returns (ret$0: Ref)
   var anon$1: Ref
   var l0$sbf: Ref
   var l0$sbfx: Ref
-  l0$fbf := con$c$FirstBackingFieldClass$T$FirstBackingFieldClass()
-  anon$0 := pg$public$x(l0$fbf)
+  l0$fbf := con$c$FirstBackingFieldClass$t$FirstBackingFieldClass()
+  anon$0 := g$public$x(l0$fbf)
   l0$fbfx := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$fbfx), df$rt$intType())
-  l0$nbf := con$c$NoBackingFieldClass$T$NoBackingFieldClass()
-  anon$1 := pg$public$x(l0$nbf)
+  l0$nbf := con$c$NoBackingFieldClass$t$NoBackingFieldClass()
+  anon$1 := g$public$x(l0$nbf)
   l0$nbfx := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(l0$nbfx), df$rt$intType())
-  l0$sbf := con$c$SecondBackingFieldClass$T$Int$T$SecondBackingFieldClass(df$rt$intToRef(10))
-  unfold acc(p$c$SecondBackingFieldClass$shared(l0$sbf), wildcard)
+  l0$sbf := con$c$SecondBackingFieldClass$t$Int$t$SecondBackingFieldClass(df$rt$intToRef(10))
+  unfold acc(pred$c$SecondBackingFieldClass$shared(l0$sbf), wildcard)
   l0$sbfx := l0$sbf.bf$x
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$x(this$dispatch: Ref) returns (ret: Ref)
+method g$public$x(this$dispatch: Ref) returns (ret: Ref)
 
 
 /inheritance_fields.kt:(1038,1045): info: Generated Viper text for createY:
 field bf$a: Ref
 
-method con$c$Y$T$Int$T$Y(p$a: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
+method con$c$Y$t$Int$t$Y(par$a: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Y())
-  ensures acc(p$c$Y$shared(ret), wildcard)
-  ensures acc(p$c$Y$unique(ret), write)
+  ensures acc(pred$c$Y$shared(ret), wildcard)
+  ensures acc(pred$c$Y$unique(ret), write)
 
 
-method f$createY$TF$T$Unit() returns (ret$0: Ref)
+method f$createY$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
   var l0$ya: Ref
-  l0$y := con$c$Y$T$Int$T$Y(df$rt$intToRef(10))
-  unfold acc(p$c$Y$shared(l0$y), wildcard)
-  unfold acc(p$c$X$shared(l0$y), wildcard)
+  l0$y := con$c$Y$t$Int$t$Y(df$rt$intToRef(10))
+  unfold acc(pred$c$Y$shared(l0$y), wildcard)
+  unfold acc(pred$c$X$shared(l0$y), wildcard)
   l0$ya := l0$y.bf$a
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
@@ -1,6 +1,6 @@
 /interface.kt:(84,98): info: Generated Viper text for testProperties:
-method f$testProperties$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+method f$testProperties$t$F$t$Foo$t$Unit(par$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -9,12 +9,12 @@ method f$testProperties$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
   var anon$2: Ref
   var anon$3: Ref
   var anon$4: Ref
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  anon$0 := ps$public$varProp(p$foo, df$rt$intToRef(0))
-  anon$2 := pg$public$varProp(p$foo)
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  anon$0 := s$public$varProp(par$foo, df$rt$intToRef(0))
+  anon$2 := g$public$varProp(par$foo)
   anon$1 := anon$2
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-  anon$4 := pg$public$valProp(p$foo)
+  anon$4 := g$public$valProp(par$foo)
   anon$3 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$intType())
   l0$x := sp$plusInts(anon$1, anon$3)
@@ -22,39 +22,39 @@ method f$testProperties$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$valProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$valProp(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$varProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$varProp(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$public$varProp(this$dispatch: Ref, anon$0: Ref)
-  returns (ret: Ref)
+method s$public$varProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
 
 
 /interface.kt:(348,358): info: Generated Viper text for createImpl:
 field bf$number: Ref
 
-method con$c$Impl$T$Int$T$Impl(p$number: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$number), df$rt$intType())
+method con$c$Impl$t$Int$t$Impl(par$number: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$number), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl())
-  ensures acc(p$c$Impl$shared(ret), wildcard)
-  ensures acc(p$c$Impl$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$Impl$shared(ret), wildcard) in
+  ensures acc(pred$c$Impl$shared(ret), wildcard)
+  ensures acc(pred$c$Impl$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$Impl$shared(ret), wildcard) in
       ret.bf$number)) ==
-    df$rt$intFromRef(p$number)
+    df$rt$intFromRef(par$number)
 
 
-method f$createImpl$TF$T$Unit() returns (ret$0: Ref)
+method f$createImpl$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$impl: Ref
   var l0$implField: Ref
-  l0$impl := con$c$Impl$T$Int$T$Impl(df$rt$intToRef(-1))
-  unfold acc(p$c$Impl$shared(l0$impl), wildcard)
+  l0$impl := con$c$Impl$t$Int$t$Impl(df$rt$intToRef(-1))
+  unfold acc(pred$c$Impl$shared(l0$impl), wildcard)
   l0$implField := l0$impl.bf$number
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$number(this$dispatch: Ref) returns (ret: Ref)
+method g$public$number(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
@@ -3,17 +3,17 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-method f$testManualPermissionFieldGetter$TF$T$ManualPermissionFields$T$Unit(p$mpf: Ref)
+method f$testManualPermissionFieldGetter$t$F$t$ManualPermissionFields$t$Unit(par$mpf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$mpf), df$rt$c$ManualPermissionFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
-  unfold acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
-  l0$a := p$mpf.bf$a
-  l0$b := p$mpf.bf$b
+  inhale acc(pred$c$ManualPermissionFields$shared(par$mpf), wildcard)
+  unfold acc(pred$c$ManualPermissionFields$shared(par$mpf), wildcard)
+  l0$a := par$mpf.bf$a
+  l0$b := par$mpf.bf$b
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -24,13 +24,13 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-method f$testManualPermissionFieldSetter$TF$T$ManualPermissionFields$T$Unit(p$mpf: Ref)
+method f$testManualPermissionFieldSetter$t$F$t$ManualPermissionFields$t$Unit(par$mpf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
+  requires df$rt$isSubtype(df$rt$typeOf(par$mpf), df$rt$c$ManualPermissionFields())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
-  p$mpf.bf$b := df$rt$intToRef(123)
+  inhale acc(pred$c$ManualPermissionFields$shared(par$mpf), wildcard)
+  par$mpf.bf$b := df$rt$intToRef(123)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
@@ -1,13 +1,13 @@
 /member_functions.kt:(51,60): info: Generated Viper text for memberFun:
 field bf$x: Ref
 
-method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
+method f$c$Foo$memberFun$t$F$t$Foo$t$Int(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Foo$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -16,19 +16,19 @@ method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
 /member_functions.kt:(102,115): info: Generated Viper text for callMemberFun:
 field bf$x: Ref
 
-method f$c$Foo$callMemberFun$TF$T$Foo$T$Unit(this$dispatch: Ref)
+method f$c$Foo$callMemberFun$t$F$t$Foo$t$Unit(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch)
+  inhale acc(pred$c$Foo$shared(this$dispatch), wildcard)
+  anon$0 := f$c$Foo$memberFun$t$F$t$Foo$t$Int(this$dispatch)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
+method f$c$Foo$memberFun$t$F$t$Foo$t$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -37,22 +37,22 @@ method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
 /member_functions.kt:(155,166): info: Generated Viper text for siblingCall:
 field bf$x: Ref
 
-method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
+method f$c$Foo$memberFun$t$F$t$Foo$t$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$c$Foo$siblingCall$TF$T$Foo$T$Foo$T$Unit(this$dispatch: Ref, p$other: Ref)
+method f$c$Foo$siblingCall$t$F$t$Foo$t$Foo$t$Unit(this$dispatch: Ref, par$other: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$c$Foo())
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Foo$shared(p$other), wildcard)
-  anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(p$other)
+  inhale acc(pred$c$Foo$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Foo$shared(par$other), wildcard)
+  anon$0 := f$c$Foo$memberFun$t$F$t$Foo$t$Int(par$other)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -60,19 +60,20 @@ method f$c$Foo$siblingCall$TF$T$Foo$T$Foo$T$Unit(this$dispatch: Ref, p$other: Re
 /member_functions.kt:(220,238): info: Generated Viper text for outerMemberFunCall:
 field bf$x: Ref
 
-method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
+method f$c$Foo$memberFun$t$F$t$Foo$t$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$outerMemberFunCall$TF$T$Foo$T$Unit(p$f: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+method f$outerMemberFunCall$t$F$t$Foo$t$Unit(par$f: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(p$f), wildcard)
-  anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(p$f)
+  inhale acc(pred$c$Foo$shared(par$f), wildcard)
+  anon$0 := f$c$Foo$memberFun$t$F$t$Foo$t$Int(par$f)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
@@ -1,40 +1,40 @@
 /multiple_interfaces.kt:(162,173): info: Generated Viper text for testDiamond:
-method con$c$D$T$D() returns (ret: Ref)
+method con$c$D$t$D() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$D())
-  ensures acc(p$c$D$shared(ret), wildcard)
-  ensures acc(p$c$D$unique(ret), write)
+  ensures acc(pred$c$D$shared(ret), wildcard)
+  ensures acc(pred$c$D$unique(ret), write)
 
 
-method f$testDiamond$TF$T$Int() returns (ret$0: Ref)
+method f$testDiamond$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  anon$1 := con$c$D$T$D()
-  anon$0 := pg$public$field(anon$1)
+  anon$1 := con$c$D$t$D()
+  anon$0 := g$public$field(anon$1)
   ret$0 := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+method g$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 /multiple_interfaces.kt:(405,415): info: Generated Viper text for testVarVal:
-method con$c$G$T$G() returns (ret: Ref)
+method con$c$G$t$G() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$G())
-  ensures acc(p$c$G$shared(ret), wildcard)
-  ensures acc(p$c$G$unique(ret), write)
+  ensures acc(pred$c$G$shared(ret), wildcard)
+  ensures acc(pred$c$G$unique(ret), write)
 
 
-method con$c$I$T$I() returns (ret: Ref)
+method con$c$I$t$I() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$I())
-  ensures acc(p$c$I$shared(ret), wildcard)
-  ensures acc(p$c$I$unique(ret), write)
+  ensures acc(pred$c$I$shared(ret), wildcard)
+  ensures acc(pred$c$I$unique(ret), write)
 
 
-method f$testVarVal$TF$T$Unit() returns (ret$0: Ref)
+method f$testVarVal$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$g: Ref
@@ -45,21 +45,22 @@ method f$testVarVal$TF$T$Unit() returns (ret$0: Ref)
   var anon$3: Ref
   var anon$4: Ref
   var anon$5: Ref
-  l0$g := con$c$G$T$G()
-  anon$1 := pg$public$field(l0$g)
+  l0$g := con$c$G$t$G()
+  anon$1 := g$public$field(l0$g)
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
-  anon$2 := ps$public$field(l0$g, df$rt$intToRef(1))
-  l0$i := con$c$I$T$I()
-  anon$4 := pg$public$field(l0$i)
+  anon$2 := s$public$field(l0$g, df$rt$intToRef(1))
+  l0$i := con$c$I$t$I()
+  anon$4 := g$public$field(l0$i)
   anon$3 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$intType())
-  anon$5 := ps$public$field(l0$i, df$rt$intToRef(1))
+  anon$5 := s$public$field(l0$i, df$rt$intToRef(1))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+method g$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+method s$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
@@ -7,62 +7,62 @@ field bf$next: Ref
 
 field bf$pf: Ref
 
-predicate p$c$Baz$shared(this$dispatch: Ref) {
+predicate pred$c$Baz$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$Baz$unique(this$dispatch: Ref) {
+predicate pred$c$Baz$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$PrimitiveFields$shared(this$dispatch: Ref) {
+predicate pred$c$PrimitiveFields$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$PrimitiveFields$unique(this$dispatch: Ref) {
+predicate pred$c$PrimitiveFields$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType()) &&
   acc(this$dispatch.bf$b, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType())
 }
 
-predicate p$c$Recursive$shared(this$dispatch: Ref) {
+predicate pred$c$Recursive$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Recursive$shared(this$dispatch.bf$next), wildcard)) &&
+  acc(pred$c$Recursive$shared(this$dispatch.bf$next), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Recursive()))
 }
 
-predicate p$c$Recursive$unique(this$dispatch: Ref) {
+predicate pred$c$Recursive$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Recursive$shared(this$dispatch.bf$next), wildcard)) &&
+  acc(pred$c$Recursive$shared(this$dispatch.bf$next), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Recursive()))
 }
 
-predicate p$c$ReferenceField$shared(this$dispatch: Ref) {
+predicate pred$c$ReferenceField$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$pf, wildcard) &&
-  acc(p$c$PrimitiveFields$shared(this$dispatch.bf$pf), wildcard) &&
+  acc(pred$c$PrimitiveFields$shared(this$dispatch.bf$pf), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$pf), df$rt$c$PrimitiveFields()) &&
-  acc(p$c$Baz$shared(this$dispatch), wildcard)
+  acc(pred$c$Baz$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$ReferenceField$unique(this$dispatch: Ref) {
+predicate pred$c$ReferenceField$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$pf, wildcard) &&
-  acc(p$c$PrimitiveFields$shared(this$dispatch.bf$pf), wildcard) &&
+  acc(pred$c$PrimitiveFields$shared(this$dispatch.bf$pf), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$pf), df$rt$c$PrimitiveFields()) &&
-  acc(p$c$Baz$unique(this$dispatch), write)
+  acc(pred$c$Baz$unique(this$dispatch), write)
 }
 
-method f$useClasses$TF$T$ReferenceField$T$Recursive$T$Unit(p$rf: Ref, p$rec: Ref)
+method f$useClasses$t$F$t$ReferenceField$t$Recursive$t$Unit(par$rf: Ref, par$rec: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
-  requires df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$c$Recursive())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceField())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rec), df$rt$c$Recursive())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
-  inhale acc(p$c$Recursive$shared(p$rec), wildcard)
+  inhale acc(pred$c$ReferenceField$shared(par$rf), wildcard)
+  inhale acc(pred$c$Recursive$shared(par$rec), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -72,39 +72,40 @@ field bf$x: Ref
 
 field bf$y: Ref
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$intType())
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$intType()) &&
   acc(this$dispatch.bf$y, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$intType())
 }
 
-predicate p$c$B$shared(this$dispatch: Ref) {
-  acc(p$c$A$shared(this$dispatch), wildcard)
+predicate pred$c$B$shared(this$dispatch: Ref) {
+  acc(pred$c$A$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$B$unique(this$dispatch: Ref) {
-  acc(p$c$A$unique(this$dispatch), write)
+predicate pred$c$B$unique(this$dispatch: Ref) {
+  acc(pred$c$A$unique(this$dispatch), write)
 }
 
-predicate p$c$C$shared(this$dispatch: Ref) {
-  acc(p$c$B$shared(this$dispatch), wildcard)
+predicate pred$c$C$shared(this$dispatch: Ref) {
+  acc(pred$c$B$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$C$unique(this$dispatch: Ref) {
-  acc(p$c$B$unique(this$dispatch), write)
+predicate pred$c$C$unique(this$dispatch: Ref) {
+  acc(pred$c$B$unique(this$dispatch), write)
 }
 
-method f$threeLayersHierarchy$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+method f$threeLayersHierarchy$t$F$t$C$t$Unit(par$c: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$c$C())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$C$shared(p$c), wildcard)
+  inhale acc(pred$c$C$shared(par$c), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -112,68 +113,68 @@ method f$threeLayersHierarchy$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
 /predicates.kt:(390,403): info: Generated Viper text for listHierarchy:
 field sp$size: Ref
 
-predicate p$pkg$kotlin_collections$c$Collection$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Iterable$shared(this$dispatch), wildcard)
+predicate pred$pkg$kotlin_collections$c$Collection$shared(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Iterable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin_collections$c$Collection$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Iterable$unique(this$dispatch), write)
+predicate pred$pkg$kotlin_collections$c$Collection$unique(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Iterable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin_collections$c$Iterable$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin_collections$c$Iterable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin_collections$c$Iterable$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin_collections$c$Iterable$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin_collections$c$List$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Collection$shared(this$dispatch), wildcard)
+predicate pred$pkg$kotlin_collections$c$List$shared(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Collection$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin_collections$c$List$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Collection$unique(this$dispatch), write)
+predicate pred$pkg$kotlin_collections$c$List$unique(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Collection$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin_collections$c$MutableCollection$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Collection$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$kotlin_collections$c$MutableIterable$shared(this$dispatch), wildcard)
+predicate pred$pkg$kotlin_collections$c$MutableCollection$shared(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Collection$shared(this$dispatch), wildcard) &&
+  acc(pred$pkg$kotlin_collections$c$MutableIterable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin_collections$c$MutableCollection$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Collection$unique(this$dispatch), write) &&
-  acc(p$pkg$kotlin_collections$c$MutableIterable$unique(this$dispatch), write)
+predicate pred$pkg$kotlin_collections$c$MutableCollection$unique(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Collection$unique(this$dispatch), write) &&
+  acc(pred$pkg$kotlin_collections$c$MutableIterable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin_collections$c$MutableIterable$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Iterable$shared(this$dispatch), wildcard)
+predicate pred$pkg$kotlin_collections$c$MutableIterable$shared(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Iterable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin_collections$c$MutableIterable$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$Iterable$unique(this$dispatch), write)
+predicate pred$pkg$kotlin_collections$c$MutableIterable$unique(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$Iterable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin_collections$c$MutableList$shared(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$kotlin_collections$c$MutableCollection$shared(this$dispatch), wildcard)
+predicate pred$pkg$kotlin_collections$c$MutableList$shared(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard) &&
+  acc(pred$pkg$kotlin_collections$c$MutableCollection$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin_collections$c$MutableList$unique(this$dispatch: Ref) {
-  acc(p$pkg$kotlin_collections$c$List$unique(this$dispatch), write) &&
-  acc(p$pkg$kotlin_collections$c$MutableCollection$unique(this$dispatch), write)
+predicate pred$pkg$kotlin_collections$c$MutableList$unique(this$dispatch: Ref) {
+  acc(pred$pkg$kotlin_collections$c$List$unique(this$dispatch), write) &&
+  acc(pred$pkg$kotlin_collections$c$MutableCollection$unique(this$dispatch), write)
 }
 
-method f$listHierarchy$TF$T$MutableList$T$Unit(p$xs: Ref)
+method f$listHierarchy$t$F$t$MutableList$t$Unit(par$xs: Ref)
   returns (ret$0: Ref)
-  requires acc(p$xs.sp$size, write)
-  requires df$rt$intFromRef(p$xs.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$xs), df$rt$c$pkg$kotlin_collections$MutableList())
-  ensures acc(p$xs.sp$size, write)
-  ensures df$rt$intFromRef(p$xs.sp$size) >= 0
+  requires acc(par$xs.sp$size, write)
+  requires df$rt$intFromRef(par$xs.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$xs), df$rt$c$pkg$kotlin_collections$MutableList())
+  ensures acc(par$xs.sp$size, write)
+  ensures df$rt$intFromRef(par$xs.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$xs), wildcard)
+  inhale acc(pred$pkg$kotlin_collections$c$MutableList$shared(par$xs), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
@@ -7,71 +7,71 @@ field bf$x: Ref
 
 field bf$y: Ref
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$B$shared(this$dispatch: Ref) {
+predicate pred$c$B$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$shared(this$dispatch), wildcard)
+  acc(pred$c$A$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$B$unique(this$dispatch: Ref) {
+predicate pred$c$B$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$unique(this$dispatch), write)
+  acc(pred$c$A$unique(this$dispatch), write)
 }
 
-predicate p$c$C$shared(this$dispatch: Ref) {
+predicate pred$c$C$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
-  acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
+  acc(pred$c$A$shared(this$dispatch.bf$x), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
-  acc(p$c$D$shared(this$dispatch), wildcard) &&
-  acc(p$c$B$shared(this$dispatch), wildcard)
+  acc(pred$c$D$shared(this$dispatch), wildcard) &&
+  acc(pred$c$B$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$C$unique(this$dispatch: Ref) {
+predicate pred$c$C$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
-  acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
+  acc(pred$c$A$shared(this$dispatch.bf$x), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
   acc(this$dispatch.bf$y, write) &&
-  acc(p$c$A$shared(this$dispatch.bf$y), wildcard) &&
+  acc(pred$c$A$shared(this$dispatch.bf$y), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$A()) &&
-  acc(p$c$D$unique(this$dispatch), write) &&
-  acc(p$c$B$unique(this$dispatch), write)
+  acc(pred$c$D$unique(this$dispatch), write) &&
+  acc(pred$c$B$unique(this$dispatch), write)
 }
 
-predicate p$c$D$shared(this$dispatch: Ref) {
+predicate pred$c$D$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$D$unique(this$dispatch: Ref) {
+predicate pred$c$D$unique(this$dispatch: Ref) {
   true
 }
 
-method f$accessSuperTypeProperty$TF$T$C$T$Unit(p$c: Ref)
+method f$accessSuperTypeProperty$t$F$t$C$t$Unit(par$c: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$c$C())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
-  inhale acc(p$c$C$shared(p$c), wildcard)
-  unfold acc(p$c$C$shared(p$c), wildcard)
-  unfold acc(p$c$B$shared(p$c), wildcard)
-  unfold acc(p$c$A$shared(p$c), wildcard)
-  l0$temp := p$c.bf$a
+  inhale acc(pred$c$C$shared(par$c), wildcard)
+  unfold acc(pred$c$C$shared(par$c), wildcard)
+  unfold acc(pred$c$B$shared(par$c), wildcard)
+  unfold acc(pred$c$A$shared(par$c), wildcard)
+  l0$temp := par$c.bf$a
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$d(this$dispatch: Ref) returns (ret: Ref)
+method g$public$d(this$dispatch: Ref) returns (ret: Ref)
 
 
 /predicates_access.kt:(306,318): info: Generated Viper text for accessNested:
@@ -83,95 +83,96 @@ field bf$x: Ref
 
 field bf$y: Ref
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$B$shared(this$dispatch: Ref) {
+predicate pred$c$B$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$shared(this$dispatch), wildcard)
+  acc(pred$c$A$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$B$unique(this$dispatch: Ref) {
+predicate pred$c$B$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$unique(this$dispatch), write)
+  acc(pred$c$A$unique(this$dispatch), write)
 }
 
-predicate p$c$C$shared(this$dispatch: Ref) {
+predicate pred$c$C$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
-  acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
+  acc(pred$c$A$shared(this$dispatch.bf$x), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
-  acc(p$c$D$shared(this$dispatch), wildcard) &&
-  acc(p$c$B$shared(this$dispatch), wildcard)
+  acc(pred$c$D$shared(this$dispatch), wildcard) &&
+  acc(pred$c$B$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$C$unique(this$dispatch: Ref) {
+predicate pred$c$C$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
-  acc(p$c$A$shared(this$dispatch.bf$x), wildcard) &&
+  acc(pred$c$A$shared(this$dispatch.bf$x), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$c$A()) &&
   acc(this$dispatch.bf$y, write) &&
-  acc(p$c$A$shared(this$dispatch.bf$y), wildcard) &&
+  acc(pred$c$A$shared(this$dispatch.bf$y), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$A()) &&
-  acc(p$c$D$unique(this$dispatch), write) &&
-  acc(p$c$B$unique(this$dispatch), write)
+  acc(pred$c$D$unique(this$dispatch), write) &&
+  acc(pred$c$B$unique(this$dispatch), write)
 }
 
-predicate p$c$D$shared(this$dispatch: Ref) {
+predicate pred$c$D$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$D$unique(this$dispatch: Ref) {
+predicate pred$c$D$unique(this$dispatch: Ref) {
   true
 }
 
-method f$accessNested$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+method f$accessNested$t$F$t$C$t$Unit(par$c: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$c$C())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
   var anon$0: Ref
-  inhale acc(p$c$C$shared(p$c), wildcard)
-  unfold acc(p$c$C$shared(p$c), wildcard)
-  anon$0 := p$c.bf$x
-  unfold acc(p$c$A$shared(anon$0), wildcard)
+  inhale acc(pred$c$C$shared(par$c), wildcard)
+  unfold acc(pred$c$C$shared(par$c), wildcard)
+  anon$0 := par$c.bf$x
+  unfold acc(pred$c$A$shared(anon$0), wildcard)
   l0$temp := anon$0.bf$a
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$d(this$dispatch: Ref) returns (ret: Ref)
+method g$public$d(this$dispatch: Ref) returns (ret: Ref)
 
 
 /predicates_access.kt:(354,368): info: Generated Viper text for accessNullable:
 field bf$a: Ref
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-method f$accessNullable$TF$NT$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$A()))
+method f$accessNullable$t$F$t$N$A$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$c$A()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale p$x != df$rt$nullValue() ==> acc(p$c$A$shared(p$x), wildcard)
-  if (!(p$x == df$rt$nullValue())) {
-    unfold acc(p$c$A$shared(p$x), wildcard)
-    l0$n := p$x.bf$a
+  inhale par$x != df$rt$nullValue() ==>
+    acc(pred$c$A$shared(par$x), wildcard)
+  if (!(par$x == df$rt$nullValue())) {
+    unfold acc(pred$c$A$shared(par$x), wildcard)
+    l0$n := par$x.bf$a
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -182,38 +183,38 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$B$shared(this$dispatch: Ref) {
+predicate pred$c$B$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$shared(this$dispatch), wildcard)
+  acc(pred$c$A$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$B$unique(this$dispatch: Ref) {
+predicate pred$c$B$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$unique(this$dispatch), write)
+  acc(pred$c$A$unique(this$dispatch), write)
 }
 
-method f$accessCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
+method f$accessCast$t$F$t$A$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale acc(p$c$A$shared(p$x), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())
-  inhale acc(p$c$B$shared(p$x), wildcard)
-  unfold acc(p$c$B$shared(p$x), wildcard)
-  l0$n := p$x.bf$b
+  inhale acc(pred$c$A$shared(par$x), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$B())
+  inhale acc(pred$c$B$shared(par$x), wildcard)
+  unfold acc(pred$c$B$shared(par$x), wildcard)
+  l0$n := par$x.bf$b
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -223,44 +224,44 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$B$shared(this$dispatch: Ref) {
+predicate pred$c$B$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$shared(this$dispatch), wildcard)
+  acc(pred$c$A$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$B$unique(this$dispatch: Ref) {
+predicate pred$c$B$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$unique(this$dispatch), write)
+  acc(pred$c$A$unique(this$dispatch), write)
 }
 
-method f$accessSafeCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
+method f$accessSafeCast$t$F$t$A$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
   var l0$y: Ref
-  inhale acc(p$c$A$shared(p$x), wildcard)
+  inhale acc(pred$c$A$shared(par$x), wildcard)
   l0$n := df$rt$intToRef(0)
-  if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {
-    l0$y := p$x
+  if (df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$B())) {
+    l0$y := par$x
   } else {
     l0$y := df$rt$nullValue()}
   inhale df$rt$isSubtype(df$rt$typeOf(l0$y), df$rt$nullable(df$rt$c$B()))
-  inhale l0$y != df$rt$nullValue() ==> acc(p$c$B$shared(l0$y), wildcard)
+  inhale l0$y != df$rt$nullValue() ==> acc(pred$c$B$shared(l0$y), wildcard)
   if (!(l0$y == df$rt$nullValue())) {
-    unfold acc(p$c$B$shared(l0$y), wildcard)
+    unfold acc(pred$c$B$shared(l0$y), wildcard)
     l0$n := l0$y.bf$b
   }
   label lbl$ret$0
@@ -272,39 +273,39 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$a, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$a), df$rt$intType())
 }
 
-predicate p$c$B$shared(this$dispatch: Ref) {
+predicate pred$c$B$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$shared(this$dispatch), wildcard)
+  acc(pred$c$A$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$B$unique(this$dispatch: Ref) {
+predicate pred$c$B$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$b, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$b), df$rt$intType()) &&
-  acc(p$c$A$unique(this$dispatch), write)
+  acc(pred$c$A$unique(this$dispatch), write)
 }
 
-method f$accessSmartCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
+method f$accessSmartCast$t$F$t$A$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale acc(p$c$A$shared(p$x), wildcard)
+  inhale acc(pred$c$A$shared(par$x), wildcard)
   l0$n := df$rt$intToRef(0)
-  if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {
-    inhale acc(p$c$B$shared(p$x), wildcard)
-    unfold acc(p$c$B$shared(p$x), wildcard)
-    l0$n := p$x.bf$b
+  if (df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$B())) {
+    inhale acc(pred$c$B$shared(par$x), wildcard)
+    unfold acc(pred$c$B$shared(par$x), wildcard)
+    l0$n := par$x.bf$b
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
@@ -3,26 +3,26 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$a: Ref, p$b: Ref)
+method con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(par$a: Ref, par$b: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveFields())
-  ensures acc(p$c$PrimitiveFields$shared(ret), wildcard)
-  ensures acc(p$c$PrimitiveFields$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$PrimitiveFields$shared(ret), wildcard) in
+  ensures acc(pred$c$PrimitiveFields$shared(ret), wildcard)
+  ensures acc(pred$c$PrimitiveFields$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$PrimitiveFields$shared(ret), wildcard) in
       ret.bf$a)) ==
-    df$rt$intFromRef(p$a) &&
-    df$rt$intFromRef((unfolding acc(p$c$PrimitiveFields$shared(ret), wildcard) in
+    df$rt$intFromRef(par$a) &&
+    df$rt$intFromRef((unfolding acc(pred$c$PrimitiveFields$shared(ret), wildcard) in
       ret.bf$b)) ==
-    df$rt$intFromRef(p$b)
+    df$rt$intFromRef(par$b)
 
 
-method f$createPrimitiveFields$TF$T$PrimitiveFields() returns (ret$0: Ref)
+method f$createPrimitiveFields$t$F$t$PrimitiveFields() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$PrimitiveFields())
-  ensures acc(p$c$PrimitiveFields$shared(ret$0), wildcard)
+  ensures acc(pred$c$PrimitiveFields$shared(ret$0), wildcard)
 {
-  ret$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(10),
+  ret$0 := con$c$PrimitiveFields$t$Int$t$Int$t$PrimitiveFields(df$rt$intToRef(10),
     df$rt$intToRef(20))
   goto lbl$ret$0
   label lbl$ret$0
@@ -31,21 +31,22 @@ method f$createPrimitiveFields$TF$T$PrimitiveFields() returns (ret$0: Ref)
 /primary_constructors.kt:(178,193): info: Generated Viper text for createRecursive:
 field bf$a: Ref
 
-method con$c$Recursive$NT$Recursive$T$Recursive(p$a: Ref)
+method con$c$Recursive$t$N$Recursive$t$Recursive(par$a: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$nullable(df$rt$c$Recursive()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$nullable(df$rt$c$Recursive()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Recursive())
-  ensures acc(p$c$Recursive$shared(ret), wildcard)
-  ensures acc(p$c$Recursive$unique(ret), write)
-  ensures (unfolding acc(p$c$Recursive$shared(ret), wildcard) in ret.bf$a) ==
-    p$a
+  ensures acc(pred$c$Recursive$shared(ret), wildcard)
+  ensures acc(pred$c$Recursive$unique(ret), write)
+  ensures (unfolding acc(pred$c$Recursive$shared(ret), wildcard) in
+      ret.bf$a) ==
+    par$a
 
 
-method f$createRecursive$TF$T$Recursive() returns (ret$0: Ref)
+method f$createRecursive$t$F$t$Recursive() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Recursive())
-  ensures acc(p$c$Recursive$shared(ret$0), wildcard)
+  ensures acc(pred$c$Recursive$shared(ret$0), wildcard)
 {
-  ret$0 := con$c$Recursive$NT$Recursive$T$Recursive(df$rt$nullValue())
+  ret$0 := con$c$Recursive$t$N$Recursive$t$Recursive(df$rt$nullValue())
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -55,21 +56,21 @@ field bf$a: Ref
 
 field bf$c: Ref
 
-method con$c$FieldInBody$T$Int$T$FieldInBody(p$c: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$intType())
+method con$c$FieldInBody$t$Int$t$FieldInBody(par$c: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$FieldInBody())
-  ensures acc(p$c$FieldInBody$shared(ret), wildcard)
-  ensures acc(p$c$FieldInBody$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$FieldInBody$shared(ret), wildcard) in
+  ensures acc(pred$c$FieldInBody$shared(ret), wildcard)
+  ensures acc(pred$c$FieldInBody$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$FieldInBody$shared(ret), wildcard) in
       ret.bf$c)) ==
-    df$rt$intFromRef(p$c)
+    df$rt$intFromRef(par$c)
 
 
-method f$createFieldInBody$TF$T$FieldInBody() returns (ret$0: Ref)
+method f$createFieldInBody$t$F$t$FieldInBody() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$FieldInBody())
-  ensures acc(p$c$FieldInBody$shared(ret$0), wildcard)
+  ensures acc(pred$c$FieldInBody$shared(ret$0), wildcard)
 {
-  ret$0 := con$c$FieldInBody$T$Int$T$FieldInBody(df$rt$intToRef(10))
+  ret$0 := con$c$FieldInBody$t$Int$t$FieldInBody(df$rt$intToRef(10))
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
@@ -1,72 +1,73 @@
 /property_getters.kt:(102,129): info: Generated Viper text for testPrimitivePropertyGetter:
-method f$testPrimitivePropertyGetter$TF$T$PrimitiveProperty$T$Int(p$pp: Ref)
+method f$testPrimitivePropertyGetter$t$F$t$PrimitiveProperty$t$Int(par$pp: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pp), df$rt$c$PrimitiveProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
-  anon$0 := pg$public$nProp(p$pp)
+  inhale acc(pred$c$PrimitiveProperty$shared(par$pp), wildcard)
+  anon$0 := g$public$nProp(par$pp)
   ret$0 := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 
 
 /property_getters.kt:(286,313): info: Generated Viper text for testReferencePropertyGetter:
-method f$testReferencePropertyGetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
+method f$testReferencePropertyGetter$t$F$t$ReferenceProperty$t$Unit(par$rp: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rp), df$rt$c$ReferenceProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$pp: Ref
   var anon$0: Ref
   var l0$ppn: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
-  anon$0 := pg$public$rProp(p$rp)
+  inhale acc(pred$c$ReferenceProperty$shared(par$rp), wildcard)
+  anon$0 := g$public$rProp(par$rp)
   l0$pp := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$pp), df$rt$c$PrimitiveProperty())
-  inhale acc(p$c$PrimitiveProperty$shared(l0$pp), wildcard)
-  anon$1 := pg$public$nProp(l0$pp)
+  inhale acc(pred$c$PrimitiveProperty$shared(l0$pp), wildcard)
+  anon$1 := g$public$nProp(l0$pp)
   l0$ppn := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(l0$ppn), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$rProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$rProp(this$dispatch: Ref) returns (ret: Ref)
 
 
 /property_getters.kt:(391,418): info: Generated Viper text for testCascadingPropertyGetter:
-method f$testCascadingPropertyGetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
+method f$testCascadingPropertyGetter$t$F$t$ReferenceProperty$t$Unit(par$rp: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rp), df$rt$c$ReferenceProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$ppn: Ref
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
-  anon$2 := pg$public$rProp(p$rp)
+  inhale acc(pred$c$ReferenceProperty$shared(par$rp), wildcard)
+  anon$2 := g$public$rProp(par$rp)
   anon$1 := anon$2
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$PrimitiveProperty())
-  inhale acc(p$c$PrimitiveProperty$shared(anon$1), wildcard)
-  anon$0 := pg$public$nProp(anon$1)
+  inhale acc(pred$c$PrimitiveProperty$shared(anon$1), wildcard)
+  anon$0 := g$public$nProp(anon$1)
   l0$ppn := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$ppn), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$rProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$rProp(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -3,13 +3,14 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$getValue$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$getValue$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$0$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$value)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$value)) in
     anon$0$0)
 }
 
@@ -18,17 +19,18 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$getSafeNextValue$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$getSafeNextValue$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$2$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     (let anon$3$0 ==
       ((anon$2$0 != df$rt$nullValue() ?
-        (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
+        (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+          (unfolding acc(pred$c$Node$shared(anon$2$0), wildcard) in
             anon$2$0.bf$value)) :
         null)) in
       (let anon$1$0 ==
@@ -43,24 +45,25 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$getSafeNextNextValue$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$getSafeNextNextValue$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$3$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     (let anon$4$0 ==
       ((anon$3$0 != df$rt$nullValue() ?
-        (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          (unfolding acc(p$c$Node$shared(anon$3$0), wildcard) in
+        (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+          (unfolding acc(pred$c$Node$shared(anon$3$0), wildcard) in
             anon$3$0.bf$next)) :
         null)) in
       (let anon$2$0 ==
         ((anon$3$0 != df$rt$nullValue() ? anon$4$0 : df$rt$nullValue())) in
         (let anon$5$0 ==
           ((anon$2$0 != df$rt$nullValue() ?
-            (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
+            (unfolding acc(pred$c$Node$shared(anon$2$0), wildcard) in
               anon$2$0.bf$value) :
             null)) in
           (let anon$1$0 ==
@@ -77,35 +80,36 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$sumFirstTwoNodes$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$sumFirstTwoNodes$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$nextNode$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     (let anon$2$0 ==
       ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-        (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          p$node.bf$value) :
+        (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+          par$node.bf$value) :
         null)) in
       (let anon$3$0 ==
         ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
+          (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+            (unfolding acc(pred$c$Node$shared(l0$nextNode$0), wildcard) in
               l0$nextNode$0.bf$value)) :
           null)) in
         (let anon$1$0 ==
           ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
-                (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+            (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+              (unfolding acc(pred$c$Node$shared(l0$nextNode$0), wildcard) in
+                (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
                   sp$plusInts(anon$2$0, anon$3$0)))) :
             null)) in
           (let anon$4$0 ==
             ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
-              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                p$node.bf$value) :
+              (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+                par$node.bf$value) :
               null)) in
             (let anon$0$0 ==
               ((!(l0$nextNode$0 == df$rt$nullValue()) ?
@@ -119,13 +123,14 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$isLastNode$TF$T$Node$T$Boolean(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$isLastNode$t$F$t$Node$t$Boolean(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let anon$0$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     df$rt$boolToRef(anon$0$0 == df$rt$nullValue()))
 }
 
@@ -134,19 +139,20 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$length$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$length$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$nextNode$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     (let anon$1$0 ==
       ((l0$nextNode$0 == df$rt$nullValue() ? df$rt$intToRef(1) : null)) in
       (let anon$2$0 ==
         ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            sp$plusInts(df$rt$intToRef(1), f$length$TF$T$Node$T$Int(l0$nextNode$0))) :
+          (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+            sp$plusInts(df$rt$intToRef(1), f$length$t$F$t$Node$t$Int(l0$nextNode$0))) :
           null)) in
         (let anon$0$0 ==
           ((l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0)) in
@@ -158,28 +164,29 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$sumAllNodes$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$sumAllNodes$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$nextNode$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     (let anon$1$0 ==
       ((l0$nextNode$0 == df$rt$nullValue() ?
-        (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          p$node.bf$value) :
+        (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+          par$node.bf$value) :
         null)) in
       (let anon$3$0 ==
         ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            p$node.bf$value) :
+          (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+            par$node.bf$value) :
           null)) in
         (let anon$2$0 ==
           ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                sp$plusInts(anon$3$0, f$sumAllNodes$TF$T$Node$T$Int(l0$nextNode$0)))) :
+            (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+              (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+                sp$plusInts(anon$3$0, f$sumAllNodes$t$F$t$Node$t$Int(l0$nextNode$0)))) :
             null)) in
           (let anon$0$0 ==
             ((l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0)) in
@@ -191,20 +198,22 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$containsValue$TF$T$Node$T$Int$T$Boolean(p$node: Ref, p$target: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
-  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
+function f$containsValue$t$F$t$Node$t$Int$t$Boolean(par$node: Ref, par$target: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
+  requires df$rt$isSubtype(df$rt$typeOf(par$target), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let anon$0$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$value)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$value)) in
     (let l0$nextNode$0 ==
-      ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+      ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+        par$node.bf$next)) in
       (let anon$2$0 ==
         ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            f$containsValue$TF$T$Node$T$Int$T$Boolean(l0$nextNode$0, p$target)) :
+          (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+            f$containsValue$t$F$t$Node$t$Int$t$Boolean(l0$nextNode$0, par$target)) :
           null)) in
         (let anon$3$0 ==
           ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
@@ -212,7 +221,7 @@ function f$containsValue$TF$T$Node$T$Int$T$Boolean(p$node: Ref, p$target: Ref): 
             null)) in
           (let anon$1$0 ==
             ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$2$0 : anon$3$0)) in
-            (df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target) ?
+            (df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(par$target) ?
               df$rt$boolToRef(true) :
               anon$1$0))))))
 }
@@ -222,22 +231,22 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$aliasAndReassign$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$aliasAndReassign$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$alias1$0 ==
-    (p$node) in
+    (par$node) in
     (let l0$alias2$0 ==
-      ((unfolding acc(p$c$Node$shared(l0$alias1$0), wildcard) in
+      ((unfolding acc(pred$c$Node$shared(l0$alias1$0), wildcard) in
         l0$alias1$0.bf$next)) in
       (let l0$fallbackValue$0 ==
         (df$rt$intToRef(-1)) in
         (let l0$fallbackValue$1 ==
           ((!(l0$alias2$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$Node$shared(l0$alias1$0), wildcard) in
-              (unfolding acc(p$c$Node$shared(l0$alias2$0), wildcard) in
+            (unfolding acc(pred$c$Node$shared(l0$alias1$0), wildcard) in
+              (unfolding acc(pred$c$Node$shared(l0$alias2$0), wildcard) in
                 l0$alias2$0.bf$value)) :
             null)) in
           (let l0$fallbackValue$2 ==
@@ -252,13 +261,13 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$id$TF$NT$Node$NT$Node(p$node: Ref): Ref
-  requires p$node != df$rt$nullValue() ==>
-    acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
+function f$id$t$F$t$N$Node$t$N$Node(par$node: Ref): Ref
+  requires par$node != df$rt$nullValue() ==>
+    acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 {
-  p$node
+  par$node
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(1438,1457): info: Generated Viper text for useIdentityFunction:
@@ -266,23 +275,23 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$id$TF$NT$Node$NT$Node(p$node: Ref): Ref
-  requires p$node != df$rt$nullValue() ==>
-    acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
+function f$id$t$F$t$N$Node$t$N$Node(par$node: Ref): Ref
+  requires par$node != df$rt$nullValue() ==>
+    acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 
 
-function f$useIdentityFunction$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$useIdentityFunction$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$sameNode$0 ==
-    (f$id$TF$NT$Node$NT$Node(p$node)) in
+    (f$id$t$F$t$N$Node$t$N$Node(par$node)) in
     (let anon$2$0 ==
       ((l0$sameNode$0 != df$rt$nullValue() ?
-        (unfolding acc(p$c$Node$shared(l0$sameNode$0), wildcard) in
+        (unfolding acc(pred$c$Node$shared(l0$sameNode$0), wildcard) in
           l0$sameNode$0.bf$value) :
         null)) in
       (let anon$1$0 ==
@@ -299,22 +308,23 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$getNextValueUsingId$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+function f$getNextValueUsingId$t$F$t$Node$t$Int(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$0$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     (let l0$nextNode$0 ==
-      ((unfolding acc(p$c$Node$shared(p$node), wildcard) in
-        f$id$TF$NT$Node$NT$Node(anon$0$0))) in
+      ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+        f$id$t$F$t$N$Node$t$N$Node(anon$0$0))) in
       (let anon$2$0 ==
         ((l0$nextNode$0 == df$rt$nullValue() ? df$rt$intToRef(0) : null)) in
         (let anon$3$0 ==
           ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
+            (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+              (unfolding acc(pred$c$Node$shared(l0$nextNode$0), wildcard) in
                 l0$nextNode$0.bf$value)) :
             null)) in
           (let anon$1$0 ==
@@ -322,9 +332,9 @@ function f$getNextValueUsingId$TF$T$Node$T$Int(p$node: Ref): Ref
             anon$1$0)))))
 }
 
-function f$id$TF$NT$Node$NT$Node(p$node: Ref): Ref
-  requires p$node != df$rt$nullValue() ==>
-    acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
+function f$id$t$F$t$N$Node$t$N$Node(par$node: Ref): Ref
+  requires par$node != df$rt$nullValue() ==>
+    acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
@@ -1,29 +1,29 @@
 /secondary_constructors.kt:(249,271): info: Generated Viper text for onlySecondConstructors:
 field bf$a: Ref
 
-method con$c$NoPrimaryConstructor$T$Boolean$T$NoPrimaryConstructor(p$b: Ref)
+method con$c$NoPrimaryConstructor$t$Boolean$t$NoPrimaryConstructor(par$b: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoPrimaryConstructor())
-  ensures acc(p$c$NoPrimaryConstructor$shared(ret), wildcard)
-  ensures acc(p$c$NoPrimaryConstructor$unique(ret), write)
+  ensures acc(pred$c$NoPrimaryConstructor$shared(ret), wildcard)
+  ensures acc(pred$c$NoPrimaryConstructor$unique(ret), write)
 
 
-method con$c$NoPrimaryConstructor$T$Int$T$NoPrimaryConstructor(p$n: Ref)
+method con$c$NoPrimaryConstructor$t$Int$t$NoPrimaryConstructor(par$n: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$NoPrimaryConstructor())
-  ensures acc(p$c$NoPrimaryConstructor$shared(ret), wildcard)
-  ensures acc(p$c$NoPrimaryConstructor$unique(ret), write)
+  ensures acc(pred$c$NoPrimaryConstructor$shared(ret), wildcard)
+  ensures acc(pred$c$NoPrimaryConstructor$unique(ret), write)
 
 
-method f$onlySecondConstructors$TF$T$Unit() returns (ret$0: Ref)
+method f$onlySecondConstructors$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$npc1: Ref
   var l0$npc2: Ref
-  l0$npc1 := con$c$NoPrimaryConstructor$T$Boolean$T$NoPrimaryConstructor(df$rt$boolToRef(true))
-  l0$npc2 := con$c$NoPrimaryConstructor$T$Int$T$NoPrimaryConstructor(df$rt$intToRef(42))
+  l0$npc1 := con$c$NoPrimaryConstructor$t$Boolean$t$NoPrimaryConstructor(df$rt$boolToRef(true))
+  l0$npc2 := con$c$NoPrimaryConstructor$t$Int$t$NoPrimaryConstructor(df$rt$intToRef(42))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -31,32 +31,32 @@ method f$onlySecondConstructors$TF$T$Unit() returns (ret$0: Ref)
 /secondary_constructors.kt:(365,392): info: Generated Viper text for primaryAndSecondConstructor:
 field bf$a: Ref
 
-method con$c$BothConstructors$T$Boolean$T$BothConstructors(p$b: Ref)
+method con$c$BothConstructors$t$Boolean$t$BothConstructors(par$b: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$BothConstructors())
-  ensures acc(p$c$BothConstructors$shared(ret), wildcard)
-  ensures acc(p$c$BothConstructors$unique(ret), write)
+  ensures acc(pred$c$BothConstructors$shared(ret), wildcard)
+  ensures acc(pred$c$BothConstructors$unique(ret), write)
 
 
-method con$c$BothConstructors$T$Int$T$BothConstructors(p$a: Ref)
+method con$c$BothConstructors$t$Int$t$BothConstructors(par$a: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$BothConstructors())
-  ensures acc(p$c$BothConstructors$shared(ret), wildcard)
-  ensures acc(p$c$BothConstructors$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$BothConstructors$shared(ret), wildcard) in
+  ensures acc(pred$c$BothConstructors$shared(ret), wildcard)
+  ensures acc(pred$c$BothConstructors$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$BothConstructors$shared(ret), wildcard) in
       ret.bf$a)) ==
-    df$rt$intFromRef(p$a)
+    df$rt$intFromRef(par$a)
 
 
-method f$primaryAndSecondConstructor$TF$T$Unit() returns (ret$0: Ref)
+method f$primaryAndSecondConstructor$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$bc1: Ref
   var l0$bc2: Ref
-  l0$bc1 := con$c$BothConstructors$T$Boolean$T$BothConstructors(df$rt$boolToRef(false))
-  l0$bc2 := con$c$BothConstructors$T$Int$T$BothConstructors(df$rt$intToRef(42))
+  l0$bc1 := con$c$BothConstructors$t$Boolean$t$BothConstructors(df$rt$boolToRef(false))
+  l0$bc2 := con$c$BothConstructors$t$Int$t$BothConstructors(df$rt$intToRef(42))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
@@ -1,12 +1,12 @@
 /setters.kt:(103,127): info: Generated Viper text for testPrimitiveFieldSetter:
 field bf$a: Ref
 
-method f$testPrimitiveFieldSetter$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
+method f$testPrimitiveFieldSetter$t$F$t$PrimitiveField$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
+  inhale acc(pred$c$PrimitiveField$shared(par$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -16,73 +16,74 @@ field bf$a: Ref
 
 field bf$pf: Ref
 
-method con$c$PrimitiveField$T$Int$T$PrimitiveField(p$a: Ref)
+method con$c$PrimitiveField$t$Int$t$PrimitiveField(par$a: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveField())
-  ensures acc(p$c$PrimitiveField$shared(ret), wildcard)
-  ensures acc(p$c$PrimitiveField$unique(ret), write)
+  ensures acc(pred$c$PrimitiveField$shared(ret), wildcard)
+  ensures acc(pred$c$PrimitiveField$unique(ret), write)
 
 
-method f$testReferenceFieldSetter$TF$T$ReferenceField$T$Unit(p$rf: Ref)
+method f$testReferenceFieldSetter$t$F$t$ReferenceField$t$Unit(par$rf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rf), df$rt$c$ReferenceField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
-  anon$0 := con$c$PrimitiveField$T$Int$T$PrimitiveField(df$rt$intToRef(0))
+  inhale acc(pred$c$ReferenceField$shared(par$rf), wildcard)
+  anon$0 := con$c$PrimitiveField$t$Int$t$PrimitiveField(df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /setters.kt:(427,454): info: Generated Viper text for testPrimitivePropertySetter:
-method f$testPrimitivePropertySetter$TF$T$PrimitiveProperty$T$Unit(p$pp: Ref)
+method f$testPrimitivePropertySetter$t$F$t$PrimitiveProperty$t$Unit(par$pp: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pp), df$rt$c$PrimitiveProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
-  anon$0 := ps$public$aProp(p$pp, df$rt$intToRef(0))
+  inhale acc(pred$c$PrimitiveProperty$shared(par$pp), wildcard)
+  anon$0 := s$public$aProp(par$pp, df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$aProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$aProp(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$public$aProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+method s$public$aProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
 
 
 /setters.kt:(504,531): info: Generated Viper text for testReferencePropertySetter:
-method con$c$PrimitiveProperty$T$PrimitiveProperty() returns (ret: Ref)
+method con$c$PrimitiveProperty$t$PrimitiveProperty() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$PrimitiveProperty())
-  ensures acc(p$c$PrimitiveProperty$shared(ret), wildcard)
-  ensures acc(p$c$PrimitiveProperty$unique(ret), write)
+  ensures acc(pred$c$PrimitiveProperty$shared(ret), wildcard)
+  ensures acc(pred$c$PrimitiveProperty$unique(ret), write)
 
 
-method f$testReferencePropertySetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
+method f$testReferencePropertySetter$t$F$t$ReferenceProperty$t$Unit(par$rp: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
+  requires df$rt$isSubtype(df$rt$typeOf(par$rp), df$rt$c$ReferenceProperty())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
-  anon$1 := con$c$PrimitiveProperty$T$PrimitiveProperty()
-  anon$0 := ps$public$ppProp(p$rp, anon$1)
+  inhale acc(pred$c$ReferenceProperty$shared(par$rp), wildcard)
+  anon$1 := con$c$PrimitiveProperty$t$PrimitiveProperty()
+  anon$0 := s$public$ppProp(par$rp, anon$1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$aProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$aProp(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$ppProp(this$dispatch: Ref) returns (ret: Ref)
+method g$public$ppProp(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$public$aProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+method s$public$aProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
 
 
-method ps$public$ppProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+method s$public$ppProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
@@ -1,20 +1,20 @@
 /subtyping.kt:(80,89): info: Generated Viper text for smartCast:
-method f$smartCast$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$smartCast$t$F$t$N$Int$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  if (p$x == df$rt$nullValue()) {
+  if (par$x == df$rt$nullValue()) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
   } else {
-    ret$0 := p$x
+    ret$0 := par$x
     goto lbl$ret$0
   }
   label lbl$ret$0
 }
 
 /subtyping.kt:(187,202): info: Generated Viper text for returnSubtyping:
-method f$returnSubtyping$TF$NT$Int() returns (ret$0: Ref)
+method f$returnSubtyping$t$F$t$N$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   ret$0 := df$rt$intToRef(0)
@@ -23,7 +23,7 @@ method f$returnSubtyping$TF$NT$Int() returns (ret$0: Ref)
 }
 
 /subtyping.kt:(233,252): info: Generated Viper text for assignmentSubtyping:
-method f$assignmentSubtyping$TF$T$Unit() returns (ret$0: Ref)
+method f$assignmentSubtyping$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
@@ -34,16 +34,17 @@ method f$assignmentSubtyping$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /subtyping.kt:(358,384): info: Generated Viper text for functionParameterSubtyping:
-method f$functionParameterSubtyping$TF$T$Unit() returns (ret$0: Ref)
+method f$functionParameterSubtyping$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  anon$0 := f$nullableParameter$TF$NT$Boolean$T$Unit(df$rt$boolToRef(false))
+  anon$0 := f$nullableParameter$t$F$t$N$Boolean$t$Unit(df$rt$boolToRef(false))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$nullableParameter$TF$NT$Boolean$T$Unit(p$b: Ref)
+method f$nullableParameter$t$F$t$N$Boolean$t$Unit(par$b: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$nullable(df$rt$boolType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$nullable(df$rt$boolType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
@@ -7,175 +7,180 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-predicate p$c$Foo$shared(this$dispatch: Ref) {
+predicate pred$c$Foo$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$w, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$w), df$rt$intType()) &&
   acc(this$dispatch.bf$y, wildcard) &&
-  acc(p$c$T$shared(this$dispatch.bf$y), wildcard) &&
+  acc(pred$c$T$shared(this$dispatch.bf$y), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$T()) &&
-  acc(p$c$S$shared(this$dispatch), wildcard)
+  acc(pred$c$S$shared(this$dispatch), wildcard)
 }
 
-predicate p$c$Foo$unique(this$dispatch: Ref) {
+predicate pred$c$Foo$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$w, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$w), df$rt$intType()) &&
   acc(this$dispatch.bf$x, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$intType()) &&
   acc(this$dispatch.bf$y, wildcard) &&
-  acc(p$c$T$shared(this$dispatch.bf$y), wildcard) &&
-  acc(p$c$T$unique(this$dispatch.bf$y), write) &&
+  acc(pred$c$T$shared(this$dispatch.bf$y), wildcard) &&
+  acc(pred$c$T$unique(this$dispatch.bf$y), write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$y), df$rt$c$T()) &&
   acc(this$dispatch.bf$z, write) &&
-  acc(p$c$T$shared(this$dispatch.bf$z), wildcard) &&
-  acc(p$c$T$unique(this$dispatch.bf$z), write) &&
+  acc(pred$c$T$shared(this$dispatch.bf$z), wildcard) &&
+  acc(pred$c$T$unique(this$dispatch.bf$z), write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$z), df$rt$c$T()) &&
-  acc(p$c$S$unique(this$dispatch), write)
+  acc(pred$c$S$unique(this$dispatch), write)
 }
 
-predicate p$c$S$shared(this$dispatch: Ref) {
+predicate pred$c$S$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$S$unique(this$dispatch: Ref) {
+predicate pred$c$S$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$shared(this$dispatch: Ref) {
+predicate pred$c$T$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$unique(this$dispatch: Ref) {
+predicate pred$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$unique_foo_arg$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
-  requires acc(p$c$Foo$unique(p$foo), write)
+method f$unique_foo_arg$t$F$t$Foo$t$Unit(par$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
+  requires acc(pred$c$Foo$unique(par$foo), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /unique_predicates.kt:(310,329): info: Generated Viper text for nullable_unique_arg:
-predicate p$c$T$shared(this$dispatch: Ref) {
+predicate pred$c$T$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$unique(this$dispatch: Ref) {
+predicate pred$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$nullable_unique_arg$TF$NT$T$T$Unit(p$t: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$c$T()))
-  requires p$t != df$rt$nullValue() ==> acc(p$c$T$unique(p$t), write)
+method f$nullable_unique_arg$t$F$t$N$T$t$Unit(par$t: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$c$T()))
+  requires par$t != df$rt$nullValue() ==>
+    acc(pred$c$T$unique(par$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale p$t != df$rt$nullValue() ==> acc(p$c$T$shared(p$t), wildcard)
+  inhale par$t != df$rt$nullValue() ==>
+    acc(pred$c$T$shared(par$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /unique_predicates.kt:(353,372): info: Generated Viper text for borrowed_unique_arg:
-predicate p$c$T$shared(this$dispatch: Ref) {
+predicate pred$c$T$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$unique(this$dispatch: Ref) {
+predicate pred$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$borrowed_unique_arg$TF$T$T$T$Unit(p$t: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$c$T())
-  requires acc(p$c$T$unique(p$t), write)
-  ensures acc(p$c$T$unique(p$t), write)
+method f$borrowed_unique_arg$t$F$t$T$t$Unit(par$t: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$c$T())
+  requires acc(pred$c$T$unique(par$t), write)
+  ensures acc(pred$c$T$unique(par$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$T$shared(p$t), wildcard)
+  inhale acc(pred$c$T$shared(par$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /unique_predicates.kt:(424,439): info: Generated Viper text for unique_receiver:
-predicate p$c$T$shared(this$dispatch: Ref) {
+predicate pred$c$T$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$unique(this$dispatch: Ref) {
+predicate pred$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$unique_receiver$TF$T$T$T$Unit(this$extension: Ref)
+method f$unique_receiver$t$F$t$T$t$Unit(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
-  requires acc(p$c$T$unique(this$extension), write)
+  requires acc(pred$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$T$shared(this$extension), wildcard)
+  inhale acc(pred$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /unique_predicates.kt:(488,512): info: Generated Viper text for borrowed_unique_receiver:
-predicate p$c$T$shared(this$dispatch: Ref) {
+predicate pred$c$T$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$unique(this$dispatch: Ref) {
+predicate pred$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$borrowed_unique_receiver$TF$T$T$T$Unit(this$extension: Ref)
+method f$borrowed_unique_receiver$t$F$t$T$t$Unit(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
-  requires acc(p$c$T$unique(this$extension), write)
-  ensures acc(p$c$T$unique(this$extension), write)
+  requires acc(pred$c$T$unique(this$extension), write)
+  ensures acc(pred$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$T$shared(this$extension), wildcard)
+  inhale acc(pred$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /unique_predicates.kt:(531,544): info: Generated Viper text for unique_result:
-predicate p$c$T$shared(this$dispatch: Ref) {
+predicate pred$c$T$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$unique(this$dispatch: Ref) {
+predicate pred$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method con$c$T$T$T() returns (ret: Ref)
+method con$c$T$t$T() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$T())
-  ensures acc(p$c$T$shared(ret), wildcard)
-  ensures acc(p$c$T$unique(ret), write)
+  ensures acc(pred$c$T$shared(ret), wildcard)
+  ensures acc(pred$c$T$unique(ret), write)
 
 
-method f$unique_result$TF$T$T() returns (ret$0: Ref)
+method f$unique_result$t$F$t$T() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$T())
-  ensures acc(p$c$T$shared(ret$0), wildcard)
-  ensures acc(p$c$T$unique(ret$0), write)
+  ensures acc(pred$c$T$shared(ret$0), wildcard)
+  ensures acc(pred$c$T$unique(ret$0), write)
 {
-  ret$0 := con$c$T$T$T()
+  ret$0 := con$c$T$t$T()
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /unique_predicates.kt:(579,601): info: Generated Viper text for unique_nullable_result:
-predicate p$c$T$shared(this$dispatch: Ref) {
+predicate pred$c$T$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$T$unique(this$dispatch: Ref) {
+predicate pred$c$T$unique(this$dispatch: Ref) {
   true
 }
 
-method f$unique_nullable_result$TF$NT$T() returns (ret$0: Ref)
+method f$unique_nullable_result$t$F$t$N$T() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$T()))
-  ensures ret$0 != df$rt$nullValue() ==> acc(p$c$T$shared(ret$0), wildcard)
-  ensures ret$0 != df$rt$nullValue() ==> acc(p$c$T$unique(ret$0), write)
+  ensures ret$0 != df$rt$nullValue() ==>
+    acc(pred$c$T$shared(ret$0), wildcard)
+  ensures ret$0 != df$rt$nullValue() ==> acc(pred$c$T$unique(ret$0), write)
 {
   ret$0 := df$rt$nullValue()
   goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
@@ -1,16 +1,16 @@
 /exp_side_effects.kt:(185,189): info: Generated Viper text for test:
 field bf$x: Ref
 
-method f$getFoo$TF$T$Foo() returns (ret: Ref)
+method f$getFoo$t$F$t$Foo() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
-  ensures acc(p$c$Foo$shared(ret), wildcard)
+  ensures acc(pred$c$Foo$shared(ret), wildcard)
 
 
-method f$sideEffect$TF$T$Int() returns (ret: Ref)
+method f$sideEffect$t$F$t$Int() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$test$TF$T$Unit() returns (ret$0: Ref)
+method f$test$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -19,11 +19,11 @@ method f$test$TF$T$Unit() returns (ret$0: Ref)
   var anon$2: Ref
   var anon$3: Ref
   var anon$4: Ref
-  anon$0 := f$getFoo$TF$T$Foo()
-  anon$1 := f$sideEffect$TF$T$Int()
-  anon$3 := f$getFoo$TF$T$Foo()
-  anon$2 := havoc$T$Int()
-  anon$4 := f$sideEffect$TF$T$Int()
+  anon$0 := f$getFoo$t$F$t$Foo()
+  anon$1 := f$sideEffect$t$F$t$Int()
+  anon$3 := f$getFoo$t$F$t$Foo()
+  anon$2 := havoc$t$Int()
+  anon$4 := f$sideEffect$t$F$t$Int()
   l0$y := sp$plusInts(anon$2, anon$4)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
@@ -1,45 +1,45 @@
 /function_call.kt:(118,130): info: Generated Viper text for functionCall:
-method f$f$TF$T$Int$T$Int(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$f$t$F$t$Int$t$Int(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$functionCall$TF$T$Unit() returns (ret$0: Ref)
+method f$functionCall$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  anon$0 := f$f$TF$T$Int$T$Int(df$rt$intToRef(0))
-  anon$1 := f$f$TF$T$Int$T$Int(df$rt$intToRef(0))
+  anon$0 := f$f$t$F$t$Int$t$Int(df$rt$intToRef(0))
+  anon$1 := f$f$t$F$t$Int$t$Int(df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_call.kt:(160,178): info: Generated Viper text for functionCallNested:
-method f$f$TF$T$Int$T$Int(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$f$t$F$t$Int$t$Int(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$functionCallNested$TF$T$Unit() returns (ret$0: Ref)
+method f$functionCallNested$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  anon$2 := f$f$TF$T$Int$T$Int(df$rt$intToRef(0))
-  anon$1 := f$f$TF$T$Int$T$Int(anon$2)
-  anon$0 := f$f$TF$T$Int$T$Int(anon$1)
+  anon$2 := f$f$t$F$t$Int$t$Int(df$rt$intToRef(0))
+  anon$1 := f$f$t$F$t$Int$t$Int(anon$2)
+  anon$0 := f$f$t$F$t$Int$t$Int(anon$1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_call.kt:(205,215): info: Generated Viper text for callItself:
-method f$callItself$TF$T$Unit() returns (ret$0: Ref)
+method f$callItself$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  anon$0 := f$callItself$TF$T$Unit()
+  anon$0 := f$callItself$t$F$t$Unit()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
@@ -1,5 +1,5 @@
 /if.kt:(23,31): info: Generated Viper text for simpleIf:
-method f$simpleIf$TF$T$Int() returns (ret$0: Ref)
+method f$simpleIf$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   if (true) {
@@ -13,11 +13,11 @@ method f$simpleIf$TF$T$Int() returns (ret$0: Ref)
 }
 
 /if.kt:(116,129): info: Generated Viper text for ifOnParameter:
-method f$ifOnParameter$TF$T$Boolean$T$Int(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$ifOnParameter$t$F$t$Boolean$t$Int(par$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  if (df$rt$boolFromRef(p$b)) {
+  if (df$rt$boolFromRef(par$b)) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
   } else {
@@ -28,28 +28,29 @@ method f$ifOnParameter$TF$T$Boolean$T$Int(p$b: Ref) returns (ret$0: Ref)
 }
 
 /if.kt:(221,235): info: Generated Viper text for ifAsExpression:
-method f$ifAsExpression$TF$T$Boolean() returns (ret$0: Ref)
+method f$ifAsExpression$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var l0$b: Ref
   l0$b := df$rt$boolToRef(false)
   if (df$rt$boolFromRef(l0$b)) {
     var anon$0: Ref
-    anon$0 := f$simpleIf$TF$T$Int()
+    anon$0 := f$simpleIf$t$F$t$Int()
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$1: Ref
-    anon$1 := f$ifOnParameter$TF$T$Boolean$T$Int(l0$b)
+    anon$1 := f$ifOnParameter$t$F$t$Boolean$t$Int(l0$b)
     ret$0 := df$rt$boolToRef(true)
   }
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$ifOnParameter$TF$T$Boolean$T$Int(p$b: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$ifOnParameter$t$F$t$Boolean$t$Int(par$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$simpleIf$TF$T$Int() returns (ret: Ref)
+method f$simpleIf$t$F$t$Int() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
@@ -1,41 +1,42 @@
 /loop.kt:(23,32): info: Generated Viper text for whileLoop:
-method f$whileLoop$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$whileLoop$t$F$t$Boolean$t$Boolean(par$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  label lbl$continue$0
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  anon$0 := p$b
+  label lbl$cont$0
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  anon$0 := par$b
   if (df$rt$boolFromRef(anon$0)) {
     var l1$a: Ref
     var l1$c: Ref
     l1$a := df$rt$intToRef(1)
     l1$c := df$rt$intToRef(2)
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ret$0 := df$rt$boolToRef(false)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /loop.kt:(138,160): info: Generated Viper text for whileFunctionCondition:
-method f$whileFunctionCondition$TF$T$Unit() returns (ret$0: Ref)
+method f$whileFunctionCondition$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  label lbl$continue$0
-  anon$0 := f$whileLoop$TF$T$Boolean$T$Boolean(df$rt$boolToRef(true))
+  label lbl$cont$0
+  anon$0 := f$whileLoop$t$F$t$Boolean$t$Boolean(df$rt$boolToRef(true))
   if (df$rt$boolFromRef(anon$0)) {
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$whileLoop$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$whileLoop$t$F$t$Boolean$t$Boolean(par$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
@@ -1,91 +1,92 @@
 /loop_invariants.kt:(146,168): info: Generated Viper text for dynamicLambdaInvariant:
-method f$dynamicLambdaInvariant$TF$TF$T$Int$T$Unit(p$f: Ref)
+method f$dynamicLambdaInvariant$t$F$t$F$t$Int$t$Unit(par$f: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  label lbl$continue$0
-    invariant df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-  anon$0 := f$returnsBoolean$TF$T$Boolean()
+  label lbl$cont$0
+    invariant df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
+  anon$0 := f$returnsBoolean$t$F$t$Boolean()
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$returnsBoolean$TF$T$Boolean() returns (ret: Ref)
+method f$returnsBoolean$t$F$t$Boolean() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 
 /loop_invariants.kt:(241,259): info: Generated Viper text for functionAssignment:
-method f$functionAssignment$TF$TF$T$Int$T$Unit(p$f: Ref)
+method f$functionAssignment$t$F$t$F$t$Int$t$Unit(par$f: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$g: Ref
   var anon$0: Ref
-  l0$g := p$f
-  label lbl$continue$0
+  l0$g := par$f
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$functionType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-  anon$0 := f$returnsBoolean$TF$T$Boolean()
+    invariant df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
+  anon$0 := f$returnsBoolean$t$F$t$Boolean()
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$functionType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$returnsBoolean$TF$T$Boolean() returns (ret: Ref)
+method f$returnsBoolean$t$F$t$Boolean() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 
 /loop_invariants.kt:(346,375): info: Generated Viper text for conditionalFunctionAssignment:
-method f$conditionalFunctionAssignment$TF$T$Boolean$TF$T$Int$TF$T$Int$T$Unit(p$b: Ref,
-  p$f: Ref, p$h: Ref)
+method f$conditionalFunctionAssignment$t$F$t$Boolean$t$F$t$Int$t$F$t$Int$t$Unit(par$b: Ref,
+  par$f: Ref, par$h: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$h), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$h), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$g: Ref
   var anon$0: Ref
-  if (df$rt$boolFromRef(p$b)) {
-    l0$g := p$f
+  if (df$rt$boolFromRef(par$b)) {
+    l0$g := par$f
   } else {
-    l0$g := p$h}
-  label lbl$continue$0
+    l0$g := par$h}
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$functionType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$h), df$rt$functionType())
-  anon$0 := f$returnsBoolean$TF$T$Boolean()
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$h), df$rt$functionType())
+  anon$0 := f$returnsBoolean$t$F$t$Boolean()
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$g), df$rt$functionType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$h), df$rt$functionType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$h), df$rt$functionType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$returnsBoolean$TF$T$Boolean() returns (ret: Ref)
+method f$returnsBoolean$t$F$t$Boolean() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/non-local-returns.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/non-local-returns.fir.diag.txt
@@ -1,5 +1,5 @@
 /non-local-returns.kt:(155,167): info: Generated Viper text for simpleReturn:
-method f$simpleReturn$TF$T$Int() returns (ret$0: Ref)
+method f$simpleReturn$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -20,7 +20,7 @@ method f$simpleReturn$TF$T$Int() returns (ret$0: Ref)
 }
 
 /non-local-returns.kt:(238,252): info: Generated Viper text for returnAtInline:
-method f$returnAtInline$TF$T$Int() returns (ret$0: Ref)
+method f$returnAtInline$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -41,7 +41,7 @@ method f$returnAtInline$TF$T$Int() returns (ret$0: Ref)
 }
 
 /non-local-returns.kt:(330,342): info: Generated Viper text for doubleInvoke:
-method f$doubleInvoke$TF$T$Int() returns (ret$0: Ref)
+method f$doubleInvoke$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -74,7 +74,7 @@ method f$doubleInvoke$TF$T$Int() returns (ret$0: Ref)
 }
 
 /non-local-returns.kt:(567,573): info: Generated Viper text for nested:
-method f$nested$TF$T$Int() returns (ret$0: Ref)
+method f$nested$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/recursion.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/recursion.fir.diag.txt
@@ -1,8 +1,8 @@
 /recursion.kt:(23,32): info: Generated Viper text for recursive:
-method f$recursive$TF$T$Unit() returns (ret$0: Ref)
+method f$recursive$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  ret$0 := f$recursive$TF$T$Unit()
+  ret$0 := f$recursive$t$F$t$Unit()
   goto lbl$ret$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/return_break_continue.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/return_break_continue.fir.diag.txt
@@ -1,5 +1,5 @@
 /return_break_continue.kt:(23,33): info: Generated Viper text for testReturn:
-method f$testReturn$TF$T$Int() returns (ret$0: Ref)
+method f$testReturn$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   ret$0 := df$rt$intToRef(0)
@@ -10,16 +10,16 @@ method f$testReturn$TF$T$Int() returns (ret$0: Ref)
 }
 
 /return_break_continue.kt:(76,90): info: Generated Viper text for returnFromLoop:
-method f$returnFromLoop$TF$T$Int() returns (ret$0: Ref)
+method f$returnFromLoop$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  label lbl$continue$0
+  label lbl$cont$0
   anon$0 := df$rt$boolToRef(true)
   if (df$rt$boolFromRef(anon$0)) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   ret$0 := df$rt$intToRef(1)
@@ -28,44 +28,44 @@ method f$returnFromLoop$TF$T$Int() returns (ret$0: Ref)
 }
 
 /return_break_continue.kt:(162,172): info: Generated Viper text for whileBreak:
-method f$whileBreak$TF$T$Boolean$T$Int(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$whileBreak$t$F$t$Boolean$t$Int(par$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$i: Ref
   var anon$0: Ref
   l0$i := df$rt$intToRef(0)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  anon$0 := p$b
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  anon$0 := par$b
   if (df$rt$boolFromRef(anon$0)) {
     l0$i := df$rt$intToRef(1)
     goto lbl$break$0
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ret$0 := l0$i
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /return_break_continue.kt:(276,289): info: Generated Viper text for whileContinue:
-method f$whileContinue$TF$T$Unit() returns (ret$0: Ref)
+method f$whileContinue$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$b: Ref
   var anon$0: Ref
   l0$b := df$rt$boolToRef(true)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$boolType())
   anon$0 := l0$b
   if (df$rt$boolFromRef(anon$0)) {
     l0$b := df$rt$boolToRef(false)
-    goto lbl$continue$0
-    goto lbl$continue$0
+    goto lbl$cont$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$boolType())
@@ -74,149 +74,150 @@ method f$whileContinue$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /return_break_continue.kt:(375,386): info: Generated Viper text for whileNested:
-method f$whileNested$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$whileNested$t$F$t$Boolean$t$Unit(par$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  label lbl$continue$0
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  anon$0 := p$b
+  label lbl$cont$0
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  anon$0 := par$b
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     var anon$2: Ref
-    label lbl$continue$1
-      invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    anon$1 := p$b
+    label lbl$cont$1
+      invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    anon$1 := par$b
     if (df$rt$boolFromRef(anon$1)) {
       goto lbl$break$1
-      goto lbl$continue$1
+      goto lbl$cont$1
     }
     label lbl$break$1
-    assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    goto lbl$continue$0
-    label lbl$continue$2
-      invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    anon$2 := p$b
+    assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    goto lbl$cont$0
+    label lbl$cont$2
+      invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    anon$2 := par$b
     if (df$rt$boolFromRef(anon$2)) {
-      goto lbl$continue$2
-      goto lbl$continue$2
+      goto lbl$cont$2
+      goto lbl$cont$2
     }
     label lbl$break$2
-    assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+    assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
     goto lbl$break$0
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /return_break_continue.kt:(556,569): info: Generated Viper text for labelledBreak:
-method f$labelledBreak$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$labelledBreak$t$F$t$Boolean$t$Unit(par$b: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  label lbl$continue$0
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  anon$0 := p$b
+  label lbl$cont$0
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  anon$0 := par$b
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
-    label lbl$continue$1
-      invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    anon$1 := p$b
+    label lbl$cont$1
+      invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    anon$1 := par$b
     if (df$rt$boolFromRef(anon$1)) {
       goto lbl$break$0
       goto lbl$break$1
       goto lbl$break$1
-      goto lbl$continue$1
+      goto lbl$cont$1
     }
     label lbl$break$1
-    assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+    assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
     goto lbl$break$0
     goto lbl$break$0
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /return_break_continue.kt:(754,770): info: Generated Viper text for labelledContinue:
-method f$labelledContinue$TF$T$Boolean$T$Unit(p$b: Ref)
+method f$labelledContinue$t$F$t$Boolean$t$Unit(par$b: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  label lbl$continue$0
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  anon$0 := p$b
+  label lbl$cont$0
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  anon$0 := par$b
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
-    label lbl$continue$1
-      invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    anon$1 := p$b
+    label lbl$cont$1
+      invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    anon$1 := par$b
     if (df$rt$boolFromRef(anon$1)) {
-      goto lbl$continue$0
-      goto lbl$continue$1
-      goto lbl$continue$1
-      goto lbl$continue$1
+      goto lbl$cont$0
+      goto lbl$cont$1
+      goto lbl$cont$1
+      goto lbl$cont$1
     }
     label lbl$break$1
-    assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    goto lbl$continue$0
-    goto lbl$continue$0
-    goto lbl$continue$0
+    assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    goto lbl$cont$0
+    goto lbl$cont$0
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /return_break_continue.kt:(970,992): info: Generated Viper text for labelledWhileShadowing:
-method f$labelledWhileShadowing$TF$T$Boolean$T$Unit(p$b: Ref)
+method f$labelledWhileShadowing$t$F$t$Boolean$t$Unit(par$b: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  label lbl$continue$0
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  anon$0 := p$b
+  label lbl$cont$0
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  anon$0 := par$b
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     var anon$2: Ref
-    label lbl$continue$1
-      invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    anon$1 := p$b
+    label lbl$cont$1
+      invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    anon$1 := par$b
     if (df$rt$boolFromRef(anon$1)) {
       goto lbl$break$1
-      goto lbl$continue$1
-      goto lbl$continue$1
+      goto lbl$cont$1
+      goto lbl$cont$1
     }
     label lbl$break$1
-    assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    label lbl$continue$2
-      invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-    anon$2 := p$b
+    assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    label lbl$cont$2
+      invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+    anon$2 := par$b
     if (df$rt$boolFromRef(anon$2)) {
       goto lbl$break$2
-      goto lbl$continue$2
-      goto lbl$continue$2
+      goto lbl$cont$2
+      goto lbl$cont$2
     }
     label lbl$break$2
-    assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+    assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
     goto lbl$break$0
-    goto lbl$continue$0
-    goto lbl$continue$0
+    goto lbl$cont$0
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
@@ -1,10 +1,10 @@
 /try_catch.kt:(158,166): info: Generated Viper text for tryCatch:
-method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$call$t$F$t$Int$t$Unit(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$tryCatch$TF$T$Unit() returns (ret$0: Ref)
+method f$tryCatch$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -16,33 +16,33 @@ method f$tryCatch$TF$T$Unit() returns (ret$0: Ref)
   if (df$rt$boolFromRef(anon$0)) {
     goto lbl$catch$0
   }
-  anon$1 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(0))
-  anon$2 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(1))
+  anon$1 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(0))
+  anon$2 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(1))
   if (df$rt$boolFromRef(anon$3)) {
     goto lbl$catch$0
   }
-  goto lbl$try_exit$0
+  goto lbl$tryExit$0
   label lbl$catch$0
-  anon$4 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(2))
-  goto lbl$try_exit$0
-  label lbl$try_exit$0
+  anon$4 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(2))
+  goto lbl$tryExit$0
+  label lbl$tryExit$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
+method g$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+method g$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 
 /try_catch.kt:(271,285): info: Generated Viper text for nestedTryCatch:
-method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$call$t$F$t$Int$t$Unit(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$nestedTryCatch$TF$T$Unit() returns (ret$0: Ref)
+method f$nestedTryCatch$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -57,43 +57,43 @@ method f$nestedTryCatch$TF$T$Unit() returns (ret$0: Ref)
   if (df$rt$boolFromRef(anon$0)) {
     goto lbl$catch$0
   }
-  anon$1 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(0))
+  anon$1 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(0))
   if (df$rt$boolFromRef(anon$2)) {
     goto lbl$catch$1
   }
-  anon$3 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(1))
+  anon$3 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(1))
   if (df$rt$boolFromRef(anon$4)) {
     goto lbl$catch$1
   }
-  goto lbl$try_exit$1
+  goto lbl$tryExit$1
   label lbl$catch$1
-  anon$5 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(2))
-  goto lbl$try_exit$1
-  label lbl$try_exit$1
+  anon$5 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(2))
+  goto lbl$tryExit$1
+  label lbl$tryExit$1
   if (df$rt$boolFromRef(anon$6)) {
     goto lbl$catch$0
   }
-  goto lbl$try_exit$0
+  goto lbl$tryExit$0
   label lbl$catch$0
-  goto lbl$try_exit$0
-  label lbl$try_exit$0
+  goto lbl$tryExit$0
+  label lbl$tryExit$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
+method g$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+method g$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 
 /try_catch.kt:(574,592): info: Generated Viper text for tryCatchWithInline:
-method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$call$t$F$t$Int$t$Unit(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$tryCatchWithInline$TF$T$Unit() returns (ret$0: Ref)
+method f$tryCatchWithInline$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -106,30 +106,30 @@ method f$tryCatchWithInline$TF$T$Unit() returns (ret$0: Ref)
   if (df$rt$boolFromRef(anon$0)) {
     goto lbl$catch$0
   }
-  anon$1 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(0))
-  anon$2 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(1))
+  anon$1 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(0))
+  anon$2 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(1))
   label lbl$ret$1
   inhale df$rt$isSubtype(df$rt$typeOf(ret$1), df$rt$unitType())
   if (df$rt$boolFromRef(anon$3)) {
     goto lbl$catch$0
   }
-  goto lbl$try_exit$0
+  goto lbl$tryExit$0
   label lbl$catch$0
-  anon$4 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(2))
-  goto lbl$try_exit$0
-  label lbl$try_exit$0
+  anon$4 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(2))
+  goto lbl$tryExit$0
+  label lbl$tryExit$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
+method g$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+method g$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 
 /try_catch.kt:(685,702): info: Generated Viper text for tryCatchShadowing:
-method f$tryCatchShadowing$TF$T$Unit() returns (ret$0: Ref)
+method f$tryCatchShadowing$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
@@ -146,28 +146,28 @@ method f$tryCatchShadowing$TF$T$Unit() returns (ret$0: Ref)
   if (df$rt$boolFromRef(anon$1)) {
     goto lbl$catch$0
   }
-  goto lbl$try_exit$0
+  goto lbl$tryExit$0
   label lbl$catch$0
   l2$x := df$rt$intToRef(2)
-  goto lbl$try_exit$0
-  label lbl$try_exit$0
+  goto lbl$tryExit$0
+  label lbl$tryExit$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
+method g$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+method g$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 
 /try_catch.kt:(813,828): info: Generated Viper text for multipleCatches:
-method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$call$t$F$t$Int$t$Unit(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$multipleCatches$TF$T$Unit() returns (ret$0: Ref)
+method f$multipleCatches$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -186,44 +186,44 @@ method f$multipleCatches$TF$T$Unit() returns (ret$0: Ref)
   if (df$rt$boolFromRef(anon$1)) {
     goto lbl$catch$1
   }
-  anon$2 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(0))
-  anon$3 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(1))
+  anon$2 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(0))
+  anon$3 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(1))
   if (df$rt$boolFromRef(anon$4)) {
     goto lbl$catch$0
   }
   if (df$rt$boolFromRef(anon$5)) {
     goto lbl$catch$1
   }
-  goto lbl$try_exit$0
+  goto lbl$tryExit$0
   label lbl$catch$0
-  anon$6 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(2))
-  goto lbl$try_exit$0
+  anon$6 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(2))
+  goto lbl$tryExit$0
   label lbl$catch$1
-  anon$7 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(3))
-  goto lbl$try_exit$0
-  label lbl$try_exit$0
+  anon$7 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(3))
+  goto lbl$tryExit$0
+  label lbl$tryExit$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
+method g$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+method g$public$message(this$dispatch: Ref) returns (ret: Ref)
 
 
 /try_catch.kt:(1044,1056): info: Generated Viper text for useException:
-method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$call$t$F$t$Int$t$Unit(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$ignore$TF$T$Exception$T$Unit(p$e: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$e), df$rt$c$pkg$java_lang$Exception())
+method f$ignore$t$F$t$Exception$t$Unit(par$e: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$e), df$rt$c$pkg$java_lang$Exception())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$useException$TF$T$Unit() returns (ret$0: Ref)
+method f$useException$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -234,20 +234,21 @@ method f$useException$TF$T$Unit() returns (ret$0: Ref)
   if (df$rt$boolFromRef(anon$0)) {
     goto lbl$catch$0
   }
-  anon$1 := f$call$TF$T$Int$T$Unit(df$rt$intToRef(0))
+  anon$1 := f$call$t$F$t$Int$t$Unit(df$rt$intToRef(0))
   if (df$rt$boolFromRef(anon$2)) {
     goto lbl$catch$0
   }
-  goto lbl$try_exit$0
+  goto lbl$tryExit$0
   label lbl$catch$0
-  anon$3 := f$ignore$TF$T$Exception$T$Unit(l2$e)
-  goto lbl$try_exit$0
-  label lbl$try_exit$0
+  anon$3 := f$ignore$t$F$t$Exception$t$Unit(l2$e)
+  goto lbl$tryExit$0
+  label lbl$tryExit$0
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
+method g$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
-method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+method g$public$message(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
@@ -1,17 +1,17 @@
 /when.kt:(23,33): info: Generated Viper text for returnWhen:
-method f$returnWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
-  p$c: Ref)
+method f$returnWhen$t$F$t$Boolean$t$Boolean$t$Boolean$t$Int(par$a: Ref, par$b: Ref,
+  par$c: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  if (df$rt$boolFromRef(p$a)) {
+  if (df$rt$boolFromRef(par$a)) {
     ret$0 := df$rt$intToRef(0)
-  } elseif (df$rt$boolFromRef(p$b)) {
+  } elseif (df$rt$boolFromRef(par$b)) {
     ret$0 := df$rt$intToRef(1)
-  } elseif (df$rt$boolFromRef(p$c)) {
+  } elseif (df$rt$boolFromRef(par$c)) {
     ret$0 := df$rt$intToRef(2)
   } else {
     ret$0 := df$rt$intToRef(3)}
@@ -20,21 +20,21 @@ method f$returnWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
 }
 
 /when.kt:(171,181): info: Generated Viper text for whenReturn:
-method f$whenReturn$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
-  p$c: Ref)
+method f$whenReturn$t$F$t$Boolean$t$Boolean$t$Boolean$t$Int(par$a: Ref, par$b: Ref,
+  par$c: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  if (df$rt$boolFromRef(p$a)) {
+  if (df$rt$boolFromRef(par$a)) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
-  } elseif (df$rt$boolFromRef(p$b)) {
+  } elseif (df$rt$boolFromRef(par$b)) {
     ret$0 := df$rt$intToRef(1)
     goto lbl$ret$0
-  } elseif (df$rt$boolFromRef(p$c)) {
+  } elseif (df$rt$boolFromRef(par$c)) {
     ret$0 := df$rt$intToRef(2)
     goto lbl$ret$0
   } else {
@@ -45,13 +45,14 @@ method f$whenReturn$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
 }
 
 /when.kt:(340,356): info: Generated Viper text for singleBranchWhen:
-method f$singleBranchWhen$TF$T$Boolean$T$Int(p$a: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+method f$singleBranchWhen$t$F$t$Boolean$t$Int(par$a: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$x: Ref
   l0$x := df$rt$intToRef(1)
-  if (df$rt$boolFromRef(p$a)) {
+  if (df$rt$boolFromRef(par$a)) {
     l0$x := df$rt$intToRef(2)
   }
   ret$0 := l0$x
@@ -60,21 +61,21 @@ method f$singleBranchWhen$TF$T$Boolean$T$Int(p$a: Ref) returns (ret$0: Ref)
 }
 
 /when.kt:(446,456): info: Generated Viper text for noElseWhen:
-method f$noElseWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
-  p$c: Ref)
+method f$noElseWhen$t$F$t$Boolean$t$Boolean$t$Boolean$t$Int(par$a: Ref, par$b: Ref,
+  par$c: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$y: Ref
   l0$y := df$rt$intToRef(0)
-  if (df$rt$boolFromRef(p$a)) {
+  if (df$rt$boolFromRef(par$a)) {
     l0$y := df$rt$intToRef(1)
-  } elseif (df$rt$boolFromRef(p$b)) {
+  } elseif (df$rt$boolFromRef(par$b)) {
     l0$y := df$rt$intToRef(2)
-  } elseif (df$rt$boolFromRef(p$c)) {
+  } elseif (df$rt$boolFromRef(par$c)) {
     l0$y := df$rt$intToRef(3)
   }
   ret$0 := l0$y
@@ -83,12 +84,13 @@ method f$noElseWhen$TF$T$Boolean$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref,
 }
 
 /when.kt:(608,626): info: Generated Viper text for whenWithSubjectVar:
-method f$whenWithSubjectVar$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$whenWithSubjectVar$t$F$t$Int$t$Int(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  anon$0 := p$x
+  anon$0 := par$x
   if (df$rt$intFromRef(anon$0) == 1) {
     ret$0 := df$rt$intToRef(2)
   } elseif (df$rt$intFromRef(anon$0) == 2) {
@@ -100,19 +102,20 @@ method f$whenWithSubjectVar$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /when.kt:(726,745): info: Generated Viper text for whenWithSubjectCall:
-method f$whenWithSubjectCall$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$whenWithSubjectCall$t$F$t$Int$t$Int(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  anon$0 := f$whenWithSubjectVar$TF$T$Int$T$Int(p$x)
+  anon$0 := f$whenWithSubjectVar$t$F$t$Int$t$Int(par$x)
   if (df$rt$intFromRef(anon$0) == 1) {
     ret$0 := df$rt$intToRef(2)
   } elseif (df$rt$intFromRef(anon$0) == 2) {
     ret$0 := df$rt$intToRef(3)
   } else {
     var anon$1: Ref
-    anon$1 := f$whenWithSubjectVar$TF$T$Int$T$Int(df$rt$intToRef(0))
+    anon$1 := f$whenWithSubjectVar$t$F$t$Int$t$Int(df$rt$intToRef(0))
     if (df$rt$intFromRef(anon$1) == 3) {
       ret$0 := df$rt$intToRef(4)
     } elseif (df$rt$intFromRef(anon$1) == 4) {
@@ -124,13 +127,13 @@ method f$whenWithSubjectCall$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$whenWithSubjectVar$TF$T$Int$T$Int(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$whenWithSubjectVar$t$F$t$Int$t$Int(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 /when.kt:(963,972): info: Generated Viper text for emptyWhen:
-method f$emptyWhen$TF$T$Int() returns (ret$0: Ref)
+method f$emptyWhen$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   ret$0 := df$rt$intToRef(1)
@@ -139,7 +142,7 @@ method f$emptyWhen$TF$T$Int() returns (ret$0: Ref)
 }
 
 /when.kt:(1015,1027): info: Generated Viper text for unusedResult:
-method f$unusedResult$TF$T$Int() returns (ret$0: Ref)
+method f$unusedResult$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$x: Ref
@@ -150,13 +153,13 @@ method f$unusedResult$TF$T$Int() returns (ret$0: Ref)
 }
 
 /when.kt:(1221,1227): info: Generated Viper text for whenIs:
-method f$whenIs$TF$T$Foo$T$Boolean(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$Foo())
+method f$whenIs$t$F$t$Foo$t$Boolean(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(p$x), wildcard)
-  anon$0 := p$x
+  inhale acc(pred$c$Foo$shared(par$x), wildcard)
+  anon$0 := par$x
   if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Bar())) {
     ret$0 := df$rt$boolToRef(true)
   } else {
@@ -166,7 +169,7 @@ method f$whenIs$TF$T$Foo$T$Boolean(p$x: Ref) returns (ret$0: Ref)
 }
 
 /when.kt:(1301,1315): info: Generated Viper text for whenSubjectVal:
-method f$whenSubjectVal$TF$T$Int() returns (ret$0: Ref)
+method f$whenSubjectVal$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l1$x: Ref
@@ -180,7 +183,7 @@ method f$whenSubjectVal$TF$T$Int() returns (ret$0: Ref)
 }
 
 /when.kt:(1392,1412): info: Generated Viper text for whenSubjectValNested:
-method f$whenSubjectValNested$TF$T$Unit() returns (ret$0: Ref)
+method f$whenSubjectValNested$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l1$x: Ref
@@ -210,7 +213,7 @@ method f$whenSubjectValNested$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /when.kt:(1674,1697): info: Generated Viper text for whenSubjectVarShadowing:
-method f$whenSubjectVarShadowing$TF$T$Unit() returns (ret$0: Ref)
+method f$whenSubjectVarShadowing$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/do_not_verify.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/do_not_verify.fir.diag.txt
@@ -1,5 +1,5 @@
 /do_not_verify.kt:(245,256): info: Generated Viper text for bad_returns:
-method f$bad_returns$TF$T$Boolean() returns (ret$0: Ref)
+method f$bad_returns$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
@@ -1,8 +1,8 @@
 /extension_properties.kt:(114,137): info: Generated Viper text for extensionGetterProperty:
-method eg$intValProp$TF$T$Int$T$Int(this$dispatch: Ref) returns (ret: Ref)
+method eg$intValProp$t$F$t$Int$t$Int(this$dispatch: Ref) returns (ret: Ref)
 
 
-method f$extensionGetterProperty$TF$T$Unit() returns (ret$0: Ref)
+method f$extensionGetterProperty$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
@@ -11,13 +11,13 @@ method f$extensionGetterProperty$TF$T$Unit() returns (ret$0: Ref)
   var anon$1: Ref
   var anon$2: Ref
   var anon$3: Ref
-  anon$0 := eg$intValProp$TF$T$Int$T$Int(df$rt$intToRef(0))
+  anon$0 := eg$intValProp$t$F$t$Int$t$Int(df$rt$intToRef(0))
   l0$a := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$a), df$rt$intType())
-  anon$3 := eg$intValProp$TF$T$Int$T$Int(df$rt$intToRef(1))
+  anon$3 := eg$intValProp$t$F$t$Int$t$Int(df$rt$intToRef(1))
   anon$2 := anon$3
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-  anon$1 := eg$intValProp$TF$T$Int$T$Int(anon$2)
+  anon$1 := eg$intValProp$t$F$t$Int$t$Int(anon$2)
   l0$b := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$intType())
   label lbl$ret$0
@@ -25,18 +25,18 @@ method f$extensionGetterProperty$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /extension_properties.kt:(210,233): info: Generated Viper text for extensionSetterProperty:
-method eg$intVarProp$TF$T$Int$T$Int(this$dispatch: Ref) returns (ret: Ref)
+method eg$intVarProp$t$F$t$Int$t$Int(this$dispatch: Ref) returns (ret: Ref)
 
 
-method es$intVarProp$TF$T$Int$T$Int$T$Unit(this$dispatch: Ref, anon$0: Ref)
+method es$intVarProp$t$F$t$Int$t$Int$t$Unit(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
 
 
-method f$extensionSetterProperty$TF$T$Unit() returns (ret$0: Ref)
+method f$extensionSetterProperty$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  anon$0 := es$intVarProp$TF$T$Int$T$Int$T$Unit(df$rt$intToRef(42), df$rt$intToRef(0))
+  anon$0 := es$intVarProp$t$F$t$Int$t$Int$t$Unit(df$rt$intToRef(42), df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -44,19 +44,19 @@ method f$extensionSetterProperty$TF$T$Unit() returns (ret$0: Ref)
 /extension_properties.kt:(414,453): info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
 field bf$x: Ref
 
-method eg$pfValProp$TF$T$PrimitiveField$T$Int(this$dispatch: Ref)
+method eg$pfValProp$t$F$t$PrimitiveField$t$Int(this$dispatch: Ref)
   returns (ret: Ref)
 
 
-method f$extensionGetterPropertyUserDefinedClass$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
+method f$extensionGetterPropertyUserDefinedClass$t$F$t$PrimitiveField$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
-  anon$0 := eg$pfValProp$TF$T$PrimitiveField$T$Int(p$pf)
+  inhale acc(pred$c$PrimitiveField$shared(par$pf), wildcard)
+  anon$0 := eg$pfValProp$t$F$t$PrimitiveField$t$Int(par$pf)
   l0$x := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
   label lbl$ret$0
@@ -66,22 +66,22 @@ method f$extensionGetterPropertyUserDefinedClass$TF$T$PrimitiveField$T$Unit(p$pf
 /extension_properties.kt:(508,547): info: Generated Viper text for extensionSetterPropertyUserDefinedClass:
 field bf$x: Ref
 
-method eg$pfVarProp$TF$T$PrimitiveField$T$Int(this$dispatch: Ref)
+method eg$pfVarProp$t$F$t$PrimitiveField$t$Int(this$dispatch: Ref)
   returns (ret: Ref)
 
 
-method es$pfVarProp$TF$T$PrimitiveField$T$Int$T$Unit(this$dispatch: Ref, anon$0: Ref)
+method es$pfVarProp$t$F$t$PrimitiveField$t$Int$t$Unit(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
 
 
-method f$extensionSetterPropertyUserDefinedClass$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
+method f$extensionSetterPropertyUserDefinedClass$t$F$t$PrimitiveField$t$Unit(par$pf: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
+  requires df$rt$isSubtype(df$rt$typeOf(par$pf), df$rt$c$PrimitiveField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
-  anon$0 := es$pfVarProp$TF$T$PrimitiveField$T$Int$T$Unit(p$pf, df$rt$intToRef(42))
+  inhale acc(pred$c$PrimitiveField$shared(par$pf), wildcard)
+  anon$0 := es$pfVarProp$t$F$t$PrimitiveField$t$Int$t$Unit(par$pf, df$rt$intToRef(42))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
@@ -1,7 +1,7 @@
-/full_viper_dump.kt:(172,173): info: Generated ExpEmbedding for f$f$TF$T$Unit:
+/full_viper_dump.kt:(172,173): info: Generated ExpEmbedding for f$f$t$F$t$Unit:
 Function(
-    name = f$f$TF$T$Unit,
-    { Declare(Var(l0$foo), T$Foo, MethodCall(callee = con$c$Foo$T$Int$T$Foo, Int(0))) },
+    name = f$f$t$F$t$Unit,
+    { Declare(Var(l0$foo), t$Foo, MethodCall(callee = con$c$Foo$t$Int$t$Foo, Int(0))) },
     return = lbl$ret$0,
 )
 
@@ -255,186 +255,186 @@ domain d$rt  {
 
 field bf$x: Ref
 
-function sp$addCharInt(arg1: Ref, arg2: Ref): Ref
+function sp$addCharInt(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) ==
-    df$rt$charFromRef(arg1) + df$rt$intFromRef(arg2)
+    df$rt$charFromRef(arg$1) + df$rt$intFromRef(arg$2)
 
 
-function sp$addStringChar(arg1: Ref, arg2: Ref): Ref
+function sp$addStringChar(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
   ensures df$rt$stringFromRef(result) ==
-    df$rt$stringFromRef(arg1) ++ Seq(df$rt$charFromRef(arg2))
+    df$rt$stringFromRef(arg$1) ++ Seq(df$rt$charFromRef(arg$2))
 
 
-function sp$addStrings(arg1: Ref, arg2: Ref): Ref
+function sp$addStrings(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
   ensures df$rt$stringFromRef(result) ==
-    df$rt$stringFromRef(arg1) ++ df$rt$stringFromRef(arg2)
+    df$rt$stringFromRef(arg$1) ++ df$rt$stringFromRef(arg$2)
 
 
-function sp$andBools(arg1: Ref, arg2: Ref): Ref
+function sp$andBools(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    (df$rt$boolFromRef(arg1) && df$rt$boolFromRef(arg2))
+    (df$rt$boolFromRef(arg$1) && df$rt$boolFromRef(arg$2))
 
 
-function sp$divInts(arg1: Ref, arg2: Ref): Ref
-  requires df$rt$intFromRef(arg2) != 0
+function sp$divInts(arg$1: Ref, arg$2: Ref): Ref
+  requires df$rt$intFromRef(arg$2) != 0
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) \ df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) \ df$rt$intFromRef(arg$2)
 
 
-function sp$geChars(arg1: Ref, arg2: Ref): Ref
+function sp$geChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) >= df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) >= df$rt$charFromRef(arg$2)
 
 
-function sp$geInts(arg1: Ref, arg2: Ref): Ref
+function sp$geInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) >= df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) >= df$rt$intFromRef(arg$2)
 
 
-function sp$gtChars(arg1: Ref, arg2: Ref): Ref
+function sp$gtChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) > df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) > df$rt$charFromRef(arg$2)
 
 
-function sp$gtInts(arg1: Ref, arg2: Ref): Ref
+function sp$gtInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) > df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) > df$rt$intFromRef(arg$2)
 
 
-function sp$impliesBools(arg1: Ref, arg2: Ref): Ref
+function sp$impliesBools(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    (df$rt$boolFromRef(arg1) ==> df$rt$boolFromRef(arg2))
+    (df$rt$boolFromRef(arg$1) ==> df$rt$boolFromRef(arg$2))
 
 
-function sp$leChars(arg1: Ref, arg2: Ref): Ref
+function sp$leChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) <= df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) <= df$rt$charFromRef(arg$2)
 
 
-function sp$leInts(arg1: Ref, arg2: Ref): Ref
+function sp$leInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) <= df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) <= df$rt$intFromRef(arg$2)
 
 
-function sp$ltChars(arg1: Ref, arg2: Ref): Ref
+function sp$ltChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) < df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) < df$rt$charFromRef(arg$2)
 
 
-function sp$ltInts(arg1: Ref, arg2: Ref): Ref
+function sp$ltInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) < df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) < df$rt$intFromRef(arg$2)
 
 
-function sp$minusInts(arg1: Ref, arg2: Ref): Ref
+function sp$minusInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) - df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) - df$rt$intFromRef(arg$2)
 
 
-function sp$negInt(arg1: Ref): Ref
+function sp$negInt(arg$1: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
-  ensures df$rt$intFromRef(result) == -df$rt$intFromRef(arg1)
+  ensures df$rt$intFromRef(result) == -df$rt$intFromRef(arg$1)
 
 
-function sp$notBool(arg1: Ref): Ref
+function sp$notBool(arg$1: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
-  ensures df$rt$boolFromRef(result) == !df$rt$boolFromRef(arg1)
+  ensures df$rt$boolFromRef(result) == !df$rt$boolFromRef(arg$1)
 
 
-function sp$orBools(arg1: Ref, arg2: Ref): Ref
+function sp$orBools(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    (df$rt$boolFromRef(arg1) || df$rt$boolFromRef(arg2))
+    (df$rt$boolFromRef(arg$1) || df$rt$boolFromRef(arg$2))
 
 
-function sp$plusInts(arg1: Ref, arg2: Ref): Ref
+function sp$plusInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) + df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) + df$rt$intFromRef(arg$2)
 
 
-function sp$remInts(arg1: Ref, arg2: Ref): Ref
-  requires df$rt$intFromRef(arg2) != 0
+function sp$remInts(arg$1: Ref, arg$2: Ref): Ref
+  requires df$rt$intFromRef(arg$2) != 0
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) % df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) % df$rt$intFromRef(arg$2)
 
 
-function sp$stringGet(arg1: Ref, arg2: Ref): Ref
-  requires df$rt$intFromRef(arg2) >= 0 &&
-    df$rt$intFromRef(arg2) < |df$rt$stringFromRef(arg1)|
+function sp$stringGet(arg$1: Ref, arg$2: Ref): Ref
+  requires df$rt$intFromRef(arg$2) >= 0 &&
+    df$rt$intFromRef(arg$2) < |df$rt$stringFromRef(arg$1)|
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) ==
-    df$rt$stringFromRef(arg1)[df$rt$intFromRef(arg2)]
+    df$rt$stringFromRef(arg$1)[df$rt$intFromRef(arg$2)]
 
 
-function sp$stringLength(arg1: Ref): Ref
+function sp$stringLength(arg$1: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
-  ensures df$rt$intFromRef(result) == |df$rt$stringFromRef(arg1)|
+  ensures df$rt$intFromRef(result) == |df$rt$stringFromRef(arg$1)|
 
 
-function sp$subCharInt(arg1: Ref, arg2: Ref): Ref
+function sp$subCharInt(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) ==
-    df$rt$charFromRef(arg1) - df$rt$intFromRef(arg2)
+    df$rt$charFromRef(arg$1) - df$rt$intFromRef(arg$2)
 
 
-function sp$subChars(arg1: Ref, arg2: Ref): Ref
+function sp$subChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$charFromRef(arg1) - df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) - df$rt$charFromRef(arg$2)
 
 
-function sp$timesInts(arg1: Ref, arg2: Ref): Ref
+function sp$timesInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) * df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) * df$rt$intFromRef(arg$2)
 
 
-predicate p$c$Foo$shared(this$dispatch: Ref) {
+predicate pred$c$Foo$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$intType())
 }
 
-predicate p$c$Foo$unique(this$dispatch: Ref) {
+predicate pred$c$Foo$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$x, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$x), df$rt$intType())
 }
 
-method con$c$Foo$T$Int$T$Foo(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method con$c$Foo$t$Int$t$Foo(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
-  ensures acc(p$c$Foo$shared(ret), wildcard)
-  ensures acc(p$c$Foo$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$Foo$shared(ret), wildcard) in
+  ensures acc(pred$c$Foo$shared(ret), wildcard)
+  ensures acc(pred$c$Foo$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$Foo$shared(ret), wildcard) in
       ret.bf$x)) ==
-    df$rt$intFromRef(p$x)
+    df$rt$intFromRef(par$x)
 
 
-method f$f$TF$T$Unit() returns (ret$0: Ref)
+method f$f$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$foo: Ref
-  l0$foo := con$c$Foo$T$Int$T$Foo(df$rt$intToRef(0))
+  l0$foo := con$c$Foo$t$Int$t$Foo(df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method havoc$T$Int() returns (ret: Ref)
+method havoc$t$Int() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_object.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_object.fir.diag.txt
@@ -1,6 +1,7 @@
 /function_object.kt:(23,35): info: Generated Viper text for unitFunction:
-method f$unitFunction$TF$TF$T$Unit$T$Unit(p$f: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
+method f$unitFunction$t$F$t$F$t$Unit$t$Unit(par$f: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -8,9 +9,9 @@ method f$unitFunction$TF$TF$T$Unit$T$Unit(p$f: Ref) returns (ret$0: Ref)
 }
 
 /function_object.kt:(90,108): info: Generated Viper text for functionObjectCall:
-method f$functionObjectCall$TF$TF$T$Boolean$T$Int$T$Int$T$Int(p$g: Ref)
+method f$functionObjectCall$t$F$t$F$t$Boolean$t$Int$t$Int$t$Int(par$g: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$g), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
@@ -21,11 +22,11 @@ method f$functionObjectCall$TF$TF$T$Boolean$T$Int$T$Int$T$Int(p$g: Ref)
 }
 
 /function_object.kt:(171,195): info: Generated Viper text for functionObjectNestedCall:
-method f$functionObjectNestedCall$TF$TF$T$Int$T$Int$TF$T$Boolean$T$Int$T$Int(p$f: Ref,
-  p$g: Ref)
+method f$functionObjectNestedCall$t$F$t$F$t$Int$t$Int$t$F$t$Boolean$t$Int$t$Int(par$f: Ref,
+  par$g: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$functionType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$functionType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$g), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
@@ -1,52 +1,52 @@
 /function_overloading.kt:(49,52): info: Generated Viper text for baz:
-method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
+method f$c$Bar$baz$t$F$t$Bar$t$Foo$t$Unit(this$dispatch: Ref, par$f: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Foo$shared(p$f), wildcard)
+  inhale acc(pred$c$Bar$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Foo$shared(par$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(74,77): info: Generated Viper text for baz:
-method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
+method f$c$Bar$baz$t$F$t$Bar$t$Bar$t$Unit(this$dispatch: Ref, par$b: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Bar$shared(p$b), wildcard)
+  inhale acc(pred$c$Bar$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Bar$shared(par$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(98,107): info: Generated Viper text for fakePrint:
-method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+method f$fakePrint$t$F$t$Bar$t$Unit(par$b: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(p$b), wildcard)
+  inhale acc(pred$c$Bar$shared(par$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(125,134): info: Generated Viper text for fakePrint:
-method f$fakePrint$TF$T$Foo$T$Unit(p$f: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+method f$fakePrint$t$F$t$Foo$t$Unit(par$f: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Foo$shared(p$f), wildcard)
+  inhale acc(pred$c$Foo$shared(par$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(152,161): info: Generated Viper text for fakePrint:
-method f$fakePrint$TF$T$Int$T$Unit(p$value: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$value), df$rt$intType())
+method f$fakePrint$t$F$t$Int$t$Unit(par$value: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$value), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -54,8 +54,9 @@ method f$fakePrint$TF$T$Int$T$Unit(p$value: Ref) returns (ret$0: Ref)
 }
 
 /function_overloading.kt:(183,192): info: Generated Viper text for fakePrint:
-method f$fakePrint$TF$T$Boolean$T$Unit(p$truth: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$truth), df$rt$boolType())
+method f$fakePrint$t$F$t$Boolean$t$Unit(par$truth: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$truth), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -63,8 +64,9 @@ method f$fakePrint$TF$T$Boolean$T$Unit(p$truth: Ref) returns (ret$0: Ref)
 }
 
 /function_overloading.kt:(219,238): info: Generated Viper text for differInNullability:
-method f$differInNullability$TF$T$Int$T$Unit(p$i: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
+method f$differInNullability$t$F$t$Int$t$Unit(par$i: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$i), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -72,9 +74,9 @@ method f$differInNullability$TF$T$Int$T$Unit(p$i: Ref) returns (ret$0: Ref)
 }
 
 /function_overloading.kt:(256,275): info: Generated Viper text for differInNullability:
-method f$differInNullability$TF$NT$Int$T$Unit(p$i: Ref)
+method f$differInNullability$t$F$t$N$Int$t$Unit(par$i: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$i), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -82,39 +84,39 @@ method f$differInNullability$TF$NT$Int$T$Unit(p$i: Ref)
 }
 
 /function_overloading.kt:(295,321): info: Generated Viper text for testGlobalScopeOverloading:
-method con$c$Bar$T$Bar() returns (ret: Ref)
+method con$c$Bar$t$Bar() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Bar())
-  ensures acc(p$c$Bar$shared(ret), wildcard)
-  ensures acc(p$c$Bar$unique(ret), write)
+  ensures acc(pred$c$Bar$shared(ret), wildcard)
+  ensures acc(pred$c$Bar$unique(ret), write)
 
 
-method con$c$Foo$T$Foo() returns (ret: Ref)
+method con$c$Foo$t$Foo() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
-  ensures acc(p$c$Foo$shared(ret), wildcard)
-  ensures acc(p$c$Foo$unique(ret), write)
+  ensures acc(pred$c$Foo$shared(ret), wildcard)
+  ensures acc(pred$c$Foo$unique(ret), write)
 
 
-method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+method f$fakePrint$t$F$t$Bar$t$Unit(par$b: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$fakePrint$TF$T$Boolean$T$Unit(p$truth: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$truth), df$rt$boolType())
+method f$fakePrint$t$F$t$Boolean$t$Unit(par$truth: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$truth), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$fakePrint$TF$T$Foo$T$Unit(p$f: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+method f$fakePrint$t$F$t$Foo$t$Unit(par$f: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$fakePrint$TF$T$Int$T$Unit(p$value: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$value), df$rt$intType())
+method f$fakePrint$t$F$t$Int$t$Unit(par$value: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$value), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testGlobalScopeOverloading$TF$T$Unit() returns (ret$0: Ref)
+method f$testGlobalScopeOverloading$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -123,44 +125,44 @@ method f$testGlobalScopeOverloading$TF$T$Unit() returns (ret$0: Ref)
   var anon$3: Ref
   var anon$4: Ref
   var anon$5: Ref
-  anon$0 := f$fakePrint$TF$T$Int$T$Unit(df$rt$intToRef(42))
-  anon$1 := f$fakePrint$TF$T$Boolean$T$Unit(df$rt$boolToRef(true))
-  anon$3 := con$c$Foo$T$Foo()
-  anon$2 := f$fakePrint$TF$T$Foo$T$Unit(anon$3)
-  anon$5 := con$c$Bar$T$Bar()
-  anon$4 := f$fakePrint$TF$T$Bar$T$Unit(anon$5)
+  anon$0 := f$fakePrint$t$F$t$Int$t$Unit(df$rt$intToRef(42))
+  anon$1 := f$fakePrint$t$F$t$Boolean$t$Unit(df$rt$boolToRef(true))
+  anon$3 := con$c$Foo$t$Foo()
+  anon$2 := f$fakePrint$t$F$t$Foo$t$Unit(anon$3)
+  anon$5 := con$c$Bar$t$Bar()
+  anon$4 := f$fakePrint$t$F$t$Bar$t$Unit(anon$5)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /function_overloading.kt:(413,441): info: Generated Viper text for testClassFunctionOverloading:
-method con$c$Bar$T$Bar() returns (ret: Ref)
+method con$c$Bar$t$Bar() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Bar())
-  ensures acc(p$c$Bar$shared(ret), wildcard)
-  ensures acc(p$c$Bar$unique(ret), write)
+  ensures acc(pred$c$Bar$shared(ret), wildcard)
+  ensures acc(pred$c$Bar$unique(ret), write)
 
 
-method con$c$Foo$T$Foo() returns (ret: Ref)
+method con$c$Foo$t$Foo() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
-  ensures acc(p$c$Foo$shared(ret), wildcard)
-  ensures acc(p$c$Foo$unique(ret), write)
+  ensures acc(pred$c$Foo$shared(ret), wildcard)
+  ensures acc(pred$c$Foo$unique(ret), write)
 
 
-method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
+method f$c$Bar$baz$t$F$t$Bar$t$Bar$t$Unit(this$dispatch: Ref, par$b: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
+method f$c$Bar$baz$t$F$t$Bar$t$Foo$t$Unit(this$dispatch: Ref, par$f: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
-  requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+  requires df$rt$isSubtype(df$rt$typeOf(par$f), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testClassFunctionOverloading$TF$T$Unit() returns (ret$0: Ref)
+method f$testClassFunctionOverloading$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$b: Ref
@@ -168,11 +170,11 @@ method f$testClassFunctionOverloading$TF$T$Unit() returns (ret$0: Ref)
   var anon$1: Ref
   var anon$2: Ref
   var anon$3: Ref
-  l0$b := con$c$Bar$T$Bar()
-  anon$1 := con$c$Foo$T$Foo()
-  anon$0 := f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(l0$b, anon$1)
-  anon$3 := con$c$Bar$T$Bar()
-  anon$2 := f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(l0$b, anon$3)
+  l0$b := con$c$Bar$t$Bar()
+  anon$1 := con$c$Foo$t$Foo()
+  anon$0 := f$c$Bar$baz$t$F$t$Bar$t$Foo$t$Unit(l0$b, anon$1)
+  anon$3 := con$c$Bar$t$Bar()
+  anon$2 := f$c$Bar$baz$t$F$t$Bar$t$Bar$t$Unit(l0$b, anon$3)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
@@ -284,162 +284,162 @@ field bf$unit: Ref
 
 field bf$unitNull: Ref
 
-function sp$addCharInt(arg1: Ref, arg2: Ref): Ref
+function sp$addCharInt(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) ==
-    df$rt$charFromRef(arg1) + df$rt$intFromRef(arg2)
+    df$rt$charFromRef(arg$1) + df$rt$intFromRef(arg$2)
 
 
-function sp$addStringChar(arg1: Ref, arg2: Ref): Ref
+function sp$addStringChar(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
   ensures df$rt$stringFromRef(result) ==
-    df$rt$stringFromRef(arg1) ++ Seq(df$rt$charFromRef(arg2))
+    df$rt$stringFromRef(arg$1) ++ Seq(df$rt$charFromRef(arg$2))
 
 
-function sp$addStrings(arg1: Ref, arg2: Ref): Ref
+function sp$addStrings(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
   ensures df$rt$stringFromRef(result) ==
-    df$rt$stringFromRef(arg1) ++ df$rt$stringFromRef(arg2)
+    df$rt$stringFromRef(arg$1) ++ df$rt$stringFromRef(arg$2)
 
 
-function sp$andBools(arg1: Ref, arg2: Ref): Ref
+function sp$andBools(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    (df$rt$boolFromRef(arg1) && df$rt$boolFromRef(arg2))
+    (df$rt$boolFromRef(arg$1) && df$rt$boolFromRef(arg$2))
 
 
-function sp$divInts(arg1: Ref, arg2: Ref): Ref
-  requires df$rt$intFromRef(arg2) != 0
+function sp$divInts(arg$1: Ref, arg$2: Ref): Ref
+  requires df$rt$intFromRef(arg$2) != 0
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) \ df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) \ df$rt$intFromRef(arg$2)
 
 
-function sp$geChars(arg1: Ref, arg2: Ref): Ref
+function sp$geChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) >= df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) >= df$rt$charFromRef(arg$2)
 
 
-function sp$geInts(arg1: Ref, arg2: Ref): Ref
+function sp$geInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) >= df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) >= df$rt$intFromRef(arg$2)
 
 
-function sp$gtChars(arg1: Ref, arg2: Ref): Ref
+function sp$gtChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) > df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) > df$rt$charFromRef(arg$2)
 
 
-function sp$gtInts(arg1: Ref, arg2: Ref): Ref
+function sp$gtInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) > df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) > df$rt$intFromRef(arg$2)
 
 
-function sp$impliesBools(arg1: Ref, arg2: Ref): Ref
+function sp$impliesBools(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    (df$rt$boolFromRef(arg1) ==> df$rt$boolFromRef(arg2))
+    (df$rt$boolFromRef(arg$1) ==> df$rt$boolFromRef(arg$2))
 
 
-function sp$leChars(arg1: Ref, arg2: Ref): Ref
+function sp$leChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) <= df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) <= df$rt$charFromRef(arg$2)
 
 
-function sp$leInts(arg1: Ref, arg2: Ref): Ref
+function sp$leInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) <= df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) <= df$rt$intFromRef(arg$2)
 
 
-function sp$ltChars(arg1: Ref, arg2: Ref): Ref
+function sp$ltChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$charFromRef(arg1) < df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) < df$rt$charFromRef(arg$2)
 
 
-function sp$ltInts(arg1: Ref, arg2: Ref): Ref
+function sp$ltInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    df$rt$intFromRef(arg1) < df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) < df$rt$intFromRef(arg$2)
 
 
-function sp$minusInts(arg1: Ref, arg2: Ref): Ref
+function sp$minusInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) - df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) - df$rt$intFromRef(arg$2)
 
 
-function sp$negInt(arg1: Ref): Ref
+function sp$negInt(arg$1: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
-  ensures df$rt$intFromRef(result) == -df$rt$intFromRef(arg1)
+  ensures df$rt$intFromRef(result) == -df$rt$intFromRef(arg$1)
 
 
-function sp$notBool(arg1: Ref): Ref
+function sp$notBool(arg$1: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
-  ensures df$rt$boolFromRef(result) == !df$rt$boolFromRef(arg1)
+  ensures df$rt$boolFromRef(result) == !df$rt$boolFromRef(arg$1)
 
 
-function sp$orBools(arg1: Ref, arg2: Ref): Ref
+function sp$orBools(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result) ==
-    (df$rt$boolFromRef(arg1) || df$rt$boolFromRef(arg2))
+    (df$rt$boolFromRef(arg$1) || df$rt$boolFromRef(arg$2))
 
 
-function sp$plusInts(arg1: Ref, arg2: Ref): Ref
+function sp$plusInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) + df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) + df$rt$intFromRef(arg$2)
 
 
-function sp$remInts(arg1: Ref, arg2: Ref): Ref
-  requires df$rt$intFromRef(arg2) != 0
+function sp$remInts(arg$1: Ref, arg$2: Ref): Ref
+  requires df$rt$intFromRef(arg$2) != 0
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) % df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) % df$rt$intFromRef(arg$2)
 
 
-function sp$stringGet(arg1: Ref, arg2: Ref): Ref
-  requires df$rt$intFromRef(arg2) >= 0 &&
-    df$rt$intFromRef(arg2) < |df$rt$stringFromRef(arg1)|
+function sp$stringGet(arg$1: Ref, arg$2: Ref): Ref
+  requires df$rt$intFromRef(arg$2) >= 0 &&
+    df$rt$intFromRef(arg$2) < |df$rt$stringFromRef(arg$1)|
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) ==
-    df$rt$stringFromRef(arg1)[df$rt$intFromRef(arg2)]
+    df$rt$stringFromRef(arg$1)[df$rt$intFromRef(arg$2)]
 
 
-function sp$stringLength(arg1: Ref): Ref
+function sp$stringLength(arg$1: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
-  ensures df$rt$intFromRef(result) == |df$rt$stringFromRef(arg1)|
+  ensures df$rt$intFromRef(result) == |df$rt$stringFromRef(arg$1)|
 
 
-function sp$subCharInt(arg1: Ref, arg2: Ref): Ref
+function sp$subCharInt(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) ==
-    df$rt$charFromRef(arg1) - df$rt$intFromRef(arg2)
+    df$rt$charFromRef(arg$1) - df$rt$intFromRef(arg$2)
 
 
-function sp$subChars(arg1: Ref, arg2: Ref): Ref
+function sp$subChars(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$charFromRef(arg1) - df$rt$charFromRef(arg2)
+    df$rt$charFromRef(arg$1) - df$rt$charFromRef(arg$2)
 
 
-function sp$timesInts(arg1: Ref, arg2: Ref): Ref
+function sp$timesInts(arg$1: Ref, arg$2: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) ==
-    df$rt$intFromRef(arg1) * df$rt$intFromRef(arg2)
+    df$rt$intFromRef(arg$1) * df$rt$intFromRef(arg$2)
 
 
-predicate p$c$A$shared(this$dispatch: Ref) {
+predicate pred$c$A$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$A$unique(this$dispatch: Ref) {
+predicate pred$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$unit, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$unit), df$rt$unitType()) &&
   acc(this$dispatch.bf$nothing, write) &&
@@ -455,7 +455,7 @@ predicate p$c$A$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$string, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$string), df$rt$stringType()) &&
   acc(this$dispatch.bf$classType, write) &&
-  acc(p$c$B$shared(this$dispatch.bf$classType), wildcard) &&
+  acc(pred$c$B$shared(this$dispatch.bf$classType), wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$classType), df$rt$c$B()) &&
   acc(this$dispatch.bf$unitNull, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$unitNull), df$rt$nullable(df$rt$unitType())) &&
@@ -473,20 +473,20 @@ predicate p$c$A$unique(this$dispatch: Ref) {
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$stringNull), df$rt$nullable(df$rt$stringType())) &&
   acc(this$dispatch.bf$classTypeNull, write) &&
   (this$dispatch.bf$classTypeNull != df$rt$nullValue() ==>
-  acc(p$c$B$shared(this$dispatch.bf$classTypeNull), wildcard)) &&
+  acc(pred$c$B$shared(this$dispatch.bf$classTypeNull), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$classTypeNull), df$rt$nullable(df$rt$c$B()))
 }
 
-predicate p$c$B$shared(this$dispatch: Ref) {
+predicate pred$c$B$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$c$B$unique(this$dispatch: Ref) {
+predicate pred$c$B$unique(this$dispatch: Ref) {
   true
 }
 
-method f$havoc$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+method f$havoc$t$F$t$A$t$Unit(par$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$localUnit: Ref
@@ -505,89 +505,89 @@ method f$havoc$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   var l0$localCharNull: Ref
   var l0$localStringNull: Ref
   var l0$localClassTypeNull: Ref
-  inhale acc(p$c$A$shared(p$a), wildcard)
-  l0$localUnit := havoc$T$Unit()
-  l0$localNothing := havoc$T$Nothing()
-  l0$localAny := havoc$T$Any()
-  l0$localInt := havoc$T$Int()
-  l0$localBoolean := havoc$T$Boolean()
-  l0$localChar := havoc$T$Char()
-  l0$localString := havoc$T$String()
-  l0$localClassType := havoc$T$B()
-  l0$localUnitNull := havoc$NT$Unit()
-  l0$localNothingNull := havoc$NT$Nothing()
-  l0$localAnyNull := havoc$NT$Any()
-  l0$localIntNull := havoc$NT$Int()
-  l0$localBooleanNull := havoc$NT$Boolean()
-  l0$localCharNull := havoc$NT$Char()
-  l0$localStringNull := havoc$NT$String()
-  l0$localClassTypeNull := havoc$NT$B()
+  inhale acc(pred$c$A$shared(par$a), wildcard)
+  l0$localUnit := havoc$t$Unit()
+  l0$localNothing := havoc$t$Nothing()
+  l0$localAny := havoc$t$Any()
+  l0$localInt := havoc$t$Int()
+  l0$localBoolean := havoc$t$Boolean()
+  l0$localChar := havoc$t$Char()
+  l0$localString := havoc$t$String()
+  l0$localClassType := havoc$t$B()
+  l0$localUnitNull := havoc$t$N$Unit()
+  l0$localNothingNull := havoc$t$N$Nothing()
+  l0$localAnyNull := havoc$t$N$Any()
+  l0$localIntNull := havoc$t$N$Int()
+  l0$localBooleanNull := havoc$t$N$Boolean()
+  l0$localCharNull := havoc$t$N$Char()
+  l0$localStringNull := havoc$t$N$String()
+  l0$localClassTypeNull := havoc$t$N$B()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method havoc$NT$Any() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
-
-
-method havoc$NT$B() returns (ret: Ref)
-  ensures ret != df$rt$nullValue() ==> acc(p$c$B$shared(ret), wildcard)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$c$B()))
-
-
-method havoc$NT$Boolean() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$boolType()))
-
-
-method havoc$NT$Char() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$charType()))
-
-
-method havoc$NT$Int() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
-
-
-method havoc$NT$Nothing() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$nothingType()))
-
-
-method havoc$NT$String() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$stringType()))
-
-
-method havoc$NT$Unit() returns (ret: Ref)
-  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$unitType()))
-
-
-method havoc$T$Any() returns (ret: Ref)
+method havoc$t$Any() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$anyType())
 
 
-method havoc$T$B() returns (ret: Ref)
-  ensures acc(p$c$B$shared(ret), wildcard)
+method havoc$t$B() returns (ret: Ref)
+  ensures acc(pred$c$B$shared(ret), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$B())
 
 
-method havoc$T$Boolean() returns (ret: Ref)
+method havoc$t$Boolean() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 
-method havoc$T$Char() returns (ret: Ref)
+method havoc$t$Char() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$charType())
 
 
-method havoc$T$Int() returns (ret: Ref)
+method havoc$t$Int() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method havoc$T$Nothing() returns (ret: Ref)
+method havoc$t$N$Any() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
+
+
+method havoc$t$N$B() returns (ret: Ref)
+  ensures ret != df$rt$nullValue() ==> acc(pred$c$B$shared(ret), wildcard)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$c$B()))
+
+
+method havoc$t$N$Boolean() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$boolType()))
+
+
+method havoc$t$N$Char() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$charType()))
+
+
+method havoc$t$N$Int() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
+
+
+method havoc$t$N$Nothing() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$nothingType()))
+
+
+method havoc$t$N$String() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$stringType()))
+
+
+method havoc$t$N$Unit() returns (ret: Ref)
+  ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$unitType()))
+
+
+method havoc$t$Nothing() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nothingType())
 
 
-method havoc$T$String() returns (ret: Ref)
+method havoc$t$String() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
-method havoc$T$Unit() returns (ret: Ref)
+method havoc$t$Unit() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
@@ -1,6 +1,7 @@
 /captured.kt:(155,165): info: Generated Viper text for captureArg:
-method f$captureArg$TF$TF$T$Int$T$Int$T$Int(p$g: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
+method f$captureArg$t$F$t$F$t$Int$t$Int$t$Int(par$g: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$g), df$rt$functionType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -21,7 +22,7 @@ method f$captureArg$TF$TF$T$Int$T$Int$T$Int(p$g: Ref) returns (ret$0: Ref)
 }
 
 /captured.kt:(225,235): info: Generated Viper text for captureVar:
-method f$captureVar$TF$T$Int() returns (ret$0: Ref)
+method f$captureVar$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$x: Ref
@@ -42,8 +43,8 @@ method f$captureVar$TF$T$Int() returns (ret$0: Ref)
 }
 
 /captured.kt:(295,311): info: Generated Viper text for captureAndShadow:
-method f$captureAndShadow$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$captureAndShadow$t$F$t$Int$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -52,7 +53,7 @@ method f$captureAndShadow$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   var l2$y: Ref
   var l2$x: Ref
   anon$0 := df$rt$intToRef(0)
-  l2$y := p$x
+  l2$y := par$x
   l2$x := df$rt$intToRef(1)
   ret$2 := sp$plusInts(sp$plusInts(anon$0, l2$x), l2$y)
   goto lbl$ret$2
@@ -66,8 +67,8 @@ method f$captureAndShadow$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /captured.kt:(513,528): info: Generated Viper text for captureVarClash:
-method f$captureVarClash$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$captureVarClash$t$F$t$Int$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -77,7 +78,7 @@ method f$captureVarClash$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   l1$x := df$rt$intToRef(1)
   anon$0 := df$rt$intToRef(0)
-  ret$2 := sp$timesInts(anon$0, p$x)
+  ret$2 := sp$timesInts(anon$0, par$x)
   goto lbl$ret$2
   label lbl$ret$2
   anon$1 := ret$2
@@ -90,9 +91,9 @@ method f$captureVarClash$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /captured.kt:(585,606): info: Generated Viper text for captureAndShadowClash:
-method f$captureAndShadowClash$TF$T$Int$T$Int(p$x: Ref)
+method f$captureAndShadowClash$t$F$t$Int$t$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -104,7 +105,7 @@ method f$captureAndShadowClash$TF$T$Int$T$Int(p$x: Ref)
   var l2$x: Ref
   l1$x := df$rt$intToRef(1)
   anon$0 := df$rt$intToRef(0)
-  l2$y := p$x
+  l2$y := par$x
   l2$x := df$rt$intToRef(2)
   ret$2 := sp$plusInts(sp$plusInts(l2$x, l2$y), anon$0)
   goto lbl$ret$2
@@ -119,9 +120,9 @@ method f$captureAndShadowClash$TF$T$Int$T$Int(p$x: Ref)
 }
 
 /captured.kt:(715,736): info: Generated Viper text for nestedLambdaShadowing:
-method f$nestedLambdaShadowing$TF$T$Int$T$Int(p$x: Ref)
+method f$nestedLambdaShadowing$t$F$t$Int$t$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -149,7 +150,7 @@ method f$nestedLambdaShadowing$TF$T$Int$T$Int(p$x: Ref)
   ret$3 := sp$plusInts(anon$3, l3$x)
   goto lbl$ret$3
   label lbl$ret$3
-  l2$y := p$x
+  l2$y := par$x
   l2$x := df$rt$intToRef(4)
   ret$2 := sp$plusInts(sp$plusInts(l2$x, l2$y), anon$0)
   goto lbl$ret$2
@@ -164,8 +165,8 @@ method f$nestedLambdaShadowing$TF$T$Int$T$Int(p$x: Ref)
 }
 
 /captured.kt:(1008,1024): info: Generated Viper text for callDoubleInvoke:
-method f$callDoubleInvoke$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$callDoubleInvoke$t$F$t$Int$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
@@ -1,6 +1,6 @@
 /inline.kt:(230,239): info: Generated Viper text for quadruple:
-method f$quadruple$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$quadruple$t$F$t$Int$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
@@ -9,12 +9,12 @@ method f$quadruple$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
   var anon$1: Ref
   var ret$2: Ref
   var l2$y: Ref
-  l1$y := sp$plusInts(p$x, p$x)
+  l1$y := sp$plusInts(par$x, par$x)
   ret$1 := l1$y
   goto lbl$ret$1
   label lbl$ret$1
   anon$0 := ret$1
-  l2$y := sp$plusInts(p$x, p$x)
+  l2$y := sp$plusInts(par$x, par$x)
   ret$2 := l2$y
   goto lbl$ret$2
   label lbl$ret$2
@@ -25,7 +25,7 @@ method f$quadruple$TF$T$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /inline.kt:(469,481): info: Generated Viper text for useBranching:
-method f$useBranching$TF$T$Int() returns (ret$0: Ref)
+method f$useBranching$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$2: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/lambdas.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/lambdas.fir.diag.txt
@@ -1,5 +1,5 @@
 /lambdas.kt:(155,166): info: Generated Viper text for explicitArg:
-method f$explicitArg$TF$T$Int() returns (ret$0: Ref)
+method f$explicitArg$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -18,7 +18,7 @@ method f$explicitArg$TF$T$Int() returns (ret$0: Ref)
 }
 
 /lambdas.kt:(216,227): info: Generated Viper text for implicitArg:
-method f$implicitArg$TF$T$Int() returns (ret$0: Ref)
+method f$implicitArg$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -37,7 +37,7 @@ method f$implicitArg$TF$T$Int() returns (ret$0: Ref)
 }
 
 /lambdas.kt:(273,281): info: Generated Viper text for lambdaIf:
-method f$lambdaIf$TF$T$Int() returns (ret$0: Ref)
+method f$lambdaIf$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var ret$1: Ref
@@ -59,7 +59,7 @@ method f$lambdaIf$TF$T$Int() returns (ret$0: Ref)
 }
 
 /lambdas.kt:(412,430): info: Generated Viper text for returnValueNotUsed:
-method f$returnValueNotUsed$TF$T$Unit() returns (ret$0: Ref)
+method f$returnValueNotUsed$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var ret$1: Ref
@@ -77,7 +77,7 @@ method f$returnValueNotUsed$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /lambdas.kt:(466,475): info: Generated Viper text for shadowing:
-method f$shadowing$TF$T$Int() returns (ret$0: Ref)
+method f$shadowing$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$x: Ref
@@ -102,7 +102,7 @@ method f$shadowing$TF$T$Int() returns (ret$0: Ref)
 }
 
 /lambdas.kt:(711,717): info: Generated Viper text for nested:
-method f$nested$TF$T$Int() returns (ret$0: Ref)
+method f$nested$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$x: Ref
@@ -129,7 +129,7 @@ method f$nested$TF$T$Int() returns (ret$0: Ref)
 }
 
 /lambdas.kt:(853,870): info: Generated Viper text for lambdaPassthrough:
-method f$lambdaPassthrough$TF$T$Unit() returns (ret$0: Ref)
+method f$lambdaPassthrough$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var ret$1: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/arithmetic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/arithmetic.fir.diag.txt
@@ -1,65 +1,65 @@
 /arithmetic.kt:(23,31): info: Generated Viper text for addition:
-method f$addition$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$addition$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  l0$y := sp$plusInts(p$x, p$x)
+  l0$y := sp$plusInts(par$x, par$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /arithmetic.kt:(66,77): info: Generated Viper text for subtraction:
-method f$subtraction$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$subtraction$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  l0$y := sp$minusInts(p$x, p$x)
+  l0$y := sp$minusInts(par$x, par$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /arithmetic.kt:(112,126): info: Generated Viper text for multiplication:
-method f$multiplication$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$multiplication$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  l0$y := sp$timesInts(p$x, p$x)
+  l0$y := sp$timesInts(par$x, par$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /arithmetic.kt:(161,169): info: Generated Viper text for division:
-method f$division$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$division$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  l0$y := sp$divInts(p$x, p$x)
+  l0$y := sp$divInts(par$x, par$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /arithmetic.kt:(273,282): info: Generated Viper text for remainder:
-method f$remainder$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$remainder$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  l0$y := sp$remInts(p$x, p$x)
+  l0$y := sp$remInts(par$x, par$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /arithmetic.kt:(386,397): info: Generated Viper text for unary_minus:
-method f$unary_minus$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$unary_minus$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$y: Ref
-  l0$y := sp$negInt(p$x)
+  l0$y := sp$negInt(par$x)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
@@ -1,70 +1,71 @@
 /as_operator.kt:(57,63): info: Generated Viper text for testAs:
-method f$testAs$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+method f$testAs$t$F$t$Foo$t$Bar(par$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
-  ensures acc(p$c$Bar$shared(ret$0), wildcard)
+  ensures acc(pred$c$Bar$shared(ret$0), wildcard)
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
-  inhale acc(p$c$Bar$shared(p$foo), wildcard)
-  ret$0 := p$foo
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Bar())
+  inhale acc(pred$c$Bar$shared(par$foo), wildcard)
+  ret$0 := par$foo
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /as_operator.kt:(97,111): info: Generated Viper text for testNullableAs:
-method f$testNullableAs$TF$NT$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+method f$testNullableAs$t$F$t$N$Foo$t$N$Bar(par$foo: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(ret$0), wildcard)
+    acc(pred$c$Bar$shared(ret$0), wildcard)
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(p$foo), wildcard)
-  ret$0 := p$foo
+  inhale par$foo != df$rt$nullValue() ==>
+    acc(pred$c$Foo$shared(par$foo), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$nullable(df$rt$c$Bar()))
+  inhale par$foo != df$rt$nullValue() ==>
+    acc(pred$c$Bar$shared(par$foo), wildcard)
+  ret$0 := par$foo
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /as_operator.kt:(148,158): info: Generated Viper text for testSafeAs:
-method f$testSafeAs$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+method f$testSafeAs$t$F$t$Foo$t$N$Bar(par$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(ret$0), wildcard)
+    acc(pred$c$Bar$shared(ret$0), wildcard)
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {
-    ret$0 := p$foo
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  if (df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Bar())) {
+    ret$0 := par$foo
   } else {
     ret$0 := df$rt$nullValue()}
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   inhale ret$0 != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(ret$0), wildcard)
+    acc(pred$c$Bar$shared(ret$0), wildcard)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /as_operator.kt:(194,212): info: Generated Viper text for testNullableSafeAs:
-method f$testNullableSafeAs$TF$NT$Foo$NT$Bar(p$foo: Ref)
+method f$testNullableSafeAs$t$F$t$N$Foo$t$N$Bar(par$foo: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(ret$0), wildcard)
+    acc(pred$c$Bar$shared(ret$0), wildcard)
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
-  if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {
-    ret$0 := p$foo
+  inhale par$foo != df$rt$nullValue() ==>
+    acc(pred$c$Foo$shared(par$foo), wildcard)
+  if (df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Bar())) {
+    ret$0 := par$foo
   } else {
     ret$0 := df$rt$nullValue()}
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   inhale ret$0 != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(ret$0), wildcard)
+    acc(pred$c$Bar$shared(ret$0), wildcard)
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
@@ -1,22 +1,22 @@
 /boolean_logic.kt:(23,31): info: Generated Viper text for negation:
-method f$negation$TF$T$Boolean$T$Boolean(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
+method f$negation$t$F$t$Boolean$t$Boolean(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := sp$notBool(p$x)
+  ret$0 := sp$notBool(par$x)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /boolean_logic.kt:(75,86): info: Generated Viper text for conjunction:
-method f$conjunction$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
+method f$conjunction$t$F$t$Boolean$t$Boolean$t$Boolean(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  if (df$rt$boolFromRef(p$x)) {
-    ret$0 := p$y
+  if (df$rt$boolFromRef(par$x)) {
+    ret$0 := par$y
   } else {
     ret$0 := df$rt$boolToRef(false)}
   goto lbl$ret$0
@@ -24,38 +24,39 @@ method f$conjunction$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
 }
 
 /boolean_logic.kt:(146,168): info: Generated Viper text for conjunctionSideEffects:
-method f$conjunctionSideEffects$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
+method f$conjunctionSideEffects$t$F$t$Boolean$t$Boolean$t$Boolean(par$x: Ref,
+  par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  anon$0 := f$negation$TF$T$Boolean$T$Boolean(p$x)
+  anon$0 := f$negation$t$F$t$Boolean$t$Boolean(par$x)
   if (df$rt$boolFromRef(anon$0)) {
-    ret$0 := f$negation$TF$T$Boolean$T$Boolean(p$y)
+    ret$0 := f$negation$t$F$t$Boolean$t$Boolean(par$y)
   } else {
     ret$0 := df$rt$boolToRef(false)}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$negation$TF$T$Boolean$T$Boolean(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
+method f$negation$t$F$t$Boolean$t$Boolean(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 
 /boolean_logic.kt:(341,352): info: Generated Viper text for disjunction:
-method f$disjunction$TF$T$Boolean$T$Boolean$T$Boolean(p$x: Ref, p$y: Ref)
+method f$disjunction$t$F$t$Boolean$t$Boolean$t$Boolean(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  if (df$rt$boolFromRef(p$x)) {
+  if (df$rt$boolFromRef(par$x)) {
     ret$0 := df$rt$boolToRef(true)
   } else {
-    ret$0 := p$y}
+    ret$0 := par$y}
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/comparison.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/comparison.fir.diag.txt
@@ -1,47 +1,47 @@
 /comparison.kt:(23,27): info: Generated Viper text for less:
-method f$less$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
+method f$less$t$F$t$Int$t$Int$t$Boolean(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := sp$ltInts(p$x, p$y)
+  ret$0 := sp$ltInts(par$x, par$y)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /comparison.kt:(79,88): info: Generated Viper text for lessEqual:
-method f$lessEqual$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
+method f$lessEqual$t$F$t$Int$t$Int$t$Boolean(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := sp$leInts(p$x, p$y)
+  ret$0 := sp$leInts(par$x, par$y)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /comparison.kt:(141,148): info: Generated Viper text for greater:
-method f$greater$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
+method f$greater$t$F$t$Int$t$Int$t$Boolean(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := sp$gtInts(p$x, p$y)
+  ret$0 := sp$gtInts(par$x, par$y)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /comparison.kt:(200,212): info: Generated Viper text for greaterEqual:
-method f$greaterEqual$TF$T$Int$T$Int$T$Boolean(p$x: Ref, p$y: Ref)
+method f$greaterEqual$t$F$t$Int$t$Int$t$Boolean(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := sp$geInts(p$x, p$y)
+  ret$0 := sp$geInts(par$x, par$y)
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
@@ -1,10 +1,10 @@
 /elvis.kt:(121,134): info: Generated Viper text for elvisOperator:
-method f$elvisOperator$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$elvisOperator$t$F$t$N$Int$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  if (p$x != df$rt$nullValue()) {
-    ret$0 := p$x
+  if (par$x != df$rt$nullValue()) {
+    ret$0 := par$x
   } else {
     ret$0 := df$rt$intToRef(3)}
   goto lbl$ret$0
@@ -12,39 +12,40 @@ method f$elvisOperator$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
 }
 
 /elvis.kt:(176,196): info: Generated Viper text for elvisOperatorComplex:
-method f$elvisOperator$TF$NT$Int$T$Int(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$elvisOperator$t$F$t$N$Int$t$Int(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$elvisOperatorComplex$TF$NT$Int$T$Int(p$x: Ref)
+method f$elvisOperatorComplex$t$F$t$N$Int$t$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  anon$0 := f$id$TF$NT$Int$NT$Int(p$x)
+  anon$0 := f$id$t$F$t$N$Int$t$N$Int(par$x)
   if (anon$0 != df$rt$nullValue()) {
     ret$0 := anon$0
   } else {
-    ret$0 := f$elvisOperator$TF$NT$Int$T$Int(df$rt$intToRef(2))}
+    ret$0 := f$elvisOperator$t$F$t$N$Int$t$Int(df$rt$intToRef(2))}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$id$TF$NT$Int$NT$Int(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$id$t$F$t$N$Int$t$N$Int(par$x: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /elvis.kt:(257,276): info: Generated Viper text for elvisOperatorReturn:
-method f$elvisOperatorReturn$TF$NT$Int$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$elvisOperatorReturn$t$F$t$N$Int$t$Int(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$y: Ref
-  if (p$x != df$rt$nullValue()) {
-    l0$y := p$x
+  if (par$x != df$rt$nullValue()) {
+    l0$y := par$x
   } else {
     var anon$0: Ref
     ret$0 := df$rt$intToRef(0)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/increment.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/increment.fir.diag.txt
@@ -1,5 +1,5 @@
 /increment.kt:(23,34): info: Generated Viper text for test_simple:
-method f$test_simple$TF$T$Unit() returns (ret$0: Ref)
+method f$test_simple$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
@@ -15,7 +15,7 @@ method f$test_simple$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /increment.kt:(121,140): info: Generated Viper text for test_postincvrement:
-method f$test_postincvrement$TF$T$Unit() returns (ret$0: Ref)
+method f$test_postincvrement$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/is_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/is_operator.fir.diag.txt
@@ -1,30 +1,32 @@
 /is_operator.kt:(23,36): info: Generated Viper text for isNonNullable:
-method f$isNonNullable$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$isNonNullable$t$F$t$N$Int$t$Boolean(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType()))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /is_operator.kt:(84,97): info: Generated Viper text for notIsNullable:
-method f$notIsNullable$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$notIsNullable$t$F$t$N$Int$t$Boolean(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := sp$notBool(df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nothingType())))
+  ret$0 := sp$notBool(df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nothingType())))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /is_operator.kt:(150,159): info: Generated Viper text for smartCast:
-method f$smartCast$TF$NT$Any$T$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+method f$smartCast$t$F$t$N$Any$t$Int(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())) {
-    ret$0 := p$x
+  if (df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())) {
+    ret$0 := par$x
     goto lbl$ret$0
   } else {
     ret$0 := df$rt$intToRef(-1)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
@@ -1,20 +1,21 @@
 /safe_call.kt:(142,154): info: Generated Viper text for testSafeCall:
 field bf$x: Ref
 
-method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$f$t$F$t$Foo$t$Unit(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testSafeCall$TF$NT$Foo$NT$Unit(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+method f$testSafeCall$t$F$t$N$Foo$t$N$Unit(par$foo: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
-  if (p$foo != df$rt$nullValue()) {
+  inhale par$foo != df$rt$nullValue() ==>
+    acc(pred$c$Foo$shared(par$foo), wildcard)
+  if (par$foo != df$rt$nullValue()) {
     var anon$0: Ref
-    anon$0 := f$c$Foo$f$TF$T$Foo$T$Unit(p$foo)
+    anon$0 := f$c$Foo$f$t$F$t$Foo$t$Unit(par$foo)
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -25,20 +26,20 @@ method f$testSafeCall$TF$NT$Foo$NT$Unit(p$foo: Ref) returns (ret$0: Ref)
 /safe_call.kt:(217,240): info: Generated Viper text for testSafeCallNonNullable:
 field bf$x: Ref
 
-method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
+method f$c$Foo$f$t$F$t$Foo$t$Unit(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$testSafeCallNonNullable$TF$T$Foo$NT$Unit(p$foo: Ref)
+method f$testSafeCallNonNullable$t$F$t$Foo$t$N$Unit(par$foo: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  if (p$foo != df$rt$nullValue()) {
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  if (par$foo != df$rt$nullValue()) {
     var anon$0: Ref
-    anon$0 := f$c$Foo$f$TF$T$Foo$T$Unit(p$foo)
+    anon$0 := f$c$Foo$f$t$F$t$Foo$t$Unit(par$foo)
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -49,17 +50,17 @@ method f$testSafeCallNonNullable$TF$T$Foo$NT$Unit(p$foo: Ref)
 /safe_call.kt:(267,287): info: Generated Viper text for testSafeCallProperty:
 field bf$x: Ref
 
-method f$testSafeCallProperty$TF$NT$Foo$NT$Int(p$foo: Ref)
+method f$testSafeCallProperty$t$F$t$N$Foo$t$N$Int(par$foo: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$nullable(df$rt$c$Foo()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
-  if (p$foo != df$rt$nullValue()) {
+  inhale par$foo != df$rt$nullValue() ==>
+    acc(pred$c$Foo$shared(par$foo), wildcard)
+  if (par$foo != df$rt$nullValue()) {
     var anon$0: Ref
-    unfold acc(p$c$Foo$shared(p$foo), wildcard)
-    anon$0 := p$foo.bf$x
+    unfold acc(pred$c$Foo$shared(par$foo), wildcard)
+    anon$0 := par$foo.bf$x
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -70,16 +71,16 @@ method f$testSafeCallProperty$TF$NT$Foo$NT$Int(p$foo: Ref)
 /safe_call.kt:(354,385): info: Generated Viper text for testSafeCallPropertyNonNullable:
 field bf$x: Ref
 
-method f$testSafeCallPropertyNonNullable$TF$T$Foo$NT$Int(p$foo: Ref)
+method f$testSafeCallPropertyNonNullable$t$F$t$Foo$t$N$Int(par$foo: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  if (p$foo != df$rt$nullValue()) {
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  if (par$foo != df$rt$nullValue()) {
     var anon$0: Ref
-    unfold acc(p$c$Foo$shared(p$foo), wildcard)
-    anon$0 := p$foo.bf$x
+    unfold acc(pred$c$Foo$shared(par$foo), wildcard)
+    anon$0 := par$foo.bf$x
     ret$0 := anon$0
   } else {
     ret$0 := df$rt$nullValue()}
@@ -90,32 +91,34 @@ method f$testSafeCallPropertyNonNullable$TF$T$Foo$NT$Int(p$foo: Ref)
 /safe_call.kt:(493,506): info: Generated Viper text for safeCallChain:
 field bf$v: Ref
 
-method f$c$Rec$nullable$TF$T$Rec$NT$Rec(this$dispatch: Ref)
+method f$c$Rec$nullable$t$F$t$Rec$t$N$Rec(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Rec())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$c$Rec()))
-  ensures ret != df$rt$nullValue() ==> acc(p$c$Rec$shared(ret), wildcard)
+  ensures ret != df$rt$nullValue() ==>
+    acc(pred$c$Rec$shared(ret), wildcard)
 
 
-method f$safeCallChain$TF$NT$Rec$NT$Int(p$rec: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$nullable(df$rt$c$Rec()))
+method f$safeCallChain$t$F$t$N$Rec$t$N$Int(par$rec: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$rec), df$rt$nullable(df$rt$c$Rec()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale p$rec != df$rt$nullValue() ==>
-    acc(p$c$Rec$shared(p$rec), wildcard)
-  if (p$rec != df$rt$nullValue()) {
-    anon$1 := f$c$Rec$nullable$TF$T$Rec$NT$Rec(p$rec)
+  inhale par$rec != df$rt$nullValue() ==>
+    acc(pred$c$Rec$shared(par$rec), wildcard)
+  if (par$rec != df$rt$nullValue()) {
+    anon$1 := f$c$Rec$nullable$t$F$t$Rec$t$N$Rec(par$rec)
   } else {
     anon$1 := df$rt$nullValue()}
   if (anon$1 != df$rt$nullValue()) {
-    anon$0 := f$c$Rec$nullable$TF$T$Rec$NT$Rec(anon$1)
+    anon$0 := f$c$Rec$nullable$t$F$t$Rec$t$N$Rec(anon$1)
   } else {
     anon$0 := df$rt$nullValue()}
   if (anon$0 != df$rt$nullValue()) {
     var anon$2: Ref
-    unfold acc(p$c$Rec$shared(anon$0), wildcard)
+    unfold acc(pred$c$Rec$shared(anon$0), wildcard)
     anon$2 := anon$0.bf$v
     ret$0 := anon$2
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_assignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_assignments.fir.diag.txt
@@ -1,5 +1,5 @@
 /pure_function_with_assignments.kt:(78,93): info: Generated Viper text for returnNumberVal:
-function f$returnNumberVal$TF$T$Int(): Ref
+function f$returnNumberVal$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$x$0 ==
@@ -8,7 +8,7 @@ function f$returnNumberVal$TF$T$Int(): Ref
 }
 
 /pure_function_with_assignments.kt:(144,178): info: Generated Viper text for multipleAssignmentsOfDifferentType:
-function f$multipleAssignmentsOfDifferentType$TF$T$Boolean(): Ref
+function f$multipleAssignmentsOfDifferentType$t$F$t$Boolean(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$a$0 ==
@@ -23,7 +23,7 @@ function f$multipleAssignmentsOfDifferentType$TF$T$Boolean(): Ref
 }
 
 /pure_function_with_assignments.kt:(292,328): info: Generated Viper text for multipleAssignmentsWithLiteralReturn:
-function f$multipleAssignmentsWithLiteralReturn$TF$T$Int(): Ref
+function f$multipleAssignmentsWithLiteralReturn$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$a$0 ==
@@ -38,7 +38,7 @@ function f$multipleAssignmentsWithLiteralReturn$TF$T$Int(): Ref
 }
 
 /pure_function_with_assignments.kt:(439,473): info: Generated Viper text for laterInitializersCanRelyOnPrevious:
-function f$laterInitializersCanRelyOnPrevious$TF$T$Int(): Ref
+function f$laterInitializersCanRelyOnPrevious$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$a$0 ==
@@ -51,15 +51,16 @@ function f$laterInitializersCanRelyOnPrevious$TF$T$Int(): Ref
 }
 
 /pure_function_with_assignments.kt:(560,591): info: Generated Viper text for initializersCanRelyOnParameters:
-function f$initializersCanRelyOnParameters$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+function f$initializersCanRelyOnParameters$t$F$t$Int$t$Int$t$Int(par$x: Ref,
+  par$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$sum$0 ==
-    (sp$plusInts(p$x, p$y)) in
+    (sp$plusInts(par$x, par$y)) in
     (let l0$diff$0 ==
-      (sp$minusInts(p$x, p$y)) in
+      (sp$minusInts(par$x, par$y)) in
       (let l0$res$0 ==
         (sp$timesInts(l0$sum$0, l0$diff$0)) in
         l0$res$0)))

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
@@ -1,6 +1,6 @@
 /pure_function_with_branching.kt:(78,98): info: Generated Viper text for noAssignmentInBlocks:
-function f$noAssignmentInBlocks$TF$T$Boolean$T$Int(p$a: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+function f$noAssignmentInBlocks$t$F$t$Boolean$t$Int(par$a: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$result$0 ==
@@ -11,79 +11,81 @@ function f$noAssignmentInBlocks$TF$T$Boolean$T$Int(p$a: Ref): Ref
 }
 
 /pure_function_with_branching.kt:(216,231): info: Generated Viper text for simpleBranching:
-function f$simpleBranching$TF$T$Boolean$T$Int(p$a: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
+function f$simpleBranching$t$F$t$Boolean$t$Int(par$a: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$result$0 ==
     (df$rt$intToRef(0)) in
     (let l0$result$1 ==
-      ((df$rt$boolFromRef(p$a) ?
+      ((df$rt$boolFromRef(par$a) ?
         sp$plusInts(l0$result$0, df$rt$intToRef(1)) :
         null)) in
       (let l0$result$2 ==
-        ((!df$rt$boolFromRef(p$a) ?
+        ((!df$rt$boolFromRef(par$a) ?
           sp$plusInts(l0$result$0, df$rt$intToRef(2)) :
           null)) in
         (let l0$result$3 ==
-          ((df$rt$boolFromRef(p$a) ? l0$result$1 : l0$result$2)) in
+          ((df$rt$boolFromRef(par$a) ? l0$result$1 : l0$result$2)) in
           l0$result$3))))
 }
 
 /pure_function_with_branching.kt:(389,404): info: Generated Viper text for nestedBranching:
-function f$nestedBranching$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+function f$nestedBranching$t$F$t$Boolean$t$Boolean$t$Int(par$a: Ref, par$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$result$0 ==
     (df$rt$intToRef(0)) in
     (let l0$result$1 ==
-      ((df$rt$boolFromRef(p$a) ?
+      ((df$rt$boolFromRef(par$a) ?
         sp$plusInts(df$rt$intToRef(1), l0$result$0) :
         null)) in
       (let l0$result$2 ==
-        ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+        ((df$rt$boolFromRef(par$b) && df$rt$boolFromRef(par$a) ?
           sp$plusInts(df$rt$intToRef(2), l0$result$1) :
           null)) in
         (let l0$result$3 ==
-          ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+          ((!df$rt$boolFromRef(par$b) && df$rt$boolFromRef(par$a) ?
             sp$plusInts(df$rt$intToRef(3), l0$result$1) :
             null)) in
           (let l0$result$4 ==
-            ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+            ((df$rt$boolFromRef(par$b) && !df$rt$boolFromRef(par$a) ?
               sp$plusInts(df$rt$intToRef(4), l0$result$0) :
               null)) in
             (let l0$result$5 ==
-              ((!df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+              ((!df$rt$boolFromRef(par$b) && !df$rt$boolFromRef(par$a) ?
                 sp$plusInts(df$rt$intToRef(5), l0$result$0) :
                 null)) in
               (let l0$result$6 ==
-                ((!df$rt$boolFromRef(p$a) ?
-                  (df$rt$boolFromRef(p$b) ? l0$result$4 : l0$result$5) :
+                ((!df$rt$boolFromRef(par$a) ?
+                  (df$rt$boolFromRef(par$b) ? l0$result$4 : l0$result$5) :
                   null)) in
                 (let l0$result$7 ==
-                  ((!df$rt$boolFromRef(p$a) ?
+                  ((!df$rt$boolFromRef(par$a) ?
                     sp$plusInts(df$rt$intToRef(6), l0$result$6) :
                     null)) in
                   (let l0$result$8 ==
-                    ((df$rt$boolFromRef(p$b) ? l0$result$2 : l0$result$3)) in
+                    ((df$rt$boolFromRef(par$b) ? l0$result$2 : l0$result$3)) in
                     (let l0$result$9 ==
-                      ((df$rt$boolFromRef(p$a) ? l0$result$8 : l0$result$7)) in
+                      ((df$rt$boolFromRef(par$a) ?
+                        l0$result$8 :
+                        l0$result$7)) in
                       (let l0$result$10 ==
                         (sp$plusInts(df$rt$intToRef(7), l0$result$9)) in
                         l0$result$10)))))))))))
 }
 
 /pure_function_with_branching.kt:(814,834): info: Generated Viper text for whenExpressionSimple:
-function f$whenExpressionSimple$TF$T$Int$T$Int(p$x: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+function f$whenExpressionSimple$t$F$t$Int$t$Int(par$x: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$y$0 ==
     (df$rt$intToRef(0)) in
     (let anon$0$0 ==
-      (p$x) in
+      (par$x) in
       (let l0$y$1 ==
         ((df$rt$intFromRef(anon$0$0) == 1 ? df$rt$intToRef(10) : null)) in
         (let l0$y$2 ==
@@ -102,61 +104,61 @@ function f$whenExpressionSimple$TF$T$Int$T$Int(p$x: Ref): Ref
 }
 
 /pure_function_with_branching.kt:(1053,1076): info: Generated Viper text for whenNoArgumentBranching:
-function f$whenNoArgumentBranching$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+function f$whenNoArgumentBranching$t$F$t$Int$t$Int$t$Int(par$x: Ref, par$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l5$z$0 ==
-    ((!(df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
-    (!(df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0) &&
-    !(df$rt$intFromRef(p$x) == 0)) ?
+    ((!(df$rt$intFromRef(par$x) < 0 || df$rt$intFromRef(par$y) < 0) &&
+    (!(df$rt$intFromRef(par$x) > 0 && df$rt$intFromRef(par$y) > 0) &&
+    !(df$rt$intFromRef(par$x) == 0)) ?
       df$rt$intToRef(5) :
       null)) in
-    (df$rt$intFromRef(p$x) == 0 ?
+    (df$rt$intFromRef(par$x) == 0 ?
       df$rt$intToRef(0) :
-      (df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0 &&
-      !(df$rt$intFromRef(p$x) == 0) ?
+      (df$rt$intFromRef(par$x) > 0 && df$rt$intFromRef(par$y) > 0 &&
+      !(df$rt$intFromRef(par$x) == 0) ?
         df$rt$intToRef(1) :
-        ((df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
-        (!(df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0) &&
-        !(df$rt$intFromRef(p$x) == 0)) ?
+        ((df$rt$intFromRef(par$x) < 0 || df$rt$intFromRef(par$y) < 0) &&
+        (!(df$rt$intFromRef(par$x) > 0 && df$rt$intFromRef(par$y) > 0) &&
+        !(df$rt$intFromRef(par$x) == 0)) ?
           df$rt$intToRef(-1) :
           l5$z$0))))
 }
 
 /pure_function_with_branching.kt:(1299,1322): info: Generated Viper text for stringEqualityBranching:
-function f$stringEqualityBranching$TF$T$String$T$Boolean(p$input: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$input), df$rt$stringType())
+function f$stringEqualityBranching$t$F$t$String$t$Boolean(par$input: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$input), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$isValid$0 ==
     (df$rt$boolToRef(false)) in
     (let l0$isValid$1 ==
-      ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) &&
-      !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+      ((df$rt$stringFromRef(par$input) == Seq(117, 115, 101, 114) &&
+      !(df$rt$stringFromRef(par$input) == Seq(97, 100, 109, 105, 110)) ?
         df$rt$boolToRef(true) :
         null)) in
       (let l0$isValid$2 ==
-        ((!(df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114)) &&
-        !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+        ((!(df$rt$stringFromRef(par$input) == Seq(117, 115, 101, 114)) &&
+        !(df$rt$stringFromRef(par$input) == Seq(97, 100, 109, 105, 110)) ?
           df$rt$boolToRef(false) :
           null)) in
         (let l0$isValid$3 ==
-          ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) ?
+          ((df$rt$stringFromRef(par$input) == Seq(117, 115, 101, 114) ?
             l0$isValid$1 :
             l0$isValid$2)) in
           (let l0$isValid$4 ==
-            ((df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
+            ((df$rt$stringFromRef(par$input) == Seq(97, 100, 109, 105, 110) ?
               l0$isValid$0 :
               l0$isValid$3)) in
-            (df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
+            (df$rt$stringFromRef(par$input) == Seq(97, 100, 109, 105, 110) ?
               df$rt$boolToRef(true) :
               l0$isValid$4))))))
 }
 
 /pure_function_with_branching.kt:(1585,1609): info: Generated Viper text for sequentialIfWithMutation:
-function f$sequentialIfWithMutation$TF$T$Int(): Ref
+function f$sequentialIfWithMutation$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$x$0 ==
@@ -173,21 +175,21 @@ function f$sequentialIfWithMutation$TF$T$Int(): Ref
 }
 
 /pure_function_with_branching.kt:(1768,1788): info: Generated Viper text for complexBooleanReturn:
-function f$complexBooleanReturn$TF$T$Int$T$Boolean(p$x: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+function f$complexBooleanReturn$t$F$t$Int$t$Boolean(par$x: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$result$0 ==
     (df$rt$boolToRef(false)) in
     (let l0$result$1 ==
-      ((df$rt$intFromRef(p$x) > 50 ? df$rt$boolToRef(true) : null)) in
+      ((df$rt$intFromRef(par$x) > 50 ? df$rt$boolToRef(true) : null)) in
       (let l0$result$2 ==
-        ((!(df$rt$intFromRef(p$x) > 50) ? df$rt$boolToRef(true) : null)) in
+        ((!(df$rt$intFromRef(par$x) > 50) ? df$rt$boolToRef(true) : null)) in
         (let l0$result$3 ==
-          ((df$rt$intFromRef(p$x) > 50 ? l0$result$1 : l0$result$2)) in
-          (df$rt$intFromRef(p$x) > 100 ?
+          ((df$rt$intFromRef(par$x) > 50 ? l0$result$1 : l0$result$2)) in
+          (df$rt$intFromRef(par$x) > 100 ?
             df$rt$boolToRef(true) :
-            (df$rt$intFromRef(p$x) < 0 && !(df$rt$intFromRef(p$x) > 50) ?
+            (df$rt$intFromRef(par$x) < 0 && !(df$rt$intFromRef(par$x) > 50) ?
               df$rt$boolToRef(false) :
               (df$rt$boolFromRef(l0$result$3) ?
                 df$rt$boolToRef(false) :

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
@@ -1,5 +1,5 @@
 /pure_function_with_reassignments.kt:(78,93): info: Generated Viper text for doubleIncrement:
-function f$doubleIncrement$TF$T$Int(): Ref
+function f$doubleIncrement$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$x$0 ==
@@ -12,7 +12,7 @@ function f$doubleIncrement$TF$T$Int(): Ref
 }
 
 /pure_function_with_reassignments.kt:(171,194): info: Generated Viper text for updateThenReadIntoOther:
-function f$updateThenReadIntoOther$TF$T$Int(): Ref
+function f$updateThenReadIntoOther$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$x$0 ==
@@ -25,7 +25,7 @@ function f$updateThenReadIntoOther$TF$T$Int(): Ref
 }
 
 /pure_function_with_reassignments.kt:(276,300): info: Generated Viper text for readOldValueBeforeUpdate:
-function f$readOldValueBeforeUpdate$TF$T$Int(): Ref
+function f$readOldValueBeforeUpdate$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$x$0 ==
@@ -40,7 +40,7 @@ function f$readOldValueBeforeUpdate$TF$T$Int(): Ref
 }
 
 /pure_function_with_reassignments.kt:(397,413): info: Generated Viper text for chainThroughTemp:
-function f$chainThroughTemp$TF$T$Int(): Ref
+function f$chainThroughTemp$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$x$0 ==
@@ -53,7 +53,7 @@ function f$chainThroughTemp$TF$T$Int(): Ref
 }
 
 /pure_function_with_reassignments.kt:(495,522): info: Generated Viper text for overwriteNotSelfReferential:
-function f$overwriteNotSelfReferential$TF$T$Int(): Ref
+function f$overwriteNotSelfReferential$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$x$0 ==
@@ -64,90 +64,90 @@ function f$overwriteNotSelfReferential$TF$T$Int(): Ref
 }
 
 /pure_function_with_reassignments.kt:(584,611): info: Generated Viper text for nestedConditionalAssignment:
-function f$nestedConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
-  p$b: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+function f$nestedConditionalAssignment$t$F$t$Boolean$t$Boolean$t$Int(par$a: Ref,
+  par$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$1$0 ==
-    ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+    ((df$rt$boolFromRef(par$b) && df$rt$boolFromRef(par$a) ?
       df$rt$intToRef(4) :
       null)) in
     (let anon$2$0 ==
-      ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+      ((!df$rt$boolFromRef(par$b) && df$rt$boolFromRef(par$a) ?
         df$rt$intToRef(3) :
         null)) in
       (let anon$0$0 ==
-        ((df$rt$boolFromRef(p$a) ?
-          (df$rt$boolFromRef(p$b) ? anon$1$0 : anon$2$0) :
+        ((df$rt$boolFromRef(par$a) ?
+          (df$rt$boolFromRef(par$b) ? anon$1$0 : anon$2$0) :
           null)) in
         (let anon$4$0 ==
-          ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+          ((df$rt$boolFromRef(par$b) && !df$rt$boolFromRef(par$a) ?
             df$rt$intToRef(2) :
             null)) in
           (let anon$5$0 ==
-            ((!df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+            ((!df$rt$boolFromRef(par$b) && !df$rt$boolFromRef(par$a) ?
               df$rt$intToRef(1) :
               null)) in
             (let anon$3$0 ==
-              ((!df$rt$boolFromRef(p$a) ?
-                (df$rt$boolFromRef(p$b) ? anon$4$0 : anon$5$0) :
+              ((!df$rt$boolFromRef(par$a) ?
+                (df$rt$boolFromRef(par$b) ? anon$4$0 : anon$5$0) :
                 null)) in
               (let l0$x$0 ==
-                ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0)) in
+                ((df$rt$boolFromRef(par$a) ? anon$0$0 : anon$3$0)) in
                 l0$x$0)))))))
 }
 
 /pure_function_with_reassignments.kt:(729,755): info: Generated Viper text for blockConditionalAssignment:
-function f$blockConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
-  p$b: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+function f$blockConditionalAssignment$t$F$t$Boolean$t$Boolean$t$Int(par$a: Ref,
+  par$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$1$0 ==
-    ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+    ((df$rt$boolFromRef(par$b) && df$rt$boolFromRef(par$a) ?
       df$rt$intToRef(10) :
       null)) in
     (let anon$2$0 ==
-      ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+      ((!df$rt$boolFromRef(par$b) && df$rt$boolFromRef(par$a) ?
         df$rt$intToRef(20) :
         null)) in
       (let l2$y$0 ==
-        ((df$rt$boolFromRef(p$a) ?
-          (df$rt$boolFromRef(p$b) ? anon$1$0 : anon$2$0) :
+        ((df$rt$boolFromRef(par$a) ?
+          (df$rt$boolFromRef(par$b) ? anon$1$0 : anon$2$0) :
           null)) in
         (let anon$0$0 ==
-          ((df$rt$boolFromRef(p$a) ?
+          ((df$rt$boolFromRef(par$a) ?
             sp$plusInts(l2$y$0, df$rt$intToRef(1)) :
             null)) in
           (let anon$3$0 ==
-            ((!df$rt$boolFromRef(p$a) ? df$rt$intToRef(30) : null)) in
+            ((!df$rt$boolFromRef(par$a) ? df$rt$intToRef(30) : null)) in
             (let l0$x$0 ==
-              ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0)) in
+              ((df$rt$boolFromRef(par$a) ? anon$0$0 : anon$3$0)) in
               l0$x$0))))))
 }
 
 /pure_function_with_reassignments.kt:(912,926): info: Generated Viper text for whenAssignment:
-function f$whenAssignment$TF$T$Int$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+function f$whenAssignment$t$F$t$Int$t$Boolean$t$Int(par$a: Ref, par$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$0$0 ==
-    (p$a) in
+    (par$a) in
     (let anon$2$0 ==
-      ((df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
+      ((df$rt$boolFromRef(par$b) && df$rt$intFromRef(anon$0$0) == 1 ?
         df$rt$intToRef(2) :
         null)) in
       (let anon$3$0 ==
-        ((!df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
+        ((!df$rt$boolFromRef(par$b) && df$rt$intFromRef(anon$0$0) == 1 ?
           df$rt$intToRef(3) :
           null)) in
         (let anon$1$0 ==
           ((df$rt$intFromRef(anon$0$0) == 1 ?
-            (df$rt$boolFromRef(p$b) ? anon$2$0 : anon$3$0) :
+            (df$rt$boolFromRef(par$b) ? anon$2$0 : anon$3$0) :
             null)) in
           (let anon$5$0 ==
             ((df$rt$intFromRef(anon$0$0) == 2 &&

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
@@ -1,47 +1,47 @@
 /pure_literal_function.kt:(72,85): info: Generated Viper text for emptyFunction:
-function f$emptyAnnotatedFunction$TF$NT$Int(): Ref
+function f$emptyAnnotatedFunction$t$F$t$N$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$intType()))
 
 
-method f$emptyFunction$TF$T$Unit() returns (ret$0: Ref)
+method f$emptyFunction$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
-  l0$x := f$emptyAnnotatedFunction$TF$NT$Int()
+  l0$x := f$emptyAnnotatedFunction$t$F$t$N$Int()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /pure_literal_function.kt:(136,158): info: Generated Viper text for emptyAnnotatedFunction:
-function f$emptyAnnotatedFunction$TF$NT$Int(): Ref
+function f$emptyAnnotatedFunction$t$F$t$N$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$intType()))
 {
   df$rt$nullValue()
 }
 
 /pure_literal_function.kt:(194,215): info: Generated Viper text for annotatedIntLitReturn:
-function f$annotatedIntLitReturn$TF$T$Int(): Ref
+function f$annotatedIntLitReturn$t$F$t$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   df$rt$intToRef(42)
 }
 
 /pure_literal_function.kt:(248,270): info: Generated Viper text for annotatedBoolLitReturn:
-function f$annotatedBoolLitReturn$TF$T$Boolean(): Ref
+function f$annotatedBoolLitReturn$t$F$t$Boolean(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   df$rt$boolToRef(true)
 }
 
 /pure_literal_function.kt:(309,331): info: Generated Viper text for annotatedCharLitReturn:
-function f$annotatedCharLitReturn$TF$T$Char(): Ref
+function f$annotatedCharLitReturn$t$F$t$Char(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
 {
   df$rt$charToRef(65)
 }
 
 /pure_literal_function.kt:(366,390): info: Generated Viper text for annotatedStringLitReturn:
-function f$annotatedStringLitReturn$TF$T$String(): Ref
+function f$annotatedStringLitReturn$t$F$t$String(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
 {
   df$rt$stringToRef(Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116))
@@ -52,10 +52,10 @@ field bf$a: Ref
 
 field bf$b: Ref
 
-function f$annotatedReferenceReturn$TF$T$X$T$X(p$x: Ref): Ref
-  requires acc(p$c$X$shared(p$x), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
+function f$annotatedReferenceReturn$t$F$t$X$t$X(par$x: Ref): Ref
+  requires acc(pred$c$X$shared(par$x), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$X())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$c$X())
 {
-  p$x
+  par$x
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
@@ -1,5 +1,5 @@
 /wrongly_annotated.kt:(53,63): info: Generated Viper text for iAmAMethod:
-method f$iAmAMethod$TF$T$Int() returns (ret$0: Ref)
+method f$iAmAMethod$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   ret$0 := df$rt$intToRef(1)
@@ -16,12 +16,12 @@ method f$iAmAMethod$TF$T$Int() returns (ret$0: Ref)
 /wrongly_annotated.kt:(380,395): info: Generated Viper text for impureExtension:
 field bf$value: Ref
 
-method f$impureExtension$TF$T$Field$T$Unit(this$extension: Ref)
+method f$impureExtension$t$F$t$Field$t$Unit(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Field())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Field$shared(this$extension), wildcard)
+  inhale acc(pred$c$Field$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
@@ -1,5 +1,5 @@
 /shadowing.kt:(23,34): info: Generated Viper text for shadowLocal:
-method f$shadowLocal$TF$T$Unit() returns (ret$0: Ref)
+method f$shadowLocal$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$foo: Ref
@@ -22,13 +22,13 @@ method f$shadowLocal$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /shadowing.kt:(232,243): info: Generated Viper text for shadowParam:
-method f$shadowParam$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$shadowParam$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$foo: Ref
   var l0$x: Ref
-  l0$foo := p$x
+  l0$foo := par$x
   l0$x := df$rt$intToRef(0)
   l0$foo := l0$x
   label lbl$ret$0
@@ -36,13 +36,13 @@ method f$shadowParam$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 }
 
 /shadowing.kt:(322,334): info: Generated Viper text for shadowNested:
-method f$shadowNested$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$shadowNested$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$foo: Ref
   var l0$x: Ref
-  l0$foo := p$x
+  l0$foo := par$x
   l0$x := df$rt$intToRef(0)
   l0$foo := l0$x
   if (true) {
@@ -51,24 +51,24 @@ method f$shadowNested$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
     l0$foo := l0$x
     l2$x := df$rt$intToRef(1)
     l0$foo := l2$x
-    label lbl$continue$0
+    label lbl$cont$0
       invariant df$rt$isSubtype(df$rt$typeOf(l2$x), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$foo), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
-      invariant df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+      invariant df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
     anon$0 := df$rt$boolToRef(true)
     if (df$rt$boolFromRef(anon$0)) {
       var l3$x: Ref
       l0$foo := l2$x
       l3$x := df$rt$intToRef(2)
       l0$foo := l3$x
-      goto lbl$continue$0
+      goto lbl$cont$0
     }
     label lbl$break$0
     assert df$rt$isSubtype(df$rt$typeOf(l2$x), df$rt$intType())
     assert df$rt$isSubtype(df$rt$typeOf(l0$foo), df$rt$intType())
     assert df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
-    assert df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+    assert df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
     l0$foo := l2$x
   }
   l0$foo := l0$x

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/any.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/any.fir.diag.txt
@@ -1,19 +1,19 @@
 /any.kt:(23,40): info: Generated Viper text for anyArgumentReturn:
-method f$anyArgumentReturn$TF$T$Any$T$Any(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$anyType())
+method f$anyArgumentReturn$t$F$t$Any$t$Any(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$anyType())
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /any.kt:(76,83): info: Generated Viper text for anyCast:
-method f$anyCast$TF$T$Int$T$Any(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$anyCast$t$F$t$Int$t$Any(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$anyType())
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
@@ -1,14 +1,14 @@
 /generics.kt:(52,65): info: Generated Viper text for genericMethod:
 field bf$t: Ref
 
-method f$c$Box$genericMethod$TF$T$Box$NT$Any$NT$Any(this$dispatch: Ref, p$x: Ref)
+method f$c$Box$genericMethod$t$F$t$Box$t$N$Any$t$N$Any(this$dispatch: Ref, par$x: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Box())
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  inhale acc(p$c$Box$shared(this$dispatch), wildcard)
-  ret$0 := p$x
+  inhale acc(pred$c$Box$shared(this$dispatch), wildcard)
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -16,14 +16,14 @@ method f$c$Box$genericMethod$TF$T$Box$NT$Any$NT$Any(this$dispatch: Ref, p$x: Ref
 /generics.kt:(107,116): info: Generated Viper text for createBox:
 field bf$t: Ref
 
-method con$c$Box$NT$Any$T$Box(p$t: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
+method con$c$Box$t$N$Any$t$Box(par$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
-  ensures acc(p$c$Box$shared(ret), wildcard)
-  ensures acc(p$c$Box$unique(ret), write)
+  ensures acc(pred$c$Box$shared(ret), wildcard)
+  ensures acc(pred$c$Box$unique(ret), write)
 
 
-method f$createBox$TF$T$Int() returns (ret$0: Ref)
+method f$createBox$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$boolBox: Ref
@@ -31,12 +31,12 @@ method f$createBox$TF$T$Int() returns (ret$0: Ref)
   var anon$0: Ref
   var l0$intBox: Ref
   var anon$1: Ref
-  l0$boolBox := con$c$Box$NT$Any$T$Box(df$rt$boolToRef(true))
-  anon$0 := havoc$NT$Any()
+  l0$boolBox := con$c$Box$t$N$Any$t$Box(df$rt$boolToRef(true))
+  anon$0 := havoc$t$N$Any()
   l0$b := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$b), df$rt$boolType())
-  l0$intBox := con$c$Box$NT$Any$T$Box(df$rt$intToRef(2))
-  anon$1 := havoc$NT$Any()
+  l0$intBox := con$c$Box$t$N$Any$t$Box(df$rt$intToRef(2))
+  anon$1 := havoc$t$N$Any()
   ret$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   goto lbl$ret$0
@@ -46,62 +46,62 @@ method f$createBox$TF$T$Int() returns (ret$0: Ref)
 /generics.kt:(227,242): info: Generated Viper text for setGenericField:
 field bf$t: Ref
 
-method con$c$Box$NT$Any$T$Box(p$t: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
+method con$c$Box$t$N$Any$t$Box(par$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
-  ensures acc(p$c$Box$shared(ret), wildcard)
-  ensures acc(p$c$Box$unique(ret), write)
+  ensures acc(pred$c$Box$shared(ret), wildcard)
+  ensures acc(pred$c$Box$unique(ret), write)
 
 
-method f$setGenericField$TF$T$Unit() returns (ret$0: Ref)
+method f$setGenericField$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$box: Ref
-  l0$box := con$c$Box$NT$Any$T$Box(df$rt$intToRef(3))
+  l0$box := con$c$Box$t$N$Any$t$Box(df$rt$intToRef(3))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /generics.kt:(293,303): info: Generated Viper text for genericFun:
-method f$genericFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
+method f$genericFun$t$F$t$N$Any$t$N$Any(par$t: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  ret$0 := p$t
+  ret$0 := par$t
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /generics.kt:(322,337): info: Generated Viper text for callGenericFunc:
-method f$callGenericFunc$TF$T$Unit() returns (ret$0: Ref)
+method f$callGenericFunc$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
   var anon$0: Ref
-  anon$0 := f$genericFun$TF$NT$Any$NT$Any(df$rt$intToRef(3))
+  anon$0 := f$genericFun$t$F$t$N$Any$t$N$Any(df$rt$intToRef(3))
   l0$x := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$genericFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
+method f$genericFun$t$F$t$N$Any$t$N$Any(par$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /generics.kt:(375,395): info: Generated Viper text for genericAsIfCondition:
 field bf$t: Ref
 
-method f$genericAsIfCondition$TF$T$Box$T$Int(p$box: Ref)
+method f$genericAsIfCondition$t$F$t$Box$t$Int(par$box: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
+  requires df$rt$isSubtype(df$rt$typeOf(par$box), df$rt$c$Box())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$Box$shared(p$box), wildcard)
-  anon$1 := havoc$NT$Any()
+  inhale acc(pred$c$Box$shared(par$box), wildcard)
+  anon$1 := havoc$t$N$Any()
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())
   if (df$rt$boolFromRef(anon$0)) {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
@@ -1,66 +1,70 @@
 /nullable.kt:(80,96): info: Generated Viper text for useNullableTwice:
-method f$useNullableTwice$TF$NT$Int$NT$Int(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$useNullableTwice$t$F$t$N$Int$t$N$Int(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$a: Ref
   var l0$b: Ref
-  l0$a := p$x
-  l0$b := p$x
+  l0$a := par$x
+  l0$b := par$x
   ret$0 := l0$a
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /nullable.kt:(162,183): info: Generated Viper text for passNullableParameter:
-method f$passNullableParameter$TF$NT$Int$NT$Int(p$x: Ref)
+method f$passNullableParameter$t$F$t$N$Int$t$N$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  anon$0 := f$useNullableTwice$TF$NT$Int$NT$Int(p$x)
-  ret$0 := p$x
+  anon$0 := f$useNullableTwice$t$F$t$N$Int$t$N$Int(par$x)
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$useNullableTwice$TF$NT$Int$NT$Int(p$x: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$useNullableTwice$t$F$t$N$Int$t$N$Int(par$x: Ref)
+  returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$intType()))
 
 
 /nullable.kt:(245,271): info: Generated Viper text for nullableNullableComparison:
-method f$nullableNullableComparison$TF$NT$Int$NT$Int$T$Boolean(p$x: Ref, p$y: Ref)
+method f$nullableNullableComparison$t$F$t$N$Int$t$N$Int$t$Boolean(par$x: Ref,
+  par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := df$rt$boolToRef(p$x == p$y)
+  ret$0 := df$rt$boolToRef(par$x == par$y)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /nullable.kt:(326,355): info: Generated Viper text for nullableNonNullableComparison:
-method f$nullableNonNullableComparison$TF$NT$Int$NT$Int$T$Boolean(p$x: Ref,
-  p$y: Ref)
+method f$nullableNonNullableComparison$t$F$t$N$Int$t$N$Int$t$Boolean(par$x: Ref,
+  par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := sp$notBool(df$rt$boolToRef(p$x == df$rt$intToRef(3)))
+  ret$0 := sp$notBool(df$rt$boolToRef(par$x == df$rt$intToRef(3)))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /nullable.kt:(410,424): info: Generated Viper text for nullComparison:
-method f$nullComparison$TF$NT$Int$T$Boolean(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+method f$nullComparison$t$F$t$N$Int$t$Boolean(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  ret$0 := df$rt$boolToRef(p$x == df$rt$nullValue())
+  ret$0 := df$rt$boolToRef(par$x == df$rt$nullValue())
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
@@ -1,10 +1,10 @@
 /smartcast.kt:(23,38): info: Generated Viper text for smartcastReturn:
-method f$smartcastReturn$TF$NT$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$nullable(df$rt$intType()))
+method f$smartcastReturn$t$F$t$N$Int$t$Int(par$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  if (!(p$n == df$rt$nullValue())) {
-    ret$0 := p$n
+  if (!(par$n == df$rt$nullValue())) {
+    ret$0 := par$n
   } else {
     ret$0 := df$rt$intToRef(0)}
   goto lbl$ret$0
@@ -12,19 +12,19 @@ method f$smartcastReturn$TF$NT$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
 }
 
 /smartcast.kt:(88,106): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
+method f$isNullOrEmptyWrong$t$F$t$N$CharSequence$t$Boolean(par$seq: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale p$seq != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
-  if (p$seq == df$rt$nullValue()) {
+  inhale par$seq != df$rt$nullValue() ==>
+    acc(pred$pkg$kotlin$c$CharSequence$shared(par$seq), wildcard)
+  if (par$seq == df$rt$nullValue()) {
     var anon$0: Ref
-    if (p$seq != df$rt$nullValue()) {
+    if (par$seq != df$rt$nullValue()) {
       var anon$1: Ref
       var anon$2: Ref
-      anon$2 := pg$public$length(p$seq)
+      anon$2 := g$public$length(par$seq)
       anon$1 := anon$2
       inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
       anon$0 := anon$1
@@ -37,4 +37,5 @@ method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
   label lbl$ret$0
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+method g$public$length(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
@@ -1,49 +1,49 @@
 /binary_search.kt:(90,110): info: Generated Viper text for mid_increased_by_one:
 field sp$size: Ref
 
-method f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
+method f$mid_increased_by_one$t$F$t$List$t$Int$t$Boolean(par$arr: Ref, par$target: Ref)
   returns (ret$0: Ref)
-  requires acc(p$arr.sp$size, write)
-  requires df$rt$intFromRef(p$arr.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  ensures acc(p$arr.sp$size, write)
-  ensures df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires acc(par$arr.sp$size, write)
+  requires df$rt$intFromRef(par$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(par$target), df$rt$intType())
+  ensures acc(par$arr.sp$size, write)
+  ensures df$rt$intFromRef(par$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var l0$size: Ref
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  l0$size := p$arr.sp$size
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$arr), wildcard)
+  l0$size := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  anon$0 := p$arr.sp$size
+  anon$0 := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$plusInts(sp$divInts(anon$0, df$rt$intToRef(2)), df$rt$intToRef(1))
-  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$arr)
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(par$arr)
   if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+    anon$2 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
       l0$mid)
-    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
+    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(par$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$3: Ref
-      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+      anon$3 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
         l0$mid)
-      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
+      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(par$target)) {
         var anon$4: Ref
-        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(anon$4, p$target)
+        ret$0 := f$mid_increased_by_one$t$F$t$List$t$Int$t$Boolean(anon$4, par$target)
       } else {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(anon$5, p$target)
+        ret$0 := f$mid_increased_by_one$t$F$t$List$t$Int$t$Boolean(anon$5, par$target)
       }
     }
   }
@@ -51,16 +51,16 @@ method f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -68,7 +68,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -84,28 +84,28 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this$dispatch: Ref,
-  p$fromIndex: Ref, p$toIndex: Ref)
+method f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(this$dispatch: Ref,
+  par$fromIndex: Ref, par$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
-  requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
-  requires df$rt$intFromRef(p$fromIndex) >= 0
-  requires df$rt$intFromRef(p$toIndex) <=
+  requires df$rt$isSubtype(df$rt$typeOf(par$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$toIndex), df$rt$intType())
+  requires df$rt$intFromRef(par$fromIndex) <= df$rt$intFromRef(par$toIndex)
+  requires df$rt$intFromRef(par$fromIndex) >= 0
+  requires df$rt$intFromRef(par$toIndex) <=
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
   ensures df$rt$intFromRef(ret.sp$size) ==
-    df$rt$intFromRef(p$toIndex) - df$rt$intFromRef(p$fromIndex)
+    df$rt$intFromRef(par$toIndex) - df$rt$intFromRef(par$fromIndex)
 
 
 /binary_search.kt:(305,313): warning: Invalid index for list 'arr', the index may be greater than the list's size.
@@ -113,49 +113,49 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
 /binary_search.kt:(511,531): info: Generated Viper text for mid_decreased_by_one:
 field sp$size: Ref
 
-method f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
+method f$mid_decreased_by_one$t$F$t$List$t$Int$t$Boolean(par$arr: Ref, par$target: Ref)
   returns (ret$0: Ref)
-  requires acc(p$arr.sp$size, write)
-  requires df$rt$intFromRef(p$arr.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  ensures acc(p$arr.sp$size, write)
-  ensures df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires acc(par$arr.sp$size, write)
+  requires df$rt$intFromRef(par$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(par$target), df$rt$intType())
+  ensures acc(par$arr.sp$size, write)
+  ensures df$rt$intFromRef(par$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var l0$size: Ref
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  l0$size := p$arr.sp$size
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$arr), wildcard)
+  l0$size := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  anon$0 := p$arr.sp$size
+  anon$0 := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$minusInts(sp$divInts(anon$0, df$rt$intToRef(2)), df$rt$intToRef(1))
-  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$arr)
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(par$arr)
   if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+    anon$2 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
       l0$mid)
-    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
+    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(par$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$3: Ref
-      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+      anon$3 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
         l0$mid)
-      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
+      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(par$target)) {
         var anon$4: Ref
-        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(anon$4, p$target)
+        ret$0 := f$mid_decreased_by_one$t$F$t$List$t$Int$t$Boolean(anon$4, par$target)
       } else {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(anon$5, p$target)
+        ret$0 := f$mid_decreased_by_one$t$F$t$List$t$Int$t$Boolean(anon$5, par$target)
       }
     }
   }
@@ -163,16 +163,16 @@ method f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -180,7 +180,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -196,28 +196,28 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this$dispatch: Ref,
-  p$fromIndex: Ref, p$toIndex: Ref)
+method f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(this$dispatch: Ref,
+  par$fromIndex: Ref, par$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
-  requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
-  requires df$rt$intFromRef(p$fromIndex) >= 0
-  requires df$rt$intFromRef(p$toIndex) <=
+  requires df$rt$isSubtype(df$rt$typeOf(par$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$toIndex), df$rt$intType())
+  requires df$rt$intFromRef(par$fromIndex) <= df$rt$intFromRef(par$toIndex)
+  requires df$rt$intFromRef(par$fromIndex) >= 0
+  requires df$rt$intFromRef(par$toIndex) <=
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
   ensures df$rt$intFromRef(ret.sp$size) ==
-    df$rt$intFromRef(p$toIndex) - df$rt$intFromRef(p$fromIndex)
+    df$rt$intFromRef(par$toIndex) - df$rt$intFromRef(par$fromIndex)
 
 
 /binary_search.kt:(726,734): warning: Invalid index for list 'arr', the index may be less than zero.
@@ -225,52 +225,52 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
 /binary_search.kt:(932,964): info: Generated Viper text for mid_decreased_by_one_in_rec_call:
 field sp$size: Ref
 
-method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(p$arr: Ref,
-  p$target: Ref)
+method f$mid_decreased_by_one_in_rec_call$t$F$t$List$t$Int$t$Boolean(par$arr: Ref,
+  par$target: Ref)
   returns (ret$0: Ref)
-  requires acc(p$arr.sp$size, write)
-  requires df$rt$intFromRef(p$arr.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  ensures acc(p$arr.sp$size, write)
-  ensures df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires acc(par$arr.sp$size, write)
+  requires df$rt$intFromRef(par$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(par$target), df$rt$intType())
+  ensures acc(par$arr.sp$size, write)
+  ensures df$rt$intFromRef(par$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var l0$size: Ref
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  l0$size := p$arr.sp$size
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$arr), wildcard)
+  l0$size := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  anon$0 := p$arr.sp$size
+  anon$0 := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$divInts(anon$0, df$rt$intToRef(2))
-  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$arr)
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(par$arr)
   if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+    anon$2 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
       l0$mid)
-    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
+    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(par$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$3: Ref
-      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+      anon$3 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
         l0$mid)
-      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
+      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(par$target)) {
         var anon$4: Ref
-        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(anon$4,
-          p$target)
+        ret$0 := f$mid_decreased_by_one_in_rec_call$t$F$t$List$t$Int$t$Boolean(anon$4,
+          par$target)
       } else {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           df$rt$intToRef(0), sp$minusInts(l0$mid, df$rt$intToRef(1)))
-        ret$0 := f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(anon$5,
-          p$target)
+        ret$0 := f$mid_decreased_by_one_in_rec_call$t$F$t$List$t$Int$t$Boolean(anon$5,
+          par$target)
       }
     }
   }
@@ -278,16 +278,16 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(p$arr: Ref,
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -295,7 +295,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -311,28 +311,28 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this$dispatch: Ref,
-  p$fromIndex: Ref, p$toIndex: Ref)
+method f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(this$dispatch: Ref,
+  par$fromIndex: Ref, par$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
-  requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
-  requires df$rt$intFromRef(p$fromIndex) >= 0
-  requires df$rt$intFromRef(p$toIndex) <=
+  requires df$rt$isSubtype(df$rt$typeOf(par$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$toIndex), df$rt$intType())
+  requires df$rt$intFromRef(par$fromIndex) <= df$rt$intFromRef(par$toIndex)
+  requires df$rt$intFromRef(par$fromIndex) >= 0
+  requires df$rt$intFromRef(par$toIndex) <=
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
   ensures df$rt$intFromRef(ret.sp$size) ==
-    df$rt$intFromRef(p$toIndex) - df$rt$intFromRef(p$fromIndex)
+    df$rt$intFromRef(par$toIndex) - df$rt$intFromRef(par$fromIndex)
 
 
 /binary_search.kt:(1345,1368): warning: Invalid sub-list range for list 'arr', the range may be greater than the list's size.
@@ -340,16 +340,16 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
 /binary_search.kt:(1405,1425): info: Generated Viper text for unsafe_binary_search:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -357,41 +357,42 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr: Ref,
-  p$target: Ref, p$left: Ref, p$right: Ref)
+method f$unsafe_binary_search$t$F$t$List$t$Int$t$Int$t$Int$t$Boolean(par$arr: Ref,
+  par$target: Ref, par$left: Ref, par$right: Ref)
   returns (ret$0: Ref)
-  requires acc(p$arr.sp$size, write)
-  requires df$rt$intFromRef(p$arr.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
-  ensures acc(p$arr.sp$size, write)
-  ensures df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires acc(par$arr.sp$size, write)
+  requires df$rt$intFromRef(par$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(par$target), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$left), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$right), df$rt$intType())
+  ensures acc(par$arr.sp$size, write)
+  ensures df$rt$intFromRef(par$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var l0$mid: Ref
   var anon$0: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  if (df$rt$intFromRef(p$left) > df$rt$intFromRef(p$right)) {
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$arr), wildcard)
+  if (df$rt$intFromRef(par$left) > df$rt$intFromRef(par$right)) {
     ret$0 := df$rt$boolToRef(false)
     goto lbl$ret$0
   }
-  l0$mid := sp$plusInts(p$left, sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2)))
-  anon$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+  l0$mid := sp$plusInts(par$left, sp$divInts(sp$minusInts(par$right, par$left),
+    df$rt$intToRef(2)))
+  anon$0 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
     l0$mid)
-  if (df$rt$intFromRef(anon$0) == df$rt$intFromRef(p$target)) {
+  if (df$rt$intFromRef(anon$0) == df$rt$intFromRef(par$target)) {
     ret$0 := df$rt$boolToRef(true)
   } else {
     var anon$1: Ref
-    anon$1 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+    anon$1 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
       l0$mid)
-    if (df$rt$intFromRef(anon$1) < df$rt$intFromRef(p$target)) {
-      ret$0 := f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr,
-        p$target, sp$plusInts(l0$mid, df$rt$intToRef(1)), p$right)
+    if (df$rt$intFromRef(anon$1) < df$rt$intFromRef(par$target)) {
+      ret$0 := f$unsafe_binary_search$t$F$t$List$t$Int$t$Int$t$Int$t$Boolean(par$arr,
+        par$target, sp$plusInts(l0$mid, df$rt$intToRef(1)), par$right)
     } else {
-      ret$0 := f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr,
-        p$target, p$left, sp$minusInts(l0$mid, df$rt$intToRef(1)))}
+      ret$0 := f$unsafe_binary_search$t$F$t$List$t$Int$t$Int$t$Int$t$Boolean(par$arr,
+        par$target, par$left, sp$minusInts(l0$mid, df$rt$intToRef(1)))}
   }
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -1,50 +1,50 @@
 /merge_sort_of_string.kt:(72,76): info: Generated Viper text for subs:
-method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
-  p$other: Ref)
+method f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(this$dispatch: Ref,
+  par$other: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
-method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
-  p$hi: Ref)
+method f$subs$t$F$t$String$t$Int$t$Int$t$String(this$extension: Ref, par$lo: Ref,
+  par$hi: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
-  requires 0 <= df$rt$intFromRef(p$lo) &&
-    df$rt$intFromRef(p$lo) <= df$rt$intFromRef(p$hi) &&
-    df$rt$intFromRef(p$hi) <= |df$rt$stringFromRef(this$extension)|
+  requires df$rt$isSubtype(df$rt$typeOf(par$lo), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$hi), df$rt$intType())
+  requires 0 <= df$rt$intFromRef(par$lo) &&
+    df$rt$intFromRef(par$lo) <= df$rt$intFromRef(par$hi) &&
+    df$rt$intFromRef(par$hi) <= |df$rt$stringFromRef(this$extension)|
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
-    df$rt$intFromRef(p$hi) - df$rt$intFromRef(p$lo)
+    df$rt$intFromRef(par$hi) - df$rt$intFromRef(par$lo)
   ensures (forall anon$builtin$2: Int ::0 <= anon$builtin$2 &&
       anon$builtin$2 < |df$rt$stringFromRef(ret$0)| ==>
       df$rt$stringFromRef(ret$0)[anon$builtin$2] ==
       df$rt$stringFromRef(this$extension)[anon$builtin$2 +
-      df$rt$intFromRef(p$lo)])
+      df$rt$intFromRef(par$lo)])
 {
   var l0$res: Ref
   var l0$i: Ref
   var anon$1: Ref
   l0$res := df$rt$stringToRef(Seq[Int]())
-  l0$i := p$lo
-  label lbl$continue$0
+  l0$i := par$lo
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$lo), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$hi), df$rt$intType())
     invariant 0 <= df$rt$intFromRef(l0$i) &&
-      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$hi)
+      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(par$hi)
     invariant |df$rt$stringFromRef(l0$res)| ==
-      df$rt$intFromRef(l0$i) - df$rt$intFromRef(p$lo)
+      df$rt$intFromRef(l0$i) - df$rt$intFromRef(par$lo)
     invariant (forall anon$builtin$1: Int ::0 <= anon$builtin$1 &&
         anon$builtin$1 < |df$rt$stringFromRef(l0$res)| ==>
         df$rt$stringFromRef(l0$res)[anon$builtin$1] ==
         df$rt$stringFromRef(this$extension)[anon$builtin$1 +
-        df$rt$intFromRef(p$lo)])
-  anon$1 := sp$ltInts(l0$i, p$hi)
+        df$rt$intFromRef(par$lo)])
+  anon$1 := sp$ltInts(l0$i, par$hi)
   if (df$rt$boolFromRef(anon$1)) {
     var anon$2: Ref
     var anon$0: Ref
@@ -52,42 +52,42 @@ method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
     l0$i := sp$plusInts(anon$0, df$rt$intToRef(1))
     anon$2 := anon$0
     l0$res := sp$addStringChar(l0$res, sp$stringGet(this$extension, anon$2))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$lo), df$rt$intType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$hi), df$rt$intType())
   assert 0 <= df$rt$intFromRef(l0$i) &&
-    df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$hi)
+    df$rt$intFromRef(l0$i) <= df$rt$intFromRef(par$hi)
   assert |df$rt$stringFromRef(l0$res)| ==
-    df$rt$intFromRef(l0$i) - df$rt$intFromRef(p$lo)
+    df$rt$intFromRef(l0$i) - df$rt$intFromRef(par$lo)
   assert (forall anon$builtin$1: Int ::0 <= anon$builtin$1 &&
       anon$builtin$1 < |df$rt$stringFromRef(l0$res)| ==>
       df$rt$stringFromRef(l0$res)[anon$builtin$1] ==
       df$rt$stringFromRef(this$extension)[anon$builtin$1 +
-      df$rt$intFromRef(p$lo)])
+      df$rt$intFromRef(par$lo)])
   ret$0 := l0$res
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /merge_sort_of_string.kt:(705,717): info: Generated Viper text for mergeStrings:
-method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
+method f$mergeStrings$t$F$t$String$t$String$t$String(par$a: Ref, par$b: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$stringType())
   requires (forall anon$builtin$3: Int ::(1 <= anon$builtin$3 &&
-      anon$builtin$3 < |df$rt$stringFromRef(p$a)| ==>
-      df$rt$stringFromRef(p$a)[anon$builtin$3 - 1] <=
-      df$rt$stringFromRef(p$a)[anon$builtin$3]) &&
-      (1 <= anon$builtin$3 && anon$builtin$3 < |df$rt$stringFromRef(p$b)| ==>
-      df$rt$stringFromRef(p$b)[anon$builtin$3 - 1] <=
-      df$rt$stringFromRef(p$b)[anon$builtin$3]))
+      anon$builtin$3 < |df$rt$stringFromRef(par$a)| ==>
+      df$rt$stringFromRef(par$a)[anon$builtin$3 - 1] <=
+      df$rt$stringFromRef(par$a)[anon$builtin$3]) &&
+      (1 <= anon$builtin$3 && anon$builtin$3 < |df$rt$stringFromRef(par$b)| ==>
+      df$rt$stringFromRef(par$b)[anon$builtin$3 - 1] <=
+      df$rt$stringFromRef(par$b)[anon$builtin$3]))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
-    |df$rt$stringFromRef(p$a)| + |df$rt$stringFromRef(p$b)|
+    |df$rt$stringFromRef(par$a)| + |df$rt$stringFromRef(par$b)|
   ensures (forall anon$builtin$4: Int ::1 <= anon$builtin$4 &&
       anon$builtin$4 < |df$rt$stringFromRef(ret$0)| ==>
       df$rt$stringFromRef(ret$0)[anon$builtin$4 - 1] <=
@@ -101,18 +101,18 @@ method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
   l0$pa := df$rt$intToRef(0)
   l0$pb := df$rt$intToRef(0)
   l0$res := df$rt$stringToRef(Seq[Int]())
-  l0$n := sp$plusInts(sp$stringLength(p$a), sp$stringLength(p$b))
-  label lbl$continue$0
+  l0$n := sp$plusInts(sp$stringLength(par$a), sp$stringLength(par$b))
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$pa), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$pb), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$n), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$stringType())
     invariant 0 <= df$rt$intFromRef(l0$pa) &&
-      df$rt$intFromRef(l0$pa) <= |df$rt$stringFromRef(p$a)|
+      df$rt$intFromRef(l0$pa) <= |df$rt$stringFromRef(par$a)|
     invariant 0 <= df$rt$intFromRef(l0$pb) &&
-      df$rt$intFromRef(l0$pb) <= |df$rt$stringFromRef(p$b)|
+      df$rt$intFromRef(l0$pb) <= |df$rt$stringFromRef(par$b)|
     invariant |df$rt$stringFromRef(l0$res)| ==
       df$rt$intFromRef(l0$pa) + df$rt$intFromRef(l0$pb)
     invariant (forall anon$builtin$2: Int ::1 <= anon$builtin$2 &&
@@ -120,60 +120,60 @@ method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
         df$rt$stringFromRef(l0$res)[anon$builtin$2 - 1] <=
         df$rt$stringFromRef(l0$res)[anon$builtin$2])
     invariant |df$rt$stringFromRef(l0$res)| == 0 ||
-      df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(p$a)| ||
+      df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(par$a)| ||
       df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
-      df$rt$stringFromRef(p$a)[df$rt$intFromRef(l0$pa)]
+      df$rt$stringFromRef(par$a)[df$rt$intFromRef(l0$pa)]
     invariant |df$rt$stringFromRef(l0$res)| == 0 ||
-      df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(p$b)| ||
+      df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(par$b)| ||
       df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
-      df$rt$stringFromRef(p$b)[df$rt$intFromRef(l0$pb)]
+      df$rt$stringFromRef(par$b)[df$rt$intFromRef(l0$pb)]
   anon$4 := sp$ltInts(sp$plusInts(l0$pa, l0$pb), l0$n)
   if (df$rt$boolFromRef(anon$4)) {
     var anon$5: Ref
-    if (df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(p$a)|) {
+    if (df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(par$a)|) {
       var anon$6: Ref
       var anon$0: Ref
       anon$0 := l0$pb
       l0$pb := sp$plusInts(anon$0, df$rt$intToRef(1))
       anon$6 := anon$0
-      anon$5 := sp$stringGet(p$b, anon$6)
-    } elseif (df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(p$b)|) {
+      anon$5 := sp$stringGet(par$b, anon$6)
+    } elseif (df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(par$b)|) {
       var anon$7: Ref
       var anon$1: Ref
       anon$1 := l0$pa
       l0$pa := sp$plusInts(anon$1, df$rt$intToRef(1))
       anon$7 := anon$1
-      anon$5 := sp$stringGet(p$a, anon$7)
-    } elseif (df$rt$stringFromRef(p$a)[df$rt$intFromRef(l0$pa)] <
-    df$rt$stringFromRef(p$b)[df$rt$intFromRef(l0$pb)]) {
+      anon$5 := sp$stringGet(par$a, anon$7)
+    } elseif (df$rt$stringFromRef(par$a)[df$rt$intFromRef(l0$pa)] <
+    df$rt$stringFromRef(par$b)[df$rt$intFromRef(l0$pb)]) {
       var anon$8: Ref
       var anon$2: Ref
       anon$2 := l0$pa
       l0$pa := sp$plusInts(anon$2, df$rt$intToRef(1))
       anon$8 := anon$2
-      anon$5 := sp$stringGet(p$a, anon$8)
+      anon$5 := sp$stringGet(par$a, anon$8)
     } else {
       var anon$9: Ref
       var anon$3: Ref
       anon$3 := l0$pb
       l0$pb := sp$plusInts(anon$3, df$rt$intToRef(1))
       anon$9 := anon$3
-      anon$5 := sp$stringGet(p$b, anon$9)
+      anon$5 := sp$stringGet(par$b, anon$9)
     }
     l0$res := sp$addStringChar(l0$res, anon$5)
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$pa), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$pb), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$n), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$stringType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$stringType())
   assert 0 <= df$rt$intFromRef(l0$pa) &&
-    df$rt$intFromRef(l0$pa) <= |df$rt$stringFromRef(p$a)|
+    df$rt$intFromRef(l0$pa) <= |df$rt$stringFromRef(par$a)|
   assert 0 <= df$rt$intFromRef(l0$pb) &&
-    df$rt$intFromRef(l0$pb) <= |df$rt$stringFromRef(p$b)|
+    df$rt$intFromRef(l0$pb) <= |df$rt$stringFromRef(par$b)|
   assert |df$rt$stringFromRef(l0$res)| ==
     df$rt$intFromRef(l0$pa) + df$rt$intFromRef(l0$pb)
   assert (forall anon$builtin$2: Int ::1 <= anon$builtin$2 &&
@@ -181,28 +181,28 @@ method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
       df$rt$stringFromRef(l0$res)[anon$builtin$2 - 1] <=
       df$rt$stringFromRef(l0$res)[anon$builtin$2])
   assert |df$rt$stringFromRef(l0$res)| == 0 ||
-    df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(p$a)| ||
+    df$rt$intFromRef(l0$pa) == |df$rt$stringFromRef(par$a)| ||
     df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
-    df$rt$stringFromRef(p$a)[df$rt$intFromRef(l0$pa)]
+    df$rt$stringFromRef(par$a)[df$rt$intFromRef(l0$pa)]
   assert |df$rt$stringFromRef(l0$res)| == 0 ||
-    df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(p$b)| ||
+    df$rt$intFromRef(l0$pb) == |df$rt$stringFromRef(par$b)| ||
     df$rt$stringFromRef(l0$res)[|df$rt$stringFromRef(l0$res)| - 1] <=
-    df$rt$stringFromRef(p$b)[df$rt$intFromRef(l0$pb)]
+    df$rt$stringFromRef(par$b)[df$rt$intFromRef(l0$pb)]
   ret$0 := l0$res
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
-  p$other: Ref)
+method f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(this$dispatch: Ref,
+  par$other: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
 /merge_sort_of_string.kt:(1883,1894): info: Generated Viper text for mergeSorted:
-method f$mergeSorted$TF$T$String$T$String(this$extension: Ref)
+method f$mergeSorted$t$F$t$String$t$String(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
@@ -220,52 +220,53 @@ method f$mergeSorted$TF$T$String$T$String(this$extension: Ref)
     var anon$1: Ref
     var anon$2: Ref
     var anon$3: Ref
-    anon$1 := f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension, df$rt$intToRef(0),
+    anon$1 := f$subs$t$F$t$String$t$Int$t$Int$t$String(this$extension, df$rt$intToRef(0),
       sp$divInts(sp$stringLength(this$extension), df$rt$intToRef(2)))
-    anon$0 := f$mergeSorted$TF$T$String$T$String(anon$1)
-    anon$3 := f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension, sp$divInts(sp$stringLength(this$extension),
+    anon$0 := f$mergeSorted$t$F$t$String$t$String(anon$1)
+    anon$3 := f$subs$t$F$t$String$t$Int$t$Int$t$String(this$extension, sp$divInts(sp$stringLength(this$extension),
       df$rt$intToRef(2)), sp$stringLength(this$extension))
-    anon$2 := f$mergeSorted$TF$T$String$T$String(anon$3)
-    ret$0 := f$mergeStrings$TF$T$String$T$String$T$String(anon$0, anon$2)
+    anon$2 := f$mergeSorted$t$F$t$String$t$String(anon$3)
+    ret$0 := f$mergeStrings$t$F$t$String$t$String$t$String(anon$0, anon$2)
   }
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$mergeStrings$TF$T$String$T$String$T$String(p$a: Ref, p$b: Ref)
+method f$mergeStrings$t$F$t$String$t$String$t$String(par$a: Ref, par$b: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$stringType())
   requires (forall anon$builtin$5: Int ::(1 <= anon$builtin$5 &&
-      anon$builtin$5 < |df$rt$stringFromRef(p$a)| ==>
-      df$rt$stringFromRef(p$a)[anon$builtin$5 - 1] <=
-      df$rt$stringFromRef(p$a)[anon$builtin$5]) &&
-      (1 <= anon$builtin$5 && anon$builtin$5 < |df$rt$stringFromRef(p$b)| ==>
-      df$rt$stringFromRef(p$b)[anon$builtin$5 - 1] <=
-      df$rt$stringFromRef(p$b)[anon$builtin$5]))
+      anon$builtin$5 < |df$rt$stringFromRef(par$a)| ==>
+      df$rt$stringFromRef(par$a)[anon$builtin$5 - 1] <=
+      df$rt$stringFromRef(par$a)[anon$builtin$5]) &&
+      (1 <= anon$builtin$5 && anon$builtin$5 < |df$rt$stringFromRef(par$b)| ==>
+      df$rt$stringFromRef(par$b)[anon$builtin$5 - 1] <=
+      df$rt$stringFromRef(par$b)[anon$builtin$5]))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret)| ==
-    |df$rt$stringFromRef(p$a)| + |df$rt$stringFromRef(p$b)|
+    |df$rt$stringFromRef(par$a)| + |df$rt$stringFromRef(par$b)|
   ensures (forall anon$builtin$6: Int ::1 <= anon$builtin$6 &&
       anon$builtin$6 < |df$rt$stringFromRef(ret)| ==>
       df$rt$stringFromRef(ret)[anon$builtin$6 - 1] <=
       df$rt$stringFromRef(ret)[anon$builtin$6])
 
 
-method f$subs$TF$T$String$T$Int$T$Int$T$String(this$extension: Ref, p$lo: Ref,
-  p$hi: Ref)
+method f$subs$t$F$t$String$t$Int$t$Int$t$String(this$extension: Ref, par$lo: Ref,
+  par$hi: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$lo), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$hi), df$rt$intType())
-  requires 0 <= df$rt$intFromRef(p$lo) &&
-    df$rt$intFromRef(p$lo) <= df$rt$intFromRef(p$hi) &&
-    df$rt$intFromRef(p$hi) <= |df$rt$stringFromRef(this$extension)|
+  requires df$rt$isSubtype(df$rt$typeOf(par$lo), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$hi), df$rt$intType())
+  requires 0 <= df$rt$intFromRef(par$lo) &&
+    df$rt$intFromRef(par$lo) <= df$rt$intFromRef(par$hi) &&
+    df$rt$intFromRef(par$hi) <= |df$rt$stringFromRef(this$extension)|
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret)| ==
-    df$rt$intFromRef(p$hi) - df$rt$intFromRef(p$lo)
+    df$rt$intFromRef(par$hi) - df$rt$intFromRef(par$lo)
   ensures (forall anon$builtin$7: Int ::0 <= anon$builtin$7 &&
       anon$builtin$7 < |df$rt$stringFromRef(ret)| ==>
       df$rt$stringFromRef(ret)[anon$builtin$7] ==
       df$rt$stringFromRef(this$extension)[anon$builtin$7 +
-      df$rt$intFromRef(p$lo)])
+      df$rt$intFromRef(par$lo)])
+

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
@@ -1,16 +1,16 @@
 /quick_sort_of_string.kt:(282,294): info: Generated Viper text for minOrMaxChar:
-method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMin: Ref)
+method f$minOrMaxChar$t$F$t$String$t$Boolean$t$Char(this$extension: Ref, par$calcMin: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$calcMin), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$calcMin), df$rt$boolType())
   requires |df$rt$stringFromRef(this$extension)| >= 1
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$charType())
-  ensures df$rt$boolFromRef(p$calcMin) ==>
+  ensures df$rt$boolFromRef(par$calcMin) ==>
     (forall anon$builtin$4: Int ::0 <= anon$builtin$4 &&
       anon$builtin$4 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$charFromRef(ret$0) <=
       df$rt$stringFromRef(this$extension)[anon$builtin$4])
-  ensures !df$rt$boolFromRef(p$calcMin) ==>
+  ensures !df$rt$boolFromRef(par$calcMin) ==>
     (forall anon$builtin$5: Int ::0 <= anon$builtin$5 &&
       anon$builtin$5 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$charFromRef(ret$0) >=
@@ -21,18 +21,18 @@ method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMi
   var anon$0: Ref
   l0$res := sp$stringGet(this$extension, df$rt$intToRef(0))
   l0$i := df$rt$intToRef(1)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$charType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$calcMin), df$rt$boolType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$calcMin), df$rt$boolType())
     invariant 0 <= df$rt$intFromRef(l0$i) &&
       df$rt$intFromRef(l0$i) <= |df$rt$stringFromRef(this$extension)|
-    invariant df$rt$boolFromRef(p$calcMin) ==>
+    invariant df$rt$boolFromRef(par$calcMin) ==>
       (forall anon$builtin$2: Int ::0 <= anon$builtin$2 &&
         anon$builtin$2 < df$rt$intFromRef(l0$i) ==>
         df$rt$charFromRef(l0$res) <=
         df$rt$stringFromRef(this$extension)[anon$builtin$2])
-    invariant !df$rt$boolFromRef(p$calcMin) ==>
+    invariant !df$rt$boolFromRef(par$calcMin) ==>
       (forall anon$builtin$3: Int ::0 <= anon$builtin$3 &&
         anon$builtin$3 < df$rt$intFromRef(l0$i) ==>
         df$rt$charFromRef(l0$res) >=
@@ -41,13 +41,13 @@ method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMi
   if (df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     var anon$2: Ref
-    if (df$rt$boolFromRef(p$calcMin)) {
+    if (df$rt$boolFromRef(par$calcMin)) {
       anon$2 := sp$ltChars(sp$stringGet(this$extension, l0$i), l0$res)
     } else {
       anon$2 := df$rt$boolToRef(false)}
     if (df$rt$boolFromRef(anon$2)) {
       anon$1 := df$rt$boolToRef(true)
-    } elseif (!df$rt$boolFromRef(p$calcMin)) {
+    } elseif (!df$rt$boolFromRef(par$calcMin)) {
       anon$1 := sp$gtChars(sp$stringGet(this$extension, l0$i), l0$res)
     } else {
       anon$1 := df$rt$boolToRef(false)}
@@ -55,20 +55,20 @@ method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMi
       l0$res := sp$stringGet(this$extension, l0$i)
     }
     l0$i := sp$plusInts(l0$i, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$charType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$calcMin), df$rt$boolType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$calcMin), df$rt$boolType())
   assert 0 <= df$rt$intFromRef(l0$i) &&
     df$rt$intFromRef(l0$i) <= |df$rt$stringFromRef(this$extension)|
-  assert df$rt$boolFromRef(p$calcMin) ==>
+  assert df$rt$boolFromRef(par$calcMin) ==>
     (forall anon$builtin$2: Int ::0 <= anon$builtin$2 &&
       anon$builtin$2 < df$rt$intFromRef(l0$i) ==>
       df$rt$charFromRef(l0$res) <=
       df$rt$stringFromRef(this$extension)[anon$builtin$2])
-  assert !df$rt$boolFromRef(p$calcMin) ==>
+  assert !df$rt$boolFromRef(par$calcMin) ==>
     (forall anon$builtin$3: Int ::0 <= anon$builtin$3 &&
       anon$builtin$3 < df$rt$intFromRef(l0$i) ==>
       df$rt$charFromRef(l0$res) >=
@@ -79,25 +79,25 @@ method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMi
 }
 
 /quick_sort_of_string.kt:(1135,1144): info: Generated Viper text for quickSort:
-method f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension: Ref, p$calcMin: Ref)
+method f$minOrMaxChar$t$F$t$String$t$Boolean$t$Char(this$extension: Ref, par$calcMin: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$calcMin), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$calcMin), df$rt$boolType())
   requires |df$rt$stringFromRef(this$extension)| >= 1
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$charType())
-  ensures df$rt$boolFromRef(p$calcMin) ==>
+  ensures df$rt$boolFromRef(par$calcMin) ==>
     (forall anon$builtin$7: Int ::0 <= anon$builtin$7 &&
       anon$builtin$7 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$charFromRef(ret) <=
       df$rt$stringFromRef(this$extension)[anon$builtin$7])
-  ensures !df$rt$boolFromRef(p$calcMin) ==>
+  ensures !df$rt$boolFromRef(par$calcMin) ==>
     (forall anon$builtin$8: Int ::0 <= anon$builtin$8 &&
       anon$builtin$8 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$charFromRef(ret) >=
       df$rt$stringFromRef(this$extension)[anon$builtin$8])
 
 
-method f$quickSort$TF$T$String$T$String(this$extension: Ref)
+method f$quickSort$t$F$t$String$t$String(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
@@ -114,35 +114,37 @@ method f$quickSort$TF$T$String$T$String(this$extension: Ref)
     ret$0 := this$extension
     goto lbl$ret$0
   }
-  l0$minVal := f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension, df$rt$boolToRef(true))
-  l0$maxVal := f$minOrMaxChar$TF$T$String$T$Boolean$T$Char(this$extension, df$rt$boolToRef(false))
-  ret$0 := f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension,
+  l0$minVal := f$minOrMaxChar$t$F$t$String$t$Boolean$t$Char(this$extension,
+    df$rt$boolToRef(true))
+  l0$maxVal := f$minOrMaxChar$t$F$t$String$t$Boolean$t$Char(this$extension,
+    df$rt$boolToRef(false))
+  ret$0 := f$quickSortRec$t$F$t$String$t$Char$t$Char$t$String(this$extension,
     l0$minVal, l0$maxVal)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
-  p$minVal: Ref, p$maxVal: Ref)
+method f$quickSortRec$t$F$t$String$t$Char$t$Char$t$String(this$extension: Ref,
+  par$minVal: Ref, par$maxVal: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$minVal), df$rt$charType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$maxVal), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$minVal), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$maxVal), df$rt$charType())
   requires (forall anon$builtin$9: Int ::0 <= anon$builtin$9 &&
       anon$builtin$9 < |df$rt$stringFromRef(this$extension)| ==>
-      df$rt$charFromRef(p$minVal) <=
+      df$rt$charFromRef(par$minVal) <=
       df$rt$stringFromRef(this$extension)[anon$builtin$9] &&
       df$rt$stringFromRef(this$extension)[anon$builtin$9] <=
-      df$rt$charFromRef(p$maxVal))
+      df$rt$charFromRef(par$maxVal))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret)| ==
     |df$rt$stringFromRef(this$extension)|
   ensures (forall anon$builtin$10: Int ::0 <= anon$builtin$10 &&
       anon$builtin$10 < |df$rt$stringFromRef(this$extension)| ==>
-      df$rt$charFromRef(p$minVal) <=
+      df$rt$charFromRef(par$minVal) <=
       df$rt$stringFromRef(ret)[anon$builtin$10] &&
       df$rt$stringFromRef(ret)[anon$builtin$10] <=
-      df$rt$charFromRef(p$maxVal))
+      df$rt$charFromRef(par$maxVal))
   ensures (forall anon$builtin$11: Int ::1 <= anon$builtin$11 &&
       anon$builtin$11 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$stringFromRef(ret)[anon$builtin$11 - 1] <=
@@ -150,7 +152,7 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
 
 
 /quick_sort_of_string.kt:(1507,1519): info: Generated Viper text for quickSortRec:
-method f$chooseIndex$TF$T$String$T$Int(this$extension: Ref)
+method f$chooseIndex$t$F$t$String$t$Int(this$extension: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   requires |df$rt$stringFromRef(this$extension)| >= 1
@@ -159,35 +161,35 @@ method f$chooseIndex$TF$T$String$T$Int(this$extension: Ref)
     df$rt$intFromRef(ret) < |df$rt$stringFromRef(this$extension)|
 
 
-method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
-  p$other: Ref)
+method f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(this$dispatch: Ref,
+  par$other: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
-method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
-  p$minVal: Ref, p$maxVal: Ref)
+method f$quickSortRec$t$F$t$String$t$Char$t$Char$t$String(this$extension: Ref,
+  par$minVal: Ref, par$maxVal: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$minVal), df$rt$charType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$maxVal), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$minVal), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$maxVal), df$rt$charType())
   requires (forall anon$builtin$6: Int ::0 <= anon$builtin$6 &&
       anon$builtin$6 < |df$rt$stringFromRef(this$extension)| ==>
-      df$rt$charFromRef(p$minVal) <=
+      df$rt$charFromRef(par$minVal) <=
       df$rt$stringFromRef(this$extension)[anon$builtin$6] &&
       df$rt$stringFromRef(this$extension)[anon$builtin$6] <=
-      df$rt$charFromRef(p$maxVal))
+      df$rt$charFromRef(par$maxVal))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
     |df$rt$stringFromRef(this$extension)|
   ensures (forall anon$builtin$7: Int ::0 <= anon$builtin$7 &&
       anon$builtin$7 < |df$rt$stringFromRef(this$extension)| ==>
-      df$rt$charFromRef(p$minVal) <=
+      df$rt$charFromRef(par$minVal) <=
       df$rt$stringFromRef(ret$0)[anon$builtin$7] &&
       df$rt$stringFromRef(ret$0)[anon$builtin$7] <=
-      df$rt$charFromRef(p$maxVal))
+      df$rt$charFromRef(par$maxVal))
   ensures (forall anon$builtin$8: Int ::1 <= anon$builtin$8 &&
       anon$builtin$8 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$stringFromRef(ret$0)[anon$builtin$8 - 1] <=
@@ -206,20 +208,20 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
     ret$0 := this$extension
     goto lbl$ret$0
   }
-  anon$1 := f$chooseIndex$TF$T$String$T$Int(this$extension)
+  anon$1 := f$chooseIndex$t$F$t$String$t$Int(this$extension)
   l0$medVal := sp$stringGet(this$extension, anon$1)
   l0$i := df$rt$intToRef(0)
   l0$lessString := df$rt$stringToRef(Seq[Int]())
   l0$greaterString := df$rt$stringToRef(Seq[Int]())
   l0$eqString := df$rt$stringToRef(Seq[Int]())
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$medVal), df$rt$charType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$lessString), df$rt$stringType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$greaterString), df$rt$stringType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$eqString), df$rt$stringType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$minVal), df$rt$charType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$maxVal), df$rt$charType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$minVal), df$rt$charType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$maxVal), df$rt$charType())
     invariant 0 <= df$rt$intFromRef(l0$i) &&
       df$rt$intFromRef(l0$i) <= |df$rt$stringFromRef(this$extension)|
     invariant |df$rt$stringFromRef(l0$lessString)| +
@@ -228,7 +230,7 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
       df$rt$intFromRef(l0$i)
     invariant (forall anon$builtin$3: Int ::0 <= anon$builtin$3 &&
         anon$builtin$3 < |df$rt$stringFromRef(l0$lessString)| ==>
-        df$rt$charFromRef(p$minVal) <=
+        df$rt$charFromRef(par$minVal) <=
         df$rt$stringFromRef(l0$lessString)[anon$builtin$3] &&
         df$rt$stringFromRef(l0$lessString)[anon$builtin$3] <=
         df$rt$charFromRef(l0$medVal))
@@ -237,7 +239,7 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
         df$rt$charFromRef(l0$medVal) <=
         df$rt$stringFromRef(l0$greaterString)[anon$builtin$4] &&
         df$rt$stringFromRef(l0$greaterString)[anon$builtin$4] <=
-        df$rt$charFromRef(p$maxVal))
+        df$rt$charFromRef(par$maxVal))
     invariant (forall anon$builtin$5: Int ::0 <= anon$builtin$5 &&
         anon$builtin$5 < |df$rt$stringFromRef(l0$eqString)| ==>
         df$rt$stringFromRef(l0$eqString)[anon$builtin$5] ==
@@ -257,7 +259,7 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
       l0$greaterString := sp$addStringChar(l0$greaterString, l3$curChar)
     } else {
       l0$eqString := sp$addStringChar(l0$eqString, l3$curChar)}
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$medVal), df$rt$charType())
@@ -265,8 +267,8 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
   assert df$rt$isSubtype(df$rt$typeOf(l0$lessString), df$rt$stringType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$greaterString), df$rt$stringType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$eqString), df$rt$stringType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$minVal), df$rt$charType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$maxVal), df$rt$charType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$minVal), df$rt$charType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$maxVal), df$rt$charType())
   assert 0 <= df$rt$intFromRef(l0$i) &&
     df$rt$intFromRef(l0$i) <= |df$rt$stringFromRef(this$extension)|
   assert |df$rt$stringFromRef(l0$lessString)| +
@@ -275,7 +277,7 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
     df$rt$intFromRef(l0$i)
   assert (forall anon$builtin$3: Int ::0 <= anon$builtin$3 &&
       anon$builtin$3 < |df$rt$stringFromRef(l0$lessString)| ==>
-      df$rt$charFromRef(p$minVal) <=
+      df$rt$charFromRef(par$minVal) <=
       df$rt$stringFromRef(l0$lessString)[anon$builtin$3] &&
       df$rt$stringFromRef(l0$lessString)[anon$builtin$3] <=
       df$rt$charFromRef(l0$medVal))
@@ -284,15 +286,15 @@ method f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(this$extension: Ref,
       df$rt$charFromRef(l0$medVal) <=
       df$rt$stringFromRef(l0$greaterString)[anon$builtin$4] &&
       df$rt$stringFromRef(l0$greaterString)[anon$builtin$4] <=
-      df$rt$charFromRef(p$maxVal))
+      df$rt$charFromRef(par$maxVal))
   assert (forall anon$builtin$5: Int ::0 <= anon$builtin$5 &&
       anon$builtin$5 < |df$rt$stringFromRef(l0$eqString)| ==>
       df$rt$stringFromRef(l0$eqString)[anon$builtin$5] ==
       df$rt$charFromRef(l0$medVal))
-  anon$4 := f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(l0$lessString,
-    p$minVal, l0$medVal)
-  anon$5 := f$quickSortRec$TF$T$String$T$Char$T$Char$T$String(l0$greaterString,
-    l0$medVal, p$maxVal)
+  anon$4 := f$quickSortRec$t$F$t$String$t$Char$t$Char$t$String(l0$lessString,
+    par$minVal, l0$medVal)
+  anon$5 := f$quickSortRec$t$F$t$String$t$Char$t$Char$t$String(l0$greaterString,
+    l0$medVal, par$maxVal)
   ret$0 := sp$addStrings(sp$addStrings(anon$4, l0$eqString), anon$5)
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
@@ -1,125 +1,128 @@
 /z_function.kt:(187,198): info: Generated Viper text for zFuncHelper:
-method f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(p$s: Ref,
-  p$res: Ref, p$i: Ref, p$checkedLeft: Ref, p$checkedRight: Ref)
+method f$zFuncHelper$t$F$t$String$t$String$t$Int$t$Int$t$Int$t$Int(par$s: Ref,
+  par$res: Ref, par$i: Ref, par$checkedLeft: Ref, par$checkedRight: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$res), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$checkedLeft), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$checkedRight), df$rt$intType())
-  requires 1 <= df$rt$intFromRef(p$i) &&
-    df$rt$intFromRef(p$i) < |df$rt$stringFromRef(p$s)|
-  requires |df$rt$stringFromRef(p$res)| == df$rt$intFromRef(p$i)
-  requires 0 <= df$rt$intFromRef(p$checkedLeft) &&
-    df$rt$intFromRef(p$checkedLeft) <= df$rt$intFromRef(p$checkedRight) &&
-    df$rt$intFromRef(p$checkedRight) <= |df$rt$stringFromRef(p$s)|
-  requires df$rt$intFromRef(p$checkedLeft) < df$rt$intFromRef(p$i)
+  requires df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$res), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$i), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$checkedLeft), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$checkedRight), df$rt$intType())
+  requires 1 <= df$rt$intFromRef(par$i) &&
+    df$rt$intFromRef(par$i) < |df$rt$stringFromRef(par$s)|
+  requires |df$rt$stringFromRef(par$res)| == df$rt$intFromRef(par$i)
+  requires 0 <= df$rt$intFromRef(par$checkedLeft) &&
+    df$rt$intFromRef(par$checkedLeft) <= df$rt$intFromRef(par$checkedRight) &&
+    df$rt$intFromRef(par$checkedRight) <= |df$rt$stringFromRef(par$s)|
+  requires df$rt$intFromRef(par$checkedLeft) < df$rt$intFromRef(par$i)
   requires (forall anon$builtin$4: Int ::0 <= anon$builtin$4 &&
-      anon$builtin$4 < df$rt$intFromRef(p$i) ==>
-      48 <= df$rt$stringFromRef(p$res)[anon$builtin$4] &&
-      df$rt$stringFromRef(p$res)[anon$builtin$4] <=
-      48 + |df$rt$stringFromRef(p$s)| - anon$builtin$4 &&
+      anon$builtin$4 < df$rt$intFromRef(par$i) ==>
+      48 <= df$rt$stringFromRef(par$res)[anon$builtin$4] &&
+      df$rt$stringFromRef(par$res)[anon$builtin$4] <=
+      48 + |df$rt$stringFromRef(par$s)| - anon$builtin$4 &&
       (forall anon$builtin$5: Int ::0 <= anon$builtin$5 &&
-        anon$builtin$5 < df$rt$stringFromRef(p$res)[anon$builtin$4] - 48 ==>
-        df$rt$stringFromRef(p$s)[anon$builtin$5] ==
-        df$rt$stringFromRef(p$s)[anon$builtin$4 + anon$builtin$5]) &&
-      (df$rt$stringFromRef(p$res)[anon$builtin$4] - 48 ==
-      |df$rt$stringFromRef(p$s)| - anon$builtin$4 ||
-      !(df$rt$stringFromRef(p$s)[anon$builtin$4 +
-      (df$rt$stringFromRef(p$res)[anon$builtin$4] - 48)] ==
-      df$rt$stringFromRef(p$s)[df$rt$stringFromRef(p$res)[anon$builtin$4] -
+        anon$builtin$5 < df$rt$stringFromRef(par$res)[anon$builtin$4] - 48 ==>
+        df$rt$stringFromRef(par$s)[anon$builtin$5] ==
+        df$rt$stringFromRef(par$s)[anon$builtin$4 + anon$builtin$5]) &&
+      (df$rt$stringFromRef(par$res)[anon$builtin$4] - 48 ==
+      |df$rt$stringFromRef(par$s)| - anon$builtin$4 ||
+      !(df$rt$stringFromRef(par$s)[anon$builtin$4 +
+      (df$rt$stringFromRef(par$res)[anon$builtin$4] - 48)] ==
+      df$rt$stringFromRef(par$s)[df$rt$stringFromRef(par$res)[anon$builtin$4] -
       48])))
   requires (forall anon$builtin$6: Int ::0 <= anon$builtin$6 &&
       anon$builtin$6 <
-      df$rt$intFromRef(p$checkedRight) - df$rt$intFromRef(p$checkedLeft) ==>
-      df$rt$stringFromRef(p$s)[df$rt$intFromRef(p$checkedLeft) +
+      df$rt$intFromRef(par$checkedRight) -
+      df$rt$intFromRef(par$checkedLeft) ==>
+      df$rt$stringFromRef(par$s)[df$rt$intFromRef(par$checkedLeft) +
       anon$builtin$6] ==
-      df$rt$stringFromRef(p$s)[anon$builtin$6])
+      df$rt$stringFromRef(par$s)[anon$builtin$6])
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
-  ensures df$rt$intFromRef(p$i) <= df$rt$intFromRef(ret$0) &&
-    df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(p$s)|
-  ensures (forall anon$builtin$7: Int ::df$rt$intFromRef(p$i) <=
+  ensures df$rt$intFromRef(par$i) <= df$rt$intFromRef(ret$0) &&
+    df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(par$s)|
+  ensures (forall anon$builtin$7: Int ::df$rt$intFromRef(par$i) <=
       anon$builtin$7 &&
       anon$builtin$7 < df$rt$intFromRef(ret$0) ==>
-      df$rt$stringFromRef(p$s)[anon$builtin$7 - df$rt$intFromRef(p$i)] ==
-      df$rt$stringFromRef(p$s)[anon$builtin$7])
+      df$rt$stringFromRef(par$s)[anon$builtin$7 - df$rt$intFromRef(par$i)] ==
+      df$rt$stringFromRef(par$s)[anon$builtin$7])
 {
   var anon$0: Ref
-  if (df$rt$intFromRef(p$checkedLeft) == 0) {
+  if (df$rt$intFromRef(par$checkedLeft) == 0) {
     anon$0 := df$rt$boolToRef(true)
   } else {
-    anon$0 := sp$leInts(p$checkedRight, p$i)}
+    anon$0 := sp$leInts(par$checkedRight, par$i)}
   if (df$rt$boolFromRef(anon$0)) {
-    ret$0 := p$i
+    ret$0 := par$i
   } else {
     var l3$bound: Ref
-    l3$bound := sp$plusInts(p$i, sp$subChars(sp$stringGet(p$res, sp$minusInts(p$i,
-      p$checkedLeft)), df$rt$charToRef(48)))
-    if (df$rt$intFromRef(l3$bound) < df$rt$intFromRef(p$checkedRight)) {
+    l3$bound := sp$plusInts(par$i, sp$subChars(sp$stringGet(par$res, sp$minusInts(par$i,
+      par$checkedLeft)), df$rt$charToRef(48)))
+    if (df$rt$intFromRef(l3$bound) < df$rt$intFromRef(par$checkedRight)) {
       ret$0 := l3$bound
     } else {
-      ret$0 := p$checkedRight}
+      ret$0 := par$checkedRight}
   }
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /z_function.kt:(1389,1398): info: Generated Viper text for zFunction:
-method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
-  p$other: Ref)
+method f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(this$dispatch: Ref,
+  par$other: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
-method f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(p$s: Ref,
-  p$res: Ref, p$i: Ref, p$checkedLeft: Ref, p$checkedRight: Ref)
+method f$zFuncHelper$t$F$t$String$t$String$t$Int$t$Int$t$Int$t$Int(par$s: Ref,
+  par$res: Ref, par$i: Ref, par$checkedLeft: Ref, par$checkedRight: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$res), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$checkedLeft), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$checkedRight), df$rt$intType())
-  requires 1 <= df$rt$intFromRef(p$i) &&
-    df$rt$intFromRef(p$i) < |df$rt$stringFromRef(p$s)|
-  requires |df$rt$stringFromRef(p$res)| == df$rt$intFromRef(p$i)
-  requires 0 <= df$rt$intFromRef(p$checkedLeft) &&
-    df$rt$intFromRef(p$checkedLeft) <= df$rt$intFromRef(p$checkedRight) &&
-    df$rt$intFromRef(p$checkedRight) <= |df$rt$stringFromRef(p$s)|
-  requires df$rt$intFromRef(p$checkedLeft) < df$rt$intFromRef(p$i)
+  requires df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$res), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$i), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$checkedLeft), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$checkedRight), df$rt$intType())
+  requires 1 <= df$rt$intFromRef(par$i) &&
+    df$rt$intFromRef(par$i) < |df$rt$stringFromRef(par$s)|
+  requires |df$rt$stringFromRef(par$res)| == df$rt$intFromRef(par$i)
+  requires 0 <= df$rt$intFromRef(par$checkedLeft) &&
+    df$rt$intFromRef(par$checkedLeft) <= df$rt$intFromRef(par$checkedRight) &&
+    df$rt$intFromRef(par$checkedRight) <= |df$rt$stringFromRef(par$s)|
+  requires df$rt$intFromRef(par$checkedLeft) < df$rt$intFromRef(par$i)
   requires (forall anon$builtin$13: Int ::0 <= anon$builtin$13 &&
-      anon$builtin$13 < df$rt$intFromRef(p$i) ==>
-      48 <= df$rt$stringFromRef(p$res)[anon$builtin$13] &&
-      df$rt$stringFromRef(p$res)[anon$builtin$13] <=
-      48 + |df$rt$stringFromRef(p$s)| - anon$builtin$13 &&
+      anon$builtin$13 < df$rt$intFromRef(par$i) ==>
+      48 <= df$rt$stringFromRef(par$res)[anon$builtin$13] &&
+      df$rt$stringFromRef(par$res)[anon$builtin$13] <=
+      48 + |df$rt$stringFromRef(par$s)| - anon$builtin$13 &&
       (forall anon$builtin$14: Int ::0 <= anon$builtin$14 &&
-        anon$builtin$14 < df$rt$stringFromRef(p$res)[anon$builtin$13] - 48 ==>
-        df$rt$stringFromRef(p$s)[anon$builtin$14] ==
-        df$rt$stringFromRef(p$s)[anon$builtin$13 + anon$builtin$14]) &&
-      (df$rt$stringFromRef(p$res)[anon$builtin$13] - 48 ==
-      |df$rt$stringFromRef(p$s)| - anon$builtin$13 ||
-      !(df$rt$stringFromRef(p$s)[anon$builtin$13 +
-      (df$rt$stringFromRef(p$res)[anon$builtin$13] - 48)] ==
-      df$rt$stringFromRef(p$s)[df$rt$stringFromRef(p$res)[anon$builtin$13] -
+        anon$builtin$14 <
+        df$rt$stringFromRef(par$res)[anon$builtin$13] - 48 ==>
+        df$rt$stringFromRef(par$s)[anon$builtin$14] ==
+        df$rt$stringFromRef(par$s)[anon$builtin$13 + anon$builtin$14]) &&
+      (df$rt$stringFromRef(par$res)[anon$builtin$13] - 48 ==
+      |df$rt$stringFromRef(par$s)| - anon$builtin$13 ||
+      !(df$rt$stringFromRef(par$s)[anon$builtin$13 +
+      (df$rt$stringFromRef(par$res)[anon$builtin$13] - 48)] ==
+      df$rt$stringFromRef(par$s)[df$rt$stringFromRef(par$res)[anon$builtin$13] -
       48])))
   requires (forall anon$builtin$15: Int ::0 <= anon$builtin$15 &&
       anon$builtin$15 <
-      df$rt$intFromRef(p$checkedRight) - df$rt$intFromRef(p$checkedLeft) ==>
-      df$rt$stringFromRef(p$s)[df$rt$intFromRef(p$checkedLeft) +
+      df$rt$intFromRef(par$checkedRight) -
+      df$rt$intFromRef(par$checkedLeft) ==>
+      df$rt$stringFromRef(par$s)[df$rt$intFromRef(par$checkedLeft) +
       anon$builtin$15] ==
-      df$rt$stringFromRef(p$s)[anon$builtin$15])
+      df$rt$stringFromRef(par$s)[anon$builtin$15])
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
-  ensures df$rt$intFromRef(p$i) <= df$rt$intFromRef(ret) &&
-    df$rt$intFromRef(ret) <= |df$rt$stringFromRef(p$s)|
-  ensures (forall anon$builtin$16: Int ::df$rt$intFromRef(p$i) <=
+  ensures df$rt$intFromRef(par$i) <= df$rt$intFromRef(ret) &&
+    df$rt$intFromRef(ret) <= |df$rt$stringFromRef(par$s)|
+  ensures (forall anon$builtin$16: Int ::df$rt$intFromRef(par$i) <=
       anon$builtin$16 &&
       anon$builtin$16 < df$rt$intFromRef(ret) ==>
-      df$rt$stringFromRef(p$s)[anon$builtin$16 - df$rt$intFromRef(p$i)] ==
-      df$rt$stringFromRef(p$s)[anon$builtin$16])
+      df$rt$stringFromRef(par$s)[anon$builtin$16 - df$rt$intFromRef(par$i)] ==
+      df$rt$stringFromRef(par$s)[anon$builtin$16])
 
 
-method f$zFunction$TF$T$String$T$String(this$extension: Ref)
+method f$zFunction$t$F$t$String$t$String(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
@@ -156,7 +159,7 @@ method f$zFunction$TF$T$String$T$String(this$extension: Ref)
     sp$stringLength(this$extension)))
   l0$checkedLeft := df$rt$intToRef(0)
   l0$checkedRight := df$rt$intToRef(0)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$checkedLeft), df$rt$intType())
@@ -196,9 +199,9 @@ method f$zFunction$TF$T$String$T$String(this$extension: Ref)
   if (df$rt$boolFromRef(anon$0)) {
     var l3$j: Ref
     var anon$1: Ref
-    l3$j := f$zFuncHelper$TF$T$String$T$String$T$Int$T$Int$T$Int$T$Int(this$extension,
+    l3$j := f$zFuncHelper$t$F$t$String$t$String$t$Int$t$Int$t$Int$t$Int(this$extension,
       l0$res, l0$i, l0$checkedLeft, l0$checkedRight)
-    label lbl$continue$1
+    label lbl$cont$1
       invariant df$rt$isSubtype(df$rt$typeOf(l3$j), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
@@ -226,7 +229,7 @@ method f$zFunction$TF$T$String$T$String(this$extension: Ref)
       anon$1 := df$rt$boolToRef(false)}
     if (df$rt$boolFromRef(anon$1)) {
       l3$j := sp$plusInts(l3$j, df$rt$intToRef(1))
-      goto lbl$continue$1
+      goto lbl$cont$1
     }
     label lbl$break$1
     assert df$rt$isSubtype(df$rt$typeOf(l3$j), df$rt$intType())
@@ -255,7 +258,7 @@ method f$zFunction$TF$T$String$T$String(this$extension: Ref)
       l0$checkedRight := l3$j
     }
     l0$i := sp$plusInts(l0$i, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
@@ -297,15 +300,15 @@ method f$zFunction$TF$T$String$T$String(this$extension: Ref)
 }
 
 /z_function.kt:(3481,3495): info: Generated Viper text for zFunctionNaive:
-method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
-  p$other: Ref)
+method f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(this$dispatch: Ref,
+  par$other: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
-method f$zFunctionNaive$TF$T$String$T$String(this$extension: Ref)
+method f$zFunctionNaive$t$F$t$String$t$String(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
@@ -337,7 +340,7 @@ method f$zFunctionNaive$TF$T$String$T$String(this$extension: Ref)
   l0$i := df$rt$intToRef(1)
   l0$res := sp$addStringChar(df$rt$stringToRef(Seq[Int]()), sp$addCharInt(df$rt$charToRef(48),
     sp$stringLength(this$extension)))
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
     invariant |df$rt$stringFromRef(l0$res)| == df$rt$intFromRef(l0$i)
@@ -364,7 +367,7 @@ method f$zFunctionNaive$TF$T$String$T$String(this$extension: Ref)
     var l3$j: Ref
     var anon$1: Ref
     l3$j := l0$i
-    label lbl$continue$1
+    label lbl$cont$1
       invariant df$rt$isSubtype(df$rt$typeOf(l3$j), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
@@ -383,7 +386,7 @@ method f$zFunctionNaive$TF$T$String$T$String(this$extension: Ref)
       anon$1 := df$rt$boolToRef(false)}
     if (df$rt$boolFromRef(anon$1)) {
       l3$j := sp$plusInts(l3$j, df$rt$intToRef(1))
-      goto lbl$continue$1
+      goto lbl$cont$1
     }
     label lbl$break$1
     assert df$rt$isSubtype(df$rt$typeOf(l3$j), df$rt$intType())
@@ -399,7 +402,7 @@ method f$zFunctionNaive$TF$T$String$T$String(this$extension: Ref)
     l0$res := sp$addStringChar(l0$res, sp$addCharInt(df$rt$charToRef(48), sp$minusInts(l3$j,
       l0$i)))
     l0$i := sp$plusInts(l0$i, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
@@ -3,16 +3,16 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeGet$TF$T$X$T$Z(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
+method f$cascadeGet$t$F$t$X$t$Z(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$X())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Z())
-  ensures acc(p$c$Z$shared(ret$0), wildcard)
+  ensures acc(pred$c$Z$shared(ret$0), wildcard)
 {
   var anon$0: Ref
-  inhale acc(p$c$X$shared(p$x), wildcard)
-  unfold acc(p$c$X$shared(p$x), wildcard)
-  anon$0 := p$x.bf$y
-  unfold acc(p$c$Y$shared(anon$0), wildcard)
+  inhale acc(pred$c$X$shared(par$x), wildcard)
+  unfold acc(pred$c$X$shared(par$x), wildcard)
+  anon$0 := par$x.bf$y
+  unfold acc(pred$c$Y$shared(anon$0), wildcard)
   ret$0 := anon$0.bf$z
   goto lbl$ret$0
   label lbl$ret$0
@@ -23,18 +23,19 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$receiverNotNullProved$TF$NT$X$T$Boolean(p$x: Ref)
+method f$receiverNotNullProved$t$F$t$N$X$t$Boolean(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$X()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$c$X()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
-  ensures df$rt$boolFromRef(ret$0) == true ==> p$x != df$rt$nullValue()
+  ensures df$rt$boolFromRef(ret$0) == true ==> par$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale p$x != df$rt$nullValue() ==> acc(p$c$X$shared(p$x), wildcard)
-  if (p$x != df$rt$nullValue()) {
+  inhale par$x != df$rt$nullValue() ==>
+    acc(pred$c$X$shared(par$x), wildcard)
+  if (par$x != df$rt$nullValue()) {
     var anon$1: Ref
-    unfold acc(p$c$X$shared(p$x), wildcard)
-    anon$1 := p$x.bf$y
+    unfold acc(pred$c$X$shared(par$x), wildcard)
+    anon$1 := par$x.bf$y
     anon$0 := anon$1
   } else {
     anon$0 := df$rt$nullValue()}
@@ -48,23 +49,24 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableGet$TF$NT$NullableX$NT$Z(p$x: Ref)
+method f$cascadeNullableGet$t$F$t$N$NullableX$t$N$Z(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$c$NullableX()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
-  ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
-  ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
+  ensures ret$0 != df$rt$nullValue() ==>
+    acc(pred$c$Z$shared(ret$0), wildcard)
+  ensures ret$0 != df$rt$nullValue() ==> par$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale p$x != df$rt$nullValue() ==>
-    acc(p$c$NullableX$shared(p$x), wildcard)
-  if (p$x != df$rt$nullValue()) {
-    unfold acc(p$c$NullableX$shared(p$x), wildcard)
-    anon$0 := p$x.bf$y
+  inhale par$x != df$rt$nullValue() ==>
+    acc(pred$c$NullableX$shared(par$x), wildcard)
+  if (par$x != df$rt$nullValue()) {
+    unfold acc(pred$c$NullableX$shared(par$x), wildcard)
+    anon$0 := par$x.bf$y
   } else {
     anon$0 := df$rt$nullValue()}
   if (anon$0 != df$rt$nullValue()) {
-    unfold acc(p$c$NullableY$shared(anon$0), wildcard)
+    unfold acc(pred$c$NullableY$shared(anon$0), wildcard)
     ret$0 := anon$0.bf$z
   } else {
     ret$0 := df$rt$nullValue()}
@@ -77,32 +79,33 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method f$cascadeNullableSmartcastGet$TF$NT$NullableX$NT$Z(p$x: Ref)
+method f$cascadeNullableSmartcastGet$t$F$t$N$NullableX$t$N$Z(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$c$NullableX()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
-  ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
-  ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
+  ensures ret$0 != df$rt$nullValue() ==>
+    acc(pred$c$Z$shared(ret$0), wildcard)
+  ensures ret$0 != df$rt$nullValue() ==> par$x != df$rt$nullValue()
 {
-  inhale p$x != df$rt$nullValue() ==>
-    acc(p$c$NullableX$shared(p$x), wildcard)
-  if (p$x == df$rt$nullValue()) {
+  inhale par$x != df$rt$nullValue() ==>
+    acc(pred$c$NullableX$shared(par$x), wildcard)
+  if (par$x == df$rt$nullValue()) {
     var anon$0: Ref
     anon$0 := df$rt$nullValue()
     ret$0 := anon$0
   } else {
     var anon$1: Ref
-    unfold acc(p$c$NullableX$shared(p$x), wildcard)
-    anon$1 := p$x.bf$y
+    unfold acc(pred$c$NullableX$shared(par$x), wildcard)
+    anon$1 := par$x.bf$y
     if (anon$1 == df$rt$nullValue()) {
       var anon$2: Ref
       anon$2 := df$rt$nullValue()
       ret$0 := anon$2
     } else {
       var anon$3: Ref
-      unfold acc(p$c$NullableX$shared(p$x), wildcard)
-      anon$3 := p$x.bf$y
-      unfold acc(p$c$NullableY$shared(anon$3), wildcard)
+      unfold acc(pred$c$NullableX$shared(par$x), wildcard)
+      anon$3 := par$x.bf$y
+      unfold acc(pred$c$NullableY$shared(anon$3), wildcard)
       ret$0 := anon$3.bf$z
     }
   }
@@ -115,24 +118,24 @@ field bf$size: Ref
 
 field bf$x: Ref
 
-method con$c$Baz$T$Baz() returns (ret: Ref)
+method con$c$Baz$t$Baz() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Baz())
-  ensures acc(p$c$Baz$shared(ret), wildcard)
-  ensures acc(p$c$Baz$unique(ret), write)
+  ensures acc(pred$c$Baz$shared(ret), wildcard)
+  ensures acc(pred$c$Baz$unique(ret), write)
 
 
-method f$nullableReceiverNotNullSafeGet$TF$T$Unit() returns (ret$0: Ref)
+method f$nullableReceiverNotNullSafeGet$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
   var anon$0: Ref
   var l0$cond1: Ref
   var anon$1: Ref
-  anon$0 := con$c$Baz$T$Baz()
+  anon$0 := con$c$Baz$t$Baz()
   l0$f := anon$0
   if (l0$f != df$rt$nullValue()) {
     var anon$2: Ref
-    unfold acc(p$c$Baz$shared(l0$f), wildcard)
+    unfold acc(pred$c$Baz$shared(l0$f), wildcard)
     anon$2 := l0$f.bf$x
     anon$1 := anon$2
   } else {
@@ -148,7 +151,7 @@ field bf$size: Ref
 
 field bf$x: Ref
 
-method f$nullableReceiverNullSafeGet$TF$T$Unit() returns (ret$0: Ref)
+method f$nullableReceiverNullSafeGet$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
@@ -157,7 +160,7 @@ method f$nullableReceiverNullSafeGet$TF$T$Unit() returns (ret$0: Ref)
   l0$f := df$rt$nullValue()
   if (l0$f != df$rt$nullValue()) {
     var anon$1: Ref
-    unfold acc(p$c$Baz$shared(l0$f), wildcard)
+    unfold acc(pred$c$Baz$shared(l0$f), wildcard)
     anon$1 := l0$f.bf$x
     anon$0 := anon$1
   } else {
@@ -173,22 +176,22 @@ field bf$size: Ref
 
 field bf$x: Ref
 
-method con$c$Baz$T$Baz() returns (ret: Ref)
+method con$c$Baz$t$Baz() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Baz())
-  ensures acc(p$c$Baz$shared(ret), wildcard)
-  ensures acc(p$c$Baz$unique(ret), write)
+  ensures acc(pred$c$Baz$shared(ret), wildcard)
+  ensures acc(pred$c$Baz$unique(ret), write)
 
 
-method f$nonNullableReceiverSafeGet$TF$T$Unit() returns (ret$0: Ref)
+method f$nonNullableReceiverSafeGet$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
   var l0$cond1: Ref
   var anon$0: Ref
-  l0$f := con$c$Baz$T$Baz()
+  l0$f := con$c$Baz$t$Baz()
   if (l0$f != df$rt$nullValue()) {
     var anon$1: Ref
-    unfold acc(p$c$Baz$shared(l0$f), wildcard)
+    unfold acc(pred$c$Baz$shared(l0$f), wildcard)
     anon$1 := l0$f.bf$x
     anon$0 := anon$1
   } else {
@@ -208,40 +211,40 @@ field bf$y: Ref
 
 field bf$z: Ref
 
-method con$c$ClassI$T$Int$T$Int$T$ClassI(p$x: Ref, p$y: Ref)
+method con$c$ClassI$t$Int$t$Int$t$ClassI(par$x: Ref, par$y: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassI())
-  ensures acc(p$c$ClassI$shared(ret), wildcard)
-  ensures acc(p$c$ClassI$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$ClassI$shared(ret), wildcard) in
+  ensures acc(pred$c$ClassI$shared(ret), wildcard)
+  ensures acc(pred$c$ClassI$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$ClassI$shared(ret), wildcard) in
       ret.bf$x)) ==
-    df$rt$intFromRef(p$x) &&
-    df$rt$intFromRef((unfolding acc(p$c$ClassI$shared(ret), wildcard) in
+    df$rt$intFromRef(par$x) &&
+    df$rt$intFromRef((unfolding acc(pred$c$ClassI$shared(ret), wildcard) in
       ret.bf$y)) ==
-    df$rt$intFromRef(p$y)
+    df$rt$intFromRef(par$y)
 
 
-method con$c$ClassII$T$Z$T$ClassII(p$z: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$c$Z())
+method con$c$ClassII$t$Z$t$ClassII(par$z: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$z), df$rt$c$Z())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassII())
-  ensures acc(p$c$ClassII$shared(ret), wildcard)
-  ensures acc(p$c$ClassII$unique(ret), write)
-  ensures (unfolding acc(p$c$ClassII$shared(ret), wildcard) in ret.bf$z) ==
-    p$z
+  ensures acc(pred$c$ClassII$shared(ret), wildcard)
+  ensures acc(pred$c$ClassII$unique(ret), write)
+  ensures (unfolding acc(pred$c$ClassII$shared(ret), wildcard) in ret.bf$z) ==
+    par$z
 
 
-method con$c$Z$T$Z() returns (ret: Ref)
+method con$c$Z$t$Z() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Z())
-  ensures acc(p$c$Z$shared(ret), wildcard)
-  ensures acc(p$c$Z$unique(ret), write)
+  ensures acc(pred$c$Z$shared(ret), wildcard)
+  ensures acc(pred$c$Z$unique(ret), write)
 
 
-method f$checkPrimary$TF$T$Int$T$Int$T$Unit(p$x: Ref, p$y: Ref)
+method f$checkPrimary$t$F$t$Int$t$Int$t$Unit(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$classI: Ref
@@ -250,22 +253,22 @@ method f$checkPrimary$TF$T$Int$T$Int$T$Unit(p$x: Ref, p$y: Ref)
   var l0$cond2: Ref
   var anon$2: Ref
   var anon$3: Ref
-  l0$classI := con$c$ClassI$T$Int$T$Int$T$ClassI(p$x, p$y)
-  l0$z := con$c$Z$T$Z()
-  if (!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y))) {
+  l0$classI := con$c$ClassI$t$Int$t$Int$t$ClassI(par$x, par$y)
+  l0$z := con$c$Z$t$Z()
+  if (!(df$rt$intFromRef(par$x) == df$rt$intFromRef(par$y))) {
     l0$cond1 := df$rt$boolToRef(true)
   } else {
     var anon$0: Ref
     var anon$1: Ref
-    unfold acc(p$c$ClassI$shared(l0$classI), wildcard)
+    unfold acc(pred$c$ClassI$shared(l0$classI), wildcard)
     anon$0 := l0$classI.bf$x
-    unfold acc(p$c$ClassI$shared(l0$classI), wildcard)
+    unfold acc(pred$c$ClassI$shared(l0$classI), wildcard)
     anon$1 := l0$classI.bf$y
     l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$0) ==
       df$rt$intFromRef(anon$1))
   }
-  anon$3 := con$c$ClassII$T$Z$T$ClassII(l0$z)
-  unfold acc(p$c$ClassII$shared(anon$3), wildcard)
+  anon$3 := con$c$ClassII$t$Z$t$ClassII(l0$z)
+  unfold acc(pred$c$ClassII$shared(anon$3), wildcard)
   anon$2 := anon$3.bf$z
   l0$cond2 := df$rt$boolToRef(anon$2 == l0$z)
   assert df$rt$boolFromRef(l0$cond1)
@@ -274,4 +277,5 @@ method f$checkPrimary$TF$T$Int$T$Int$T$Unit(p$x: Ref, p$y: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$z(this$dispatch: Ref) returns (ret: Ref)
+method g$public$z(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
@@ -1,16 +1,16 @@
 /binary_search.kt:(90,108): info: Generated Viper text for safe_binary_search:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -18,7 +18,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -34,73 +34,73 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this$dispatch: Ref,
-  p$fromIndex: Ref, p$toIndex: Ref)
+method f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(this$dispatch: Ref,
+  par$fromIndex: Ref, par$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
-  requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
-  requires df$rt$intFromRef(p$fromIndex) >= 0
-  requires df$rt$intFromRef(p$toIndex) <=
+  requires df$rt$isSubtype(df$rt$typeOf(par$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$toIndex), df$rt$intType())
+  requires df$rt$intFromRef(par$fromIndex) <= df$rt$intFromRef(par$toIndex)
+  requires df$rt$intFromRef(par$fromIndex) >= 0
+  requires df$rt$intFromRef(par$toIndex) <=
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
   ensures df$rt$intFromRef(ret.sp$size) ==
-    df$rt$intFromRef(p$toIndex) - df$rt$intFromRef(p$fromIndex)
+    df$rt$intFromRef(par$toIndex) - df$rt$intFromRef(par$fromIndex)
 
 
-method f$safe_binary_search$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
+method f$safe_binary_search$t$F$t$List$t$Int$t$Boolean(par$arr: Ref, par$target: Ref)
   returns (ret$0: Ref)
-  requires acc(p$arr.sp$size, write)
-  requires df$rt$intFromRef(p$arr.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  ensures acc(p$arr.sp$size, write)
-  ensures df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires acc(par$arr.sp$size, write)
+  requires df$rt$intFromRef(par$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(par$target), df$rt$intType())
+  ensures acc(par$arr.sp$size, write)
+  ensures df$rt$intFromRef(par$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var l0$size: Ref
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  l0$size := p$arr.sp$size
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$arr), wildcard)
+  l0$size := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
-  anon$0 := p$arr.sp$size
+  anon$0 := par$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   l0$mid := sp$divInts(anon$0, df$rt$intToRef(2))
-  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$arr)
+  anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(par$arr)
   if (df$rt$boolFromRef(anon$1)) {
     ret$0 := df$rt$boolToRef(false)
   } else {
     var anon$2: Ref
-    anon$2 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+    anon$2 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
       l0$mid)
-    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(p$target)) {
+    if (df$rt$intFromRef(anon$2) == df$rt$intFromRef(par$target)) {
       ret$0 := df$rt$boolToRef(true)
     } else {
       var anon$3: Ref
-      anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+      anon$3 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
         l0$mid)
-      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(p$target)) {
+      if (df$rt$intFromRef(anon$3) < df$rt$intFromRef(par$target)) {
         var anon$4: Ref
-        anon$4 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$4 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           sp$plusInts(l0$mid, df$rt$intToRef(1)), l0$size)
-        ret$0 := f$safe_binary_search$TF$T$List$T$Int$T$Boolean(anon$4, p$target)
+        ret$0 := f$safe_binary_search$t$F$t$List$t$Int$t$Boolean(anon$4, par$target)
       } else {
         var anon$5: Ref
-        anon$5 := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(p$arr,
+        anon$5 := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(par$arr,
           df$rt$intToRef(0), l0$mid)
-        ret$0 := f$safe_binary_search$TF$T$List$T$Int$T$Boolean(anon$5, p$target)
+        ret$0 := f$safe_binary_search$t$F$t$List$t$Int$t$Boolean(anon$5, par$target)
       }
     }
   }
@@ -111,16 +111,16 @@ method f$safe_binary_search$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
 /binary_search.kt:(537,563): info: Generated Viper text for unsafe_binary_search_fixed:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -128,55 +128,56 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr: Ref,
-  p$target: Ref, p$left: Ref, p$right: Ref)
+method f$unsafe_binary_search_fixed$t$F$t$List$t$Int$t$Int$t$Int$t$Boolean(par$arr: Ref,
+  par$target: Ref, par$left: Ref, par$right: Ref)
   returns (ret$0: Ref)
-  requires acc(p$arr.sp$size, write)
-  requires df$rt$intFromRef(p$arr.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
-  ensures acc(p$arr.sp$size, write)
-  ensures df$rt$intFromRef(p$arr.sp$size) >= 0
+  requires acc(par$arr.sp$size, write)
+  requires df$rt$intFromRef(par$arr.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires df$rt$isSubtype(df$rt$typeOf(par$target), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$left), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$right), df$rt$intType())
+  ensures acc(par$arr.sp$size, write)
+  ensures df$rt$intFromRef(par$arr.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
   var anon$1: Ref
   var l0$mid: Ref
   var anon$3: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
-  if (df$rt$intFromRef(p$left) > df$rt$intFromRef(p$right)) {
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$arr), wildcard)
+  if (df$rt$intFromRef(par$left) > df$rt$intFromRef(par$right)) {
     anon$1 := df$rt$boolToRef(true)
   } else {
-    anon$1 := sp$ltInts(p$left, df$rt$intToRef(0))}
+    anon$1 := sp$ltInts(par$left, df$rt$intToRef(0))}
   if (df$rt$boolFromRef(anon$1)) {
     anon$0 := df$rt$boolToRef(true)
   } else {
     var anon$2: Ref
-    anon$2 := p$arr.sp$size
+    anon$2 := par$arr.sp$size
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-    anon$0 := sp$geInts(p$right, anon$2)
+    anon$0 := sp$geInts(par$right, anon$2)
   }
   if (df$rt$boolFromRef(anon$0)) {
     ret$0 := df$rt$boolToRef(false)
     goto lbl$ret$0
   }
-  l0$mid := sp$plusInts(p$left, sp$divInts(sp$minusInts(p$right, p$left), df$rt$intToRef(2)))
-  anon$3 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+  l0$mid := sp$plusInts(par$left, sp$divInts(sp$minusInts(par$right, par$left),
+    df$rt$intToRef(2)))
+  anon$3 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
     l0$mid)
-  if (df$rt$intFromRef(anon$3) == df$rt$intFromRef(p$target)) {
+  if (df$rt$intFromRef(anon$3) == df$rt$intFromRef(par$target)) {
     ret$0 := df$rt$boolToRef(true)
   } else {
     var anon$4: Ref
-    anon$4 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$arr,
+    anon$4 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$arr,
       l0$mid)
-    if (df$rt$intFromRef(anon$4) < df$rt$intFromRef(p$target)) {
-      ret$0 := f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr,
-        p$target, sp$plusInts(l0$mid, df$rt$intToRef(1)), p$right)
+    if (df$rt$intFromRef(anon$4) < df$rt$intFromRef(par$target)) {
+      ret$0 := f$unsafe_binary_search_fixed$t$F$t$List$t$Int$t$Int$t$Int$t$Boolean(par$arr,
+        par$target, sp$plusInts(l0$mid, df$rt$intToRef(1)), par$right)
     } else {
-      ret$0 := f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr,
-        p$target, p$left, sp$minusInts(l0$mid, df$rt$intToRef(1)))}
+      ret$0 := f$unsafe_binary_search_fixed$t$F$t$List$t$Int$t$Int$t$Int$t$Boolean(par$arr,
+        par$target, par$left, sp$minusInts(l0$mid, df$rt$intToRef(1)))}
   }
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
@@ -3,23 +3,23 @@ field bf$c$CustomList$private$value: Ref
 
 field sp$size: Ref
 
-method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$index: Ref)
+method f$c$CustomList$get$t$F$t$CustomList$t$Int$t$Int(this$dispatch: Ref, par$index: Ref)
   returns (ret$0: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
 {
-  inhale acc(p$c$CustomList$shared(this$dispatch), wildcard)
-  unfold acc(p$c$CustomList$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$CustomList$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$CustomList$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$c$CustomList$private$value
   goto lbl$ret$0
   label lbl$ret$0
@@ -30,26 +30,26 @@ field bf$c$CustomList$private$value: Ref
 
 field sp$size: Ref
 
-method con$c$CustomList$T$Int$T$Int$T$CustomList(p$size: Ref, p$value: Ref)
+method con$c$CustomList$t$Int$t$Int$t$CustomList(par$size: Ref, par$value: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$size), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$value), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$size), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$value), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CustomList())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$c$CustomList$shared(ret), wildcard)
-  ensures acc(p$c$CustomList$unique(ret), write)
+  ensures acc(pred$c$CustomList$shared(ret), wildcard)
+  ensures acc(pred$c$CustomList$unique(ret), write)
 
 
-method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$index: Ref)
+method f$c$CustomList$get$t$F$t$CustomList$t$Int$t$Int(this$dispatch: Ref, par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -57,7 +57,7 @@ method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$inde
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$c$CustomList$isEmpty$TF$T$CustomList$T$Boolean(this$dispatch: Ref)
+method f$c$CustomList$isEmpty$t$F$t$CustomList$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -73,23 +73,23 @@ method f$c$CustomList$isEmpty$TF$T$CustomList$T$Boolean(this$dispatch: Ref)
     df$rt$intFromRef(this$dispatch.sp$size) > 0
 
 
-method f$test$TF$T$Int$T$Unit(p$n: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+method f$test$t$F$t$Int$t$Unit(par$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$customList: Ref
   var anon$0: Ref
-  l0$customList := con$c$CustomList$T$Int$T$Int$T$CustomList(p$n, df$rt$intToRef(0))
-  anon$0 := f$c$CustomList$isEmpty$TF$T$CustomList$T$Boolean(l0$customList)
+  l0$customList := con$c$CustomList$t$Int$t$Int$t$CustomList(par$n, df$rt$intToRef(0))
+  anon$0 := f$c$CustomList$isEmpty$t$F$t$CustomList$t$Boolean(l0$customList)
   if (!df$rt$boolFromRef(anon$0)) {
     var anon$1: Ref
     var anon$2: Ref
     var anon$3: Ref
     anon$2 := l0$customList.sp$size
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-    anon$1 := f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(l0$customList,
+    anon$1 := f$c$CustomList$get$t$F$t$CustomList$t$Int$t$Int(l0$customList,
       sp$minusInts(anon$2, df$rt$intToRef(1)))
-    anon$3 := f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(l0$customList,
+    anon$3 := f$c$CustomList$get$t$F$t$CustomList$t$Int$t$Int(l0$customList,
       df$rt$intToRef(0))
   }
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
@@ -1,7 +1,7 @@
 /list.kt:(77,88): info: Generated Viper text for declaration:
 field sp$size: Ref
 
-method f$declaration$TF$T$Unit() returns (ret$0: Ref)
+method f$declaration$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$l1: Ref
@@ -14,60 +14,60 @@ method f$declaration$TF$T$Unit() returns (ret$0: Ref)
 /list.kt:(187,201): info: Generated Viper text for initialization:
 field sp$size: Ref
 
-method f$initialization$TF$T$List$T$Unit(p$l: Ref) returns (ret$0: Ref)
-  requires acc(p$l.sp$size, write)
-  requires df$rt$intFromRef(p$l.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
-  ensures acc(p$l.sp$size, write)
-  ensures df$rt$intFromRef(p$l.sp$size) >= 0
+method f$initialization$t$F$t$List$t$Unit(par$l: Ref) returns (ret$0: Ref)
+  requires acc(par$l.sp$size, write)
+  requires df$rt$intFromRef(par$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$c$pkg$kotlin_collections$List())
+  ensures acc(par$l.sp$size, write)
+  ensures df$rt$intFromRef(par$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$myList: Ref
   var l0$myEmptyList: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
-  l0$myList := p$l
-  l0$myEmptyList := f$pkg$kotlin_collections$emptyList$TF$T$List()
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$l), wildcard)
+  l0$myList := par$l
+  l0$myEmptyList := f$pkg$kotlin_collections$emptyList$t$F$t$List()
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
+method f$pkg$kotlin_collections$emptyList$t$F$t$List() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(ret.sp$size) == 0
 
 
 /list.kt:(297,304): info: Generated Viper text for add_get:
 field sp$size: Ref
 
-method f$add_get$TF$T$MutableList$T$Unit(p$l: Ref) returns (ret$0: Ref)
-  requires acc(p$l.sp$size, write)
-  requires df$rt$intFromRef(p$l.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
-  ensures acc(p$l.sp$size, write)
-  ensures df$rt$intFromRef(p$l.sp$size) >= 0
+method f$add_get$t$F$t$MutableList$t$Unit(par$l: Ref) returns (ret$0: Ref)
+  requires acc(par$l.sp$size, write)
+  requires df$rt$intFromRef(par$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$c$pkg$kotlin_collections$MutableList())
+  ensures acc(par$l.sp$size, write)
+  ensures df$rt$intFromRef(par$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
-  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(p$l,
+  inhale acc(pred$pkg$kotlin_collections$c$MutableList$shared(par$l), wildcard)
+  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$t$F$t$MutableList$t$Int$t$Boolean(par$l,
     df$rt$intToRef(1))
-  l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(p$l,
+  l0$n := f$pkg$kotlin_collections$c$MutableList$get$t$F$t$MutableList$t$Int$t$Int(par$l,
     df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(this$dispatch: Ref,
-  p$element: Ref)
+method f$pkg$kotlin_collections$c$MutableList$add$t$F$t$MutableList$t$Int$t$Boolean(this$dispatch: Ref,
+  par$element: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
-  requires df$rt$isSubtype(df$rt$typeOf(p$element), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$element), df$rt$intType())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -75,16 +75,16 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boole
     old(df$rt$intFromRef(this$dispatch.sp$size)) + 1
 
 
-method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$MutableList$get$t$F$t$MutableList$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -95,21 +95,21 @@ method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(t
 /list.kt:(379,391): info: Generated Viper text for last_or_null:
 field sp$size: Ref
 
-method f$last_or_null$TF$T$List$NT$Int(p$l: Ref) returns (ret$0: Ref)
-  requires acc(p$l.sp$size, write)
-  requires df$rt$intFromRef(p$l.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
-  ensures acc(p$l.sp$size, write)
-  ensures df$rt$intFromRef(p$l.sp$size) >= 0
+method f$last_or_null$t$F$t$List$t$N$Int(par$l: Ref) returns (ret$0: Ref)
+  requires acc(par$l.sp$size, write)
+  requires df$rt$intFromRef(par$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$c$pkg$kotlin_collections$List())
+  ensures acc(par$l.sp$size, write)
+  ensures df$rt$intFromRef(par$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$size: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
-  l0$size := p$l.sp$size
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$l), wildcard)
+  l0$size := par$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   if (!(df$rt$intFromRef(l0$size) == 0)) {
     var anon$0: Ref
-    anon$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$l,
+    anon$0 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$l,
       sp$minusInts(l0$size, df$rt$intToRef(1)))
     ret$0 := anon$0
     goto lbl$ret$0
@@ -120,16 +120,16 @@ method f$last_or_null$TF$T$List$NT$Int(p$l: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -140,19 +140,19 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
 /list.kt:(545,553): info: Generated Viper text for is_empty:
 field sp$size: Ref
 
-method f$is_empty$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
-  requires acc(p$l.sp$size, write)
-  requires df$rt$intFromRef(p$l.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
-  ensures acc(p$l.sp$size, write)
-  ensures df$rt$intFromRef(p$l.sp$size) >= 0
+method f$is_empty$t$F$t$List$t$Int(par$l: Ref) returns (ret$0: Ref)
+  requires acc(par$l.sp$size, write)
+  requires df$rt$intFromRef(par$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$c$pkg$kotlin_collections$List())
+  ensures acc(par$l.sp$size, write)
+  ensures df$rt$intFromRef(par$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
-  anon$0 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$l)
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$l), wildcard)
+  anon$0 := f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(par$l)
   if (!df$rt$boolFromRef(anon$0)) {
-    ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$l,
+    ret$0 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$l,
       df$rt$intToRef(0))
   } else {
     ret$0 := df$rt$intToRef(1)}
@@ -160,16 +160,16 @@ method f$is_empty$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -177,7 +177,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -196,45 +196,47 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
 /list.kt:(670,683): info: Generated Viper text for nullable_list:
 field sp$size: Ref
 
-method f$nullable_list$TF$NT$List$T$Unit(p$l: Ref) returns (ret$0: Ref)
-  requires p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
-  requires p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$nullable(df$rt$c$pkg$kotlin_collections$List()))
-  ensures p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
-  ensures p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0
+method f$nullable_list$t$F$t$N$List$t$Unit(par$l: Ref) returns (ret$0: Ref)
+  requires par$l != df$rt$nullValue() ==> acc(par$l.sp$size, write)
+  requires par$l != df$rt$nullValue() ==>
+    df$rt$intFromRef(par$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$nullable(df$rt$c$pkg$kotlin_collections$List()))
+  ensures par$l != df$rt$nullValue() ==> acc(par$l.sp$size, write)
+  ensures par$l != df$rt$nullValue() ==>
+    df$rt$intFromRef(par$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale p$l != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
-  if (!(p$l == df$rt$nullValue())) {
+  inhale par$l != df$rt$nullValue() ==>
+    acc(pred$pkg$kotlin_collections$c$List$shared(par$l), wildcard)
+  if (!(par$l == df$rt$nullValue())) {
     var anon$1: Ref
-    anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$l)
+    anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(par$l)
     anon$0 := sp$notBool(anon$1)
   } else {
     anon$0 := df$rt$boolToRef(false)}
   if (df$rt$boolFromRef(anon$0)) {
     var l2$x: Ref
     var anon$2: Ref
-    anon$2 := p$l.sp$size
+    anon$2 := par$l.sp$size
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
-    l2$x := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$l, sp$minusInts(anon$2,
-      df$rt$intToRef(1)))
+    l2$x := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$l,
+      sp$minusInts(anon$2, df$rt$intToRef(1)))
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -242,7 +244,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$List$isEmpty$t$F$t$List$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -256,3 +258,4 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
     df$rt$intFromRef(this$dispatch.sp$size) == 0
   ensures !df$rt$boolFromRef(ret) ==>
     df$rt$intFromRef(this$dispatch.sp$size) > 0
+

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
@@ -1,5 +1,5 @@
 /stdlib_replacement_tests.kt:(104,113): info: Generated Viper text for useChecks:
-method f$useChecks$TF$T$Unit() returns (ret$0: Ref)
+method f$useChecks$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var ret$1: Ref
@@ -19,8 +19,8 @@ method f$useChecks$TF$T$Unit() returns (ret$0: Ref)
 /stdlib_replacement_tests.kt:(298,305): info: Generated Viper text for useRuns:
 field bf$size: Ref
 
-method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$useRuns$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -37,7 +37,7 @@ method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$7: Ref
   var ret$4: Ref
   var anon$1: Ref
-  ret$2 := sp$plusInts(p$x, df$rt$intToRef(1))
+  ret$2 := sp$plusInts(par$x, df$rt$intToRef(1))
   goto lbl$ret$2
   label lbl$ret$2
   anon$4 := ret$2
@@ -49,9 +49,9 @@ method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   anon$2 := anon$3
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$2) ==
-    1 + df$rt$intFromRef(p$x))
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
-  anon$0 := p$x
+    1 + df$rt$intFromRef(par$x))
+  inhale df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
+  anon$0 := par$x
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   anon$1 := anon$0
   ret$4 := sp$plusInts(anon$1, df$rt$intToRef(1))
@@ -66,7 +66,7 @@ method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   anon$5 := anon$6
   inhale df$rt$isSubtype(df$rt$typeOf(anon$5), df$rt$intType())
   l0$cond2 := df$rt$boolToRef(df$rt$intFromRef(anon$5) ==
-    1 + df$rt$intFromRef(p$x))
+    1 + df$rt$intFromRef(par$x))
   assert df$rt$boolFromRef(l0$cond1)
   assert df$rt$boolFromRef(l0$cond2)
   label lbl$ret$0
@@ -76,8 +76,8 @@ method f$useRuns$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 /stdlib_replacement_tests.kt:(459,466): info: Generated Viper text for useAlso:
 field bf$size: Ref
 
-method f$useAlso$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$useAlso$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -86,11 +86,11 @@ method f$useAlso$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var ret$2: Ref
   var anon$1: Ref
-  anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
+  anon$0 := sp$plusInts(par$x, df$rt$intToRef(1))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   anon$1 := anon$0
-  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(p$x)
+  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(par$x)
   label lbl$ret$2
   inhale df$rt$isSubtype(df$rt$typeOf(ret$2), df$rt$unitType())
   ret$1 := anon$0
@@ -106,8 +106,8 @@ method f$useAlso$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 /stdlib_replacement_tests.kt:(531,537): info: Generated Viper text for useLet:
 field bf$size: Ref
 
-method f$useLet$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$useLet$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -118,8 +118,8 @@ method f$useLet$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$4: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
-  anon$0 := p$x
+  inhale df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
+  anon$0 := par$x
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   anon$1 := anon$0
   ret$2 := sp$plusInts(anon$1, df$rt$intToRef(1))
@@ -134,7 +134,7 @@ method f$useLet$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   anon$2 := anon$3
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$2) ==
-    1 + df$rt$intFromRef(p$x))
+    1 + df$rt$intFromRef(par$x))
   assert df$rt$boolFromRef(l0$cond1)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -143,8 +143,8 @@ method f$useLet$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 /stdlib_replacement_tests.kt:(621,628): info: Generated Viper text for useWith:
 field bf$size: Ref
 
-method f$useWith$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$useWith$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -154,11 +154,11 @@ method f$useWith$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$4: Ref
   var ret$2: Ref
   var anon$1: Ref
-  anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
+  anon$0 := sp$plusInts(par$x, df$rt$intToRef(1))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   anon$1 := anon$0
-  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(p$x)
+  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(par$x)
   label lbl$ret$2
   inhale df$rt$isSubtype(df$rt$typeOf(ret$2), df$rt$unitType())
   anon$4 := ret$2
@@ -176,8 +176,8 @@ method f$useWith$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
 /stdlib_replacement_tests.kt:(694,702): info: Generated Viper text for useApply:
 field bf$size: Ref
 
-method f$useApply$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+method f$useApply$t$F$t$Int$t$Unit(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -186,11 +186,11 @@ method f$useApply$TF$T$Int$T$Unit(p$x: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var ret$2: Ref
   var anon$1: Ref
-  anon$0 := sp$plusInts(p$x, df$rt$intToRef(1))
+  anon$0 := sp$plusInts(par$x, df$rt$intToRef(1))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   anon$1 := anon$0
-  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(p$x)
+  assert df$rt$intFromRef(anon$1) == 1 + df$rt$intFromRef(par$x)
   label lbl$ret$2
   inhale df$rt$isSubtype(df$rt$typeOf(ret$2), df$rt$unitType())
   ret$1 := anon$0

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
@@ -3,18 +3,18 @@ field bf$char: Ref
 
 field bf$size: Ref
 
-method con$c$CharBox$T$Char$T$CharBox(p$char: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$char), df$rt$charType())
+method con$c$CharBox$t$Char$t$CharBox(par$char: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$char), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CharBox())
-  ensures acc(p$c$CharBox$shared(ret), wildcard)
-  ensures acc(p$c$CharBox$unique(ret), write)
-  ensures df$rt$charFromRef((unfolding acc(p$c$CharBox$shared(ret), wildcard) in
+  ensures acc(pred$c$CharBox$shared(ret), wildcard)
+  ensures acc(pred$c$CharBox$unique(ret), write)
+  ensures df$rt$charFromRef((unfolding acc(pred$c$CharBox$shared(ret), wildcard) in
       ret.bf$char)) ==
-    df$rt$charFromRef(p$char)
+    df$rt$charFromRef(par$char)
 
 
-method f$testChars$TF$T$Char$T$Unit(p$c: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+method f$testChars$t$F$t$Char$t$Unit(par$c: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$box: Ref
@@ -22,9 +22,9 @@ method f$testChars$TF$T$Char$T$Unit(p$c: Ref) returns (ret$0: Ref)
   var l0$cond1: Ref
   var anon$0: Ref
   var l0$charZ: Ref
-  l0$box := con$c$CharBox$T$Char$T$CharBox(df$rt$charToRef(97))
+  l0$box := con$c$CharBox$t$Char$t$CharBox(df$rt$charToRef(97))
   l0$charA := df$rt$charToRef(97)
-  unfold acc(p$c$CharBox$shared(l0$box), wildcard)
+  unfold acc(pred$c$CharBox$shared(l0$box), wildcard)
   anon$0 := l0$box.bf$char
   l0$cond1 := df$rt$boolToRef(df$rt$charFromRef(l0$charA) ==
     df$rt$charFromRef(anon$0))

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
@@ -3,58 +3,59 @@ field bf$size: Ref
 
 field bf$str: Ref
 
-predicate p$c$StringBox$shared(this$dispatch: Ref) {
+predicate pred$c$StringBox$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
-predicate p$c$StringBox$unique(this$dispatch: Ref) {
+predicate pred$c$StringBox$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
-predicate p$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
+  acc(pred$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
+  acc(pred$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
+  acc(pred$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
+  acc(pred$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
 }
 
-method con$c$StringBox$T$String$T$StringBox(p$str: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+method con$c$StringBox$t$String$t$StringBox(par$str: Ref)
+  returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$StringBox())
-  ensures acc(p$c$StringBox$shared(ret), wildcard)
-  ensures acc(p$c$StringBox$unique(ret), write)
-  ensures df$rt$stringFromRef((unfolding acc(p$c$StringBox$shared(ret), wildcard) in
+  ensures acc(pred$c$StringBox$shared(ret), wildcard)
+  ensures acc(pred$c$StringBox$unique(ret), write)
+  ensures df$rt$stringFromRef((unfolding acc(pred$c$StringBox$shared(ret), wildcard) in
       ret.bf$str)) ==
-    df$rt$stringFromRef(p$str)
+    df$rt$stringFromRef(par$str)
 
 
-method f$testType$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+method f$testType$t$F$t$String$t$Unit(par$s: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -63,14 +64,14 @@ method f$testType$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
   var l0$cond2: Ref
   var anon$2: Ref
   var anon$3: Ref
-  anon$1 := con$c$StringBox$T$String$T$StringBox(p$s)
-  unfold acc(p$c$StringBox$shared(anon$1), wildcard)
+  anon$1 := con$c$StringBox$t$String$t$StringBox(par$s)
+  unfold acc(pred$c$StringBox$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$str
   l0$cond1 := df$rt$boolToRef(df$rt$stringFromRef(anon$0) ==
-    df$rt$stringFromRef(p$s))
-  anon$3 := con$c$StringBox$T$String$T$StringBox(df$rt$stringToRef(Seq(115,
+    df$rt$stringFromRef(par$s))
+  anon$3 := con$c$StringBox$t$String$t$StringBox(df$rt$stringToRef(Seq(115,
     116, 114)))
-  unfold acc(p$c$StringBox$shared(anon$3), wildcard)
+  unfold acc(pred$c$StringBox$shared(anon$3), wildcard)
   anon$2 := anon$3.bf$str
   l0$cond2 := df$rt$boolToRef(df$rt$stringFromRef(anon$2) ==
     Seq(115, 116, 114))
@@ -85,68 +86,70 @@ field bf$size: Ref
 
 field bf$str: Ref
 
-predicate p$c$StringBox$shared(this$dispatch: Ref) {
+predicate pred$c$StringBox$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
-predicate p$c$StringBox$unique(this$dispatch: Ref) {
+predicate pred$c$StringBox$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$str, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$str), df$rt$stringType())
 }
 
-predicate p$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
+  acc(pred$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
+  acc(pred$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
+  acc(pred$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
+  acc(pred$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
 }
 
-method con$c$StringBox$T$String$T$StringBox(p$str: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+method con$c$StringBox$t$String$t$StringBox(par$str: Ref)
+  returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$StringBox())
-  ensures acc(p$c$StringBox$shared(ret), wildcard)
-  ensures acc(p$c$StringBox$unique(ret), write)
-  ensures df$rt$stringFromRef((unfolding acc(p$c$StringBox$shared(ret), wildcard) in
+  ensures acc(pred$c$StringBox$shared(ret), wildcard)
+  ensures acc(pred$c$StringBox$unique(ret), write)
+  ensures df$rt$stringFromRef((unfolding acc(pred$c$StringBox$shared(ret), wildcard) in
       ret.bf$str)) ==
-    df$rt$stringFromRef(p$str)
+    df$rt$stringFromRef(par$str)
 
 
-method f$testLengthField$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+method f$testLengthField$t$F$t$String$t$Unit(par$s: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$len: Ref
   var l0$cond1: Ref
   var anon$0: Ref
   var anon$1: Ref
-  l0$len := sp$stringLength(p$s)
-  anon$1 := con$c$StringBox$T$String$T$StringBox(df$rt$stringToRef(Seq(115,
+  l0$len := sp$stringLength(par$s)
+  anon$1 := con$c$StringBox$t$String$t$StringBox(df$rt$stringToRef(Seq(115,
     116, 114)))
-  unfold acc(p$c$StringBox$shared(anon$1), wildcard)
+  unfold acc(pred$c$StringBox$shared(anon$1), wildcard)
   anon$0 := anon$1.bf$str
   l0$cond1 := df$rt$boolToRef(|df$rt$stringFromRef(anon$0)| == 3)
   assert df$rt$boolFromRef(l0$cond1)
@@ -157,46 +160,46 @@ method f$testLengthField$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
 /strings.kt:(552,559): info: Generated Viper text for testOps:
 field bf$size: Ref
 
-predicate p$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
+  acc(pred$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
+  acc(pred$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
+  acc(pred$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
+  acc(pred$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
 }
 
-method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
-  p$other: Ref)
+method f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(this$dispatch: Ref,
+  par$other: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
 
 
-method f$testOps$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+method f$testOps$t$F$t$String$t$Unit(par$s: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$c: Ref
@@ -204,14 +207,14 @@ method f$testOps$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
   var l0$str: Ref
   var l0$helloWorld: Ref
   var l0$stringPlusInteger: Ref
-  if (|df$rt$stringFromRef(p$s)| > 0) {
-    l0$c := sp$stringGet(p$s, df$rt$intToRef(0))
+  if (|df$rt$stringFromRef(par$s)| > 0) {
+    l0$c := sp$stringGet(par$s, df$rt$intToRef(0))
   } else {
     l0$c := df$rt$charToRef(97)}
   if (df$rt$charFromRef(l0$c) == 97) {
     anon$0 := df$rt$boolToRef(true)
   } else {
-    anon$0 := sp$gtInts(sp$stringLength(p$s), df$rt$intToRef(0))}
+    anon$0 := sp$gtInts(sp$stringLength(par$s), df$rt$intToRef(0))}
   assert df$rt$boolFromRef(anon$0)
   l0$str := df$rt$stringToRef(Seq(97, 98, 97))
   assert df$rt$stringFromRef(l0$str)[0] == df$rt$stringFromRef(l0$str)[2]
@@ -223,7 +226,7 @@ method f$testOps$TF$T$String$T$Unit(p$s: Ref) returns (ret$0: Ref)
     111, 32, 87, 111, 114, 108, 100)), df$rt$charToRef(33))
   assert df$rt$stringFromRef(l0$helloWorld) ==
     Seq(72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33)
-  l0$stringPlusInteger := f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(df$rt$stringToRef(Seq(52,
+  l0$stringPlusInteger := f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(df$rt$stringToRef(Seq(52,
     50)), df$rt$intToRef(42))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
@@ -1,71 +1,71 @@
 /multiple_interfaces.kt:(799,804): info: Generated Viper text for take1:
-method f$take1$TF$T$InterfaceWithImplementation1$T$Unit(p$obj: Ref)
+method f$take1$t$F$t$InterfaceWithImplementation1$t$Unit(par$obj: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$InterfaceWithImplementation1())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$InterfaceWithImplementation1$shared(p$obj), wildcard)
-  anon$1 := pg$public$field(p$obj)
+  inhale acc(pred$c$InterfaceWithImplementation1$shared(par$obj), wildcard)
+  anon$1 := g$public$field(par$obj)
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+method g$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 /multiple_interfaces.kt:(863,868): info: Generated Viper text for take2:
-method f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(p$obj: Ref)
+method f$take2$t$F$t$InterfaceWithoutImplementation2$t$Unit(par$obj: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$InterfaceWithoutImplementation2())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$InterfaceWithoutImplementation2$shared(p$obj), wildcard)
-  anon$1 := pg$public$field(p$obj)
+  inhale acc(pred$c$InterfaceWithoutImplementation2$shared(par$obj), wildcard)
+  anon$1 := g$public$field(par$obj)
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+method g$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 /multiple_interfaces.kt:(930,935): info: Generated Viper text for take3:
 field bf$field: Ref
 
-method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
+method f$take3$t$F$t$AbstractWithFinalImplementation3$t$Unit(par$obj: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$AbstractWithFinalImplementation3())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$AbstractWithFinalImplementation3$shared(p$obj), wildcard)
+  inhale acc(pred$c$AbstractWithFinalImplementation3$shared(par$obj), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /multiple_interfaces.kt:(998,1003): info: Generated Viper text for take4:
-method f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(p$obj: Ref)
+method f$take4$t$F$t$AbstractWithOpenImplementation4$t$Unit(par$obj: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$AbstractWithOpenImplementation4())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$AbstractWithOpenImplementation4$shared(p$obj), wildcard)
-  anon$1 := pg$public$field(p$obj)
+  inhale acc(pred$c$AbstractWithOpenImplementation4$shared(par$obj), wildcard)
+  anon$1 := g$public$field(par$obj)
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+method g$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 /multiple_interfaces.kt:(1683,1694): info: Generated Viper text for createImpls:
@@ -73,43 +73,43 @@ field bf$field: Ref
 
 field bf$size: Ref
 
-method con$c$Impl12$T$Impl12() returns (ret: Ref)
+method con$c$Impl12$t$Impl12() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl12())
-  ensures acc(p$c$Impl12$shared(ret), wildcard)
-  ensures acc(p$c$Impl12$unique(ret), write)
+  ensures acc(pred$c$Impl12$shared(ret), wildcard)
+  ensures acc(pred$c$Impl12$unique(ret), write)
 
 
-method con$c$Impl14$T$Impl14() returns (ret: Ref)
+method con$c$Impl14$t$Impl14() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl14())
-  ensures acc(p$c$Impl14$shared(ret), wildcard)
-  ensures acc(p$c$Impl14$unique(ret), write)
+  ensures acc(pred$c$Impl14$shared(ret), wildcard)
+  ensures acc(pred$c$Impl14$unique(ret), write)
 
 
-method con$c$Impl23$T$Impl23() returns (ret: Ref)
+method con$c$Impl23$t$Impl23() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl23())
-  ensures acc(p$c$Impl23$shared(ret), wildcard)
-  ensures acc(p$c$Impl23$unique(ret), write)
+  ensures acc(pred$c$Impl23$shared(ret), wildcard)
+  ensures acc(pred$c$Impl23$unique(ret), write)
 
 
-method con$c$Impl24$T$Impl24() returns (ret: Ref)
+method con$c$Impl24$t$Impl24() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl24())
-  ensures acc(p$c$Impl24$shared(ret), wildcard)
-  ensures acc(p$c$Impl24$unique(ret), write)
+  ensures acc(pred$c$Impl24$shared(ret), wildcard)
+  ensures acc(pred$c$Impl24$unique(ret), write)
 
 
-method con$c$Impl3$T$Impl3() returns (ret: Ref)
+method con$c$Impl3$t$Impl3() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Impl3())
-  ensures acc(p$c$Impl3$shared(ret), wildcard)
-  ensures acc(p$c$Impl3$unique(ret), write)
+  ensures acc(pred$c$Impl3$shared(ret), wildcard)
+  ensures acc(pred$c$Impl3$unique(ret), write)
 
 
-method f$create6$TF$T$InheritingInterfaceWithoutImplementation6()
+method f$create6$t$F$t$InheritingInterfaceWithoutImplementation6()
   returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$InheritingInterfaceWithoutImplementation6())
-  ensures acc(p$c$InheritingInterfaceWithoutImplementation6$shared(ret), wildcard)
+  ensures acc(pred$c$InheritingInterfaceWithoutImplementation6$shared(ret), wildcard)
 
 
-method f$createImpls$TF$T$Unit() returns (ret$0: Ref)
+method f$createImpls$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$impl12: Ref
@@ -150,58 +150,58 @@ method f$createImpls$TF$T$Unit() returns (ret$0: Ref)
   var l0$cond4: Ref
   var anon$20: Ref
   var l0$cond5: Ref
-  l0$impl12 := con$c$Impl12$T$Impl12()
-  unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
+  l0$impl12 := con$c$Impl12$t$Impl12()
+  unfold acc(pred$c$Impl12$shared(l0$impl12), wildcard)
   anon$0 := l0$impl12.bf$field
   l0$start12 := sp$minusInts(sp$plusInts(anon$0, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$1 := f$take1$TF$T$InterfaceWithImplementation1$T$Unit(l0$impl12)
-  anon$2 := f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(l0$impl12)
-  l0$impl23 := con$c$Impl23$T$Impl23()
-  unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
-  unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
+  anon$1 := f$take1$t$F$t$InterfaceWithImplementation1$t$Unit(l0$impl12)
+  anon$2 := f$take2$t$F$t$InterfaceWithoutImplementation2$t$Unit(l0$impl12)
+  l0$impl23 := con$c$Impl23$t$Impl23()
+  unfold acc(pred$c$Impl23$shared(l0$impl23), wildcard)
+  unfold acc(pred$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
   anon$3 := l0$impl23.bf$field
   l0$start23 := sp$minusInts(sp$plusInts(anon$3, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$4 := f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(l0$impl23)
-  anon$5 := f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(l0$impl23)
-  l0$impl3 := con$c$Impl3$T$Impl3()
-  unfold acc(p$c$Impl3$shared(l0$impl3), wildcard)
-  unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
+  anon$4 := f$take2$t$F$t$InterfaceWithoutImplementation2$t$Unit(l0$impl23)
+  anon$5 := f$take3$t$F$t$AbstractWithFinalImplementation3$t$Unit(l0$impl23)
+  l0$impl3 := con$c$Impl3$t$Impl3()
+  unfold acc(pred$c$Impl3$shared(l0$impl3), wildcard)
+  unfold acc(pred$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
   anon$6 := l0$impl3.bf$field
   l0$start3 := sp$minusInts(sp$plusInts(anon$6, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$7 := f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(l0$impl3)
-  l0$impl24 := con$c$Impl24$T$Impl24()
-  anon$9 := pg$public$field(l0$impl24)
+  anon$7 := f$take3$t$F$t$AbstractWithFinalImplementation3$t$Unit(l0$impl3)
+  l0$impl24 := con$c$Impl24$t$Impl24()
+  anon$9 := g$public$field(l0$impl24)
   anon$8 := anon$9
   inhale df$rt$isSubtype(df$rt$typeOf(anon$8), df$rt$intType())
   l0$start24 := sp$minusInts(sp$plusInts(anon$8, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$10 := f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(l0$impl24)
-  anon$11 := f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(l0$impl24)
-  l0$impl14 := con$c$Impl14$T$Impl14()
-  unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
+  anon$10 := f$take2$t$F$t$InterfaceWithoutImplementation2$t$Unit(l0$impl24)
+  anon$11 := f$take4$t$F$t$AbstractWithOpenImplementation4$t$Unit(l0$impl24)
+  l0$impl14 := con$c$Impl14$t$Impl14()
+  unfold acc(pred$c$Impl14$shared(l0$impl14), wildcard)
   anon$12 := l0$impl14.bf$field
   l0$start14 := sp$minusInts(sp$plusInts(anon$12, df$rt$intToRef(1)), df$rt$intToRef(1))
-  anon$13 := f$take1$TF$T$InterfaceWithImplementation1$T$Unit(l0$impl14)
-  anon$14 := f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(l0$impl14)
-  l0$impl6 := f$create6$TF$T$InheritingInterfaceWithoutImplementation6()
-  anon$16 := pg$public$field(l0$impl6)
+  anon$13 := f$take1$t$F$t$InterfaceWithImplementation1$t$Unit(l0$impl14)
+  anon$14 := f$take4$t$F$t$AbstractWithOpenImplementation4$t$Unit(l0$impl14)
+  l0$impl6 := f$create6$t$F$t$InheritingInterfaceWithoutImplementation6()
+  anon$16 := g$public$field(l0$impl6)
   anon$15 := anon$16
   inhale df$rt$isSubtype(df$rt$typeOf(anon$15), df$rt$intType())
   l0$start6 := sp$minusInts(sp$plusInts(anon$15, df$rt$intToRef(1)), df$rt$intToRef(1))
-  unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
+  unfold acc(pred$c$Impl12$shared(l0$impl12), wildcard)
   anon$17 := l0$impl12.bf$field
   l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(l0$start12) ==
     df$rt$intFromRef(anon$17))
-  unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
-  unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
+  unfold acc(pred$c$Impl23$shared(l0$impl23), wildcard)
+  unfold acc(pred$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
   anon$18 := l0$impl23.bf$field
   l0$cond2 := df$rt$boolToRef(df$rt$intFromRef(l0$start23) ==
     df$rt$intFromRef(anon$18))
-  unfold acc(p$c$Impl3$shared(l0$impl3), wildcard)
-  unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
+  unfold acc(pred$c$Impl3$shared(l0$impl3), wildcard)
+  unfold acc(pred$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
   anon$19 := l0$impl3.bf$field
   l0$cond3 := df$rt$boolToRef(df$rt$intFromRef(l0$start3) ==
     df$rt$intFromRef(anon$19))
-  unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
+  unfold acc(pred$c$Impl14$shared(l0$impl14), wildcard)
   anon$20 := l0$impl14.bf$field
   l0$cond4 := df$rt$boolToRef(df$rt$intFromRef(l0$start14) ==
     df$rt$intFromRef(anon$20))
@@ -215,28 +215,29 @@ method f$createImpls$TF$T$Unit() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$take1$TF$T$InterfaceWithImplementation1$T$Unit(p$obj: Ref)
+method f$take1$t$F$t$InterfaceWithImplementation1$t$Unit(par$obj: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$InterfaceWithImplementation1())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(p$obj: Ref)
+method f$take2$t$F$t$InterfaceWithoutImplementation2$t$Unit(par$obj: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$InterfaceWithoutImplementation2())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
+method f$take3$t$F$t$AbstractWithFinalImplementation3$t$Unit(par$obj: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$AbstractWithFinalImplementation3())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(p$obj: Ref)
+method f$take4$t$F$t$AbstractWithOpenImplementation4$t$Unit(par$obj: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$c$AbstractWithOpenImplementation4())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+method g$public$field(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
@@ -1,36 +1,36 @@
 /override_properties_types.kt:(520,530): info: Generated Viper text for extractInt:
 field bf$field: Ref
 
-method f$extractInt$TF$T$Base$T$Boolean$NT$Int(p$base: Ref, p$returnNull: Ref)
+method f$extractInt$t$F$t$Base$t$Boolean$t$N$Int(par$base: Ref, par$returnNull: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$Base())
-  requires df$rt$isSubtype(df$rt$typeOf(p$returnNull), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$base), df$rt$c$Base())
+  requires df$rt$isSubtype(df$rt$typeOf(par$returnNull), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
-  ensures ret$0 == df$rt$nullValue() ==> df$rt$boolFromRef(p$returnNull)
+  ensures ret$0 == df$rt$nullValue() ==> df$rt$boolFromRef(par$returnNull)
 {
-  inhale acc(p$c$Base$shared(p$base), wildcard)
-  if (df$rt$boolFromRef(p$returnNull)) {
+  inhale acc(pred$c$Base$shared(par$base), wildcard)
+  if (df$rt$boolFromRef(par$returnNull)) {
     var anon$0: Ref
     anon$0 := df$rt$nullValue()
     ret$0 := anon$0
   } else {
     var anon$1: Ref
-    if (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$OpenClassOpenFieldVarDerived())) {
+    if (df$rt$isSubtype(df$rt$typeOf(par$base), df$rt$c$OpenClassOpenFieldVarDerived())) {
       var anon$2: Ref
-      inhale acc(p$c$OpenClassOpenFieldVarDerived$shared(p$base), wildcard)
-      anon$2 := pg$public$field(p$base)
+      inhale acc(pred$c$OpenClassOpenFieldVarDerived$shared(par$base), wildcard)
+      anon$2 := g$public$field(par$base)
       anon$1 := anon$2
       inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$intType())
-    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$FinalClassOpenFieldVarDerived())) {
-      inhale acc(p$c$FinalClassOpenFieldVarDerived$shared(p$base), wildcard)
-      anon$1 := havoc$T$Int()
-    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$FinalClassFinalFieldValDerived())) {
-      inhale acc(p$c$FinalClassFinalFieldValDerived$shared(p$base), wildcard)
-      unfold acc(p$c$FinalClassFinalFieldValDerived$shared(p$base), wildcard)
-      anon$1 := p$base.bf$field
-    } elseif (df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$OpenClassFinalFieldVarDerived())) {
-      inhale acc(p$c$OpenClassFinalFieldVarDerived$shared(p$base), wildcard)
-      anon$1 := havoc$T$Int()
+    } elseif (df$rt$isSubtype(df$rt$typeOf(par$base), df$rt$c$FinalClassOpenFieldVarDerived())) {
+      inhale acc(pred$c$FinalClassOpenFieldVarDerived$shared(par$base), wildcard)
+      anon$1 := havoc$t$Int()
+    } elseif (df$rt$isSubtype(df$rt$typeOf(par$base), df$rt$c$FinalClassFinalFieldValDerived())) {
+      inhale acc(pred$c$FinalClassFinalFieldValDerived$shared(par$base), wildcard)
+      unfold acc(pred$c$FinalClassFinalFieldValDerived$shared(par$base), wildcard)
+      anon$1 := par$base.bf$field
+    } elseif (df$rt$isSubtype(df$rt$typeOf(par$base), df$rt$c$OpenClassFinalFieldVarDerived())) {
+      inhale acc(pred$c$OpenClassFinalFieldVarDerived$shared(par$base), wildcard)
+      anon$1 := havoc$t$Int()
     } else {
       anon$1 := df$rt$intToRef(0)}
     ret$0 := anon$1
@@ -39,7 +39,8 @@ method f$extractInt$TF$T$Base$T$Boolean$NT$Int(p$base: Ref, p$returnNull: Ref)
   label lbl$ret$0
 }
 
-method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+method g$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+method s$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
@@ -1,44 +1,44 @@
 /private_properties.kt:(222,237): info: Generated Viper text for getBooleanField:
-method f$c$A$getBooleanField$TF$T$A$T$Boolean(this$dispatch: Ref)
+method f$c$A$getBooleanField$t$F$t$A$t$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$A())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale acc(p$c$A$shared(this$dispatch), wildcard)
-  anon$0 := pg$c$A$private$field(this$dispatch)
+  inhale acc(pred$c$A$shared(this$dispatch), wildcard)
+  anon$0 := g$c$A$private$field(this$dispatch)
   ret$0 := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
+method g$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
+method s$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
 
 
 /private_properties.kt:(316,330): info: Generated Viper text for getStringField:
 field bf$c$B$private$field: Ref
 
-method f$c$B$getStringField$TF$T$B$T$String(this$dispatch: Ref)
+method f$c$B$getStringField$t$F$t$B$t$String(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$B())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
 {
-  inhale acc(p$c$B$shared(this$dispatch), wildcard)
-  unfold acc(p$c$B$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$B$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$B$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$c$B$private$field
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
+method g$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
+method s$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
 
 
@@ -49,19 +49,19 @@ field bf$field: Ref
 
 field bf$size: Ref
 
-method con$c$C$T$C() returns (ret: Ref)
+method con$c$C$t$C() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$C())
-  ensures acc(p$c$C$shared(ret), wildcard)
-  ensures acc(p$c$C$unique(ret), write)
+  ensures acc(pred$c$C$shared(ret), wildcard)
+  ensures acc(pred$c$C$unique(ret), write)
 
 
-method con$c$D$T$D() returns (ret: Ref)
+method con$c$D$t$D() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$D())
-  ensures acc(p$c$D$shared(ret), wildcard)
-  ensures acc(p$c$D$unique(ret), write)
+  ensures acc(pred$c$D$shared(ret), wildcard)
+  ensures acc(pred$c$D$unique(ret), write)
 
 
-method f$extractPublic$TF$T$Unit() returns (ret$0: Ref)
+method f$extractPublic$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -70,11 +70,11 @@ method f$extractPublic$TF$T$Unit() returns (ret$0: Ref)
   var l0$cond2: Ref
   var anon$2: Ref
   var anon$3: Ref
-  anon$1 := con$c$C$T$C()
-  anon$0 := havoc$T$Int()
+  anon$1 := con$c$C$t$C()
+  anon$0 := havoc$t$Int()
   l0$cond1 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType()))
-  anon$3 := con$c$D$T$D()
-  unfold acc(p$c$D$shared(anon$3), wildcard)
+  anon$3 := con$c$D$t$D()
+  unfold acc(pred$c$D$shared(anon$3), wildcard)
   anon$2 := anon$3.bf$field
   l0$cond2 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType()))
   assert df$rt$boolFromRef(l0$cond1)
@@ -83,8 +83,9 @@ method f$extractPublic$TF$T$Unit() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
+method g$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
 
 
-method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
+method s$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
@@ -1,23 +1,23 @@
 /as_type_contract.kt:(150,154): info: Generated Viper text for getX:
 field bf$x: Ref
 
-method f$getX$TF$T$Any$NT$Int(p$a: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
+method f$getX$t$F$t$Any$t$N$Int(par$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 != df$rt$nullValue() ==>
-    !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
+    !df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$c$IntHolder())
 {
   var anon$0: Ref
-  if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())) {
-    anon$0 := p$a
+  if (df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$c$IntHolder())) {
+    anon$0 := par$a
   } else {
     anon$0 := df$rt$nullValue()}
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$c$IntHolder()))
   inhale anon$0 != df$rt$nullValue() ==>
-    acc(p$c$IntHolder$shared(anon$0), wildcard)
+    acc(pred$c$IntHolder$shared(anon$0), wildcard)
   if (anon$0 != df$rt$nullValue()) {
     var anon$1: Ref
-    unfold acc(p$c$IntHolder$shared(anon$0), wildcard)
+    unfold acc(pred$c$IntHolder$shared(anon$0), wildcard)
     anon$1 := anon$0.bf$x
     ret$0 := anon$1
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
@@ -1,9 +1,9 @@
 /cond_effects.kt:(121,146): info: Generated Viper text for compoundConditionalEffect:
-method f$compoundConditionalEffect$TF$T$Boolean$T$Unit(p$b: Ref)
+method f$compoundConditionalEffect$t$F$t$Boolean$t$Unit(par$b: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
-  ensures true ==> df$rt$boolFromRef(p$b) && false
+  ensures true ==> df$rt$boolFromRef(par$b) && false
 {
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -12,13 +12,14 @@ method f$compoundConditionalEffect$TF$T$Boolean$T$Unit(p$b: Ref)
 /cond_effects.kt:(190,220): warning: Cannot verify that if the function returns then (b && false).
 
 /cond_effects.kt:(271,287): info: Generated Viper text for mayReturnNonNull:
-method f$mayReturnNonNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+method f$mayReturnNonNull$t$F$t$N$Any$t$N$Any(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 == df$rt$nullValue() ==>
-    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+    df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -26,13 +27,13 @@ method f$mayReturnNonNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(328,360): warning: Cannot verify that if a null value is returned then x is Int.
 
 /cond_effects.kt:(424,437): info: Generated Viper text for mayReturnNull:
-method f$mayReturnNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+method f$mayReturnNull$t$F$t$N$Any$t$N$Any(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
   ensures ret$0 != df$rt$nullValue() ==>
-    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+    df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -40,18 +41,19 @@ method f$mayReturnNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
 /cond_effects.kt:(478,513): warning: Cannot verify that if a non-null value is returned then x is Int.
 
 /cond_effects.kt:(723,741): info: Generated Viper text for isNullOrEmptyWrong:
-method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
+method f$isNullOrEmptyWrong$t$F$t$N$CharSequence$t$Boolean(par$seq: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
-  ensures df$rt$boolFromRef(ret$0) == false ==> p$seq != df$rt$nullValue()
+  ensures df$rt$boolFromRef(ret$0) == false ==>
+    par$seq != df$rt$nullValue()
 {
-  inhale p$seq != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
-  if (!(p$seq == df$rt$nullValue())) {
+  inhale par$seq != df$rt$nullValue() ==>
+    acc(pred$pkg$kotlin$c$CharSequence$shared(par$seq), wildcard)
+  if (!(par$seq == df$rt$nullValue())) {
     var anon$0: Ref
     var anon$1: Ref
-    anon$1 := pg$public$length(p$seq)
+    anon$1 := g$public$length(par$seq)
     anon$0 := anon$1
     inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
     ret$0 := sp$notBool(df$rt$boolToRef(df$rt$intFromRef(anon$0) == 0))
@@ -61,25 +63,25 @@ method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
   label lbl$ret$0
 }
 
-method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+method g$public$length(this$dispatch: Ref) returns (ret: Ref)
 
 
 /cond_effects.kt:(796,832): warning: Cannot verify that if a false value is returned then seq != null.
 
 /cond_effects.kt:(925,942): info: Generated Viper text for recursiveContract:
-method f$recursiveContract$TF$T$Int$NT$Any$T$Boolean(p$n: Ref, p$x: Ref)
+method f$recursiveContract$t$F$t$Int$t$N$Any$t$Boolean(par$n: Ref, par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType())
+    df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$stringType())
 {
-  if (df$rt$intFromRef(p$n) == 0) {
-    ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType()))
+  if (df$rt$intFromRef(par$n) == 0) {
+    ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType()))
   } else {
-    ret$0 := f$recursiveContract$TF$T$Int$NT$Any$T$Boolean(sp$minusInts(p$n,
-      df$rt$intToRef(1)), p$x)}
+    ret$0 := f$recursiveContract$t$F$t$Int$t$N$Any$t$Boolean(sp$minusInts(par$n,
+      df$rt$intToRef(1)), par$x)}
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
@@ -1,12 +1,12 @@
 /contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
-method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
+method f$c$Class$is2$t$F$t$Class$t$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl1())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Class$shared(this$dispatch), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -15,7 +15,7 @@ method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
 /contracts_with_receivers.kt:(196,239): warning: Cannot verify that if a true value is returned then this is Impl1.
 
 /contracts_with_receivers.kt:(341,359): info: Generated Viper text for is1butWithDispatch:
-method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: Ref,
+method f$c$Class$is1butWithDispatch$t$F$t$Class$t$Class$t$Boolean(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
@@ -24,8 +24,8 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  inhale acc(pred$c$Class$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -34,13 +34,14 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
 /contracts_with_receivers.kt:(404,460): warning: Cannot verify that if a true value is returned then this is Impl2.
 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
-method f$is1$TF$T$Class$T$Boolean(this$extension: Ref) returns (ret$0: Ref)
+method f$is1$t$F$t$Class$t$Boolean(this$extension: Ref)
+  returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  inhale acc(pred$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/is_type_contract.fir.diag.txt
@@ -1,11 +1,11 @@
 /is_type_contract.kt:(162,183): info: Generated Viper text for unverifiableTypeCheck:
-method f$unverifiableTypeCheck$TF$NT$Int$T$Boolean(p$x: Ref)
+method f$unverifiableTypeCheck$t$F$t$N$Int$t$Boolean(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
-  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
+  ensures true ==> df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$unitType())
 {
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$stringType()))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -13,11 +13,11 @@ method f$unverifiableTypeCheck$TF$NT$Int$T$Boolean(p$x: Ref)
 /is_type_contract.kt:(227,256): warning: Cannot verify that if the function returns then x is Unit.
 
 /is_type_contract.kt:(330,352): info: Generated Viper text for nullableNotNonNullable:
-method f$nullableNotNonNullable$TF$NT$Int$T$Unit(p$x: Ref)
+method f$nullableNotNonNullable$t$F$t$N$Int$t$Unit(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
-  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  ensures true ==> df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
 {
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
@@ -1,28 +1,28 @@
 /list.kt:(91,110): info: Generated Viper text for empty_list_expr_get:
 field sp$size: Ref
 
-method f$empty_list_expr_get$TF$T$Unit() returns (ret$0: Ref)
+method f$empty_list_expr_get$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$s: Ref
   var anon$0: Ref
-  anon$0 := f$pkg$kotlin_collections$emptyList$TF$T$List()
-  l0$s := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(anon$0,
+  anon$0 := f$pkg$kotlin_collections$emptyList$t$F$t$List()
+  l0$s := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(anon$0,
     df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -30,11 +30,11 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
+method f$pkg$kotlin_collections$emptyList$t$F$t$List() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(ret.sp$size) == 0
 
 
@@ -43,28 +43,28 @@ method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
 /list.kt:(168,182): info: Generated Viper text for empty_list_get:
 field sp$size: Ref
 
-method f$empty_list_get$TF$T$Unit() returns (ret$0: Ref)
+method f$empty_list_get$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$myList: Ref
   var l0$s: Ref
-  l0$myList := f$pkg$kotlin_collections$emptyList$TF$T$List()
-  l0$s := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(l0$myList,
+  l0$myList := f$pkg$kotlin_collections$emptyList$t$F$t$List()
+  l0$s := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(l0$myList,
     df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -72,11 +72,11 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
+method f$pkg$kotlin_collections$emptyList$t$F$t$List() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(ret.sp$size) == 0
 
 
@@ -85,16 +85,16 @@ method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
 /list.kt:(270,281): info: Generated Viper text for unsafe_last:
 field sp$size: Ref
 
-method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -102,20 +102,20 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
     old(df$rt$intFromRef(this$dispatch.sp$size))
 
 
-method f$unsafe_last$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
-  requires acc(p$l.sp$size, write)
-  requires df$rt$intFromRef(p$l.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
-  ensures acc(p$l.sp$size, write)
-  ensures df$rt$intFromRef(p$l.sp$size) >= 0
+method f$unsafe_last$t$F$t$List$t$Int(par$l: Ref) returns (ret$0: Ref)
+  requires acc(par$l.sp$size, write)
+  requires df$rt$intFromRef(par$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$c$pkg$kotlin_collections$List())
+  ensures acc(par$l.sp$size, write)
+  ensures df$rt$intFromRef(par$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
-  anon$0 := p$l.sp$size
+  inhale acc(pred$pkg$kotlin_collections$c$List$shared(par$l), wildcard)
+  anon$0 := par$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
-  ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$l, sp$minusInts(anon$0,
-    df$rt$intToRef(1)))
+  ret$0 := f$pkg$kotlin_collections$c$List$get$t$F$t$List$t$Int$t$Int(par$l,
+    sp$minusInts(anon$0, df$rt$intToRef(1)))
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -125,32 +125,32 @@ method f$unsafe_last$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
 /list.kt:(350,357): info: Generated Viper text for add_get:
 field sp$size: Ref
 
-method f$add_get$TF$T$MutableList$T$Unit(p$l: Ref) returns (ret$0: Ref)
-  requires acc(p$l.sp$size, write)
-  requires df$rt$intFromRef(p$l.sp$size) >= 0
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
-  ensures acc(p$l.sp$size, write)
-  ensures df$rt$intFromRef(p$l.sp$size) >= 0
+method f$add_get$t$F$t$MutableList$t$Unit(par$l: Ref) returns (ret$0: Ref)
+  requires acc(par$l.sp$size, write)
+  requires df$rt$intFromRef(par$l.sp$size) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$c$pkg$kotlin_collections$MutableList())
+  ensures acc(par$l.sp$size, write)
+  ensures df$rt$intFromRef(par$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
-  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(p$l,
+  inhale acc(pred$pkg$kotlin_collections$c$MutableList$shared(par$l), wildcard)
+  anon$0 := f$pkg$kotlin_collections$c$MutableList$add$t$F$t$MutableList$t$Int$t$Boolean(par$l,
     df$rt$intToRef(1))
-  l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(p$l,
+  l0$n := f$pkg$kotlin_collections$c$MutableList$get$t$F$t$MutableList$t$Int$t$Int(par$l,
     df$rt$intToRef(1))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(this$dispatch: Ref,
-  p$element: Ref)
+method f$pkg$kotlin_collections$c$MutableList$add$t$F$t$MutableList$t$Int$t$Boolean(this$dispatch: Ref,
+  par$element: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
-  requires df$rt$isSubtype(df$rt$typeOf(p$element), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$element), df$rt$intType())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -158,16 +158,16 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boole
     old(df$rt$intFromRef(this$dispatch.sp$size)) + 1
 
 
-method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(this$dispatch: Ref,
-  p$index: Ref)
+method f$pkg$kotlin_collections$c$MutableList$get$t$F$t$MutableList$t$Int$t$Int(this$dispatch: Ref,
+  par$index: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
-  requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
-  requires df$rt$intFromRef(p$index) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$index), df$rt$intType())
+  requires df$rt$intFromRef(par$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
-    df$rt$intFromRef(p$index)
+    df$rt$intFromRef(par$index)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
@@ -180,47 +180,47 @@ method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(t
 /list.kt:(432,446): info: Generated Viper text for empty_list_sub:
 field sp$size: Ref
 
-method f$empty_list_sub$TF$T$Unit() returns (ret$0: Ref)
+method f$empty_list_sub$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$l: Ref
   var anon$0: Ref
-  anon$0 := f$pkg$kotlin_collections$emptyList$TF$T$List()
-  l0$l := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(anon$0,
+  anon$0 := f$pkg$kotlin_collections$emptyList$t$F$t$List()
+  l0$l := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(anon$0,
     df$rt$intToRef(0), df$rt$intToRef(1))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this$dispatch: Ref,
-  p$fromIndex: Ref, p$toIndex: Ref)
+method f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(this$dispatch: Ref,
+  par$fromIndex: Ref, par$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
-  requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
-  requires df$rt$intFromRef(p$fromIndex) >= 0
-  requires df$rt$intFromRef(p$toIndex) <=
+  requires df$rt$isSubtype(df$rt$typeOf(par$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$toIndex), df$rt$intType())
+  requires df$rt$intFromRef(par$fromIndex) <= df$rt$intFromRef(par$toIndex)
+  requires df$rt$intFromRef(par$fromIndex) >= 0
+  requires df$rt$intFromRef(par$toIndex) <=
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
   ensures df$rt$intFromRef(ret.sp$size) ==
-    df$rt$intFromRef(p$toIndex) - df$rt$intFromRef(p$fromIndex)
+    df$rt$intFromRef(par$toIndex) - df$rt$intFromRef(par$fromIndex)
 
 
-method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
+method f$pkg$kotlin_collections$emptyList$t$F$t$List() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(ret.sp$size) == 0
 
 
@@ -229,47 +229,47 @@ method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
 /list.kt:(515,538): info: Generated Viper text for empty_list_sub_negative:
 field sp$size: Ref
 
-method f$empty_list_sub_negative$TF$T$Unit() returns (ret$0: Ref)
+method f$empty_list_sub_negative$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$l: Ref
   var anon$0: Ref
-  anon$0 := f$pkg$kotlin_collections$emptyList$TF$T$List()
-  l0$l := f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(anon$0,
+  anon$0 := f$pkg$kotlin_collections$emptyList$t$F$t$List()
+  l0$l := f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(anon$0,
     df$rt$intToRef(-1), df$rt$intToRef(1))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this$dispatch: Ref,
-  p$fromIndex: Ref, p$toIndex: Ref)
+method f$pkg$kotlin_collections$c$List$subList$t$F$t$List$t$Int$t$Int$t$List(this$dispatch: Ref,
+  par$fromIndex: Ref, par$toIndex: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
-  requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
-  requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
-  requires df$rt$intFromRef(p$fromIndex) >= 0
-  requires df$rt$intFromRef(p$toIndex) <=
+  requires df$rt$isSubtype(df$rt$typeOf(par$fromIndex), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$toIndex), df$rt$intType())
+  requires df$rt$intFromRef(par$fromIndex) <= df$rt$intFromRef(par$toIndex)
+  requires df$rt$intFromRef(par$fromIndex) >= 0
+  requires df$rt$intFromRef(par$toIndex) <=
     df$rt$intFromRef(this$dispatch.sp$size)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
   ensures df$rt$intFromRef(ret.sp$size) ==
-    df$rt$intFromRef(p$toIndex) - df$rt$intFromRef(p$fromIndex)
+    df$rt$intFromRef(par$toIndex) - df$rt$intFromRef(par$fromIndex)
 
 
-method f$pkg$kotlin_collections$emptyList$TF$T$List() returns (ret: Ref)
+method f$pkg$kotlin_collections$emptyList$t$F$t$List() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$pkg$kotlin_collections$List())
   ensures acc(ret.sp$size, write)
   ensures df$rt$intFromRef(ret.sp$size) >= 0
-  ensures acc(p$pkg$kotlin_collections$c$List$shared(ret), wildcard)
+  ensures acc(pred$pkg$kotlin_collections$c$List$shared(ret), wildcard)
   ensures df$rt$intFromRef(ret.sp$size) == 0
 
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_booleans.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_booleans.kt:(121,146): info: Generated Viper text for incorrectly_returns_false:
-method f$incorrectly_returns_false$TF$T$Boolean() returns (ret$0: Ref)
+method f$incorrectly_returns_false$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -11,7 +11,7 @@ method f$incorrectly_returns_false$TF$T$Boolean() returns (ret$0: Ref)
 /returns_booleans.kt:(183,196): warning: Function may return a false value.
 
 /returns_booleans.kt:(264,288): info: Generated Viper text for incorrectly_returns_true:
-method f$incorrectly_returns_true$TF$T$Boolean() returns (ret$0: Ref)
+method f$incorrectly_returns_true$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false
 {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_not_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_not_null.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_not_null.kt:(121,133): info: Generated Viper text for returns_null:
-method f$returns_null$TF$NT$Int() returns (ret$0: Ref)
+method f$returns_null$t$F$t$N$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 != df$rt$nullValue()
 {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_null.fir.diag.txt
@@ -1,7 +1,7 @@
 /returns_null.kt:(121,146): info: Generated Viper text for returns_null_unverifiable:
-method f$returns_null_unverifiable$TF$NT$Int$NT$Int(p$x: Ref)
+method f$returns_null_unverifiable$t$F$t$N$Int$t$N$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures true ==> false
 {
@@ -13,13 +13,13 @@ method f$returns_null_unverifiable$TF$NT$Int$NT$Int(p$x: Ref)
 /returns_null.kt:(187,210): warning: Cannot verify that if the function returns then false.
 
 /returns_null.kt:(277,302): info: Generated Viper text for non_nullable_returns_null:
-method f$non_nullable_returns_null$TF$T$Int$T$Int(p$x: Ref)
+method f$non_nullable_returns_null$t$F$t$Int$t$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures ret$0 == df$rt$nullValue()
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
@@ -1,7 +1,7 @@
 /viper_verify.kt:(125,137): info: Generated Viper text for verify_false:
 field bf$size: Ref
 
-method f$verify_false$TF$T$Unit() returns (ret$0: Ref)
+method f$verify_false$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   assert false
@@ -14,7 +14,7 @@ method f$verify_false$TF$T$Unit() returns (ret$0: Ref)
 /viper_verify.kt:(181,196): info: Generated Viper text for verify_compound:
 field bf$size: Ref
 
-method f$verify_compound$TF$T$Unit() returns (ret$0: Ref)
+method f$verify_compound$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
@@ -1,32 +1,33 @@
 /as_type_contract.kt:(152,162): info: Generated Viper text for asOperator:
-method f$asOperator$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+method f$asOperator$t$F$t$Foo$t$Bar(par$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
-  ensures acc(p$c$Bar$shared(ret$0), wildcard)
-  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
+  ensures acc(pred$c$Bar$shared(ret$0), wildcard)
+  ensures true ==> df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Bar())
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
-  inhale acc(p$c$Bar$shared(p$foo), wildcard)
-  ret$0 := p$foo
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Bar())
+  inhale acc(pred$c$Bar$shared(par$foo), wildcard)
+  ret$0 := par$foo
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /as_type_contract.kt:(307,321): info: Generated Viper text for safeAsOperator:
-method f$safeAsOperator$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+method f$safeAsOperator$t$F$t$Foo$t$N$Bar(par$foo: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(ret$0), wildcard)
+    acc(pred$c$Bar$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==>
-    df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
+    df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Bar())
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Bar$shared(p$foo), wildcard)
-  ret$0 := p$foo
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$nullable(df$rt$c$Bar()))
+  inhale par$foo != df$rt$nullValue() ==>
+    acc(pred$c$Bar$shared(par$foo), wildcard)
+  ret$0 := par$foo
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -34,25 +35,25 @@ method f$safeAsOperator$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
 /as_type_contract.kt:(504,508): info: Generated Viper text for getX:
 field bf$x: Ref
 
-method f$getX$TF$T$Any$NT$Int(p$a: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$anyType())
+method f$getX$t$F$t$Any$t$N$Int(par$a: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 != df$rt$nullValue() ==>
-    df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
+    df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$c$IntHolder())
   ensures ret$0 == df$rt$nullValue() ==>
-    !df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())
+    !df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$c$IntHolder())
 {
   var anon$0: Ref
-  if (df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$IntHolder())) {
-    anon$0 := p$a
+  if (df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$c$IntHolder())) {
+    anon$0 := par$a
   } else {
     anon$0 := df$rt$nullValue()}
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$c$IntHolder()))
   inhale anon$0 != df$rt$nullValue() ==>
-    acc(p$c$IntHolder$shared(anon$0), wildcard)
+    acc(pred$c$IntHolder$shared(anon$0), wildcard)
   if (anon$0 != df$rt$nullValue()) {
     var anon$1: Ref
-    unfold acc(p$c$IntHolder$shared(anon$0), wildcard)
+    unfold acc(pred$c$IntHolder$shared(anon$0), wildcard)
     anon$1 := anon$0.bf$x
     ret$0 := anon$1
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
@@ -1,19 +1,19 @@
 /contracts_with_receivers.kt:(148,151): info: Generated Viper text for is2:
-method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
+method f$c$Class$is2$t$F$t$Class$t$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Class$shared(this$dispatch), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /contracts_with_receivers.kt:(341,359): info: Generated Viper text for is1butWithDispatch:
-method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: Ref,
+method f$c$Class$is1butWithDispatch$t$F$t$Class$t$Class$t$Boolean(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
@@ -22,21 +22,22 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  inhale acc(pred$c$Class$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
-method f$is1$TF$T$Class$T$Boolean(this$extension: Ref) returns (ret$0: Ref)
+method f$is1$t$F$t$Class$t$Boolean(this$extension: Ref)
+  returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
+  inhale acc(pred$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -1,17 +1,17 @@
 /is_type_contract.kt:(157,165): info: Generated Viper text for isString:
-method f$isString$TF$NT$Any$T$Boolean(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+method f$isString$t$F$t$N$Any$t$Boolean(par$x: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType())
+    df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$stringType())
 {
-  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$stringType()))
+  ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$stringType()))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /is_type_contract.kt:(322,330): info: Generated Viper text for isString:
-method f$isString$TF$T$Any$T$Boolean(this$extension: Ref)
+method f$isString$t$F$t$Any$t$Boolean(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -24,11 +24,12 @@ method f$isString$TF$T$Any$T$Boolean(this$extension: Ref)
 }
 
 /is_type_contract.kt:(491,508): info: Generated Viper text for subtypeTransitive:
-method f$subtypeTransitive$TF$T$Unit$T$Unit(p$x: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$unitType())
+method f$subtypeTransitive$t$F$t$Unit$t$Unit(par$x: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$unitType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==>
-    df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
+    df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$anyType()))
 {
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -37,18 +38,18 @@ method f$subtypeTransitive$TF$T$Unit$T$Unit(p$x: Ref) returns (ret$0: Ref)
 /is_type_contract.kt:(686,707): info: Generated Viper text for constructorReturnType:
 field bf$bar: Ref
 
-method con$c$Foo$T$Foo() returns (ret: Ref)
+method con$c$Foo$t$Foo() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Foo())
-  ensures acc(p$c$Foo$shared(ret), wildcard)
-  ensures acc(p$c$Foo$unique(ret), write)
+  ensures acc(pred$c$Foo$shared(ret), wildcard)
+  ensures acc(pred$c$Foo$unique(ret), write)
 
 
-method f$constructorReturnType$TF$T$Boolean() returns (ret$0: Ref)
+method f$constructorReturnType$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
   var anon$0: Ref
-  anon$0 := con$c$Foo$T$Foo()
+  anon$0 := con$c$Foo$t$Foo()
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Foo()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -57,12 +58,13 @@ method f$constructorReturnType$TF$T$Boolean() returns (ret$0: Ref)
 /is_type_contract.kt:(832,848): info: Generated Viper text for subtypeSuperType:
 field bf$bar: Ref
 
-method f$subtypeSuperType$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+method f$subtypeSuperType$t$F$t$Bar$t$Unit(par$bar: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$bar), df$rt$c$Bar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
-  ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Foo())
+  ensures true ==> df$rt$isSubtype(df$rt$typeOf(par$bar), df$rt$c$Foo())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
+  inhale acc(pred$c$Bar$shared(par$bar), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -70,15 +72,15 @@ method f$subtypeSuperType$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
 /is_type_contract.kt:(965,976): info: Generated Viper text for typeOfField:
 field bf$bar: Ref
 
-method f$typeOfField$TF$T$Foo$T$Boolean(p$foo: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+method f$typeOfField$t$F$t$Foo$t$Boolean(par$foo: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$foo), df$rt$c$Foo())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
-  unfold acc(p$c$Foo$shared(p$foo), wildcard)
-  anon$0 := p$foo.bf$bar
+  inhale acc(pred$c$Foo$shared(par$foo), wildcard)
+  unfold acc(pred$c$Foo$shared(par$foo), wildcard)
+  anon$0 := par$foo.bf$bar
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Bar()))
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
@@ -1,5 +1,5 @@
 /returns_booleans.kt:(121,133): info: Generated Viper text for returns_true:
-method f$returns_true$TF$T$Boolean() returns (ret$0: Ref)
+method f$returns_true$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures true
   ensures df$rt$boolFromRef(ret$0) == true
@@ -10,7 +10,7 @@ method f$returns_true$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 /returns_booleans.kt:(268,281): info: Generated Viper text for returns_false:
-method f$returns_false$TF$T$Boolean() returns (ret$0: Ref)
+method f$returns_false$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures true
   ensures df$rt$boolFromRef(ret$0) == false
@@ -21,12 +21,12 @@ method f$returns_false$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 /returns_booleans.kt:(418,435): info: Generated Viper text for conditional_basic:
-method f$conditional_basic$TF$T$Boolean$T$Boolean(p$b: Ref)
+method f$conditional_basic$t$F$t$Boolean$t$Boolean(par$b: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> true
-  ensures df$rt$boolFromRef(ret$0) == false ==> df$rt$boolFromRef(p$b)
+  ensures df$rt$boolFromRef(ret$0) == false ==> df$rt$boolFromRef(par$b)
 {
   ret$0 := df$rt$boolToRef(true)
   goto lbl$ret$0
@@ -34,16 +34,17 @@ method f$conditional_basic$TF$T$Boolean$T$Boolean(p$b: Ref)
 }
 
 /returns_booleans.kt:(612,636): info: Generated Viper text for binary_logic_expressions:
-method f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$a: Ref,
-  p$b: Ref)
+method f$binary_logic_expressions$t$F$t$Boolean$t$Boolean$t$Boolean(par$a: Ref,
+  par$b: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false ==>
-    df$rt$boolFromRef(p$b) && false
+    df$rt$boolFromRef(par$b) && false
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    (true || df$rt$boolFromRef(p$a)) && (df$rt$boolFromRef(p$b) || true)
+    (true || df$rt$boolFromRef(par$a)) &&
+    (df$rt$boolFromRef(par$b) || true)
 {
   ret$0 := df$rt$boolToRef(true)
   goto lbl$ret$0
@@ -51,13 +52,14 @@ method f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$a: Ref,
 }
 
 /returns_booleans.kt:(855,866): info: Generated Viper text for logical_not:
-method f$logical_not$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$logical_not$t$F$t$Boolean$t$Boolean(par$b: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
-    !df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$b)
+    !df$rt$boolFromRef(par$b) && df$rt$boolFromRef(par$b)
   ensures df$rt$boolFromRef(ret$0) == false ==>
-    df$rt$boolFromRef(p$b) || !df$rt$boolFromRef(p$b)
+    df$rt$boolFromRef(par$b) || !df$rt$boolFromRef(par$b)
 {
   ret$0 := df$rt$boolToRef(false)
   goto lbl$ret$0
@@ -65,26 +67,28 @@ method f$logical_not$TF$T$Boolean$T$Boolean(p$b: Ref) returns (ret$0: Ref)
 }
 
 /returns_booleans.kt:(1052,1075): info: Generated Viper text for call_fun_with_contracts:
-method f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$a: Ref,
-  p$b: Ref)
+method f$binary_logic_expressions$t$F$t$Boolean$t$Boolean$t$Boolean(par$a: Ref,
+  par$b: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$a), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
   ensures df$rt$boolFromRef(ret) == false ==>
-    df$rt$boolFromRef(p$b) && false
+    df$rt$boolFromRef(par$b) && false
   ensures df$rt$boolFromRef(ret) == true ==>
-    (true || df$rt$boolFromRef(p$a)) && (df$rt$boolFromRef(p$b) || true)
+    (true || df$rt$boolFromRef(par$a)) &&
+    (df$rt$boolFromRef(par$b) || true)
 
 
-method f$call_fun_with_contracts$TF$T$Boolean$T$Boolean(p$b: Ref)
+method f$call_fun_with_contracts$t$F$t$Boolean$t$Boolean(par$b: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
   var l0$a: Ref
-  l0$a := f$binary_logic_expressions$TF$T$Boolean$T$Boolean$T$Boolean(p$b, p$b)
+  l0$a := f$binary_logic_expressions$t$F$t$Boolean$t$Boolean$t$Boolean(par$b,
+    par$b)
   ret$0 := l0$a
   goto lbl$ret$0
   label lbl$ret$0
@@ -93,7 +97,7 @@ method f$call_fun_with_contracts$TF$T$Boolean$T$Boolean(p$b: Ref)
 /returns_booleans.kt:(1268,1281): info: Generated Viper text for isNullOrEmpty:
 field sp$size: Ref
 
-method f$isNullOrEmpty$TF$NT$Collection$T$Boolean(this$extension: Ref)
+method f$isNullOrEmpty$t$F$t$N$Collection$t$Boolean(this$extension: Ref)
   returns (ret$0: Ref)
   requires this$extension != df$rt$nullValue() ==>
     acc(this$extension.sp$size, write)
@@ -109,16 +113,16 @@ method f$isNullOrEmpty$TF$NT$Collection$T$Boolean(this$extension: Ref)
     this$extension != df$rt$nullValue()
 {
   inhale this$extension != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin_collections$c$Collection$shared(this$extension), wildcard)
+    acc(pred$pkg$kotlin_collections$c$Collection$shared(this$extension), wildcard)
   if (this$extension == df$rt$nullValue()) {
     ret$0 := df$rt$boolToRef(true)
   } else {
-    ret$0 := f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection$T$Boolean(this$extension)}
+    ret$0 := f$pkg$kotlin_collections$c$Collection$isEmpty$t$F$t$Collection$t$Boolean(this$extension)}
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection$T$Boolean(this$dispatch: Ref)
+method f$pkg$kotlin_collections$c$Collection$isEmpty$t$F$t$Collection$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -132,3 +136,4 @@ method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection$T$Boolean(t
     df$rt$intFromRef(this$dispatch.sp$size) == 0
   ensures !df$rt$boolFromRef(ret) ==>
     df$rt$intFromRef(this$dispatch.sp$size) > 0
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_null.fir.diag.txt
@@ -1,7 +1,7 @@
 /returns_null.kt:(121,140): info: Generated Viper text for simple_returns_null:
-method f$simple_returns_null$TF$NT$Int$NT$Int(p$x: Ref)
+method f$simple_returns_null$t$F$t$N$Int$t$N$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==> false
@@ -12,63 +12,63 @@ method f$simple_returns_null$TF$NT$Int$NT$Int(p$x: Ref)
 }
 
 /returns_null.kt:(300,320): info: Generated Viper text for returns_null_implies:
-method f$returns_null_implies$TF$NT$Boolean$NT$Boolean(p$x: Ref)
+method f$returns_null_implies$t$F$t$N$Boolean$t$N$Boolean(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$boolType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$boolType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$boolType()))
-  ensures ret$0 == df$rt$nullValue() ==> p$x == df$rt$nullValue()
-  ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
+  ensures ret$0 == df$rt$nullValue() ==> par$x == df$rt$nullValue()
+  ensures ret$0 != df$rt$nullValue() ==> par$x != df$rt$nullValue()
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /returns_null.kt:(511,531): info: Generated Viper text for returns_null_with_if:
-method f$returns_null_with_if$TF$NT$Int$NT$Int$NT$Int$NT$Int(p$x: Ref, p$y: Ref,
-  p$z: Ref)
+method f$returns_null_with_if$t$F$t$N$Int$t$N$Int$t$N$Int$t$N$Int(par$x: Ref,
+  par$y: Ref, par$z: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$nullable(df$rt$intType()))
-  requires df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$nullable(df$rt$intType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$z), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==>
-    p$x == df$rt$nullValue() && p$y == df$rt$nullValue() ||
-    p$z == df$rt$nullValue()
+    par$x == df$rt$nullValue() && par$y == df$rt$nullValue() ||
+    par$z == df$rt$nullValue()
   ensures ret$0 != df$rt$nullValue() ==>
-    p$x != df$rt$nullValue() || p$y != df$rt$nullValue()
+    par$x != df$rt$nullValue() || par$y != df$rt$nullValue()
 {
-  if (p$x == df$rt$nullValue()) {
-    ret$0 := p$y
+  if (par$x == df$rt$nullValue()) {
+    ret$0 := par$y
     goto lbl$ret$0
   } else {
-    ret$0 := p$z
+    ret$0 := par$z
     goto lbl$ret$0
   }
   label lbl$ret$0
 }
 
 /returns_null.kt:(833,862): info: Generated Viper text for non_nullable_returns_not_null:
-method f$non_nullable_returns_not_null$TF$T$Int$T$Int(p$x: Ref)
+method f$non_nullable_returns_not_null$t$F$t$Int$t$Int(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures ret$0 != df$rt$nullValue()
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /returns_null.kt:(981,1010): info: Generated Viper text for non_nullable_compared_to_null:
-method f$non_nullable_compared_to_null$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref)
+method f$non_nullable_compared_to_null$t$F$t$Int$t$Int$t$Int(par$x: Ref, par$y: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
-  ensures true ==> p$y == df$rt$nullValue() || p$x != df$rt$nullValue()
+  ensures true ==> par$y == df$rt$nullValue() || par$x != df$rt$nullValue()
 {
-  ret$0 := p$x
+  ret$0 := par$x
   goto lbl$ret$0
   label lbl$ret$0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/simple.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/simple.fir.diag.txt
@@ -1,5 +1,5 @@
 /simple.kt:(84,100): info: Generated Viper text for without_contract:
-method f$without_contract$TF$T$Unit() returns (ret$0: Ref)
+method f$without_contract$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -7,7 +7,7 @@ method f$without_contract$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /simple.kt:(148,161): info: Generated Viper text for with_contract:
-method f$with_contract$TF$T$Unit() returns (ret$0: Ref)
+method f$with_contract$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true
 {

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
@@ -1,7 +1,7 @@
 /custom_run_functions.kt:(1194,1200): info: Generated Viper text for useRun:
 field bf$size: Ref
 
-method f$useRun$TF$T$Unit() returns (ret$0: Ref)
+method f$useRun$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$genericResult: Ref
@@ -361,17 +361,17 @@ method f$useRun$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /custom_run_functions.kt:(2354,2369): info: Generated Viper text for complexScenario:
-method f$complexScenario$TF$T$Boolean$T$Boolean(p$arg: Ref)
+method f$complexScenario$t$F$t$Boolean$t$Boolean(par$arg: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
-  ensures df$rt$boolFromRef(ret$0) == true ==> df$rt$boolFromRef(p$arg)
-  ensures df$rt$boolFromRef(ret$0) == false ==> !df$rt$boolFromRef(p$arg)
+  ensures df$rt$boolFromRef(ret$0) == true ==> df$rt$boolFromRef(par$arg)
+  ensures df$rt$boolFromRef(ret$0) == false ==> !df$rt$boolFromRef(par$arg)
 {
   var anon$11: Ref
   var anon$12: Ref
   var ret$1: Ref
-  if (df$rt$boolFromRef(p$arg)) {
+  if (df$rt$boolFromRef(par$arg)) {
     var anon$13: Ref
     var ret$2: Ref
     var anon$14: Ref
@@ -538,13 +538,13 @@ field bf$member: Ref
 
 field bf$size: Ref
 
-method con$c$CustomClass$T$CustomClass() returns (ret: Ref)
+method con$c$CustomClass$t$CustomClass() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$CustomClass())
-  ensures acc(p$c$CustomClass$shared(ret), wildcard)
-  ensures acc(p$c$CustomClass$unique(ret), write)
+  ensures acc(pred$c$CustomClass$shared(ret), wildcard)
+  ensures acc(pred$c$CustomClass$unique(ret), write)
 
 
-method f$testCustomClass$TF$T$Unit() returns (ret$0: Ref)
+method f$testCustomClass$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$custom: Ref
@@ -559,8 +559,8 @@ method f$testCustomClass$TF$T$Unit() returns (ret$0: Ref)
   var ret$3: Ref
   var anon$5: Ref
   var ret$4: Ref
-  l0$custom := con$c$CustomClass$T$CustomClass()
-  unfold acc(p$c$CustomClass$shared(l0$custom), wildcard)
+  l0$custom := con$c$CustomClass$t$CustomClass()
+  unfold acc(pred$c$CustomClass$shared(l0$custom), wildcard)
   ret$2 := l0$custom.bf$member
   goto lbl$ret$2
   label lbl$ret$2
@@ -572,7 +572,7 @@ method f$testCustomClass$TF$T$Unit() returns (ret$0: Ref)
   anon$1 := ret$1
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
-  unfold acc(p$c$CustomClass$shared(l0$custom), wildcard)
+  unfold acc(pred$c$CustomClass$shared(l0$custom), wildcard)
   ret$4 := l0$custom.bf$member
   goto lbl$ret$4
   label lbl$ret$4

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/inline_returns.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/inline_returns.fir.diag.txt
@@ -1,7 +1,7 @@
 /inline_returns.kt:(324,337): info: Generated Viper text for simple_return:
 field bf$size: Ref
 
-method f$simple_return$TF$T$Unit() returns (ret$0: Ref)
+method f$simple_return$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$cond1: Ref
@@ -22,7 +22,7 @@ method f$simple_return$TF$T$Unit() returns (ret$0: Ref)
 }
 
 /inline_returns.kt:(434,448): info: Generated Viper text for unnamed_return:
-method f$unnamed_return$TF$T$Boolean() returns (ret$0: Ref)
+method f$unnamed_return$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -44,7 +44,7 @@ method f$unnamed_return$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 /inline_returns.kt:(605,623): info: Generated Viper text for named_local_return:
-method f$named_local_return$TF$T$Boolean() returns (ret$0: Ref)
+method f$named_local_return$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -66,7 +66,7 @@ method f$named_local_return$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 /inline_returns.kt:(785,806): info: Generated Viper text for named_nonlocal_return:
-method f$named_nonlocal_return$TF$T$Boolean() returns (ret$0: Ref)
+method f$named_nonlocal_return$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -88,7 +88,7 @@ method f$named_nonlocal_return$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 /inline_returns.kt:(985,1007): info: Generated Viper text for double_nonlocal_return:
-method f$double_nonlocal_return$TF$T$Boolean() returns (ret$0: Ref)
+method f$double_nonlocal_return$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -124,7 +124,7 @@ method f$double_nonlocal_return$TF$T$Boolean() returns (ret$0: Ref)
 }
 
 /inline_returns.kt:(1358,1386): info: Generated Viper text for named_double_nonlocal_return:
-method f$named_double_nonlocal_return$TF$T$Boolean() returns (ret$0: Ref)
+method f$named_double_nonlocal_return$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
@@ -1,7 +1,7 @@
 /scoped_receivers.kt:(407,433): info: Generated Viper text for with_run_extension_labeled:
 field bf$size: Ref
 
-method f$with_run_extension_labeled$TF$NT$Int$T$Unit(this$extension: Ref)
+method f$with_run_extension_labeled$t$F$t$N$Int$t$Unit(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$nullable(df$rt$intType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -1,9 +1,9 @@
 /viper_casts_while_inlining.kt:(250,255): info: Generated Viper text for idFun:
-method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
+method f$idFun$t$F$t$N$Any$t$N$Any(par$arg: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  ret$0 := p$arg
+  ret$0 := par$arg
   goto lbl$ret$0
   label lbl$ret$0
 }
@@ -11,18 +11,18 @@ method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret$0: Ref)
 /viper_casts_while_inlining.kt:(609,626): info: Generated Viper text for checkMemberAccess:
 field bf$member: Ref
 
-method con$c$ClassWithMember$T$Int$T$ClassWithMember(p$member: Ref)
+method con$c$ClassWithMember$t$Int$t$ClassWithMember(par$member: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$member), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$member), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithMember())
-  ensures acc(p$c$ClassWithMember$shared(ret), wildcard)
-  ensures acc(p$c$ClassWithMember$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithMember$shared(ret), wildcard) in
+  ensures acc(pred$c$ClassWithMember$shared(ret), wildcard)
+  ensures acc(pred$c$ClassWithMember$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$ClassWithMember$shared(ret), wildcard) in
       ret.bf$member)) ==
-    df$rt$intFromRef(p$member)
+    df$rt$intFromRef(par$member)
 
 
-method f$checkMemberAccess$TF$T$Boolean() returns (ret$0: Ref)
+method f$checkMemberAccess$t$F$t$Boolean() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -43,14 +43,14 @@ method f$checkMemberAccess$TF$T$Boolean() returns (ret$0: Ref)
   var ret$4: Ref
   var anon$3: Ref
   var anon$11: Ref
-  l0$obj := con$c$ClassWithMember$T$Int$T$ClassWithMember(df$rt$intToRef(42))
+  l0$obj := con$c$ClassWithMember$t$Int$t$ClassWithMember(df$rt$intToRef(42))
   inhale df$rt$isSubtype(df$rt$typeOf(l0$obj), df$rt$nullable(df$rt$anyType()))
   anon$0 := l0$obj
-  anon$7 := f$idFun$TF$NT$Any$NT$Any(anon$0)
+  anon$7 := f$idFun$t$F$t$N$Any$t$N$Any(anon$0)
   anon$1 := anon$7
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$ClassWithMember())
-  inhale acc(p$c$ClassWithMember$shared(anon$1), wildcard)
-  unfold acc(p$c$ClassWithMember$shared(anon$1), wildcard)
+  inhale acc(pred$c$ClassWithMember$shared(anon$1), wildcard)
+  unfold acc(pred$c$ClassWithMember$shared(anon$1), wildcard)
   ret$2 := anon$1.bf$member
   goto lbl$ret$2
   label lbl$ret$2
@@ -65,9 +65,9 @@ method f$checkMemberAccess$TF$T$Boolean() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(l0$obj), df$rt$nullable(df$rt$anyType()))
   anon$2 := l0$obj
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$c$ClassWithMember())
-  inhale acc(p$c$ClassWithMember$shared(anon$2), wildcard)
+  inhale acc(pred$c$ClassWithMember$shared(anon$2), wildcard)
   anon$3 := anon$2
-  unfold acc(p$c$ClassWithMember$shared(l0$obj), wildcard)
+  unfold acc(pred$c$ClassWithMember$shared(l0$obj), wildcard)
   anon$11 := l0$obj.bf$member
   ret$0 := df$rt$boolToRef(df$rt$intFromRef(anon$11) == 42)
   goto lbl$ret$0
@@ -83,26 +83,27 @@ method f$checkMemberAccess$TF$T$Boolean() returns (ret$0: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
+method f$idFun$t$F$t$N$Any$t$N$Any(par$arg: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /viper_casts_while_inlining.kt:(895,919): info: Generated Viper text for checkGenericMemberAccess:
 field bf$wrapped: Ref
 
-method con$c$Box$NT$Any$T$Box(p$wrapped: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$wrapped), df$rt$nullable(df$rt$anyType()))
+method con$c$Box$t$N$Any$t$Box(par$wrapped: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$wrapped), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Box())
-  ensures acc(p$c$Box$shared(ret), wildcard)
-  ensures acc(p$c$Box$unique(ret), write)
-  ensures (unfolding acc(p$c$Box$shared(ret), wildcard) in ret.bf$wrapped) ==
-    p$wrapped
+  ensures acc(pred$c$Box$shared(ret), wildcard)
+  ensures acc(pred$c$Box$unique(ret), write)
+  ensures (unfolding acc(pred$c$Box$shared(ret), wildcard) in
+      ret.bf$wrapped) ==
+    par$wrapped
 
 
-method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
+method f$checkGenericMemberAccess$t$F$t$Box$t$Boolean(par$box: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
+  requires df$rt$isSubtype(df$rt$typeOf(par$box), df$rt$c$Box())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -122,32 +123,32 @@ method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
   var anon$3: Ref
   var anon$10: Ref
   var anon$11: Ref
-  inhale acc(p$c$Box$shared(p$box), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$nullable(df$rt$anyType()))
-  anon$0 := p$box
-  anon$4 := f$idFun$TF$NT$Any$NT$Any(anon$0)
+  inhale acc(pred$c$Box$shared(par$box), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$box), df$rt$nullable(df$rt$anyType()))
+  anon$0 := par$box
+  anon$4 := f$idFun$t$F$t$N$Any$t$N$Any(anon$0)
   anon$1 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$Box())
-  inhale acc(p$c$Box$shared(anon$1), wildcard)
-  unfold acc(p$c$Box$shared(anon$1), wildcard)
+  inhale acc(pred$c$Box$shared(anon$1), wildcard)
+  unfold acc(pred$c$Box$shared(anon$1), wildcard)
   ret$2 := anon$1.bf$wrapped
   goto lbl$ret$2
   label lbl$ret$2
   ret$1 := ret$2
   goto lbl$ret$1
   label lbl$ret$1
-  unfold acc(p$c$Box$shared(p$box), wildcard)
-  anon$8 := p$box.bf$wrapped
-  anon$7 := con$c$Box$NT$Any$T$Box(anon$8)
+  unfold acc(pred$c$Box$shared(par$box), wildcard)
+  anon$8 := par$box.bf$wrapped
+  anon$7 := con$c$Box$t$N$Any$t$Box(anon$8)
   anon$2 := anon$7
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$c$Box())
-  inhale acc(p$c$Box$shared(anon$2), wildcard)
+  inhale acc(pred$c$Box$shared(anon$2), wildcard)
   anon$3 := anon$2
-  unfold acc(p$c$Box$shared(anon$3), wildcard)
+  unfold acc(pred$c$Box$shared(anon$3), wildcard)
   anon$10 := anon$3.bf$wrapped
-  unfold acc(p$c$Box$shared(p$box), wildcard)
-  anon$11 := p$box.bf$wrapped
+  unfold acc(pred$c$Box$shared(par$box), wildcard)
+  anon$11 := par$box.bf$wrapped
   ret$0 := df$rt$boolToRef(anon$10 == anon$11)
   goto lbl$ret$0
   label lbl$ret$4
@@ -162,17 +163,17 @@ method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
   label lbl$ret$0
 }
 
-method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
+method f$idFun$t$F$t$N$Any$t$N$Any(par$arg: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /viper_casts_while_inlining.kt:(1161,1182): info: Generated Viper text for checkArgumentIsCopied:
 field bf$a: Ref
 
-method f$checkArgumentIsCopied$TF$T$ClassWithVar$T$Unit(p$x: Ref)
+method f$checkArgumentIsCopied$t$F$t$ClassWithVar$t$Unit(par$x: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$ClassWithVar())
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$c$ClassWithVar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -183,8 +184,8 @@ method f$checkArgumentIsCopied$TF$T$ClassWithVar$T$Unit(p$x: Ref)
   var anon$5: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale acc(p$c$ClassWithVar$shared(p$x), wildcard)
-  anon$4 := havoc$T$Int()
+  inhale acc(pred$c$ClassWithVar$shared(par$x), wildcard)
+  anon$4 := havoc$t$Int()
   anon$0 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -213,9 +214,9 @@ field bf$c: Ref
 
 field bf$i: Ref
 
-method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
+method f$accessManyMembers$t$F$t$ManyMembers$t$Unit(par$m: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$c$ManyMembers())
+  requires df$rt$isSubtype(df$rt$typeOf(par$m), df$rt$c$ManyMembers())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$4: Ref
@@ -245,22 +246,22 @@ method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
   var anon$20: Ref
   var anon$21: Ref
   var anon$22: Ref
-  inhale acc(p$c$ManyMembers$shared(p$m), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
-  anon$0 := p$m
+  inhale acc(pred$c$ManyMembers$shared(par$m), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$m), df$rt$nullable(df$rt$anyType()))
+  anon$0 := par$m
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$ManyMembers())
-  inhale acc(p$c$ManyMembers$shared(anon$0), wildcard)
+  inhale acc(pred$c$ManyMembers$shared(anon$0), wildcard)
   anon$1 := anon$0
-  unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
+  unfold acc(pred$c$ManyMembers$shared(anon$1), wildcard)
   anon$9 := anon$1.bf$i
-  anon$8 := f$idFun$TF$NT$Any$NT$Any(anon$9)
+  anon$8 := f$idFun$t$F$t$N$Any$t$N$Any(anon$9)
   anon$7 := anon$8
   inhale df$rt$isSubtype(df$rt$typeOf(anon$7), df$rt$intType())
-  anon$12 := havoc$T$Boolean()
-  anon$11 := f$idFun$TF$NT$Any$NT$Any(anon$12)
+  anon$12 := havoc$t$Boolean()
+  anon$11 := f$idFun$t$F$t$N$Any$t$N$Any(anon$12)
   anon$10 := anon$11
   inhale df$rt$isSubtype(df$rt$typeOf(anon$10), df$rt$boolType())
-  unfold acc(p$c$ManyMembers$shared(anon$1), wildcard)
+  unfold acc(pred$c$ManyMembers$shared(anon$1), wildcard)
   ret$2 := anon$1.bf$c
   goto lbl$ret$2
   label lbl$ret$2
@@ -272,23 +273,23 @@ method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
   anon$5 := ret$1
   anon$4 := anon$5
   inhale df$rt$isSubtype(df$rt$typeOf(anon$4), df$rt$c$ClassWithVar())
-  inhale acc(p$c$ClassWithVar$shared(anon$4), wildcard)
-  inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
-  anon$2 := p$m
-  anon$16 := f$idFun$TF$NT$Any$NT$Any(anon$2)
+  inhale acc(pred$c$ClassWithVar$shared(anon$4), wildcard)
+  inhale df$rt$isSubtype(df$rt$typeOf(par$m), df$rt$nullable(df$rt$anyType()))
+  anon$2 := par$m
+  anon$16 := f$idFun$t$F$t$N$Any$t$N$Any(anon$2)
   anon$3 := anon$16
   inhale df$rt$isSubtype(df$rt$typeOf(anon$3), df$rt$c$ManyMembers())
-  inhale acc(p$c$ManyMembers$shared(anon$3), wildcard)
-  unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
+  inhale acc(pred$c$ManyMembers$shared(anon$3), wildcard)
+  unfold acc(pred$c$ManyMembers$shared(anon$3), wildcard)
   anon$19 := anon$3.bf$i
-  anon$18 := f$idFun$TF$NT$Any$NT$Any(anon$19)
+  anon$18 := f$idFun$t$F$t$N$Any$t$N$Any(anon$19)
   anon$17 := anon$18
   inhale df$rt$isSubtype(df$rt$typeOf(anon$17), df$rt$intType())
-  anon$22 := havoc$T$Boolean()
-  anon$21 := f$idFun$TF$NT$Any$NT$Any(anon$22)
+  anon$22 := havoc$t$Boolean()
+  anon$21 := f$idFun$t$F$t$N$Any$t$N$Any(anon$22)
   anon$20 := anon$21
   inhale df$rt$isSubtype(df$rt$typeOf(anon$20), df$rt$boolType())
-  unfold acc(p$c$ManyMembers$shared(anon$3), wildcard)
+  unfold acc(pred$c$ManyMembers$shared(anon$3), wildcard)
   ret$4 := anon$3.bf$c
   goto lbl$ret$4
   label lbl$ret$4
@@ -300,13 +301,13 @@ method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
   anon$14 := ret$3
   anon$13 := anon$14
   inhale df$rt$isSubtype(df$rt$typeOf(anon$13), df$rt$c$ClassWithVar())
-  inhale acc(p$c$ClassWithVar$shared(anon$13), wildcard)
+  inhale acc(pred$c$ClassWithVar$shared(anon$13), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$NT$Any$NT$Any(p$arg: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$nullable(df$rt$anyType()))
+method f$idFun$t$F$t$N$Any$t$N$Any(par$arg: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
@@ -321,10 +322,10 @@ field bf$i: Ref
 
 field bf$size: Ref
 
-method f$checkEvaluatedOnce$TF$T$Int$T$ManyMembers$T$Unit(p$i: Ref, p$mm: Ref)
+method f$checkEvaluatedOnce$t$F$t$Int$t$ManyMembers$t$Unit(par$i: Ref, par$mm: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$mm), df$rt$c$ManyMembers())
+  requires df$rt$isSubtype(df$rt$typeOf(par$i), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$mm), df$rt$c$ManyMembers())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -336,13 +337,13 @@ method f$checkEvaluatedOnce$TF$T$Int$T$ManyMembers$T$Unit(p$i: Ref, p$mm: Ref)
   var anon$6: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale acc(p$c$ManyMembers$shared(p$mm), wildcard)
-  anon$5 := havoc$T$Boolean()
+  inhale acc(pred$c$ManyMembers$shared(par$mm), wildcard)
+  anon$5 := havoc$t$Boolean()
   if (df$rt$boolFromRef(anon$5)) {
     anon$4 := df$rt$intToRef(1)
   } else {
     anon$4 := df$rt$intToRef(-1)}
-  anon$0 := sp$plusInts(p$i, anon$4)
+  anon$0 := sp$plusInts(par$i, anon$4)
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   anon$1 := anon$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -3,7 +3,7 @@ field bf$delta: Ref
 
 field bf$size: Ref
 
-method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(this$dispatch: Ref,
+method f$c$ClassWithExtension$applyDelta$t$F$t$ClassWithExtension$t$Int$t$Unit(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
@@ -14,11 +14,11 @@ method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(th
   var anon$0: Ref
   var l0$withLabels: Ref
   var anon$1: Ref
-  inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
-  unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$ClassWithExtension$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$ClassWithExtension$shared(this$dispatch), wildcard)
   anon$0 := this$dispatch.bf$delta
   l0$withoutLabels := sp$plusInts(this$extension, anon$0)
-  unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$ClassWithExtension$shared(this$dispatch), wildcard)
   anon$1 := this$dispatch.bf$delta
   l0$withLabels := sp$plusInts(anon$1, this$extension)
   assert df$rt$intFromRef(l0$withoutLabels) ==
@@ -30,13 +30,13 @@ method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(th
 /multiple_receivers.kt:(531,542): info: Generated Viper text for returnDelta:
 field bf$delta: Ref
 
-method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref)
+method f$c$ClassWithExtension$returnDelta$t$F$t$ClassWithExtension$t$Int(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
-  unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
+  inhale acc(pred$c$ClassWithExtension$shared(this$dispatch), wildcard)
+  unfold acc(pred$c$ClassWithExtension$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$delta
   goto lbl$ret$0
   label lbl$ret$0
@@ -45,13 +45,13 @@ method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(this$dis
 /multiple_receivers.kt:(579,599): info: Generated Viper text for extensionReturnDelta:
 field bf$delta: Ref
 
-method f$extensionReturnDelta$TF$T$ClassWithExtension$T$Int(this$extension: Ref)
+method f$extensionReturnDelta$t$F$t$ClassWithExtension$t$Int(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
-  unfold acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
+  inhale acc(pred$c$ClassWithExtension$shared(this$extension), wildcard)
+  unfold acc(pred$c$ClassWithExtension$shared(this$extension), wildcard)
   ret$0 := this$extension.bf$delta
   goto lbl$ret$0
   label lbl$ret$0
@@ -62,18 +62,18 @@ field bf$delta: Ref
 
 field bf$size: Ref
 
-method con$c$ClassWithExtension$T$Int$T$ClassWithExtension(p$delta: Ref)
+method con$c$ClassWithExtension$t$Int$t$ClassWithExtension(par$delta: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$delta), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$delta), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithExtension())
-  ensures acc(p$c$ClassWithExtension$shared(ret), wildcard)
-  ensures acc(p$c$ClassWithExtension$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithExtension$shared(ret), wildcard) in
+  ensures acc(pred$c$ClassWithExtension$shared(ret), wildcard)
+  ensures acc(pred$c$ClassWithExtension$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$ClassWithExtension$shared(ret), wildcard) in
       ret.bf$delta)) ==
-    df$rt$intFromRef(p$delta)
+    df$rt$intFromRef(par$delta)
 
 
-method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(this$dispatch: Ref,
+method f$c$ClassWithExtension$applyDelta$t$F$t$ClassWithExtension$t$Int$t$Unit(this$dispatch: Ref,
   this$extension: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
@@ -81,13 +81,13 @@ method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(th
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
-method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref)
+method f$c$ClassWithExtension$returnDelta$t$F$t$ClassWithExtension$t$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
-method f$checkClassWithExtension$TF$T$Unit() returns (ret$0: Ref)
+method f$checkClassWithExtension$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$3: Ref
@@ -105,18 +105,18 @@ method f$checkClassWithExtension$TF$T$Unit() returns (ret$0: Ref)
   var ret$3: Ref
   var anon$2: Ref
   var anon$11: Ref
-  anon$5 := con$c$ClassWithExtension$T$Int$T$ClassWithExtension(df$rt$intToRef(42))
+  anon$5 := con$c$ClassWithExtension$t$Int$t$ClassWithExtension(df$rt$intToRef(42))
   anon$0 := anon$5
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$ClassWithExtension())
-  inhale acc(p$c$ClassWithExtension$shared(anon$0), wildcard)
+  inhale acc(pred$c$ClassWithExtension$shared(anon$0), wildcard)
   anon$1 := anon$0
-  anon$7 := f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(anon$1,
+  anon$7 := f$c$ClassWithExtension$applyDelta$t$F$t$ClassWithExtension$t$Int$t$Unit(anon$1,
     df$rt$intToRef(42))
-  anon$8 := f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(anon$1)
-  anon$9 := f$extensionReturnDelta$TF$T$ClassWithExtension$T$Int(anon$1)
+  anon$8 := f$c$ClassWithExtension$returnDelta$t$F$t$ClassWithExtension$t$Int(anon$1)
+  anon$9 := f$extensionReturnDelta$t$F$t$ClassWithExtension$t$Int(anon$1)
   anon$2 := df$rt$intToRef(42)
-  unfold acc(p$c$ClassWithExtension$shared(anon$1), wildcard)
+  unfold acc(pred$c$ClassWithExtension$shared(anon$1), wildcard)
   anon$11 := anon$1.bf$delta
   ret$3 := sp$plusInts(anon$2, anon$11)
   goto lbl$ret$3
@@ -137,7 +137,8 @@ method f$checkClassWithExtension$TF$T$Unit() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$extensionReturnDelta$TF$T$ClassWithExtension$T$Int(this$extension: Ref)
+method f$extensionReturnDelta$t$F$t$ClassWithExtension$t$Int(this$extension: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/nullability.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/nullability.fir.diag.txt
@@ -1,5 +1,5 @@
 /nullability.kt:(24,35): info: Generated Viper text for return_null:
-method f$return_null$TF$NT$Int() returns (ret$0: Ref)
+method f$return_null$t$F$t$N$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   ret$0 := df$rt$nullValue()

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -3,41 +3,42 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$isAlternating$TF$T$Node$T$Boolean$T$Boolean(p$node: Ref, p$expectsPositive: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
-  requires df$rt$isSubtype(df$rt$typeOf(p$expectsPositive), df$rt$boolType())
+function f$isAlternating$t$F$t$Node$t$Boolean$t$Boolean(par$node: Ref, par$expectsPositive: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
+  requires df$rt$isSubtype(df$rt$typeOf(par$expectsPositive), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let anon$1$0 ==
-    ((df$rt$boolFromRef(p$expectsPositive) ?
-      (unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$value) :
+    ((df$rt$boolFromRef(par$expectsPositive) ?
+      (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+        par$node.bf$value) :
       null)) in
     (let anon$0$0 ==
-      ((df$rt$boolFromRef(p$expectsPositive) ?
-        (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+      ((df$rt$boolFromRef(par$expectsPositive) ?
+        (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
           sp$gtInts(anon$1$0, df$rt$intToRef(0))) :
         null)) in
       (let anon$3$0 ==
-        ((!df$rt$boolFromRef(p$expectsPositive) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            p$node.bf$value) :
+        ((!df$rt$boolFromRef(par$expectsPositive) ?
+          (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+            par$node.bf$value) :
           null)) in
         (let anon$2$0 ==
-          ((!df$rt$boolFromRef(p$expectsPositive) ?
-            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+          ((!df$rt$boolFromRef(par$expectsPositive) ?
+            (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
               sp$ltInts(anon$3$0, df$rt$intToRef(0))) :
             null)) in
           (let l0$isCurrentValid$0 ==
-            ((df$rt$boolFromRef(p$expectsPositive) ? anon$0$0 : anon$2$0)) in
+            ((df$rt$boolFromRef(par$expectsPositive) ? anon$0$0 : anon$2$0)) in
             (let l0$nextNode$0 ==
-              ((unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                p$node.bf$next)) in
+              ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+                par$node.bf$next)) in
               (let anon$5$0 ==
                 ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                  (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                    f$isAlternating$TF$T$Node$T$Boolean$T$Boolean(l0$nextNode$0,
-                    sp$notBool(p$expectsPositive))) :
+                  (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+                    f$isAlternating$t$F$t$Node$t$Boolean$t$Boolean(l0$nextNode$0,
+                    sp$notBool(par$expectsPositive))) :
                   null)) in
                 (let anon$6$0 ==
                   ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
@@ -55,20 +56,21 @@ field bf$next: Ref
 
 field bf$value: Ref
 
-function f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
-  requires df$rt$intFromRef((unfolding acc(p$c$Node$shared(p$node), wildcard) in
-      p$node.bf$value)) >=
+function f$isStrictlyAscendingAndPositive$t$F$t$Node$t$Boolean(par$node: Ref): Ref
+  requires acc(pred$c$Node$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$Node())
+  requires df$rt$intFromRef((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$value)) >=
     0
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$nextNode$0 ==
-    ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
+    ((unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+      par$node.bf$next)) in
     (let anon$2$0 ==
       ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-        (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
+        (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+          (unfolding acc(pred$c$Node$shared(l0$nextNode$0), wildcard) in
             l0$nextNode$0.bf$value)) :
         null)) in
       (let anon$3$0 ==
@@ -79,23 +81,23 @@ function f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(p$node: Ref): Ref
         (let anon$5$0 ==
           ((!(df$rt$intFromRef(anon$2$0) < 0) &&
           !(l0$nextNode$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
+            (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+              (unfolding acc(pred$c$Node$shared(l0$nextNode$0), wildcard) in
                 l0$nextNode$0.bf$value)) :
             null)) in
           (let anon$6$0 ==
             ((!(df$rt$intFromRef(anon$2$0) < 0) &&
             !(l0$nextNode$0 == df$rt$nullValue()) ?
-              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                p$node.bf$value) :
+              (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+                par$node.bf$value) :
               null)) in
             (let anon$4$0 ==
               ((!(df$rt$intFromRef(anon$2$0) < 0) &&
               !(l0$nextNode$0 == df$rt$nullValue()) ?
-                (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                  (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                    (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
-                      sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(l0$nextNode$0))))) :
+                (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+                  (unfolding acc(pred$c$Node$shared(par$node), wildcard) in
+                    (unfolding acc(pred$c$Node$shared(l0$nextNode$0), wildcard) in
+                      sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isStrictlyAscendingAndPositive$t$F$t$Node$t$Boolean(l0$nextNode$0))))) :
                 null)) in
               (let anon$1$0 ==
                 ((!(l0$nextNode$0 == df$rt$nullValue()) ?
@@ -119,31 +121,31 @@ field bf$right: Ref
 
 field bf$value: Ref
 
-function f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(p$node: Ref): Ref
-  requires acc(p$c$TreeNode$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$TreeNode())
+function f$isLocallyValidBST$t$F$t$TreeNode$t$Boolean(par$node: Ref): Ref
+  requires acc(pred$c$TreeNode$shared(par$node), wildcard)
+  requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$c$TreeNode())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$leftNode$0 ==
-    ((unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-      p$node.bf$left)) in
+    ((unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+      par$node.bf$left)) in
     (let anon$1$0 ==
       ((!(l0$leftNode$0 == df$rt$nullValue()) ?
-        (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-          (unfolding acc(p$c$TreeNode$shared(l0$leftNode$0), wildcard) in
+        (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+          (unfolding acc(pred$c$TreeNode$shared(l0$leftNode$0), wildcard) in
             l0$leftNode$0.bf$value)) :
         null)) in
       (let anon$2$0 ==
         ((!(l0$leftNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-            p$node.bf$value) :
+          (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+            par$node.bf$value) :
           null)) in
         (let anon$0$0 ==
           ((!(l0$leftNode$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-              (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                (unfolding acc(p$c$TreeNode$shared(l0$leftNode$0), wildcard) in
-                  sp$andBools(sp$ltInts(anon$1$0, anon$2$0), f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(l0$leftNode$0))))) :
+            (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+              (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+                (unfolding acc(pred$c$TreeNode$shared(l0$leftNode$0), wildcard) in
+                  sp$andBools(sp$ltInts(anon$1$0, anon$2$0), f$isLocallyValidBST$t$F$t$TreeNode$t$Boolean(l0$leftNode$0))))) :
             null)) in
           (let anon$3$0 ==
             ((!!(l0$leftNode$0 == df$rt$nullValue()) ?
@@ -154,25 +156,25 @@ function f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(p$node: Ref): Ref
                 anon$0$0 :
                 anon$3$0)) in
               (let l0$rightNode$0 ==
-                ((unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                  p$node.bf$right)) in
+                ((unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+                  par$node.bf$right)) in
                 (let anon$5$0 ==
                   ((!(l0$rightNode$0 == df$rt$nullValue()) ?
-                    (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                      (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
+                    (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+                      (unfolding acc(pred$c$TreeNode$shared(l0$rightNode$0), wildcard) in
                         l0$rightNode$0.bf$value)) :
                     null)) in
                   (let anon$6$0 ==
                     ((!(l0$rightNode$0 == df$rt$nullValue()) ?
-                      (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                        p$node.bf$value) :
+                      (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+                        par$node.bf$value) :
                       null)) in
                     (let anon$4$0 ==
                       ((!(l0$rightNode$0 == df$rt$nullValue()) ?
-                        (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                          (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                            (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
-                              sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(l0$rightNode$0))))) :
+                        (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+                          (unfolding acc(pred$c$TreeNode$shared(par$node), wildcard) in
+                            (unfolding acc(pred$c$TreeNode$shared(l0$rightNode$0), wildcard) in
+                              sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isLocallyValidBST$t$F$t$TreeNode$t$Boolean(l0$rightNode$0))))) :
                         null)) in
                       (let anon$7$0 ==
                         ((!!(l0$rightNode$0 == df$rt$nullValue()) ?

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
@@ -1,70 +1,71 @@
 /pure_function_rely_on_branch.kt:(70,80): info: Generated Viper text for safeDivide:
-function f$safeDivide$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+function f$safeDivide$t$F$t$Int$t$Int$t$Int(par$x: Ref, par$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$res$0 ==
     (df$rt$intToRef(0)) in
     (let l0$res$1 ==
-      ((!(df$rt$intFromRef(p$y) == 0) ? sp$divInts(p$x, p$y) : null)) in
+      ((!(df$rt$intFromRef(par$y) == 0) ? sp$divInts(par$x, par$y) : null)) in
       (let l0$res$2 ==
-        ((!(df$rt$intFromRef(p$y) == 0) ? l0$res$1 : l0$res$0)) in
+        ((!(df$rt$intFromRef(par$y) == 0) ? l0$res$1 : l0$res$0)) in
         l0$res$2)))
 }
 
 /pure_function_rely_on_branch.kt:(206,221): info: Generated Viper text for getStringLength:
-function f$getStringLength$TF$T$Any$T$Int(p$obj: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$anyType())
+function f$getStringLength$t$F$t$Any$t$Int(par$obj: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$len$0 ==
     (df$rt$intToRef(-1)) in
     (let l0$len$1 ==
-      ((df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$stringType()) ?
-        sp$stringLength(p$obj) :
+      ((df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$stringType()) ?
+        sp$stringLength(par$obj) :
         null)) in
       (let l0$len$2 ==
-        ((df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$stringType()) ?
+        ((df$rt$isSubtype(df$rt$typeOf(par$obj), df$rt$stringType()) ?
           l0$len$1 :
           l0$len$0)) in
         l0$len$2)))
 }
 
 /pure_function_rely_on_branch.kt:(354,370): info: Generated Viper text for safeNestedDivide:
-function f$safeNestedDivide$TF$T$Int$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref, p$z: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$intType())
+function f$safeNestedDivide$t$F$t$Int$t$Int$t$Int$t$Int(par$x: Ref, par$y: Ref,
+  par$z: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$z), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$res$0 ==
     (df$rt$intToRef(0)) in
     (let l0$res$1 ==
-      ((!(df$rt$intFromRef(p$z) == 0) && !(df$rt$intFromRef(p$y) == 0) ?
-        sp$divInts(sp$divInts(p$x, p$y), p$z) :
+      ((!(df$rt$intFromRef(par$z) == 0) && !(df$rt$intFromRef(par$y) == 0) ?
+        sp$divInts(sp$divInts(par$x, par$y), par$z) :
         null)) in
       (let l0$res$2 ==
-        ((!(df$rt$intFromRef(p$z) == 0) ? l0$res$1 : l0$res$0)) in
+        ((!(df$rt$intFromRef(par$z) == 0) ? l0$res$1 : l0$res$0)) in
         (let l0$res$3 ==
-          ((!(df$rt$intFromRef(p$y) == 0) ? l0$res$2 : l0$res$0)) in
+          ((!(df$rt$intFromRef(par$y) == 0) ? l0$res$2 : l0$res$0)) in
           l0$res$3))))
 }
 
 /pure_function_rely_on_branch.kt:(546,567): info: Generated Viper text for safeInverseDifference:
-function f$safeInverseDifference$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
+function f$safeInverseDifference$t$F$t$Int$t$Int$t$Int(par$x: Ref, par$y: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$x), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$res$0 ==
     (df$rt$intToRef(0)) in
     (let l0$res$1 ==
-      ((!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y)) ?
-        sp$divInts(df$rt$intToRef(100), sp$minusInts(p$x, p$y)) :
+      ((!(df$rt$intFromRef(par$x) == df$rt$intFromRef(par$y)) ?
+        sp$divInts(df$rt$intToRef(100), sp$minusInts(par$x, par$y)) :
         null)) in
       (let l0$res$2 ==
-        ((!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y)) ?
+        ((!(df$rt$intFromRef(par$x) == df$rt$intFromRef(par$y)) ?
           l0$res$1 :
           l0$res$0)) in
         l0$res$2)))

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
@@ -5,46 +5,46 @@ field bf$left: Ref
 
 field bf$right: Ref
 
-predicate p$c$Node$shared(this$dispatch: Ref) {
+predicate pred$c$Node$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$left, wildcard) &&
   (this$dispatch.bf$left != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$left), df$rt$nullable(df$rt$c$Node())) &&
   acc(this$dispatch.bf$right, wildcard) &&
   (this$dispatch.bf$right != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$right), df$rt$nullable(df$rt$c$Node()))
 }
 
-predicate p$c$Node$unique(this$dispatch: Ref) {
+predicate pred$c$Node$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$data, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$data), df$rt$intType()) &&
   acc(this$dispatch.bf$left, wildcard) &&
   (this$dispatch.bf$left != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
   (this$dispatch.bf$left != df$rt$nullValue() ==>
-  acc(p$c$Node$unique(this$dispatch.bf$left), write)) &&
+  acc(pred$c$Node$unique(this$dispatch.bf$left), write)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$left), df$rt$nullable(df$rt$c$Node())) &&
   acc(this$dispatch.bf$right, wildcard) &&
   (this$dispatch.bf$right != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
   (this$dispatch.bf$right != df$rt$nullValue() ==>
-  acc(p$c$Node$unique(this$dispatch.bf$right), write)) &&
+  acc(pred$c$Node$unique(this$dispatch.bf$right), write)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$right), df$rt$nullable(df$rt$c$Node()))
 }
 
-method f$get_left_val$TF$T$Node$NT$Int(p$n: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
-  requires acc(p$c$Node$unique(p$n), write)
+method f$get_left_val$t$F$t$Node$t$N$Int(par$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$c$Node())
+  requires acc(pred$c$Node$unique(par$n), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  inhale acc(p$c$Node$shared(p$n), wildcard)
-  unfold acc(p$c$Node$shared(p$n), wildcard)
-  anon$0 := p$n.bf$left
+  inhale acc(pred$c$Node$shared(par$n), wildcard)
+  unfold acc(pred$c$Node$shared(par$n), wildcard)
+  anon$0 := par$n.bf$left
   if (anon$0 != df$rt$nullValue()) {
     var anon$1: Ref
-    anon$1 := havoc$T$Int()
+    anon$1 := havoc$t$Int()
     ret$0 := anon$1
   } else {
     ret$0 := df$rt$nullValue()}
@@ -61,83 +61,84 @@ field bf$right: Ref
 
 field bf$size: Ref
 
-predicate p$c$Node$shared(this$dispatch: Ref) {
+predicate pred$c$Node$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$left, wildcard) &&
   (this$dispatch.bf$left != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$left), df$rt$nullable(df$rt$c$Node())) &&
   acc(this$dispatch.bf$right, wildcard) &&
   (this$dispatch.bf$right != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$right), df$rt$nullable(df$rt$c$Node()))
 }
 
-predicate p$c$Node$unique(this$dispatch: Ref) {
+predicate pred$c$Node$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$data, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$data), df$rt$intType()) &&
   acc(this$dispatch.bf$left, wildcard) &&
   (this$dispatch.bf$left != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$left), wildcard)) &&
   (this$dispatch.bf$left != df$rt$nullValue() ==>
-  acc(p$c$Node$unique(this$dispatch.bf$left), write)) &&
+  acc(pred$c$Node$unique(this$dispatch.bf$left), write)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$left), df$rt$nullable(df$rt$c$Node())) &&
   acc(this$dispatch.bf$right, wildcard) &&
   (this$dispatch.bf$right != df$rt$nullValue() ==>
-  acc(p$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
+  acc(pred$c$Node$shared(this$dispatch.bf$right), wildcard)) &&
   (this$dispatch.bf$right != df$rt$nullValue() ==>
-  acc(p$c$Node$unique(this$dispatch.bf$right), write)) &&
+  acc(pred$c$Node$unique(this$dispatch.bf$right), write)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$right), df$rt$nullable(df$rt$c$Node()))
 }
 
-predicate p$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
+  acc(pred$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
+  acc(pred$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
+  acc(pred$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
+  acc(pred$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
 }
 
-method con$c$Node$T$Int$NT$Node$NT$Node$T$Node(p$data: Ref, p$left: Ref, p$right: Ref)
+method con$c$Node$t$Int$t$N$Node$t$N$Node$t$Node(par$data: Ref, par$left: Ref,
+  par$right: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$data), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$nullable(df$rt$c$Node()))
-  requires p$left != df$rt$nullValue() ==>
-    acc(p$c$Node$unique(p$left), write)
-  requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$nullable(df$rt$c$Node()))
-  requires p$right != df$rt$nullValue() ==>
-    acc(p$c$Node$unique(p$right), write)
+  requires df$rt$isSubtype(df$rt$typeOf(par$data), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$left), df$rt$nullable(df$rt$c$Node()))
+  requires par$left != df$rt$nullValue() ==>
+    acc(pred$c$Node$unique(par$left), write)
+  requires df$rt$isSubtype(df$rt$typeOf(par$right), df$rt$nullable(df$rt$c$Node()))
+  requires par$right != df$rt$nullValue() ==>
+    acc(pred$c$Node$unique(par$right), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Node())
-  ensures acc(p$c$Node$shared(ret), wildcard)
-  ensures acc(p$c$Node$unique(ret), write)
-  ensures (unfolding acc(p$c$Node$shared(ret), wildcard) in ret.bf$left) ==
-    p$left &&
-    (unfolding acc(p$c$Node$shared(ret), wildcard) in ret.bf$right) ==
-    p$right
+  ensures acc(pred$c$Node$shared(ret), wildcard)
+  ensures acc(pred$c$Node$unique(ret), write)
+  ensures (unfolding acc(pred$c$Node$shared(ret), wildcard) in ret.bf$left) ==
+    par$left &&
+    (unfolding acc(pred$c$Node$shared(ret), wildcard) in ret.bf$right) ==
+    par$right
 
 
-method f$test$TF$T$Unit() returns (ret$0: Ref)
+method f$test$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
@@ -150,24 +151,24 @@ method f$test$TF$T$Unit() returns (ret$0: Ref)
   var l0$expr2: Ref
   var anon$5: Ref
   var anon$6: Ref
-  anon$0 := con$c$Node$T$Int$NT$Node$NT$Node$T$Node(df$rt$intToRef(4), df$rt$nullValue(),
+  anon$0 := con$c$Node$t$Int$t$N$Node$t$N$Node$t$Node(df$rt$intToRef(4), df$rt$nullValue(),
     df$rt$nullValue())
-  anon$2 := con$c$Node$T$Int$NT$Node$NT$Node$T$Node(df$rt$intToRef(2), df$rt$nullValue(),
+  anon$2 := con$c$Node$t$Int$t$N$Node$t$N$Node$t$Node(df$rt$intToRef(2), df$rt$nullValue(),
     df$rt$nullValue())
-  anon$3 := con$c$Node$T$Int$NT$Node$NT$Node$T$Node(df$rt$intToRef(1), df$rt$nullValue(),
+  anon$3 := con$c$Node$t$Int$t$N$Node$t$N$Node$t$Node(df$rt$intToRef(1), df$rt$nullValue(),
     df$rt$nullValue())
-  anon$1 := con$c$Node$T$Int$NT$Node$NT$Node$T$Node(df$rt$intToRef(3), anon$2,
+  anon$1 := con$c$Node$t$Int$t$N$Node$t$N$Node$t$Node(df$rt$intToRef(3), anon$2,
     anon$3)
-  l0$n := con$c$Node$T$Int$NT$Node$NT$Node$T$Node(df$rt$intToRef(5), anon$0,
+  l0$n := con$c$Node$t$Int$t$N$Node$t$N$Node$t$Node(df$rt$intToRef(5), anon$0,
     anon$1)
-  anon$4 := havoc$T$Int()
+  anon$4 := havoc$t$Int()
   l0$expr1 := df$rt$boolToRef(df$rt$intFromRef(anon$4) == 5)
   assert df$rt$boolFromRef(l0$expr1)
-  unfold acc(p$c$Node$shared(l0$n), wildcard)
+  unfold acc(pred$c$Node$shared(l0$n), wildcard)
   anon$6 := l0$n.bf$left
   if (anon$6 != df$rt$nullValue()) {
     var anon$7: Ref
-    anon$7 := havoc$T$Int()
+    anon$7 := havoc$t$Int()
     anon$5 := anon$7
   } else {
     anon$5 := df$rt$nullValue()}

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
@@ -3,36 +3,36 @@ field bf$data: Ref
 
 field bf$next: Ref
 
-predicate p$c$Link$shared(this$dispatch: Ref) {
+predicate pred$c$Link$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
+  acc(pred$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Link()))
 }
 
-predicate p$c$Link$unique(this$dispatch: Ref) {
+predicate pred$c$Link$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$data, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$data), df$rt$intType()) &&
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
+  acc(pred$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Link$unique(this$dispatch.bf$next), write)) &&
+  acc(pred$c$Link$unique(this$dispatch.bf$next), write)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Link()))
 }
 
-method f$getVal$TF$T$Link$NT$Int(p$l: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$Link())
-  requires acc(p$c$Link$unique(p$l), write)
+method f$getVal$t$F$t$Link$t$N$Int(par$l: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$l), df$rt$c$Link())
+  requires acc(pred$c$Link$unique(par$l), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  inhale acc(p$c$Link$shared(p$l), wildcard)
-  unfold acc(p$c$Link$shared(p$l), wildcard)
-  anon$0 := p$l.bf$next
+  inhale acc(pred$c$Link$shared(par$l), wildcard)
+  unfold acc(pred$c$Link$shared(par$l), wildcard)
+  anon$0 := par$l.bf$next
   if (anon$0 != df$rt$nullValue()) {
     var anon$1: Ref
-    anon$1 := havoc$T$Int()
+    anon$1 := havoc$t$Int()
     ret$0 := anon$1
   } else {
     ret$0 := df$rt$nullValue()}
@@ -47,68 +47,68 @@ field bf$next: Ref
 
 field bf$size: Ref
 
-predicate p$c$Link$shared(this$dispatch: Ref) {
+predicate pred$c$Link$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
+  acc(pred$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Link()))
 }
 
-predicate p$c$Link$unique(this$dispatch: Ref) {
+predicate pred$c$Link$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$data, write) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$data), df$rt$intType()) &&
   acc(this$dispatch.bf$next, wildcard) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
+  acc(pred$c$Link$shared(this$dispatch.bf$next), wildcard)) &&
   (this$dispatch.bf$next != df$rt$nullValue() ==>
-  acc(p$c$Link$unique(this$dispatch.bf$next), write)) &&
+  acc(pred$c$Link$unique(this$dispatch.bf$next), write)) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$next), df$rt$nullable(df$rt$c$Link()))
 }
 
-predicate p$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
+predicate pred$pkg$java_io$c$Serializable$unique(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$shared(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
-  acc(p$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
+  acc(pred$pkg$kotlin$c$Cloneable$shared(this$dispatch), wildcard) &&
+  acc(pred$pkg$java_io$c$Serializable$shared(this$dispatch), wildcard)
 }
 
-predicate p$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$BooleanArray$unique(this$dispatch: Ref) {
   acc(this$dispatch.bf$size, wildcard) &&
   df$rt$isSubtype(df$rt$typeOf(this$dispatch.bf$size), df$rt$intType()) &&
-  acc(p$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
-  acc(p$pkg$java_io$c$Serializable$unique(this$dispatch), write)
+  acc(pred$pkg$kotlin$c$Cloneable$unique(this$dispatch), write) &&
+  acc(pred$pkg$java_io$c$Serializable$unique(this$dispatch), write)
 }
 
-predicate p$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$shared(this$dispatch: Ref) {
   true
 }
 
-predicate p$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
+predicate pred$pkg$kotlin$c$Cloneable$unique(this$dispatch: Ref) {
   true
 }
 
-method con$c$Link$T$Int$NT$Link$T$Link(p$data: Ref, p$next: Ref)
+method con$c$Link$t$Int$t$N$Link$t$Link(par$data: Ref, par$next: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$data), df$rt$intType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$next), df$rt$nullable(df$rt$c$Link()))
-  requires p$next != df$rt$nullValue() ==>
-    acc(p$c$Link$unique(p$next), write)
+  requires df$rt$isSubtype(df$rt$typeOf(par$data), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$next), df$rt$nullable(df$rt$c$Link()))
+  requires par$next != df$rt$nullValue() ==>
+    acc(pred$c$Link$unique(par$next), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Link())
-  ensures acc(p$c$Link$shared(ret), wildcard)
-  ensures acc(p$c$Link$unique(ret), write)
-  ensures (unfolding acc(p$c$Link$shared(ret), wildcard) in ret.bf$next) ==
-    p$next
+  ensures acc(pred$c$Link$shared(ret), wildcard)
+  ensures acc(pred$c$Link$unique(ret), write)
+  ensures (unfolding acc(pred$c$Link$shared(ret), wildcard) in ret.bf$next) ==
+    par$next
 
 
-method f$test$TF$T$Unit() returns (ret$0: Ref)
+method f$test$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$l: Ref
@@ -118,16 +118,16 @@ method f$test$TF$T$Unit() returns (ret$0: Ref)
   var l0$expr2: Ref
   var anon$2: Ref
   var anon$3: Ref
-  anon$0 := con$c$Link$T$Int$NT$Link$T$Link(df$rt$intToRef(3), df$rt$nullValue())
-  l0$l := con$c$Link$T$Int$NT$Link$T$Link(df$rt$intToRef(5), anon$0)
-  anon$1 := havoc$T$Int()
+  anon$0 := con$c$Link$t$Int$t$N$Link$t$Link(df$rt$intToRef(3), df$rt$nullValue())
+  l0$l := con$c$Link$t$Int$t$N$Link$t$Link(df$rt$intToRef(5), anon$0)
+  anon$1 := havoc$t$Int()
   l0$expr1 := df$rt$boolToRef(df$rt$intFromRef(anon$1) == 5)
   assert df$rt$boolFromRef(l0$expr1)
-  unfold acc(p$c$Link$shared(l0$l), wildcard)
+  unfold acc(pred$c$Link$shared(l0$l), wildcard)
   anon$3 := l0$l.bf$next
   if (anon$3 != df$rt$nullValue()) {
     var anon$4: Ref
-    anon$4 := havoc$T$Int()
+    anon$4 := havoc$t$Int()
     anon$2 := anon$4
   } else {
     anon$2 := df$rt$nullValue()}

--- a/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
@@ -1,24 +1,25 @@
 /unit_return_type.kt:(171,176): info: Generated Viper text for idFun:
-method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
+method f$idFun$t$F$t$N$Any$t$N$Any(par$t: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  ret$0 := p$t
+  ret$0 := par$t
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /unit_return_type.kt:(195,208): info: Generated Viper text for directReturns:
-method f$directReturns$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$directReturns$t$F$t$Boolean$t$Unit(par$b: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  if (df$rt$boolFromRef(p$b)) {
+  if (df$rt$boolFromRef(par$b)) {
     goto lbl$ret$0
   } else {
     var anon$0: Ref
     var anon$1: Ref
-    anon$1 := f$idFun$TF$NT$Any$NT$Any(p$b)
+    anon$1 := f$idFun$t$F$t$N$Any$t$N$Any(par$b)
     anon$0 := anon$1
     inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())
     if (df$rt$boolFromRef(anon$0)) {
@@ -29,21 +30,22 @@ method f$directReturns$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
+method f$idFun$t$F$t$N$Any$t$N$Any(par$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
 /unit_return_type.kt:(374,387): info: Generated Viper text for useInlineUnit:
 field bf$size: Ref
 
-method f$idFun$TF$NT$Any$NT$Any(p$t: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$anyType()))
+method f$idFun$t$F$t$N$Any$t$N$Any(par$t: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$t), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$anyType()))
 
 
-method f$useInlineUnit$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
+method f$useInlineUnit$t$F$t$Boolean$t$Unit(par$b: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$unitRes: Ref
@@ -51,8 +53,8 @@ method f$useInlineUnit$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$nullable(df$rt$anyType()))
-  anon$0 := p$b
+  inhale df$rt$isSubtype(df$rt$typeOf(par$b), df$rt$nullable(df$rt$anyType()))
+  anon$0 := par$b
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())
   anon$1 := anon$0
   if (df$rt$boolFromRef(anon$1)) {
@@ -60,7 +62,7 @@ method f$useInlineUnit$TF$T$Boolean$T$Unit(p$b: Ref) returns (ret$0: Ref)
     var anon$2: Ref
     var anon$3: Ref
     l4$tmp := df$rt$intToRef(42)
-    anon$3 := f$idFun$TF$NT$Any$NT$Any(l4$tmp)
+    anon$3 := f$idFun$t$F$t$N$Any$t$N$Any(l4$tmp)
     anon$2 := anon$3
     inhale df$rt$isSubtype(df$rt$typeOf(anon$2), df$rt$intType())
   }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/and_or_then.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/and_or_then.fir.diag.txt
@@ -1,47 +1,47 @@
 /and_or_then.kt:(64,75): info: Generated Viper text for resultOrArg:
-method f$resultOrArg$TF$T$Boolean$T$Boolean(p$arg: Ref)
+method f$resultOrArg$t$F$t$Boolean$t$Boolean(par$arg: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
-  ensures df$rt$boolFromRef(ret$0) || df$rt$boolFromRef(p$arg)
+  ensures df$rt$boolFromRef(ret$0) || df$rt$boolFromRef(par$arg)
 {
-  ret$0 := sp$notBool(p$arg)
+  ret$0 := sp$notBool(par$arg)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /and_or_then.kt:(200,211): info: Generated Viper text for testImplies:
-method f$testImplies$TF$T$Boolean$T$Boolean(p$arg: Ref)
+method f$testImplies$t$F$t$Boolean$t$Boolean(par$arg: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
-  ensures df$rt$boolFromRef(p$arg) ==> !df$rt$boolFromRef(ret$0)
-  ensures df$rt$boolFromRef(ret$0) ==> !df$rt$boolFromRef(p$arg)
-  ensures !df$rt$boolFromRef(p$arg) ==> df$rt$boolFromRef(ret$0)
-  ensures !df$rt$boolFromRef(ret$0) ==> df$rt$boolFromRef(p$arg)
+  ensures df$rt$boolFromRef(par$arg) ==> !df$rt$boolFromRef(ret$0)
+  ensures df$rt$boolFromRef(ret$0) ==> !df$rt$boolFromRef(par$arg)
+  ensures !df$rt$boolFromRef(par$arg) ==> df$rt$boolFromRef(ret$0)
+  ensures !df$rt$boolFromRef(ret$0) ==> df$rt$boolFromRef(par$arg)
 {
-  ret$0 := sp$notBool(p$arg)
+  ret$0 := sp$notBool(par$arg)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /and_or_then.kt:(417,424): info: Generated Viper text for testAnd:
-method f$testAnd$TF$T$Boolean$T$Boolean$T$Boolean(p$arg1: Ref, p$arg2: Ref)
+method f$testAnd$t$F$t$Boolean$t$Boolean$t$Boolean(par$arg1: Ref, par$arg2: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg1), df$rt$boolType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg2), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg1), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg2), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) ==>
-    df$rt$boolFromRef(p$arg1) && df$rt$boolFromRef(p$arg2)
+    df$rt$boolFromRef(par$arg1) && df$rt$boolFromRef(par$arg2)
   ensures !df$rt$boolFromRef(ret$0) ==>
-    !df$rt$boolFromRef(p$arg1) || !df$rt$boolFromRef(p$arg2)
-  ensures df$rt$boolFromRef(p$arg1) && df$rt$boolFromRef(p$arg2) ==>
+    !df$rt$boolFromRef(par$arg1) || !df$rt$boolFromRef(par$arg2)
+  ensures df$rt$boolFromRef(par$arg1) && df$rt$boolFromRef(par$arg2) ==>
     df$rt$boolFromRef(ret$0)
-  ensures !df$rt$boolFromRef(p$arg1) ==> !df$rt$boolFromRef(ret$0)
-  ensures !df$rt$boolFromRef(p$arg2) ==> !df$rt$boolFromRef(ret$0)
+  ensures !df$rt$boolFromRef(par$arg1) ==> !df$rt$boolFromRef(ret$0)
+  ensures !df$rt$boolFromRef(par$arg2) ==> !df$rt$boolFromRef(ret$0)
 {
-  if (df$rt$boolFromRef(p$arg1)) {
-    ret$0 := p$arg2
+  if (df$rt$boolFromRef(par$arg1)) {
+    ret$0 := par$arg2
   } else {
     ret$0 := df$rt$boolToRef(false)}
   goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
@@ -1,5 +1,5 @@
 /forall_with_triggers.kt:(50,73): info: Generated Viper text for forAllWithSimpleTrigger:
-method f$forAllWithSimpleTrigger$TF$T$Int() returns (ret$0: Ref)
+method f$forAllWithSimpleTrigger$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures (forall anon$builtin$1: Int ::
       { anon$builtin$1 * anon$builtin$1 }
@@ -12,7 +12,7 @@ method f$forAllWithSimpleTrigger$TF$T$Int() returns (ret$0: Ref)
 }
 
 /forall_with_triggers.kt:(318,344): info: Generated Viper text for forAllWithMultipleTriggers:
-method f$forAllWithMultipleTriggers$TF$T$Int() returns (ret$0: Ref)
+method f$forAllWithMultipleTriggers$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures (forall anon$builtin$1: Int ::
       { anon$builtin$1 * anon$builtin$1 }
@@ -26,9 +26,9 @@ method f$forAllWithMultipleTriggers$TF$T$Int() returns (ret$0: Ref)
 }
 
 /forall_with_triggers.kt:(590,614): info: Generated Viper text for forAllWithTriggersInLoop:
-method f$forAllWithTriggersInLoop$TF$T$String$T$Int(p$str: Ref)
+method f$forAllWithTriggersInLoop$t$F$t$String$t$Int(par$str: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$res: Ref
@@ -36,33 +36,34 @@ method f$forAllWithTriggersInLoop$TF$T$String$T$Int(p$str: Ref)
   var anon$1: Ref
   l0$res := df$rt$intToRef(0)
   l0$i := df$rt$intToRef(10)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
     invariant (forall anon$builtin$0: Int ::
-        { df$rt$stringFromRef(p$str)[anon$builtin$0] }
+        { df$rt$stringFromRef(par$str)[anon$builtin$0] }
         0 <= anon$builtin$0 &&
-        anon$builtin$0 < |df$rt$stringFromRef(p$str)| ==>
-        (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) *
-        (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) >=
+        anon$builtin$0 < |df$rt$stringFromRef(par$str)| ==>
+        (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) *
+        (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) >=
         df$rt$intFromRef(l0$res))
   anon$1 := sp$gtInts(l0$i, df$rt$intToRef(0))
   if (df$rt$boolFromRef(anon$1)) {
     var anon$0: Ref
     anon$0 := l0$i
     l0$i := sp$minusInts(anon$0, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
   assert (forall anon$builtin$0: Int ::
-      { df$rt$stringFromRef(p$str)[anon$builtin$0] }
-      0 <= anon$builtin$0 && anon$builtin$0 < |df$rt$stringFromRef(p$str)| ==>
-      (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) *
-      (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) >=
+      { df$rt$stringFromRef(par$str)[anon$builtin$0] }
+      0 <= anon$builtin$0 &&
+      anon$builtin$0 < |df$rt$stringFromRef(par$str)| ==>
+      (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) *
+      (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) >=
       df$rt$intFromRef(l0$res))
   ret$0 := l0$res
   goto lbl$ret$0
@@ -70,7 +71,7 @@ method f$forAllWithTriggersInLoop$TF$T$String$T$Int(p$str: Ref)
 }
 
 /forall_with_triggers.kt:(990,1011): info: Generated Viper text for forAllWithoutTriggers:
-method f$forAllWithoutTriggers$TF$T$Int() returns (ret$0: Ref)
+method f$forAllWithoutTriggers$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures (forall anon$builtin$1: Int ::anon$builtin$1 * anon$builtin$1 >=
       0)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/pure_function_with_literal_return.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/pure_function_with_literal_return.fir.diag.txt
@@ -1,35 +1,35 @@
 /pure_function_with_literal_return.kt:(70,91): info: Generated Viper text for annotatedIntLitReturn:
-function f$annotatedIntLitReturn$TF$T$Int$T$Int(p$arg: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$intType())
+function f$annotatedIntLitReturn$t$F$t$Int$t$Int(par$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$intType())
   requires true
-  requires df$rt$intFromRef(p$arg) >= 42
-  requires df$rt$intFromRef(p$arg) <= 42
+  requires df$rt$intFromRef(par$arg) >= 42
+  requires df$rt$intFromRef(par$arg) <= 42
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
   ensures df$rt$intFromRef(result) == 42
   ensures (forall anon$builtin$1: Int ::
       { anon$builtin$1 == df$rt$intFromRef(result) }
       anon$builtin$1 == df$rt$intFromRef(result) ==>
-      anon$builtin$1 == df$rt$intFromRef(p$arg))
+      anon$builtin$1 == df$rt$intFromRef(par$arg))
 {
   df$rt$intToRef(42)
 }
 
 /pure_function_with_literal_return.kt:(403,425): info: Generated Viper text for annotatedBoolLitReturn:
-function f$annotatedBoolLitReturn$TF$T$Int$T$Boolean(p$arg: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$intType())
-  requires df$rt$intFromRef(p$arg) <= 0
-  requires df$rt$intFromRef(p$arg) >= 0
+function f$annotatedBoolLitReturn$t$F$t$Int$t$Boolean(par$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$intType())
+  requires df$rt$intFromRef(par$arg) <= 0
+  requires df$rt$intFromRef(par$arg) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
   ensures df$rt$boolFromRef(result)
-  ensures df$rt$intFromRef(p$arg) == 0
+  ensures df$rt$intFromRef(par$arg) == 0
 {
   df$rt$boolToRef(true)
 }
 
 /pure_function_with_literal_return.kt:(628,650): info: Generated Viper text for annotatedCharLitReturn:
-function f$annotatedCharLitReturn$TF$T$String$T$Char(p$arg: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$stringType())
-  requires df$rt$stringFromRef(p$arg) ==
+function f$annotatedCharLitReturn$t$F$t$String$t$Char(par$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$stringType())
+  requires df$rt$stringFromRef(par$arg) ==
     Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) == 65
@@ -38,9 +38,9 @@ function f$annotatedCharLitReturn$TF$T$String$T$Char(p$arg: Ref): Ref
 }
 
 /pure_function_with_literal_return.kt:(834,858): info: Generated Viper text for annotatedStringLitReturn:
-function f$annotatedStringLitReturn$TF$T$Boolean$T$String(p$arg: Ref): Ref
-  requires df$rt$isSubtype(df$rt$typeOf(p$arg), df$rt$boolType())
-  requires df$rt$boolFromRef(p$arg)
+function f$annotatedStringLitReturn$t$F$t$Boolean$t$String(par$arg: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(par$arg), df$rt$boolType())
+  requires df$rt$boolFromRef(par$arg)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
   ensures df$rt$stringFromRef(result) ==
     Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
@@ -1,5 +1,5 @@
 /simple_forall.kt:(64,92): info: Generated Viper text for anyIntegerSquaredAtLeastZero:
-method f$anyIntegerSquaredAtLeastZero$TF$T$Int() returns (ret$0: Ref)
+method f$anyIntegerSquaredAtLeastZero$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures (forall anon$builtin$1: Int ::anon$builtin$1 * anon$builtin$1 >=
       0 &&
@@ -11,7 +11,7 @@ method f$anyIntegerSquaredAtLeastZero$TF$T$Int() returns (ret$0: Ref)
 }
 
 /simple_forall.kt:(259,298): info: Generated Viper text for anyIntegerSquaredIsAtLeastOneExceptZero:
-method f$anyIntegerSquaredIsAtLeastOneExceptZero$TF$T$Int()
+method f$anyIntegerSquaredIsAtLeastOneExceptZero$t$F$t$Int()
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures (forall anon$builtin$1: Int ::!(anon$builtin$1 == 0) ==>
@@ -23,9 +23,9 @@ method f$anyIntegerSquaredIsAtLeastOneExceptZero$TF$T$Int()
 }
 
 /simple_forall.kt:(460,503): info: Generated Viper text for anyIntegerSquaredIsAtLeastZeroStringVersion:
-method f$anyIntegerSquaredIsAtLeastZeroStringVersion$TF$T$String$T$Int(p$str: Ref)
+method f$anyIntegerSquaredIsAtLeastZeroStringVersion$t$F$t$String$t$Int(par$str: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var l0$res: Ref
@@ -33,30 +33,30 @@ method f$anyIntegerSquaredIsAtLeastZeroStringVersion$TF$T$String$T$Int(p$str: Re
   var anon$1: Ref
   l0$res := df$rt$intToRef(0)
   l0$i := df$rt$intToRef(10)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
     invariant (forall anon$builtin$0: Int ::0 <= anon$builtin$0 &&
-        anon$builtin$0 < |df$rt$stringFromRef(p$str)| ==>
-        (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) *
-        (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) >=
+        anon$builtin$0 < |df$rt$stringFromRef(par$str)| ==>
+        (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) *
+        (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) >=
         df$rt$intFromRef(l0$res))
   anon$1 := sp$gtInts(l0$i, df$rt$intToRef(0))
   if (df$rt$boolFromRef(anon$1)) {
     var anon$0: Ref
     anon$0 := l0$i
     l0$i := sp$minusInts(anon$0, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$str), df$rt$stringType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$str), df$rt$stringType())
   assert (forall anon$builtin$0: Int ::0 <= anon$builtin$0 &&
-      anon$builtin$0 < |df$rt$stringFromRef(p$str)| ==>
-      (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) *
-      (df$rt$stringFromRef(p$str)[anon$builtin$0] - 97) >=
+      anon$builtin$0 < |df$rt$stringFromRef(par$str)| ==>
+      (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) *
+      (df$rt$stringFromRef(par$str)[anon$builtin$0] - 97) >=
       df$rt$intFromRef(l0$res))
   ret$0 := l0$res
   goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
@@ -1,8 +1,8 @@
 /simple_loop.kt:(239,243): info: Generated Viper text for test:
 field bf$size: Ref
 
-method f$test$TF$T$Int$T$Unit(p$n: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+method f$test$t$F$t$Int$t$Unit(par$n: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$it: Ref
@@ -10,57 +10,57 @@ method f$test$TF$T$Int$T$Unit(p$n: Ref) returns (ret$0: Ref)
   var anon$0: Ref
   l0$it := df$rt$intToRef(0)
   l0$holds := df$rt$boolToRef(true)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$it), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$holds), df$rt$boolType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
     invariant df$rt$intFromRef(l0$it) <= 10
     invariant df$rt$boolFromRef(l0$holds)
   anon$0 := sp$ltInts(l0$it, df$rt$intToRef(10))
   if (df$rt$boolFromRef(anon$0)) {
     l0$it := sp$plusInts(l0$it, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$it), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$holds), df$rt$boolType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
   assert df$rt$intFromRef(l0$it) <= 10
   assert df$rt$boolFromRef(l0$holds)
   assert df$rt$intFromRef(l0$it) == 10
-  if (df$rt$intFromRef(l0$it) <= df$rt$intFromRef(p$n)) {
+  if (df$rt$intFromRef(l0$it) <= df$rt$intFromRef(par$n)) {
     var anon$1: Ref
-    label lbl$continue$1
+    label lbl$cont$1
       invariant df$rt$isSubtype(df$rt$typeOf(l0$it), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$holds), df$rt$boolType())
-      invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-      invariant df$rt$intFromRef(l0$it) <= df$rt$intFromRef(p$n)
+      invariant df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+      invariant df$rt$intFromRef(l0$it) <= df$rt$intFromRef(par$n)
       invariant df$rt$boolFromRef(l0$holds)
-    anon$1 := sp$ltInts(l0$it, p$n)
+    anon$1 := sp$ltInts(l0$it, par$n)
     if (df$rt$boolFromRef(anon$1)) {
       l0$it := sp$plusInts(l0$it, df$rt$intToRef(1))
-      goto lbl$continue$1
+      goto lbl$cont$1
     }
     label lbl$break$1
     assert df$rt$isSubtype(df$rt$typeOf(l0$it), df$rt$intType())
     assert df$rt$isSubtype(df$rt$typeOf(l0$holds), df$rt$boolType())
-    assert df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-    assert df$rt$intFromRef(l0$it) <= df$rt$intFromRef(p$n)
+    assert df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+    assert df$rt$intFromRef(l0$it) <= df$rt$intFromRef(par$n)
     assert df$rt$boolFromRef(l0$holds)
-    assert df$rt$intFromRef(l0$it) == df$rt$intFromRef(p$n)
+    assert df$rt$intFromRef(l0$it) == df$rt$intFromRef(par$n)
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /simple_loop.kt:(652,666): info: Generated Viper text for loopInsideLoop:
-method f$loopInsideLoop$TF$T$Unit() returns (ret$0: Ref)
+method f$loopInsideLoop$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$i: Ref
   var anon$0: Ref
   l0$i := df$rt$intToRef(0)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
     invariant df$rt$intFromRef(l0$i) <= 10
   anon$0 := sp$ltInts(l0$i, df$rt$intToRef(10))
@@ -68,7 +68,7 @@ method f$loopInsideLoop$TF$T$Unit() returns (ret$0: Ref)
     var l1$j: Ref
     var anon$1: Ref
     l1$j := sp$plusInts(l0$i, df$rt$intToRef(1))
-    label lbl$continue$1
+    label lbl$cont$1
       invariant df$rt$isSubtype(df$rt$typeOf(l1$j), df$rt$intType())
       invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
       invariant df$rt$intFromRef(l0$i) < df$rt$intFromRef(l1$j)
@@ -76,7 +76,7 @@ method f$loopInsideLoop$TF$T$Unit() returns (ret$0: Ref)
     anon$1 := sp$ltInts(l1$j, df$rt$intToRef(10))
     if (df$rt$boolFromRef(anon$1)) {
       l1$j := sp$plusInts(l1$j, df$rt$intToRef(1))
-      goto lbl$continue$1
+      goto lbl$cont$1
     }
     label lbl$break$1
     assert df$rt$isSubtype(df$rt$typeOf(l1$j), df$rt$intType())
@@ -84,7 +84,7 @@ method f$loopInsideLoop$TF$T$Unit() returns (ret$0: Ref)
     assert df$rt$intFromRef(l0$i) < df$rt$intFromRef(l1$j)
     assert df$rt$intFromRef(l1$j) <= 10
     l0$i := sp$plusInts(l0$i, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
@@ -96,13 +96,13 @@ method f$loopInsideLoop$TF$T$Unit() returns (ret$0: Ref)
 /simple_loop.kt:(974,983): info: Generated Viper text for withBreak:
 field bf$size: Ref
 
-method f$withBreak$TF$T$Unit() returns (ret$0: Ref)
+method f$withBreak$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$i: Ref
   var anon$0: Ref
   l0$i := df$rt$intToRef(0)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
     invariant df$rt$intFromRef(l0$i) <= 10
   anon$0 := df$rt$boolToRef(true)
@@ -110,7 +110,7 @@ method f$withBreak$TF$T$Unit() returns (ret$0: Ref)
     if (df$rt$intFromRef(l0$i) >= 10) {
       goto lbl$break$0
     }
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
@@ -125,38 +125,38 @@ field bf$e: Ref
 
 field bf$size: Ref
 
-method con$c$WithVar$T$Int$T$WithVar(p$e: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$e), df$rt$intType())
+method con$c$WithVar$t$Int$t$WithVar(par$e: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$e), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$WithVar())
-  ensures acc(p$c$WithVar$shared(ret), wildcard)
-  ensures acc(p$c$WithVar$unique(ret), write)
+  ensures acc(pred$c$WithVar$shared(ret), wildcard)
+  ensures acc(pred$c$WithVar$unique(ret), write)
 
 
-method f$c$WithVar$doSomething$TF$T$WithVar$T$Boolean(this$dispatch: Ref)
+method f$c$WithVar$doSomething$t$F$t$WithVar$t$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$WithVar())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 
-method f$test_boolean_postcondition$TF$T$Unit() returns (ret$0: Ref)
+method f$test_boolean_postcondition$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$withVar: Ref
   var l0$boolean: Ref
   var anon$0: Ref
-  l0$withVar := con$c$WithVar$T$Int$T$WithVar(df$rt$intToRef(42))
+  l0$withVar := con$c$WithVar$t$Int$t$WithVar(df$rt$intToRef(42))
   l0$boolean := df$rt$boolToRef(true)
-  label lbl$continue$0
-    invariant acc(p$c$WithVar$shared(l0$withVar), wildcard)
+  label lbl$cont$0
+    invariant acc(pred$c$WithVar$shared(l0$withVar), wildcard)
     invariant df$rt$isSubtype(df$rt$typeOf(l0$withVar), df$rt$c$WithVar())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$boolean), df$rt$boolType())
   anon$0 := l0$boolean
   if (df$rt$boolFromRef(anon$0)) {
-    l0$boolean := f$c$WithVar$doSomething$TF$T$WithVar$T$Boolean(l0$withVar)
-    goto lbl$continue$0
+    l0$boolean := f$c$WithVar$doSomething$t$F$t$WithVar$t$Boolean(l0$withVar)
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert acc(p$c$WithVar$shared(l0$withVar), wildcard)
+  assert acc(pred$c$WithVar$shared(l0$withVar), wildcard)
   assert df$rt$isSubtype(df$rt$typeOf(l0$withVar), df$rt$c$WithVar())
   assert df$rt$isSubtype(df$rt$typeOf(l0$boolean), df$rt$boolType())
   assert !df$rt$boolFromRef(l0$boolean)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
@@ -1,16 +1,16 @@
 /simple_postcondition.kt:(64,75): info: Generated Viper text for testGreater:
-method f$testGreater$TF$T$Int$T$Int(p$init: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$init), df$rt$intType())
+method f$testGreater$t$F$t$Int$t$Int(par$init: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$init), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
-  ensures df$rt$intFromRef(ret$0) > df$rt$intFromRef(p$init)
+  ensures df$rt$intFromRef(ret$0) > df$rt$intFromRef(par$init)
 {
-  ret$0 := sp$plusInts(p$init, df$rt$intToRef(5))
+  ret$0 := sp$plusInts(par$init, df$rt$intToRef(5))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /simple_postcondition.kt:(201,211): info: Generated Viper text for testString:
-method f$testString$TF$T$Char() returns (ret$0: Ref)
+method f$testString$t$F$t$Char() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$charType())
   ensures df$rt$charFromRef(ret$0) == 97
 {
@@ -20,20 +20,20 @@ method f$testString$TF$T$Char() returns (ret$0: Ref)
 }
 
 /simple_postcondition.kt:(323,343): info: Generated Viper text for testWithPrecondition:
-method f$testWithPrecondition$TF$T$Int$T$Int(p$int: Ref)
+method f$testWithPrecondition$t$F$t$Int$t$Int(par$int: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$int), df$rt$intType())
-  requires df$rt$intFromRef(p$int) > 10
+  requires df$rt$isSubtype(df$rt$typeOf(par$int), df$rt$intType())
+  requires df$rt$intFromRef(par$int) > 10
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) > 0
 {
-  ret$0 := sp$minusInts(p$int, df$rt$intToRef(10))
+  ret$0 := sp$minusInts(par$int, df$rt$intToRef(10))
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /simple_postcondition.kt:(492,507): info: Generated Viper text for returnGreater13:
-method f$returnGreater13$TF$T$Int() returns (ret$0: Ref)
+method f$returnGreater13$t$F$t$Int() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) > 13
 {
@@ -43,24 +43,26 @@ method f$returnGreater13$TF$T$Int() returns (ret$0: Ref)
 }
 
 /simple_postcondition.kt:(600,637): info: Generated Viper text for testPostconditionIsUsedByPrecondition:
-method f$returnGreater13$TF$T$Int() returns (ret: Ref)
+method f$returnGreater13$t$F$t$Int() returns (ret: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
   ensures df$rt$intFromRef(ret) > 13
 
 
-method f$testPostconditionIsUsedByPrecondition$TF$T$Int()
+method f$testPostconditionIsUsedByPrecondition$t$F$t$Int()
   returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  anon$0 := f$returnGreater13$TF$T$Int()
-  ret$0 := f$testWithPrecondition$TF$T$Int$T$Int(anon$0)
+  anon$0 := f$returnGreater13$t$F$t$Int()
+  ret$0 := f$testWithPrecondition$t$F$t$Int$t$Int(anon$0)
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$testWithPrecondition$TF$T$Int$T$Int(p$int: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$int), df$rt$intType())
-  requires df$rt$intFromRef(p$int) > 10
+method f$testWithPrecondition$t$F$t$Int$t$Int(par$int: Ref)
+  returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$int), df$rt$intType())
+  requires df$rt$intFromRef(par$int) > 10
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
   ensures df$rt$intFromRef(ret) > 0
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
@@ -1,26 +1,26 @@
 /simple_precondition.kt:(238,242): info: Generated Viper text for test:
 field bf$size: Ref
 
-method f$test$TF$T$Int$T$Unit(p$idx: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$idx), df$rt$intType())
-  requires 0 <= df$rt$intFromRef(p$idx)
-  requires df$rt$intFromRef(p$idx) < 3
+method f$test$t$F$t$Int$t$Unit(par$idx: Ref) returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$idx), df$rt$intType())
+  requires 0 <= df$rt$intFromRef(par$idx)
+  requires df$rt$intFromRef(par$idx) < 3
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  assert 0 <= df$rt$intFromRef(p$idx)
-  assert df$rt$intFromRef(p$idx) < 3
-  assert !(df$rt$intFromRef(p$idx) == 100)
-  assert Seq(97, 97, 97)[df$rt$intFromRef(p$idx)] == 97
+  assert 0 <= df$rt$intFromRef(par$idx)
+  assert df$rt$intFromRef(par$idx) < 3
+  assert !(df$rt$intFromRef(par$idx) == 100)
+  assert Seq(97, 97, 97)[df$rt$intFromRef(par$idx)] == 97
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
 /simple_precondition.kt:(446,469): info: Generated Viper text for inlineWithSpecification:
-method f$inlineWithSpecification$TF$T$Boolean$T$Unit(p$bool: Ref)
+method f$inlineWithSpecification$t$F$t$Boolean$t$Unit(par$bool: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$bool), df$rt$boolType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$bool), df$rt$boolType())
   requires true
-  requires df$rt$boolFromRef(p$bool)
+  requires df$rt$boolFromRef(par$bool)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   label lbl$ret$0
@@ -28,7 +28,7 @@ method f$inlineWithSpecification$TF$T$Boolean$T$Unit(p$bool: Ref)
 }
 
 /simple_precondition.kt:(560,569): info: Generated Viper text for good_call:
-method f$good_call$TF$T$Unit() returns (ret$0: Ref)
+method f$good_call$t$F$t$Unit() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -36,7 +36,7 @@ method f$good_call$TF$T$Unit() returns (ret$0: Ref)
   var anon$0: Ref
   var ret$2: Ref
   var anon$1: Ref
-  anon$2 := f$test$TF$T$Int$T$Unit(df$rt$intToRef(2))
+  anon$2 := f$test$t$F$t$Int$t$Unit(df$rt$intToRef(2))
   anon$0 := df$rt$boolToRef(true)
   label lbl$ret$1
   inhale df$rt$isSubtype(df$rt$typeOf(ret$1), df$rt$unitType())
@@ -47,8 +47,9 @@ method f$good_call$TF$T$Unit() returns (ret$0: Ref)
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
 
-method f$test$TF$T$Int$T$Unit(p$idx: Ref) returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$idx), df$rt$intType())
-  requires 0 <= df$rt$intFromRef(p$idx)
-  requires df$rt$intFromRef(p$idx) < 3
+method f$test$t$F$t$Int$t$Unit(par$idx: Ref) returns (ret: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$idx), df$rt$intType())
+  requires 0 <= df$rt$intFromRef(par$idx)
+  requires df$rt$intFromRef(par$idx) < 3
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,60 +1,60 @@
 /string_iterations.kt:(71,83): info: Generated Viper text for firstAtLeast:
-method f$firstAtLeast$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
+method f$firstAtLeast$t$F$t$String$t$Char$t$Int(this$extension: Ref, par$c: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures 0 <= df$rt$intFromRef(ret$0) &&
     df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(this$extension)|
   ensures (forall anon$builtin$2: Int ::0 <= anon$builtin$2 &&
       anon$builtin$2 < df$rt$intFromRef(ret$0) ==>
       df$rt$stringFromRef(this$extension)[anon$builtin$2] <
-      df$rt$charFromRef(p$c))
+      df$rt$charFromRef(par$c))
   ensures !(df$rt$intFromRef(ret$0) ==
     |df$rt$stringFromRef(this$extension)|) ==>
     df$rt$stringFromRef(this$extension)[df$rt$intFromRef(ret$0)] >=
-    df$rt$charFromRef(p$c)
+    df$rt$charFromRef(par$c)
 {
   var l0$i: Ref
   var anon$0: Ref
   l0$i := df$rt$intToRef(0)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
     invariant 0 <= df$rt$intFromRef(l0$i) &&
       df$rt$intFromRef(l0$i) <= |df$rt$stringFromRef(this$extension)|
     invariant (forall anon$builtin$1: Int ::0 <= anon$builtin$1 &&
         anon$builtin$1 < df$rt$intFromRef(l0$i) ==>
         df$rt$stringFromRef(this$extension)[anon$builtin$1] <
-        df$rt$charFromRef(p$c))
+        df$rt$charFromRef(par$c))
   anon$0 := sp$ltInts(l0$i, sp$stringLength(this$extension))
   if (df$rt$boolFromRef(anon$0)) {
     if (df$rt$stringFromRef(this$extension)[df$rt$intFromRef(l0$i)] >=
-    df$rt$charFromRef(p$c)) {
+    df$rt$charFromRef(par$c)) {
       goto lbl$break$0
     }
     l0$i := sp$plusInts(l0$i, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
   assert 0 <= df$rt$intFromRef(l0$i) &&
     df$rt$intFromRef(l0$i) <= |df$rt$stringFromRef(this$extension)|
   assert (forall anon$builtin$1: Int ::0 <= anon$builtin$1 &&
       anon$builtin$1 < df$rt$intFromRef(l0$i) ==>
       df$rt$stringFromRef(this$extension)[anon$builtin$1] <
-      df$rt$charFromRef(p$c))
+      df$rt$charFromRef(par$c))
   ret$0 := l0$i
   goto lbl$ret$0
   label lbl$ret$0
 }
 
 /string_iterations.kt:(606,614): info: Generated Viper text for lastLess:
-method f$lastLess$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
+method f$lastLess$t$F$t$String$t$Char$t$Int(this$extension: Ref, par$c: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures -1 <= df$rt$intFromRef(ret$0) &&
     df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(this$extension)| - 1
@@ -62,43 +62,43 @@ method f$lastLess$TF$T$String$T$Char$T$Int(this$extension: Ref, p$c: Ref)
       anon$builtin$2 &&
       anon$builtin$2 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$stringFromRef(this$extension)[anon$builtin$2] >=
-      df$rt$charFromRef(p$c))
+      df$rt$charFromRef(par$c))
   ensures !(df$rt$intFromRef(ret$0) == -1) ==>
     df$rt$stringFromRef(this$extension)[df$rt$intFromRef(ret$0)] <
-    df$rt$charFromRef(p$c)
+    df$rt$charFromRef(par$c)
 {
   var l0$i: Ref
   var anon$0: Ref
   l0$i := sp$minusInts(sp$stringLength(this$extension), df$rt$intToRef(1))
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
     invariant -1 <= df$rt$intFromRef(l0$i) &&
       df$rt$intFromRef(l0$i) < |df$rt$stringFromRef(this$extension)|
     invariant (forall anon$builtin$1: Int ::df$rt$intFromRef(l0$i) <
         anon$builtin$1 &&
         anon$builtin$1 < |df$rt$stringFromRef(this$extension)| ==>
         df$rt$stringFromRef(this$extension)[anon$builtin$1] >=
-        df$rt$charFromRef(p$c))
+        df$rt$charFromRef(par$c))
   anon$0 := sp$gtInts(l0$i, df$rt$intToRef(-1))
   if (df$rt$boolFromRef(anon$0)) {
     if (df$rt$stringFromRef(this$extension)[df$rt$intFromRef(l0$i)] <
-    df$rt$charFromRef(p$c)) {
+    df$rt$charFromRef(par$c)) {
       goto lbl$break$0
     }
     l0$i := sp$minusInts(l0$i, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
   assert -1 <= df$rt$intFromRef(l0$i) &&
     df$rt$intFromRef(l0$i) < |df$rt$stringFromRef(this$extension)|
   assert (forall anon$builtin$1: Int ::df$rt$intFromRef(l0$i) <
       anon$builtin$1 &&
       anon$builtin$1 < |df$rt$stringFromRef(this$extension)| ==>
       df$rt$stringFromRef(this$extension)[anon$builtin$1] >=
-      df$rt$charFromRef(p$c))
+      df$rt$charFromRef(par$c))
   ret$0 := l0$i
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
@@ -1,45 +1,45 @@
 /strings_in_conditions.kt:(50,69): info: Generated Viper text for firstNotSortedIndex:
-method f$firstNotSortedIndex$TF$T$String$T$Int(p$s: Ref)
+method f$firstNotSortedIndex$t$F$t$String$t$Int(par$s: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures 0 <= df$rt$intFromRef(ret$0) &&
-    df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(p$s)|
+    df$rt$intFromRef(ret$0) <= |df$rt$stringFromRef(par$s)|
   ensures (forall anon$builtin$2: Int ::0 <= anon$builtin$2 &&
       anon$builtin$2 + 1 < df$rt$intFromRef(ret$0) ==>
-      df$rt$stringFromRef(p$s)[anon$builtin$2] <=
-      df$rt$stringFromRef(p$s)[anon$builtin$2 + 1])
+      df$rt$stringFromRef(par$s)[anon$builtin$2] <=
+      df$rt$stringFromRef(par$s)[anon$builtin$2 + 1])
 {
-  if (|df$rt$stringFromRef(p$s)| == 0) {
+  if (|df$rt$stringFromRef(par$s)| == 0) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
   } else {
     var l3$i: Ref
     var anon$0: Ref
     l3$i := df$rt$intToRef(1)
-    label lbl$continue$0
+    label lbl$cont$0
       invariant df$rt$isSubtype(df$rt$typeOf(l3$i), df$rt$intType())
-      invariant df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+      invariant df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
       invariant (forall anon$builtin$1: Int ::0 <= anon$builtin$1 &&
           anon$builtin$1 + 1 < df$rt$intFromRef(l3$i) ==>
-          df$rt$stringFromRef(p$s)[anon$builtin$1] <=
-          df$rt$stringFromRef(p$s)[anon$builtin$1 + 1])
-    if (df$rt$intFromRef(l3$i) < |df$rt$stringFromRef(p$s)|) {
-      anon$0 := sp$leChars(sp$stringGet(p$s, sp$minusInts(l3$i, df$rt$intToRef(1))),
-        sp$stringGet(p$s, l3$i))
+          df$rt$stringFromRef(par$s)[anon$builtin$1] <=
+          df$rt$stringFromRef(par$s)[anon$builtin$1 + 1])
+    if (df$rt$intFromRef(l3$i) < |df$rt$stringFromRef(par$s)|) {
+      anon$0 := sp$leChars(sp$stringGet(par$s, sp$minusInts(l3$i, df$rt$intToRef(1))),
+        sp$stringGet(par$s, l3$i))
     } else {
       anon$0 := df$rt$boolToRef(false)}
     if (df$rt$boolFromRef(anon$0)) {
       l3$i := sp$plusInts(l3$i, df$rt$intToRef(1))
-      goto lbl$continue$0
+      goto lbl$cont$0
     }
     label lbl$break$0
     assert df$rt$isSubtype(df$rt$typeOf(l3$i), df$rt$intType())
-    assert df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
+    assert df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
     assert (forall anon$builtin$1: Int ::0 <= anon$builtin$1 &&
         anon$builtin$1 + 1 < df$rt$intFromRef(l3$i) ==>
-        df$rt$stringFromRef(p$s)[anon$builtin$1] <=
-        df$rt$stringFromRef(p$s)[anon$builtin$1 + 1])
+        df$rt$stringFromRef(par$s)[anon$builtin$1] <=
+        df$rt$stringFromRef(par$s)[anon$builtin$1 + 1])
     ret$0 := l3$i
     goto lbl$ret$0
   }
@@ -47,7 +47,7 @@ method f$firstNotSortedIndex$TF$T$String$T$Int(p$s: Ref)
 }
 
 /strings_in_conditions.kt:(621,636): info: Generated Viper text for returnNewString:
-method f$returnNewString$TF$T$String() returns (ret$0: Ref)
+method f$returnNewString$t$F$t$String() returns (ret$0: Ref)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
 {
   ret$0 := df$rt$stringToRef(Seq(52, 50))
@@ -56,68 +56,71 @@ method f$returnNewString$TF$T$String() returns (ret$0: Ref)
 }
 
 /strings_in_conditions.kt:(672,689): info: Generated Viper text for addCharacterTimes:
-method f$addCharacterTimes$TF$T$String$T$Char$T$Int$T$String(p$s: Ref, p$c: Ref,
-  p$n: Ref)
+method f$addCharacterTimes$t$F$t$String$t$Char$t$Int$t$String(par$s: Ref, par$c: Ref,
+  par$n: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-  requires df$rt$intFromRef(p$n) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+  requires df$rt$intFromRef(par$n) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
   ensures |df$rt$stringFromRef(ret$0)| ==
-    |df$rt$stringFromRef(p$s)| + df$rt$intFromRef(p$n)
-  ensures (forall anon$builtin$2: Int ::|df$rt$stringFromRef(p$s)| <=
+    |df$rt$stringFromRef(par$s)| + df$rt$intFromRef(par$n)
+  ensures (forall anon$builtin$2: Int ::|df$rt$stringFromRef(par$s)| <=
       anon$builtin$2 &&
       anon$builtin$2 < |df$rt$stringFromRef(ret$0)| ==>
-      df$rt$stringFromRef(ret$0)[anon$builtin$2] == df$rt$charFromRef(p$c))
+      df$rt$stringFromRef(ret$0)[anon$builtin$2] ==
+      df$rt$charFromRef(par$c))
 {
   var l0$i: Ref
   var l0$res: Ref
   var anon$0: Ref
   l0$i := df$rt$intToRef(0)
-  l0$res := p$s
-  label lbl$continue$0
+  l0$res := par$s
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
+    invariant df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
     invariant 0 <= df$rt$intFromRef(l0$i) &&
-      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+      df$rt$intFromRef(l0$i) <= df$rt$intFromRef(par$n)
     invariant |df$rt$stringFromRef(l0$res)| ==
-      |df$rt$stringFromRef(p$s)| + df$rt$intFromRef(l0$i)
-    invariant (forall anon$builtin$1: Int ::|df$rt$stringFromRef(p$s)| <=
+      |df$rt$stringFromRef(par$s)| + df$rt$intFromRef(l0$i)
+    invariant (forall anon$builtin$1: Int ::|df$rt$stringFromRef(par$s)| <=
         anon$builtin$1 &&
         anon$builtin$1 < |df$rt$stringFromRef(l0$res)| ==>
         df$rt$stringFromRef(l0$res)[anon$builtin$1] ==
-        df$rt$charFromRef(p$c))
-  anon$0 := sp$ltInts(l0$i, p$n)
+        df$rt$charFromRef(par$c))
+  anon$0 := sp$ltInts(l0$i, par$n)
   if (df$rt$boolFromRef(anon$0)) {
-    l0$res := sp$addStringChar(l0$res, p$c)
-    goto lbl$continue$0
+    l0$res := sp$addStringChar(l0$res, par$c)
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$res), df$rt$stringType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$stringType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$charType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$s), df$rt$stringType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$c), df$rt$charType())
+  assert df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
   assert 0 <= df$rt$intFromRef(l0$i) &&
-    df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+    df$rt$intFromRef(l0$i) <= df$rt$intFromRef(par$n)
   assert |df$rt$stringFromRef(l0$res)| ==
-    |df$rt$stringFromRef(p$s)| + df$rt$intFromRef(l0$i)
-  assert (forall anon$builtin$1: Int ::|df$rt$stringFromRef(p$s)| <=
+    |df$rt$stringFromRef(par$s)| + df$rt$intFromRef(l0$i)
+  assert (forall anon$builtin$1: Int ::|df$rt$stringFromRef(par$s)| <=
       anon$builtin$1 &&
       anon$builtin$1 < |df$rt$stringFromRef(l0$res)| ==>
-      df$rt$stringFromRef(l0$res)[anon$builtin$1] == df$rt$charFromRef(p$c))
+      df$rt$stringFromRef(l0$res)[anon$builtin$1] ==
+      df$rt$charFromRef(par$c))
   ret$0 := l0$res
   goto lbl$ret$0
   label lbl$ret$0
 }
 
-method f$pkg$kotlin$c$String$plus$TF$T$String$NT$Any$T$String(this$dispatch: Ref,
-  p$other: Ref)
+method f$pkg$kotlin$c$String$plus$t$F$t$String$t$N$Any$t$String(this$dispatch: Ref,
+  par$other: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$stringType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$nullable(df$rt$anyType()))
+  requires df$rt$isSubtype(df$rt$typeOf(par$other), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$stringType())
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/sum_of_1_to_n.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/sum_of_1_to_n.fir.diag.txt
@@ -1,56 +1,57 @@
 /sum_of_1_to_n.kt:(64,91): info: Generated Viper text for recursiveSumOfIntegersUpToN:
-method f$recursiveSumOfIntegersUpToN$TF$T$Int$T$Int(p$n: Ref)
+method f$recursiveSumOfIntegersUpToN$t$F$t$Int$t$Int(par$n: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-  requires df$rt$intFromRef(p$n) >= 0
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+  requires df$rt$intFromRef(par$n) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) ==
-    df$rt$intFromRef(p$n) * (df$rt$intFromRef(p$n) + 1) \ 2
+    df$rt$intFromRef(par$n) * (df$rt$intFromRef(par$n) + 1) \ 2
 {
-  if (df$rt$intFromRef(p$n) == 0) {
+  if (df$rt$intFromRef(par$n) == 0) {
     ret$0 := df$rt$intToRef(0)
     goto lbl$ret$0
   } else {
     var anon$0: Ref
-    anon$0 := f$recursiveSumOfIntegersUpToN$TF$T$Int$T$Int(sp$minusInts(p$n,
+    anon$0 := f$recursiveSumOfIntegersUpToN$t$F$t$Int$t$Int(sp$minusInts(par$n,
       df$rt$intToRef(1)))
-    ret$0 := sp$plusInts(p$n, anon$0)
+    ret$0 := sp$plusInts(par$n, anon$0)
     goto lbl$ret$0
   }
   label lbl$ret$0
 }
 
 /sum_of_1_to_n.kt:(296,314): info: Generated Viper text for sumOfIntegersUpToN:
-method f$sumOfIntegersUpToN$TF$T$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-  requires df$rt$intFromRef(p$n) >= 0
+method f$sumOfIntegersUpToN$t$F$t$Int$t$Int(par$n: Ref)
+  returns (ret$0: Ref)
+  requires df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+  requires df$rt$intFromRef(par$n) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
   ensures df$rt$intFromRef(ret$0) ==
-    df$rt$intFromRef(p$n) * (df$rt$intFromRef(p$n) + 1) \ 2
+    df$rt$intFromRef(par$n) * (df$rt$intFromRef(par$n) + 1) \ 2
 {
   var l0$sum: Ref
   var l0$i: Ref
   var anon$0: Ref
   l0$sum := df$rt$intToRef(0)
   l0$i := df$rt$intToRef(0)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l0$sum), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-    invariant df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-    invariant df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+    invariant df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+    invariant df$rt$intFromRef(l0$i) <= df$rt$intFromRef(par$n)
     invariant df$rt$intFromRef(l0$sum) ==
       df$rt$intFromRef(l0$i) * (df$rt$intFromRef(l0$i) + 1) \ 2
-  anon$0 := sp$ltInts(l0$i, p$n)
+  anon$0 := sp$ltInts(l0$i, par$n)
   if (df$rt$boolFromRef(anon$0)) {
     l0$sum := sp$plusInts(l0$sum, sp$plusInts(l0$i, df$rt$intToRef(1)))
     l0$i := sp$plusInts(l0$i, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l0$sum), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$i), df$rt$intType())
-  assert df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$intType())
-  assert df$rt$intFromRef(l0$i) <= df$rt$intFromRef(p$n)
+  assert df$rt$isSubtype(df$rt$typeOf(par$n), df$rt$intType())
+  assert df$rt$intFromRef(l0$i) <= df$rt$intFromRef(par$n)
   assert df$rt$intFromRef(l0$sum) ==
     df$rt$intFromRef(l0$i) * (df$rt$intFromRef(l0$i) + 1) \ 2
   ret$0 := l0$sum

--- a/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
@@ -3,20 +3,20 @@ field bf$field: Ref
 
 field bf$size: Ref
 
-method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
+method con$c$ClassWithField$t$Int$t$ClassWithField(par$field: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$field), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$field), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithField())
-  ensures acc(p$c$ClassWithField$shared(ret), wildcard)
-  ensures acc(p$c$ClassWithField$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithField$shared(ret), wildcard) in
+  ensures acc(pred$c$ClassWithField$shared(ret), wildcard)
+  ensures acc(pred$c$ClassWithField$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$ClassWithField$shared(ret), wildcard) in
       ret.bf$field)) ==
-    df$rt$intFromRef(p$field)
+    df$rt$intFromRef(par$field)
 
 
-method f$test_while$TF$T$ClassWithField$T$Unit(p$param: Ref)
+method f$test_while$t$F$t$ClassWithField$t$Unit(par$param: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
+  requires df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$c$ClassWithField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$c: Ref
@@ -27,10 +27,10 @@ method f$test_while$TF$T$ClassWithField$T$Unit(p$param: Ref)
   var anon$1: Ref
   var l0$cond2: Ref
   var anon$2: Ref
-  inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
-  l0$c := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(13))
-  unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
-  l0$initParamField := p$param.bf$field
+  inhale acc(pred$c$ClassWithField$shared(par$param), wildcard)
+  l0$c := con$c$ClassWithField$t$Int$t$ClassWithField(df$rt$intToRef(13))
+  unfold acc(pred$c$ClassWithField$shared(par$param), wildcard)
+  l0$initParamField := par$param.bf$field
   if (df$rt$intFromRef(l0$initParamField) > 0) {
     l0$iteration := df$rt$intToRef(0)
   } else {
@@ -38,36 +38,36 @@ method f$test_while$TF$T$ClassWithField$T$Unit(p$param: Ref)
     l3$intermediate := sp$plusInts(sp$negInt(l0$initParamField), df$rt$intToRef(1))
     l0$iteration := sp$timesInts(l3$intermediate, l3$intermediate)
   }
-  label lbl$continue$0
-    invariant acc(p$c$ClassWithField$shared(l0$c), wildcard)
+  label lbl$cont$0
+    invariant acc(pred$c$ClassWithField$shared(l0$c), wildcard)
     invariant df$rt$isSubtype(df$rt$typeOf(l0$c), df$rt$c$ClassWithField())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$initParamField), df$rt$intType())
     invariant df$rt$isSubtype(df$rt$typeOf(l0$iteration), df$rt$intType())
-    invariant acc(p$c$ClassWithField$shared(p$param), wildcard)
-    invariant df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
+    invariant acc(pred$c$ClassWithField$shared(par$param), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$c$ClassWithField())
   anon$0 := sp$ltInts(l0$iteration, df$rt$intToRef(10))
   if (df$rt$boolFromRef(anon$0)) {
     var l4$field: Ref
     var l4$paramField: Ref
-    unfold acc(p$c$ClassWithField$shared(l0$c), wildcard)
+    unfold acc(pred$c$ClassWithField$shared(l0$c), wildcard)
     l4$field := l0$c.bf$field
-    unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
-    l4$paramField := p$param.bf$field
+    unfold acc(pred$c$ClassWithField$shared(par$param), wildcard)
+    l4$paramField := par$param.bf$field
     l0$iteration := sp$plusInts(l0$iteration, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
-  assert acc(p$c$ClassWithField$shared(l0$c), wildcard)
+  assert acc(pred$c$ClassWithField$shared(l0$c), wildcard)
   assert df$rt$isSubtype(df$rt$typeOf(l0$c), df$rt$c$ClassWithField())
   assert df$rt$isSubtype(df$rt$typeOf(l0$initParamField), df$rt$intType())
   assert df$rt$isSubtype(df$rt$typeOf(l0$iteration), df$rt$intType())
-  assert acc(p$c$ClassWithField$shared(p$param), wildcard)
-  assert df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
-  unfold acc(p$c$ClassWithField$shared(l0$c), wildcard)
+  assert acc(pred$c$ClassWithField$shared(par$param), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$c$ClassWithField())
+  unfold acc(pred$c$ClassWithField$shared(l0$c), wildcard)
   anon$1 := l0$c.bf$field
   l0$cond1 := df$rt$boolToRef(df$rt$intFromRef(anon$1) == 13)
-  unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
-  anon$2 := p$param.bf$field
+  unfold acc(pred$c$ClassWithField$shared(par$param), wildcard)
+  anon$2 := par$param.bf$field
   l0$cond2 := df$rt$boolToRef(df$rt$intFromRef(l0$initParamField) ==
     df$rt$intFromRef(anon$2))
   assert df$rt$boolFromRef(l0$cond1)
@@ -81,20 +81,20 @@ field bf$field: Ref
 
 field bf$size: Ref
 
-method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
+method con$c$ClassWithField$t$Int$t$ClassWithField(par$field: Ref)
   returns (ret: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$field), df$rt$intType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$field), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassWithField())
-  ensures acc(p$c$ClassWithField$shared(ret), wildcard)
-  ensures acc(p$c$ClassWithField$unique(ret), write)
-  ensures df$rt$intFromRef((unfolding acc(p$c$ClassWithField$shared(ret), wildcard) in
+  ensures acc(pred$c$ClassWithField$shared(ret), wildcard)
+  ensures acc(pred$c$ClassWithField$unique(ret), write)
+  ensures df$rt$intFromRef((unfolding acc(pred$c$ClassWithField$shared(ret), wildcard) in
       ret.bf$field)) ==
-    df$rt$intFromRef(p$field)
+    df$rt$intFromRef(par$field)
 
 
-method f$test_while_with_inlining$TF$T$ClassWithField$T$Unit(p$param: Ref)
+method f$test_while_with_inlining$t$F$t$ClassWithField$t$Unit(par$param: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
+  requires df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$c$ClassWithField())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$local: Ref
@@ -110,49 +110,49 @@ method f$test_while_with_inlining$TF$T$ClassWithField$T$Unit(p$param: Ref)
   var anon$6: Ref
   var anon$7: Ref
   var anon$8: Ref
-  inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
-  l0$local := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(13))
-  anon$4 := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(42))
+  inhale acc(pred$c$ClassWithField$shared(par$param), wildcard)
+  l0$local := con$c$ClassWithField$t$Int$t$ClassWithField(df$rt$intToRef(13))
+  anon$4 := con$c$ClassWithField$t$Int$t$ClassWithField(df$rt$intToRef(42))
   anon$0 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$ClassWithField())
-  inhale acc(p$c$ClassWithField$shared(anon$0), wildcard)
+  inhale acc(pred$c$ClassWithField$shared(anon$0), wildcard)
   anon$1 := anon$0
   l2$iteration := df$rt$intToRef(0)
-  label lbl$continue$0
+  label lbl$cont$0
     invariant df$rt$isSubtype(df$rt$typeOf(l2$iteration), df$rt$intType())
-    invariant acc(p$c$ClassWithField$shared(anon$1), wildcard)
+    invariant acc(pred$c$ClassWithField$shared(anon$1), wildcard)
     invariant df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$ClassWithField())
-    invariant acc(p$c$ClassWithField$shared(l0$local), wildcard)
+    invariant acc(pred$c$ClassWithField$shared(l0$local), wildcard)
     invariant df$rt$isSubtype(df$rt$typeOf(l0$local), df$rt$c$ClassWithField())
-    invariant acc(p$c$ClassWithField$shared(p$param), wildcard)
-    invariant df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
+    invariant acc(pred$c$ClassWithField$shared(par$param), wildcard)
+    invariant df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$c$ClassWithField())
   anon$6 := sp$ltInts(l2$iteration, df$rt$intToRef(10))
   if (df$rt$boolFromRef(anon$6)) {
     var l3$paramField: Ref
     var l3$localField: Ref
     var l3$thisField: Ref
-    unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
-    l3$paramField := p$param.bf$field
-    unfold acc(p$c$ClassWithField$shared(l0$local), wildcard)
+    unfold acc(pred$c$ClassWithField$shared(par$param), wildcard)
+    l3$paramField := par$param.bf$field
+    unfold acc(pred$c$ClassWithField$shared(l0$local), wildcard)
     l3$localField := l0$local.bf$field
-    unfold acc(p$c$ClassWithField$shared(anon$1), wildcard)
+    unfold acc(pred$c$ClassWithField$shared(anon$1), wildcard)
     l3$thisField := anon$1.bf$field
     l2$iteration := sp$plusInts(l2$iteration, df$rt$intToRef(1))
-    goto lbl$continue$0
+    goto lbl$cont$0
   }
   label lbl$break$0
   assert df$rt$isSubtype(df$rt$typeOf(l2$iteration), df$rt$intType())
-  assert acc(p$c$ClassWithField$shared(anon$1), wildcard)
+  assert acc(pred$c$ClassWithField$shared(anon$1), wildcard)
   assert df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$ClassWithField())
-  assert acc(p$c$ClassWithField$shared(l0$local), wildcard)
+  assert acc(pred$c$ClassWithField$shared(l0$local), wildcard)
   assert df$rt$isSubtype(df$rt$typeOf(l0$local), df$rt$c$ClassWithField())
-  assert acc(p$c$ClassWithField$shared(p$param), wildcard)
-  assert df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
-  unfold acc(p$c$ClassWithField$shared(anon$1), wildcard)
+  assert acc(pred$c$ClassWithField$shared(par$param), wildcard)
+  assert df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$c$ClassWithField())
+  unfold acc(pred$c$ClassWithField$shared(anon$1), wildcard)
   anon$7 := anon$1.bf$field
   assert df$rt$intFromRef(anon$7) == 42
-  unfold acc(p$c$ClassWithField$shared(l0$local), wildcard)
+  unfold acc(pred$c$ClassWithField$shared(l0$local), wildcard)
   anon$8 := l0$local.bf$field
   assert df$rt$intFromRef(anon$8) == 13
   label lbl$ret$2
@@ -172,39 +172,39 @@ method f$test_while_with_inlining$TF$T$ClassWithField$T$Unit(p$param: Ref)
 /while.kt:(1311,1336): info: Generated Viper text for test_while_with_smartcast:
 field bf$field: Ref
 
-method f$test_while_with_smartcast$TF$T$Any$T$Any$T$Unit(p$param: Ref, p$innerParam: Ref)
+method f$test_while_with_smartcast$t$F$t$Any$t$Any$t$Unit(par$param: Ref, par$innerParam: Ref)
   returns (ret$0: Ref)
-  requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$anyType())
-  requires df$rt$isSubtype(df$rt$typeOf(p$innerParam), df$rt$anyType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$anyType())
+  requires df$rt$isSubtype(df$rt$typeOf(par$innerParam), df$rt$anyType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  if (df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())) {
+  if (df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$c$ClassWithField())) {
     var l2$iteration: Ref
     var anon$0: Ref
     l2$iteration := df$rt$intToRef(0)
-    label lbl$continue$0
+    label lbl$cont$0
       invariant df$rt$isSubtype(df$rt$typeOf(l2$iteration), df$rt$intType())
-      invariant df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$anyType())
-      invariant df$rt$isSubtype(df$rt$typeOf(p$innerParam), df$rt$anyType())
+      invariant df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$anyType())
+      invariant df$rt$isSubtype(df$rt$typeOf(par$innerParam), df$rt$anyType())
     anon$0 := sp$ltInts(l2$iteration, df$rt$intToRef(10))
     if (df$rt$boolFromRef(anon$0)) {
       var l3$paramField: Ref
-      inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
-      unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
-      l3$paramField := p$param.bf$field
-      if (df$rt$isSubtype(df$rt$typeOf(p$innerParam), df$rt$c$ClassWithField())) {
+      inhale acc(pred$c$ClassWithField$shared(par$param), wildcard)
+      unfold acc(pred$c$ClassWithField$shared(par$param), wildcard)
+      l3$paramField := par$param.bf$field
+      if (df$rt$isSubtype(df$rt$typeOf(par$innerParam), df$rt$c$ClassWithField())) {
         var l5$innerParamField: Ref
-        inhale acc(p$c$ClassWithField$shared(p$innerParam), wildcard)
-        unfold acc(p$c$ClassWithField$shared(p$innerParam), wildcard)
-        l5$innerParamField := p$innerParam.bf$field
+        inhale acc(pred$c$ClassWithField$shared(par$innerParam), wildcard)
+        unfold acc(pred$c$ClassWithField$shared(par$innerParam), wildcard)
+        l5$innerParamField := par$innerParam.bf$field
       }
       l2$iteration := sp$plusInts(l2$iteration, df$rt$intToRef(1))
-      goto lbl$continue$0
+      goto lbl$cont$0
     }
     label lbl$break$0
     assert df$rt$isSubtype(df$rt$typeOf(l2$iteration), df$rt$intType())
-    assert df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$anyType())
-    assert df$rt$isSubtype(df$rt$typeOf(p$innerParam), df$rt$anyType())
+    assert df$rt$isSubtype(df$rt$typeOf(par$param), df$rt$anyType())
+    assert df$rt$isSubtype(df$rt$typeOf(par$innerParam), df$rt$anyType())
   }
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
@@ -54,15 +54,7 @@ sealed class NameType(val name: String) {
     object Function : NameType("f")
     object Predicate : NameType("pred")
     object Havoc : NameType("havoc")
-    sealed class Label(val lblName: String) : NameType(lblName) {
-        override fun toString(): String = "lbl$$lblName"
-        object Return : Label("ret")
-        object Break : Label("break")
-        object Continue : Label("cont")
-        object Catch : Label("catch")
-        object TryExit : Label("tryExit")
-    }
-
+    object Label : NameType("lbl")
     object Variable : NameType("v")
     object Domain : NameType("d")
     object DomainFunction : NameType("df")

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
@@ -13,7 +13,7 @@ package org.jetbrains.kotlin.formver.viper
  */
 const val SEPARATOR = "$"
 interface SymbolicName {
-    val mangledType: String?
+    val mangledType: NameType?
         get() = null
     context(nameResolver: NameResolver)
     val mangledScope: String?

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
@@ -38,6 +38,8 @@ val SymbolicName.debugMangled: String
  */
 sealed class NameType(val name: String) {
 
+    override fun toString(): String = name
+
     object Property : NameType("p")
     object BackingField : NameType("bf")
     object Getter : NameType("g")
@@ -52,7 +54,8 @@ sealed class NameType(val name: String) {
     object Function : NameType("f")
     object Predicate : NameType("pred")
     object Havoc : NameType("havoc")
-    sealed class Label(lblName: String) : NameType(lblName) {
+    sealed class Label(val lblName: String) : NameType(lblName) {
+        override fun toString(): String = "lbl$$lblName"
         object Return : Label("ret")
         object Break : Label("break")
         object Continue : Label("cont")

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SymbolicName.kt
@@ -32,3 +32,36 @@ val SymbolicName.debugMangled: String
         return debugResolver.resolve(this)
     }
 
+
+/**
+ * Collects all types of names we can have.
+ */
+sealed class NameType(val name: String) {
+
+    object Property : NameType("p")
+    object BackingField : NameType("bf")
+    object Getter : NameType("g")
+    object Setter : NameType("s")
+    object ExtensionSetter : NameType("es")
+    object ExtensionGetter : NameType("eg")
+    object Type : NameType("t") {
+        object Class : NameType("c")
+    }
+
+    object Constructor : NameType("con")
+    object Function : NameType("f")
+    object Predicate : NameType("pred")
+    object Havoc : NameType("havoc")
+    sealed class Label(lblName: String) : NameType(lblName) {
+        object Return : Label("ret")
+        object Break : Label("break")
+        object Continue : Label("cont")
+        object Catch : Label("catch")
+        object TryExit : Label("tryExit")
+    }
+
+    object Variable : NameType("v")
+    object Domain : NameType("d")
+    object DomainFunction : NameType("df")
+    object Special : NameType("sp") // I think we should not have this. Like, what does special mean?
+}

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Domain.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Domain.kt
@@ -15,8 +15,8 @@ import viper.silver.ast.NamedDomainAxiom
  */
 
 data class DomainName(val baseName: String) : SymbolicName {
-    override val mangledType: String
-        get() = "d"
+    override val mangledType: NameType
+        get() = NameType.Domain
     context(nameResolver: NameResolver)
     override val mangledBaseName: String
         get() = baseName
@@ -28,8 +28,8 @@ data class UnqualifiedDomainFuncName(val baseName: String) : SymbolicName {
 }
 
 data class QualifiedDomainFuncName(val domainName: DomainName, val funcName: SymbolicName) : SymbolicName {
-    override val mangledType: String
-        get() = "df"
+    override val mangledType: NameType
+        get() = NameType.DomainFunction
     context(nameResolver: NameResolver)
     override val mangledScope: String
         get() = domainName.mangledBaseName


### PR DESCRIPTION
This PR updates how we specify the name type. Before there was a string property `mangledType` on `SymbolicName`. This property describes what kind of entity the name refers to e.g. getter, property, function, type.

This strings should be duplicate free but they are distributed in many files. To have a better overview on the used strings a sealed class `NameType` was introduced which collects all the name types.

The changes in the resulting viper program can be categorized into:
- type name update: Before the type of a function looked like this `TF$T$Unit` which was changed to `t$F$t$Unit`. Basically the upper case `T` was replaced with a lowercase to match the other type names. Also it was separated using `$`.
- Label names changed slightly. E.g. `try_exit` to `tryExit`
- Parameters in the type domain changed from `arg1` to `arg$1`
- Property getters type name is just `g` instead of `pg`
- Predicates are prefixed with `pred` instead of `p`
- Parameters are prefixed with `par` instead of `p`



## Notes: 
- The `NameType` `Special` will be removed in a future #103 . It only makes sense to remove it, once we got rid off the `SpecialName`. Removing `SpecialName` requires a larger reconstruction.
- In a future PR #114  we will change the structure to use Enums. At the moment this is not possible, because this would break the name resolver.
