### PR TITLE
Access-permissions on interfaces

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.descriptors.isInterface
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.processAllDeclarations
@@ -234,7 +233,6 @@ class ProgramConverter(
         val newDetails =
             ClassEmbeddingDetails(
                 embedding,
-                symbol.classKind.isInterface,
             )
         embedding.initDetails(newDetails)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassEmbeddingDetails.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassEmbeddingDetails.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 class ClassEmbeddingDetails(
     val type: ClassTypeEmbedding,
-    val isInterface: Boolean,
 ) : TypeInvariantHolder {
     private var _superTypes: List<PretypeEmbedding>? = null
     val superTypes: List<PretypeEmbedding>
@@ -110,19 +109,26 @@ class ClassEmbeddingDetails(
 
     override fun subTypeInvariant(): TypeInvariantEmbedding = type.subTypeInvariant()
 
-    // Returns the sequence of classes in a hierarchy that need to be unfolded in order to access the given field
-    fun hierarchyPathTo(field: FieldEmbedding): Sequence<ClassTypeEmbedding> = sequence {
-        val className = field.containingClass?.name
-        require(className != null) { "Cannot find hierarchy unfold path of a field with no class information" }
-        if (className == type.name) {
-            yield(this@ClassEmbeddingDetails.type)
-        } else {
-            val sup = classSuperTypes.firstOrNull { !it.details.isInterface }
-                ?: throw IllegalArgumentException("Reached top of the hierarchy without finding the field")
+    /**
+     * Returns the sequence of types to unfold to reach [target] from the current type.
+     * Returns an empty sequence if the current type already is [target].
+     * Throws if [target] is unreachable.
+     */
+    fun hierarchyPathTo(target: ClassTypeEmbedding): Sequence<ClassTypeEmbedding> =
+        pathToOrNull(target)?.asSequence()
+            ?: throw IllegalArgumentException("Could not find a path from ${type.name} to ${target.name} in the class hierarchy")
 
-            yield(this@ClassEmbeddingDetails.type)
-            yieldAll(sup.details.hierarchyPathTo(field))
+    /**
+     * Returns the path of types to unfold from the current type to reach [target], or `null` if unreachable.
+     * An empty list means the current type IS the target.
+     */
+    private fun pathToOrNull(target: ClassTypeEmbedding): List<ClassTypeEmbedding>? {
+        if (type == target) return emptyList()
+        for (sup in classSuperTypes) {
+            val subPath = sup.details.pathToOrNull(target) ?: continue
+            return listOf(type) + subPath
         }
+        return null
     }
 
     fun <R> flatMapUniqueFields(action: (SimpleKotlinName, FieldEmbedding) -> List<R>): List<R> {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/TypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/TypeEmbedding.kt
@@ -100,9 +100,13 @@ data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbedding
     override val debugTreeView: TreeView
         get() = PlaintextLeaf(name.mangled)
 
-    fun hierarchyPathTo(field: FieldEmbedding): Sequence<ClassTypeEmbedding>? =
-        // TODO: Find a nicer solution to avoid this cast. It should really be: type.hierarchyPathTo(field)
-        (pretype as? ClassTypeEmbedding)?.details?.hierarchyPathTo(field)
+    fun hierarchyPathTo(field: FieldEmbedding): Sequence<ClassTypeEmbedding>? {
+        if (pretype !is ClassTypeEmbedding) return null
+        val target = requireNotNull(field.containingClass) {
+            "Cannot find hierarchy path of a field with no class information"
+        }
+        return pretype.details.hierarchyPathTo(target).plus(target)
+    }
 }
 
 data class TypeEmbeddingFlags(val nullable: Boolean) {

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
@@ -239,6 +239,12 @@ public class FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated ext
       }
 
       @Test
+      @TestMetadata("heap_dependent_specifications.kt")
+      public void testHeap_dependent_specifications() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt");
+      }
+
+      @Test
       @TestMetadata("pure_function_rely_on_branch.kt")
       public void testPure_function_rely_on_branch() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.kt");


### PR DESCRIPTION
## Summary

This PR was extracted from #92 and concerns the implementation of interface-related permissions. Currently, we mostly apply the same permission handling to classes and interfaces, but limit the operations that can be performed with interfaces in certain locations, e.g. when traversing subtyping hierarchies. To implement a proper inheritance system, a separate permissions system for interfaces should be  developed. 

This PR contains some work in this regard, but lacks the fundamental theoretical backbone. Hopefully, it can be reused when a proper system for interface permissions was agreed on.

> **Draft — most changes were ad hoc changes that are not verified to be correct or complete.**

## Changes

- Removes the `isInterface: Boolean` field from `ClassEmbeddingDetails` and replaces the field-based `hierarchyPathTo(field)` with a target-based `hierarchyPathTo(target)` backed by a private `pathToOrNull` that searches **all** class supertypes, including interfaces.
- Moves field-to-target resolution into `TypeEmbedding.hierarchyPathTo(field)`.

## Remaining tasks

- Development of a proper strategy to handle permissions releated to interfaces.
- Implementation of this strategy in the codebase.