### PR TITLE
Move shared-access predicate invariants to preconditions

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -413,6 +413,7 @@ class ProgramConverter(
                     addAll(it.pureInvariants())
                     addAll(it.accessInvariants())
                     addAll(it.provenInvariants())
+                    addIfNotNull(it.sharedPredicateAccessInvariant())
                     if (it.isUnique) {
                         addIfNotNull(it.type.uniquePredicateAccessInvariant()?.fillHole(it))
                     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullNamedFunctionSignature.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullNamedFunctionSignature.kt
@@ -115,13 +115,12 @@ fun FullNamedFunctionSignature.toViperFunction(
             "Postcondition tries to acquire permissions, which is not allowed in a function"
         )
     }
-    val preconditions = formalArgs.mapNotNull { it.sharedPredicateAccessInvariant() } + getPreconditions()
     return UserFunction(
         name,
         formalArgs.map { it.toLocalVarDecl() },
         // TODO: Be explicit about the return types of functions instead of boxing them into a Ref
         Type.Ref,
-        preconditions.pureToViper(toBuiltin = true),
+        getPreconditions().pureToViper(toBuiltin = true),
         postconditions.pureToViper(toBuiltin = true),
         body,
         declarationSource.asPosition

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -224,10 +224,12 @@ data class FunctionCall(val function: NamedFunctionSignature, val args: List<Exp
     override val subexpressions: List<ExpEmbedding>
         get() = args
 
-    override fun toViper(ctx: LinearizationContext): Exp = function.toFuncApp(
-        args.map { it.toViper(ctx) },
-        ctx.source.asPosition
-    )
+    override fun toViper(ctx: LinearizationContext): Exp {
+        return function.toFuncApp(
+            args.map { it.toViper(ctx) },
+            ctx.source.asPosition
+        )
+    }
 
     override fun <R> accept(v: ExpVisitor<R>): R =
         v.visitFunctionCall(this)
@@ -276,13 +278,6 @@ data class FunctionExp(
     override val type: TypeEmbedding = body.type
 
     override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
-        signature?.formalArgs?.forEach { arg ->
-            // Ideally, we would want to assume these rather than inhale them to prevent inconsistencies with
-            // permissions. Unfortunately, Silicon for some reason does not allow Assumes.
-            listOfNotNull(arg.sharedPredicateAccessInvariant()).forEach { invariant ->
-                ctx.addStatement { Stmt.Inhale(invariant.toViperBuiltinType(ctx), ctx.source.asPosition) }
-            }
-        }
         body.toViperMaybeStoringIn(result, ctx)
         ctx.addLabel(returnLabel.toViper(ctx))
     }

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated.java
@@ -245,6 +245,12 @@ public class FirLightTreeFormVerPluginNoVerificationDiagnosticsTestGenerated ext
       }
 
       @Test
+      @TestMetadata("heap_dependent_specifications.kt")
+      public void testHeap_dependent_specifications() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.kt");
+      }
+
+      @Test
       @TestMetadata("pure_function_rely_on_branch.kt")
       public void testPure_function_rely_on_branch() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.kt");

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
@@ -6,11 +6,11 @@ field bf$b: Ref
 method f$testPrimitiveFieldGetter$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   l0$a := p$pf.bf$a
   l0$b := havoc$T$Int()
@@ -30,6 +30,7 @@ field bf$g: Ref
 method f$testReferenceFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$f: Ref
@@ -38,7 +39,6 @@ method f$testReferenceFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$fb: Ref
   var l0$ga: Ref
   var l0$gb: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   l0$f := p$rf.bf$f
   l0$g := havoc$T$PrimitiveFields()
@@ -64,6 +64,7 @@ field bf$g: Ref
 method f$testCascadingFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$fa: Ref
@@ -72,7 +73,6 @@ method f$testCascadingFieldGetter$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$ga: Ref
   var anon$1: Ref
   var l0$gb: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := p$rf.bf$f
   unfold acc(p$c$PrimitiveFields$shared(anon$0), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
@@ -10,6 +10,7 @@ field bf$uniqueVar: Ref
 method f$testPrimitiveFieldGetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   requires acc(p$c$PrimitiveFields$unique(p$pf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -17,7 +18,6 @@ method f$testPrimitiveFieldGetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   l0$sharedVal := p$pf.bf$sharedVal
   l0$sharedVar := havoc$T$Int()
@@ -40,13 +40,13 @@ field bf$uniqueVar: Ref
 method f$testPrimitiveFieldGetterShared$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   unfold acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   l0$sharedVal := p$pf.bf$sharedVal
   l0$sharedVar := havoc$T$Int()
@@ -69,6 +69,7 @@ field bf$uniqueVar: Ref
 method f$testReferenceFieldGetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   requires acc(p$c$ReferenceFields$unique(p$rf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -76,7 +77,6 @@ method f$testReferenceFieldGetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   l0$sharedVal := p$rf.bf$sharedVal
   l0$sharedVar := havoc$T$PrimitiveFields()
@@ -99,13 +99,13 @@ field bf$uniqueVar: Ref
 method f$testReferenceFieldGetterShared$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$sharedVal: Ref
   var l0$sharedVar: Ref
   var l0$uniqueVal: Ref
   var l0$uniqueVar: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   unfold acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   l0$sharedVal := p$rf.bf$sharedVal
   l0$sharedVar := havoc$T$PrimitiveFields()

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
@@ -6,10 +6,10 @@ field bf$unique: Ref
 method f$testPrimitiveFieldSetterUnique$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   requires acc(p$c$PrimitiveFields$unique(p$pf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -22,9 +22,9 @@ field bf$unique: Ref
 method f$testPrimitiveFieldSetterShared$TF$T$PrimitiveFields$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveFields())
+  requires acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$PrimitiveFields$shared(p$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -46,12 +46,12 @@ method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$uniq
 method f$testReferenceFieldSetterUnique$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   requires acc(p$c$ReferenceFields$unique(p$rf), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(5),
     df$rt$intToRef(6))
   anon$1 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(7),
@@ -77,11 +77,11 @@ method con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(p$shared: Ref, p$uniq
 method f$testReferenceFieldSetterShared$TF$T$ReferenceFields$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceFields())
+  requires acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceFields$shared(p$rf), wildcard)
   anon$0 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(9),
     df$rt$intToRef(10))
   anon$1 := con$c$PrimitiveFields$T$Int$T$Int$T$PrimitiveFields(df$rt$intToRef(11),

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
@@ -7,9 +7,9 @@ field bf$y: Ref
 
 method f$c$Foo$getY$TF$T$Foo$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$y
   goto lbl$ret$0
@@ -27,11 +27,11 @@ field bf$z: Ref
 
 method f$c$Bar$sum$TF$T$Bar$T$Int(this$dispatch: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
   unfold acc(p$c$Bar$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   anon$0 := this$dispatch.bf$x
@@ -53,14 +53,16 @@ field bf$z: Ref
 
 method f$c$Foo$getY$TF$T$Foo$T$Int(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$callSuperMethod$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$bar), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
+  unfold acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := f$c$Foo$getY$TF$T$Foo$T$Int(p$bar)
   goto lbl$ret$0
   label lbl$ret$0
@@ -78,9 +80,9 @@ field bf$z: Ref
 method f$accessSuperField$TF$T$Bar$T$Boolean(p$bar: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$bar), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := havoc$T$Boolean()
   goto lbl$ret$0
   label lbl$ret$0
@@ -97,9 +99,9 @@ field bf$z: Ref
 
 method f$accessNewField$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$bar), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
   unfold acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := p$bar.bf$z
   goto lbl$ret$0
@@ -117,14 +119,15 @@ field bf$z: Ref
 
 method f$c$Bar$sum$TF$T$Bar$T$Int(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$callNewMethod$TF$T$Bar$T$Int(p$bar: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$bar), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
   ret$0 := f$c$Bar$sum$TF$T$Bar$T$Int(p$bar)
   goto lbl$ret$0
   label lbl$ret$0
@@ -141,9 +144,9 @@ field bf$z: Ref
 
 method f$setSuperField$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$bar), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -160,9 +163,9 @@ field bf$z: Ref
 method f$accessSuperSuperField$TF$T$Baz$T$Int(p$baz: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$baz), df$rt$c$Baz())
+  requires acc(p$c$Baz$shared(p$baz), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Baz$shared(p$baz), wildcard)
   unfold acc(p$c$Bar$shared(p$baz), wildcard)
   unfold acc(p$c$Foo$shared(p$baz), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
@@ -3,6 +3,7 @@ field bf$fieldNotOverride: Ref
 
 method con$c$B$T$FieldB$T$B(p$fieldOverride: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$fieldOverride), df$rt$c$FieldB())
+  requires acc(p$c$FieldB$shared(p$fieldOverride), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$B())
   ensures acc(p$c$B$shared(ret), wildcard)
   ensures acc(p$c$B$unique(ret), write)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
@@ -1,6 +1,7 @@
 /interface.kt:(84,98): info: Generated Viper text for testProperties:
 method f$testProperties$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
@@ -9,7 +10,6 @@ method f$testProperties$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
   var anon$2: Ref
   var anon$3: Ref
   var anon$4: Ref
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   anon$0 := ps$public$varProp(p$foo, df$rt$intToRef(0))
   anon$2 := pg$public$varProp(p$foo)
   anon$1 := anon$2
@@ -58,3 +58,4 @@ method f$createImpl$TF$T$Unit() returns (ret$0: Ref)
 }
 
 method pg$public$number(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
@@ -6,11 +6,11 @@ field bf$b: Ref
 method f$testManualPermissionFieldGetter$TF$T$ManualPermissionFields$T$Unit(p$mpf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
+  requires acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$a: Ref
   var l0$b: Ref
-  inhale acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   unfold acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   l0$a := p$mpf.bf$a
   l0$b := p$mpf.bf$b
@@ -27,9 +27,9 @@ field bf$b: Ref
 method f$testManualPermissionFieldSetter$TF$T$ManualPermissionFields$T$Unit(p$mpf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$mpf), df$rt$c$ManualPermissionFields())
+  requires acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$ManualPermissionFields$shared(p$mpf), wildcard)
   p$mpf.bf$b := df$rt$intToRef(123)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
@@ -4,9 +4,9 @@ field bf$x: Ref
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   unfold acc(p$c$Foo$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$x
   goto lbl$ret$0
@@ -19,10 +19,10 @@ field bf$x: Ref
 method f$c$Foo$callMemberFun$TF$T$Foo$T$Unit(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
   anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -31,6 +31,7 @@ method f$c$Foo$callMemberFun$TF$T$Foo$T$Unit(this$dispatch: Ref)
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
@@ -40,18 +41,19 @@ field bf$x: Ref
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$c$Foo$siblingCall$TF$T$Foo$T$Foo$T$Unit(this$dispatch: Ref, p$other: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$other), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$other), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Foo$shared(p$other), wildcard)
   anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(p$other)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -63,15 +65,16 @@ field bf$x: Ref
 method f$c$Foo$memberFun$TF$T$Foo$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
 method f$outerMemberFunCall$TF$T$Foo$T$Unit(p$f: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$f), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(p$f), wildcard)
   anon$0 := f$c$Foo$memberFun$TF$T$Foo$T$Int(p$f)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
@@ -58,11 +58,11 @@ predicate p$c$ReferenceField$unique(this$dispatch: Ref) {
 method f$useClasses$TF$T$ReferenceField$T$Recursive$T$Unit(p$rf: Ref, p$rec: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
+  requires acc(p$c$ReferenceField$shared(p$rf), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$c$Recursive())
+  requires acc(p$c$Recursive$shared(p$rec), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
-  inhale acc(p$c$Recursive$shared(p$rec), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -102,9 +102,9 @@ predicate p$c$C$unique(this$dispatch: Ref) {
 
 method f$threeLayersHierarchy$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  requires acc(p$c$C$shared(p$c), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$C$shared(p$c), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -169,11 +169,11 @@ method f$listHierarchy$TF$T$MutableList$T$Unit(p$xs: Ref)
   requires acc(p$xs.sp$size, write)
   requires df$rt$intFromRef(p$xs.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$xs), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires acc(p$pkg$kotlin_collections$c$MutableList$shared(p$xs), wildcard)
   ensures acc(p$xs.sp$size, write)
   ensures df$rt$intFromRef(p$xs.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$xs), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
@@ -59,10 +59,10 @@ predicate p$c$D$unique(this$dispatch: Ref) {
 method f$accessSuperTypeProperty$TF$T$C$T$Unit(p$c: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  requires acc(p$c$C$shared(p$c), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
-  inhale acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$B$shared(p$c), wildcard)
   unfold acc(p$c$A$shared(p$c), wildcard)
@@ -134,11 +134,11 @@ predicate p$c$D$unique(this$dispatch: Ref) {
 
 method f$accessNested$TF$T$C$T$Unit(p$c: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$c), df$rt$c$C())
+  requires acc(p$c$C$shared(p$c), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$temp: Ref
   var anon$0: Ref
-  inhale acc(p$c$C$shared(p$c), wildcard)
   unfold acc(p$c$C$shared(p$c), wildcard)
   anon$0 := p$c.bf$x
   unfold acc(p$c$A$shared(anon$0), wildcard)
@@ -165,10 +165,10 @@ predicate p$c$A$unique(this$dispatch: Ref) {
 
 method f$accessNullable$TF$NT$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$A()))
+  requires p$x != df$rt$nullValue() ==> acc(p$c$A$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale p$x != df$rt$nullValue() ==> acc(p$c$A$shared(p$x), wildcard)
   if (!(p$x == df$rt$nullValue())) {
     unfold acc(p$c$A$shared(p$x), wildcard)
     l0$n := p$x.bf$a
@@ -206,10 +206,10 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 
 method f$accessCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
+  requires acc(p$c$A$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale acc(p$c$A$shared(p$x), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())
   inhale acc(p$c$B$shared(p$x), wildcard)
   unfold acc(p$c$B$shared(p$x), wildcard)
@@ -247,11 +247,11 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 
 method f$accessSafeCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
+  requires acc(p$c$A$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
   var l0$y: Ref
-  inhale acc(p$c$A$shared(p$x), wildcard)
   l0$n := df$rt$intToRef(0)
   if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {
     l0$y := p$x
@@ -296,10 +296,10 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 
 method f$accessSmartCast$TF$T$A$T$Unit(p$x: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$A())
+  requires acc(p$c$A$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$n: Ref
-  inhale acc(p$c$A$shared(p$x), wildcard)
   l0$n := df$rt$intToRef(0)
   if (df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$B())) {
     inhale acc(p$c$B$shared(p$x), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
@@ -34,6 +34,8 @@ field bf$a: Ref
 method con$c$Recursive$NT$Recursive$T$Recursive(p$a: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$nullable(df$rt$c$Recursive()))
+  requires p$a != df$rt$nullValue() ==>
+    acc(p$c$Recursive$shared(p$a), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Recursive())
   ensures acc(p$c$Recursive$shared(ret), wildcard)
   ensures acc(p$c$Recursive$unique(ret), write)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
@@ -2,10 +2,10 @@
 method f$testPrimitivePropertyGetter$TF$T$PrimitiveProperty$T$Int(p$pp: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
+  requires acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   anon$0 := pg$public$nProp(p$pp)
   ret$0 := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
@@ -20,13 +20,13 @@ method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 method f$testReferencePropertyGetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
+  requires acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$pp: Ref
   var anon$0: Ref
   var l0$ppn: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$0 := pg$public$rProp(p$rp)
   l0$pp := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$pp), df$rt$c$PrimitiveProperty())
@@ -48,13 +48,13 @@ method pg$public$rProp(this$dispatch: Ref) returns (ret: Ref)
 method f$testCascadingPropertyGetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
+  requires acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$ppn: Ref
   var anon$0: Ref
   var anon$1: Ref
   var anon$2: Ref
-  inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$2 := pg$public$rProp(p$rp)
   anon$1 := anon$2
   inhale df$rt$isSubtype(df$rt$typeOf(anon$1), df$rt$c$PrimitiveProperty())
@@ -70,3 +70,4 @@ method pg$public$nProp(this$dispatch: Ref) returns (ret: Ref)
 
 
 method pg$public$rProp(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -4,13 +4,15 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$getValue$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let anon$0$0 ==
+  (let anon$1$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$value)) in
-    anon$0$0)
+    (let anon$0$0 ==
+      (anon$1$0) in
+      anon$0$0))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(164,180): info: Generated Viper text for getSafeNextValue:
@@ -19,23 +21,35 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$getSafeNextValue$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let anon$2$0 ==
+  (let anon$3$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-    (let anon$3$0 ==
-      ((anon$2$0 != df$rt$nullValue() ?
+    (let anon$5$0 ==
+      ((anon$3$0 != df$rt$nullValue() ?
         (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
-            anon$2$0.bf$value)) :
+          (unfolding acc(p$c$Node$shared(anon$3$0), wildcard) in
+            anon$3$0.bf$value)) :
         null)) in
-      (let anon$1$0 ==
-        ((anon$2$0 != df$rt$nullValue() ? anon$3$0 : df$rt$nullValue())) in
-        (let anon$0$0 ==
-          ((anon$1$0 != df$rt$nullValue() ? anon$1$0 : df$rt$intToRef(-1))) in
-          anon$0$0))))
+      (let anon$4$0 ==
+        ((anon$3$0 != df$rt$nullValue() ? anon$5$0 : null)) in
+        (let anon$6$0 ==
+          ((!(anon$3$0 != df$rt$nullValue()) ? df$rt$nullValue() : null)) in
+          (let anon$2$0 ==
+            ((anon$3$0 != df$rt$nullValue() ? anon$4$0 : anon$6$0)) in
+            (let anon$7$0 ==
+              ((anon$2$0 != df$rt$nullValue() ? anon$2$0 : null)) in
+              (let anon$8$0 ==
+                ((!(anon$2$0 != df$rt$nullValue()) ?
+                  df$rt$intToRef(-1) :
+                  null)) in
+                (let anon$1$0 ==
+                  ((anon$2$0 != df$rt$nullValue() ? anon$7$0 : anon$8$0)) in
+                  (let anon$0$0 ==
+                    (anon$1$0) in
+                    anon$0$0)))))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(247,267): info: Generated Viper text for getSafeNextNextValue:
@@ -44,32 +58,50 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$getSafeNextNextValue$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let anon$3$0 ==
+  (let anon$4$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-    (let anon$4$0 ==
-      ((anon$3$0 != df$rt$nullValue() ?
+    (let anon$6$0 ==
+      ((anon$4$0 != df$rt$nullValue() ?
         (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          (unfolding acc(p$c$Node$shared(anon$3$0), wildcard) in
-            anon$3$0.bf$next)) :
+          (unfolding acc(p$c$Node$shared(anon$4$0), wildcard) in
+            anon$4$0.bf$next)) :
         null)) in
-      (let anon$2$0 ==
-        ((anon$3$0 != df$rt$nullValue() ? anon$4$0 : df$rt$nullValue())) in
-        (let anon$5$0 ==
-          ((anon$2$0 != df$rt$nullValue() ?
-            (unfolding acc(p$c$Node$shared(anon$2$0), wildcard) in
-              anon$2$0.bf$value) :
-            null)) in
-          (let anon$1$0 ==
-            ((anon$2$0 != df$rt$nullValue() ? anon$5$0 : df$rt$nullValue())) in
-            (let anon$0$0 ==
-              ((anon$1$0 != df$rt$nullValue() ?
-                anon$1$0 :
-                df$rt$intToRef(0))) in
-              anon$0$0))))))
+      (let anon$5$0 ==
+        ((anon$4$0 != df$rt$nullValue() ? anon$6$0 : null)) in
+        (let anon$7$0 ==
+          ((!(anon$4$0 != df$rt$nullValue()) ? df$rt$nullValue() : null)) in
+          (let anon$3$0 ==
+            ((anon$4$0 != df$rt$nullValue() ? anon$5$0 : anon$7$0)) in
+            (let anon$9$0 ==
+              ((anon$3$0 != df$rt$nullValue() ?
+                (unfolding acc(p$c$Node$shared(anon$3$0), wildcard) in
+                  anon$3$0.bf$value) :
+                null)) in
+              (let anon$8$0 ==
+                ((anon$3$0 != df$rt$nullValue() ? anon$9$0 : null)) in
+                (let anon$10$0 ==
+                  ((!(anon$3$0 != df$rt$nullValue()) ?
+                    df$rt$nullValue() :
+                    null)) in
+                  (let anon$2$0 ==
+                    ((anon$3$0 != df$rt$nullValue() ? anon$8$0 : anon$10$0)) in
+                    (let anon$11$0 ==
+                      ((anon$2$0 != df$rt$nullValue() ? anon$2$0 : null)) in
+                      (let anon$12$0 ==
+                        ((!(anon$2$0 != df$rt$nullValue()) ?
+                          df$rt$intToRef(0) :
+                          null)) in
+                        (let anon$1$0 ==
+                          ((anon$2$0 != df$rt$nullValue() ?
+                            anon$11$0 :
+                            anon$12$0)) in
+                          (let anon$0$0 ==
+                            (anon$1$0) in
+                            anon$0$0)))))))))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(339,355): info: Generated Viper text for sumFirstTwoNodes:
@@ -78,40 +110,46 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$sumFirstTwoNodes$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$nextNode$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-    (let anon$2$0 ==
+    (let anon$4$0 ==
       ((!(l0$nextNode$0 == df$rt$nullValue()) ?
         (unfolding acc(p$c$Node$shared(p$node), wildcard) in
           p$node.bf$value) :
         null)) in
-      (let anon$3$0 ==
+      (let anon$5$0 ==
         ((!(l0$nextNode$0 == df$rt$nullValue()) ?
           (unfolding acc(p$c$Node$shared(p$node), wildcard) in
             (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
               l0$nextNode$0.bf$value)) :
           null)) in
-        (let anon$1$0 ==
+        (let anon$3$0 ==
           ((!(l0$nextNode$0 == df$rt$nullValue()) ?
             (unfolding acc(p$c$Node$shared(p$node), wildcard) in
               (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
                 (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                  sp$plusInts(anon$2$0, anon$3$0)))) :
+                  sp$plusInts(anon$4$0, anon$5$0)))) :
             null)) in
-          (let anon$4$0 ==
-            ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
-              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                p$node.bf$value) :
-              null)) in
-            (let anon$0$0 ==
-              ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                anon$1$0 :
-                anon$4$0)) in
-              anon$0$0))))))
+          (let anon$2$0 ==
+            ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$3$0 : null)) in
+            (let anon$7$0 ==
+              ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+                (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                  p$node.bf$value) :
+                null)) in
+              (let anon$6$0 ==
+                ((!!(l0$nextNode$0 == df$rt$nullValue()) ? anon$7$0 : null)) in
+                (let anon$1$0 ==
+                  ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                    anon$2$0 :
+                    anon$6$0)) in
+                  (let anon$0$0 ==
+                    (anon$1$0) in
+                    anon$0$0)))))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(526,536): info: Generated Viper text for isLastNode:
@@ -120,13 +158,15 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$isLastNode$TF$T$Node$T$Boolean(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
-  (let anon$0$0 ==
+  (let anon$1$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-    df$rt$boolToRef(anon$0$0 == df$rt$nullValue()))
+    (let anon$0$0 ==
+      (df$rt$boolToRef(anon$1$0 == df$rt$nullValue())) in
+      anon$0$0))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(602,608): info: Generated Viper text for length:
@@ -135,22 +175,28 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$length$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$nextNode$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-    (let anon$1$0 ==
+    (let anon$3$0 ==
       ((l0$nextNode$0 == df$rt$nullValue() ? df$rt$intToRef(1) : null)) in
       (let anon$2$0 ==
-        ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            sp$plusInts(df$rt$intToRef(1), f$length$TF$T$Node$T$Int(l0$nextNode$0))) :
-          null)) in
-        (let anon$0$0 ==
-          ((l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0)) in
-          anon$0$0))))
+        ((l0$nextNode$0 == df$rt$nullValue() ? anon$3$0 : null)) in
+        (let anon$5$0 ==
+          ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+              sp$plusInts(df$rt$intToRef(1), f$length$TF$T$Node$T$Int(l0$nextNode$0))) :
+            null)) in
+          (let anon$4$0 ==
+            ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$5$0 : null)) in
+            (let anon$1$0 ==
+              ((l0$nextNode$0 == df$rt$nullValue() ? anon$2$0 : anon$4$0)) in
+              (let anon$0$0 ==
+                (anon$1$0) in
+                anon$0$0)))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(763,774): info: Generated Viper text for sumAllNodes:
@@ -159,31 +205,37 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$sumAllNodes$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$nextNode$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-    (let anon$1$0 ==
+    (let anon$3$0 ==
       ((l0$nextNode$0 == df$rt$nullValue() ?
         (unfolding acc(p$c$Node$shared(p$node), wildcard) in
           p$node.bf$value) :
         null)) in
-      (let anon$3$0 ==
-        ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            p$node.bf$value) :
-          null)) in
-        (let anon$2$0 ==
+      (let anon$2$0 ==
+        ((l0$nextNode$0 == df$rt$nullValue() ? anon$3$0 : null)) in
+        (let anon$6$0 ==
           ((!(l0$nextNode$0 == df$rt$nullValue()) ?
             (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                sp$plusInts(anon$3$0, f$sumAllNodes$TF$T$Node$T$Int(l0$nextNode$0)))) :
+              p$node.bf$value) :
             null)) in
-          (let anon$0$0 ==
-            ((l0$nextNode$0 == df$rt$nullValue() ? anon$1$0 : anon$2$0)) in
-            anon$0$0)))))
+          (let anon$5$0 ==
+            ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                  sp$plusInts(anon$6$0, f$sumAllNodes$TF$T$Node$T$Int(l0$nextNode$0)))) :
+              null)) in
+            (let anon$4$0 ==
+              ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$5$0 : null)) in
+              (let anon$1$0 ==
+                ((l0$nextNode$0 == df$rt$nullValue() ? anon$2$0 : anon$4$0)) in
+                (let anon$0$0 ==
+                  (anon$1$0) in
+                  anon$0$0))))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(952,965): info: Generated Viper text for containsValue:
@@ -192,29 +244,43 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$containsValue$TF$T$Node$T$Int$T$Boolean(p$node: Ref, p$target: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let anon$0$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$value)) in
-    (let l0$nextNode$0 ==
-      ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-      (let anon$2$0 ==
-        ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            f$containsValue$TF$T$Node$T$Int$T$Boolean(l0$nextNode$0, p$target)) :
-          null)) in
-        (let anon$3$0 ==
-          ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
-            df$rt$boolToRef(false) :
+    (let anon$1$0 ==
+      ((df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target) ?
+        df$rt$boolToRef(true) :
+        null)) in
+      (let l0$nextNode$0 ==
+        ((unfolding acc(p$c$Node$shared(p$node), wildcard) in
+          p$node.bf$next)) in
+        (let anon$5$0 ==
+          ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+              f$containsValue$TF$T$Node$T$Int$T$Boolean(l0$nextNode$0, p$target)) :
             null)) in
-          (let anon$1$0 ==
-            ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$2$0 : anon$3$0)) in
-            (df$rt$intFromRef(anon$0$0) == df$rt$intFromRef(p$target) ?
-              df$rt$boolToRef(true) :
-              anon$1$0))))))
+          (let anon$4$0 ==
+            ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$5$0 : null)) in
+            (let anon$7$0 ==
+              ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+                df$rt$boolToRef(false) :
+                null)) in
+              (let anon$6$0 ==
+                ((!!(l0$nextNode$0 == df$rt$nullValue()) ? anon$7$0 : null)) in
+                (let anon$3$0 ==
+                  ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                    anon$4$0 :
+                    anon$6$0)) in
+                  (let anon$2$0 ==
+                    (anon$3$0) in
+                    (df$rt$intFromRef(anon$0$0) ==
+                    df$rt$intFromRef(p$target) ?
+                      anon$1$0 :
+                      anon$2$0))))))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(1162,1178): info: Generated Viper text for aliasAndReassign:
@@ -223,8 +289,8 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$aliasAndReassign$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$alias1$0 ==
@@ -244,7 +310,9 @@ function f$aliasAndReassign$TF$T$Node$T$Int(p$node: Ref): Ref
             ((!(l0$alias2$0 == df$rt$nullValue()) ?
               l0$fallbackValue$1 :
               l0$fallbackValue$0)) in
-            l0$fallbackValue$2)))))
+            (let anon$0$0 ==
+              (l0$fallbackValue$2) in
+              anon$0$0))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(1384,1386): info: Generated Viper text for id:
@@ -253,12 +321,14 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$id$TF$NT$Node$NT$Node(p$node: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
   requires p$node != df$rt$nullValue() ==>
     acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 {
-  p$node
+  (let anon$0$0 ==
+    (p$node) in
+    anon$0$0)
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(1438,1457): info: Generated Viper text for useIdentityFunction:
@@ -267,31 +337,43 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$id$TF$NT$Node$NT$Node(p$node: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
   requires p$node != df$rt$nullValue() ==>
     acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 
 
 function f$useIdentityFunction$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let l0$sameNode$0 ==
     (f$id$TF$NT$Node$NT$Node(p$node)) in
-    (let anon$2$0 ==
+    (let anon$4$0 ==
       ((l0$sameNode$0 != df$rt$nullValue() ?
         (unfolding acc(p$c$Node$shared(l0$sameNode$0), wildcard) in
           l0$sameNode$0.bf$value) :
         null)) in
-      (let anon$1$0 ==
-        ((l0$sameNode$0 != df$rt$nullValue() ?
-          anon$2$0 :
-          df$rt$nullValue())) in
-        (let anon$0$0 ==
-          ((anon$1$0 != df$rt$nullValue() ? anon$1$0 : df$rt$intToRef(0))) in
-          anon$0$0))))
+      (let anon$3$0 ==
+        ((l0$sameNode$0 != df$rt$nullValue() ? anon$4$0 : null)) in
+        (let anon$5$0 ==
+          ((!(l0$sameNode$0 != df$rt$nullValue()) ?
+            df$rt$nullValue() :
+            null)) in
+          (let anon$2$0 ==
+            ((l0$sameNode$0 != df$rt$nullValue() ? anon$3$0 : anon$5$0)) in
+            (let anon$6$0 ==
+              ((anon$2$0 != df$rt$nullValue() ? anon$2$0 : null)) in
+              (let anon$7$0 ==
+                ((!(anon$2$0 != df$rt$nullValue()) ?
+                  df$rt$intToRef(0) :
+                  null)) in
+                (let anon$1$0 ==
+                  ((anon$2$0 != df$rt$nullValue() ? anon$6$0 : anon$7$0)) in
+                  (let anon$0$0 ==
+                    (anon$1$0) in
+                    anon$0$0)))))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt:(1550,1569): info: Generated Viper text for getNextValueUsingId:
@@ -300,8 +382,8 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$getNextValueUsingId$TF$T$Node$T$Int(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
   (let anon$0$0 ==
@@ -309,22 +391,28 @@ function f$getNextValueUsingId$TF$T$Node$T$Int(p$node: Ref): Ref
     (let l0$nextNode$0 ==
       ((unfolding acc(p$c$Node$shared(p$node), wildcard) in
         f$id$TF$NT$Node$NT$Node(anon$0$0))) in
-      (let anon$2$0 ==
+      (let anon$4$0 ==
         ((l0$nextNode$0 == df$rt$nullValue() ? df$rt$intToRef(0) : null)) in
         (let anon$3$0 ==
-          ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
-                l0$nextNode$0.bf$value)) :
-            null)) in
-          (let anon$1$0 ==
-            ((l0$nextNode$0 == df$rt$nullValue() ? anon$2$0 : anon$3$0)) in
-            anon$1$0)))))
+          ((l0$nextNode$0 == df$rt$nullValue() ? anon$4$0 : null)) in
+          (let anon$6$0 ==
+            ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
+                  l0$nextNode$0.bf$value)) :
+              null)) in
+            (let anon$5$0 ==
+              ((!(l0$nextNode$0 == df$rt$nullValue()) ? anon$6$0 : null)) in
+              (let anon$2$0 ==
+                ((l0$nextNode$0 == df$rt$nullValue() ? anon$3$0 : anon$5$0)) in
+                (let anon$1$0 ==
+                  (anon$2$0) in
+                  anon$1$0))))))))
 }
 
 function f$id$TF$NT$Node$NT$Node(p$node: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
   requires p$node != df$rt$nullValue() ==>
     acc(p$c$Node$shared(p$node), wildcard)
-  requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
@@ -4,9 +4,9 @@ field bf$a: Ref
 method f$testPrimitiveFieldSetter$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
+  requires acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -27,10 +27,10 @@ method con$c$PrimitiveField$T$Int$T$PrimitiveField(p$a: Ref)
 method f$testReferenceFieldSetter$TF$T$ReferenceField$T$Unit(p$rf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rf), df$rt$c$ReferenceField())
+  requires acc(p$c$ReferenceField$shared(p$rf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$ReferenceField$shared(p$rf), wildcard)
   anon$0 := con$c$PrimitiveField$T$Int$T$PrimitiveField(df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -40,10 +40,10 @@ method f$testReferenceFieldSetter$TF$T$ReferenceField$T$Unit(p$rf: Ref)
 method f$testPrimitivePropertySetter$TF$T$PrimitiveProperty$T$Unit(p$pp: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pp), df$rt$c$PrimitiveProperty())
+  requires acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveProperty$shared(p$pp), wildcard)
   anon$0 := ps$public$aProp(p$pp, df$rt$intToRef(0))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
@@ -65,11 +65,11 @@ method con$c$PrimitiveProperty$T$PrimitiveProperty() returns (ret: Ref)
 method f$testReferencePropertySetter$TF$T$ReferenceProperty$T$Unit(p$rp: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rp), df$rt$c$ReferenceProperty())
+  requires acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$ReferenceProperty$shared(p$rp), wildcard)
   anon$1 := con$c$PrimitiveProperty$T$PrimitiveProperty()
   anon$0 := ps$public$ppProp(p$rp, anon$1)
   label lbl$ret$0
@@ -86,3 +86,4 @@ method ps$public$aProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
 
 
 method ps$public$ppProp(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
@@ -50,10 +50,10 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 
 method f$unique_foo_arg$TF$T$Foo$T$Unit(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   requires acc(p$c$Foo$unique(p$foo), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -69,10 +69,10 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 
 method f$nullable_unique_arg$TF$NT$T$T$Unit(p$t: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$nullable(df$rt$c$T()))
+  requires p$t != df$rt$nullValue() ==> acc(p$c$T$shared(p$t), wildcard)
   requires p$t != df$rt$nullValue() ==> acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale p$t != df$rt$nullValue() ==> acc(p$c$T$shared(p$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -88,11 +88,11 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 
 method f$borrowed_unique_arg$TF$T$T$T$Unit(p$t: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$t), df$rt$c$T())
+  requires acc(p$c$T$shared(p$t), wildcard)
   requires acc(p$c$T$unique(p$t), write)
   ensures acc(p$c$T$unique(p$t), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$T$shared(p$t), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -109,10 +109,10 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 method f$unique_receiver$TF$T$T$T$Unit(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
+  requires acc(p$c$T$shared(this$extension), wildcard)
   requires acc(p$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -129,11 +129,11 @@ predicate p$c$T$unique(this$dispatch: Ref) {
 method f$borrowed_unique_receiver$TF$T$T$T$Unit(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$T())
+  requires acc(p$c$T$shared(this$extension), wildcard)
   requires acc(p$c$T$unique(this$extension), write)
   ensures acc(p$c$T$unique(this$extension), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$T$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
@@ -220,6 +220,7 @@ method f$call$TF$T$Int$T$Unit(p$x: Ref) returns (ret: Ref)
 
 method f$ignore$TF$T$Exception$T$Unit(p$e: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$e), df$rt$c$pkg$java_lang$Exception())
+  requires acc(p$pkg$java_lang$c$Exception$shared(p$e), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -251,3 +252,4 @@ method pg$public$cause(this$dispatch: Ref) returns (ret: Ref)
 
 
 method pg$public$message(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
@@ -152,10 +152,10 @@ method f$unusedResult$TF$T$Int() returns (ret$0: Ref)
 /when.kt:(1221,1227): info: Generated Viper text for whenIs:
 method f$whenIs$TF$T$Foo$T$Boolean(p$x: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(p$x), wildcard)
   anon$0 := p$x
   if (df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Bar())) {
     ret$0 := df$rt$boolToRef(true)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
@@ -51,11 +51,11 @@ method eg$pfValProp$TF$T$PrimitiveField$T$Int(this$dispatch: Ref)
 method f$extensionGetterPropertyUserDefinedClass$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
+  requires acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$x: Ref
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   anon$0 := eg$pfValProp$TF$T$PrimitiveField$T$Int(p$pf)
   l0$x := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(l0$x), df$rt$intType())
@@ -77,10 +77,10 @@ method es$pfVarProp$TF$T$PrimitiveField$T$Int$T$Unit(this$dispatch: Ref, anon$0:
 method f$extensionSetterPropertyUserDefinedClass$TF$T$PrimitiveField$T$Unit(p$pf: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$pf), df$rt$c$PrimitiveField())
+  requires acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale acc(p$c$PrimitiveField$shared(p$pf), wildcard)
   anon$0 := es$pfVarProp$TF$T$PrimitiveField$T$Int$T$Unit(p$pf, df$rt$intToRef(42))
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
@@ -2,11 +2,11 @@
 method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$f), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Foo$shared(p$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -15,11 +15,11 @@ method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
 method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$b), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Bar$shared(p$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -27,9 +27,9 @@ method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
 /function_overloading.kt:(98,107): info: Generated Viper text for fakePrint:
 method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$b), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Bar$shared(p$b), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -37,9 +37,9 @@ method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret$0: Ref)
 /function_overloading.kt:(125,134): info: Generated Viper text for fakePrint:
 method f$fakePrint$TF$T$Foo$T$Unit(p$f: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$f), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Foo$shared(p$f), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -96,6 +96,7 @@ method con$c$Foo$T$Foo() returns (ret: Ref)
 
 method f$fakePrint$TF$T$Bar$T$Unit(p$b: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$b), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -106,6 +107,7 @@ method f$fakePrint$TF$T$Boolean$T$Unit(p$truth: Ref) returns (ret: Ref)
 
 method f$fakePrint$TF$T$Foo$T$Unit(p$f: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$f), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
@@ -149,14 +151,18 @@ method con$c$Foo$T$Foo() returns (ret: Ref)
 method f$c$Bar$baz$TF$T$Bar$T$Bar$T$Unit(this$dispatch: Ref, p$b: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$b), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$c$Bar$baz$TF$T$Bar$T$Foo$T$Unit(this$dispatch: Ref, p$f: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$f), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$f), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
@@ -487,6 +487,7 @@ predicate p$c$B$unique(this$dispatch: Ref) {
 
 method f$havoc$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$a), df$rt$c$A())
+  requires acc(p$c$A$shared(p$a), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$localUnit: Ref
@@ -505,7 +506,6 @@ method f$havoc$TF$T$A$T$Unit(p$a: Ref) returns (ret$0: Ref)
   var l0$localCharNull: Ref
   var l0$localStringNull: Ref
   var l0$localClassTypeNull: Ref
-  inhale acc(p$c$A$shared(p$a), wildcard)
   l0$localUnit := havoc$T$Unit()
   l0$localNothing := havoc$T$Nothing()
   l0$localAny := havoc$T$Any()

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
@@ -1,10 +1,10 @@
 /as_operator.kt:(57,63): info: Generated Viper text for testAs:
 method f$testAs$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$foo), wildcard)
   ret$0 := p$foo
@@ -15,12 +15,12 @@ method f$testAs$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
 /as_operator.kt:(97,111): info: Generated Viper text for testNullableAs:
 method f$testNullableAs$TF$NT$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+  requires p$foo != df$rt$nullValue() ==>
+    acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(p$foo), wildcard)
@@ -32,11 +32,11 @@ method f$testNullableAs$TF$NT$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
 /as_operator.kt:(148,158): info: Generated Viper text for testSafeAs:
 method f$testSafeAs$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {
     ret$0 := p$foo
   } else {
@@ -52,12 +52,12 @@ method f$testSafeAs$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
 method f$testNullableSafeAs$TF$NT$Foo$NT$Bar(p$foo: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+  requires p$foo != df$rt$nullValue() ==>
+    acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
   if (df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())) {
     ret$0 := p$foo
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
@@ -3,15 +3,16 @@ field bf$x: Ref
 
 method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$testSafeCall$TF$NT$Foo$NT$Unit(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+  requires p$foo != df$rt$nullValue() ==>
+    acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
     anon$0 := f$c$Foo$f$TF$T$Foo$T$Unit(p$foo)
@@ -27,15 +28,16 @@ field bf$x: Ref
 
 method f$c$Foo$f$TF$T$Foo$T$Unit(this$dispatch: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$testSafeCallNonNullable$TF$T$Foo$NT$Unit(p$foo: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
     anon$0 := f$c$Foo$f$TF$T$Foo$T$Unit(p$foo)
@@ -52,10 +54,10 @@ field bf$x: Ref
 method f$testSafeCallProperty$TF$NT$Foo$NT$Int(p$foo: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+  requires p$foo != df$rt$nullValue() ==>
+    acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale p$foo != df$rt$nullValue() ==>
-    acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
     unfold acc(p$c$Foo$shared(p$foo), wildcard)
@@ -73,9 +75,9 @@ field bf$x: Ref
 method f$testSafeCallPropertyNonNullable$TF$T$Foo$NT$Int(p$foo: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   if (p$foo != df$rt$nullValue()) {
     var anon$0: Ref
     unfold acc(p$c$Foo$shared(p$foo), wildcard)
@@ -93,18 +95,19 @@ field bf$v: Ref
 method f$c$Rec$nullable$TF$T$Rec$NT$Rec(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Rec())
+  requires acc(p$c$Rec$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$nullable(df$rt$c$Rec()))
   ensures ret != df$rt$nullValue() ==> acc(p$c$Rec$shared(ret), wildcard)
 
 
 method f$safeCallChain$TF$NT$Rec$NT$Int(p$rec: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$rec), df$rt$nullable(df$rt$c$Rec()))
+  requires p$rec != df$rt$nullValue() ==>
+    acc(p$c$Rec$shared(p$rec), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale p$rec != df$rt$nullValue() ==>
-    acc(p$c$Rec$shared(p$rec), wildcard)
   if (p$rec != df$rt$nullValue()) {
     anon$1 := f$c$Rec$nullable$TF$T$Rec$NT$Rec(p$rec)
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_assignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_assignments.fir.diag.txt
@@ -4,7 +4,9 @@ function f$returnNumberVal$TF$T$Int(): Ref
 {
   (let l0$x$0 ==
     (df$rt$intToRef(42)) in
-    l0$x$0)
+    (let anon$0$0 ==
+      (l0$x$0) in
+      anon$0$0))
 }
 
 /pure_function_with_assignments.kt:(144,178): info: Generated Viper text for multipleAssignmentsOfDifferentType:
@@ -19,7 +21,9 @@ function f$multipleAssignmentsOfDifferentType$TF$T$Boolean(): Ref
         (df$rt$boolToRef(true)) in
         (let l0$d$0 ==
           (df$rt$charToRef(65)) in
-          l0$c$0))))
+          (let anon$0$0 ==
+            (l0$c$0) in
+            anon$0$0)))))
 }
 
 /pure_function_with_assignments.kt:(292,328): info: Generated Viper text for multipleAssignmentsWithLiteralReturn:
@@ -34,7 +38,9 @@ function f$multipleAssignmentsWithLiteralReturn$TF$T$Int(): Ref
         (df$rt$boolToRef(true)) in
         (let l0$d$0 ==
           (df$rt$charToRef(65)) in
-          df$rt$intToRef(42)))))
+          (let anon$0$0 ==
+            (df$rt$intToRef(42)) in
+            anon$0$0)))))
 }
 
 /pure_function_with_assignments.kt:(439,473): info: Generated Viper text for laterInitializersCanRelyOnPrevious:
@@ -47,7 +53,9 @@ function f$laterInitializersCanRelyOnPrevious$TF$T$Int(): Ref
       (sp$plusInts(l0$a$0, df$rt$intToRef(2))) in
       (let l0$c$0 ==
         (sp$timesInts(l0$b$0, df$rt$intToRef(2))) in
-        l0$c$0)))
+        (let anon$0$0 ==
+          (l0$c$0) in
+          anon$0$0))))
 }
 
 /pure_function_with_assignments.kt:(560,591): info: Generated Viper text for initializersCanRelyOnParameters:
@@ -62,5 +70,7 @@ function f$initializersCanRelyOnParameters$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: R
       (sp$minusInts(p$x, p$y)) in
       (let l0$res$0 ==
         (sp$timesInts(l0$sum$0, l0$diff$0)) in
-        l0$res$0)))
+        (let anon$0$0 ==
+          (l0$res$0) in
+          anon$0$0))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
@@ -7,7 +7,9 @@ function f$noAssignmentInBlocks$TF$T$Boolean$T$Int(p$a: Ref): Ref
     (df$rt$intToRef(0)) in
     (let l0$result$1 ==
       (sp$plusInts(l0$result$0, df$rt$intToRef(1))) in
-      l0$result$1))
+      (let anon$0$0 ==
+        (l0$result$1) in
+        anon$0$0)))
 }
 
 /pure_function_with_branching.kt:(216,231): info: Generated Viper text for simpleBranching:
@@ -27,7 +29,9 @@ function f$simpleBranching$TF$T$Boolean$T$Int(p$a: Ref): Ref
           null)) in
         (let l0$result$3 ==
           ((df$rt$boolFromRef(p$a) ? l0$result$1 : l0$result$2)) in
-          l0$result$3))))
+          (let anon$0$0 ==
+            (l0$result$3) in
+            anon$0$0)))))
 }
 
 /pure_function_with_branching.kt:(389,404): info: Generated Viper text for nestedBranching:
@@ -72,7 +76,9 @@ function f$nestedBranching$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
                       ((df$rt$boolFromRef(p$a) ? l0$result$8 : l0$result$7)) in
                       (let l0$result$10 ==
                         (sp$plusInts(df$rt$intToRef(7), l0$result$9)) in
-                        l0$result$10)))))))))))
+                        (let anon$0$0 ==
+                          (l0$result$10) in
+                          anon$0$0))))))))))))
 }
 
 /pure_function_with_branching.kt:(814,834): info: Generated Viper text for whenExpressionSimple:
@@ -86,19 +92,26 @@ function f$whenExpressionSimple$TF$T$Int$T$Int(p$x: Ref): Ref
       (p$x) in
       (let l0$y$1 ==
         ((df$rt$intFromRef(anon$0$0) == 1 ? df$rt$intToRef(10) : null)) in
-        (let l0$y$2 ==
-          ((!(df$rt$intFromRef(anon$0$0) == 2) &&
+        (let anon$1$0 ==
+          ((df$rt$intFromRef(anon$0$0) == 2 &&
           !(df$rt$intFromRef(anon$0$0) == 1) ?
-            df$rt$intToRef(30) :
+            df$rt$intToRef(20) :
             null)) in
-          (let l0$y$3 ==
-            ((df$rt$intFromRef(anon$0$0) == 2 ? l0$y$0 : l0$y$2)) in
-            (let l0$y$4 ==
-              ((df$rt$intFromRef(anon$0$0) == 1 ? l0$y$1 : l0$y$3)) in
-              (df$rt$intFromRef(anon$0$0) == 2 &&
-              !(df$rt$intFromRef(anon$0$0) == 1) ?
-                df$rt$intToRef(20) :
-                sp$plusInts(l0$y$4, df$rt$intToRef(1)))))))))
+          (let l0$y$2 ==
+            ((!(df$rt$intFromRef(anon$0$0) == 2) &&
+            !(df$rt$intFromRef(anon$0$0) == 1) ?
+              df$rt$intToRef(30) :
+              null)) in
+            (let l0$y$3 ==
+              ((df$rt$intFromRef(anon$0$0) == 2 ? l0$y$0 : l0$y$2)) in
+              (let l0$y$4 ==
+                ((df$rt$intFromRef(anon$0$0) == 1 ? l0$y$1 : l0$y$3)) in
+                (let anon$2$0 ==
+                  (sp$plusInts(l0$y$4, df$rt$intToRef(1))) in
+                  (df$rt$intFromRef(anon$0$0) == 2 &&
+                  !(df$rt$intFromRef(anon$0$0) == 1) ?
+                    anon$1$0 :
+                    anon$2$0)))))))))
 }
 
 /pure_function_with_branching.kt:(1053,1076): info: Generated Viper text for whenNoArgumentBranching:
@@ -107,22 +120,41 @@ function f$whenNoArgumentBranching$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
   requires df$rt$isSubtype(df$rt$typeOf(p$y), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let l5$z$0 ==
-    ((!(df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
-    (!(df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0) &&
-    !(df$rt$intFromRef(p$x) == 0)) ?
-      df$rt$intToRef(5) :
-      null)) in
-    (df$rt$intFromRef(p$x) == 0 ?
-      df$rt$intToRef(0) :
-      (df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0 &&
+  (let anon$0$0 ==
+    ((df$rt$intFromRef(p$x) == 0 ? df$rt$intToRef(0) : null)) in
+    (let anon$1$0 ==
+      ((df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0 &&
       !(df$rt$intFromRef(p$x) == 0) ?
         df$rt$intToRef(1) :
-        ((df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
+        null)) in
+      (let anon$2$0 ==
+        (((df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
         (!(df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0) &&
         !(df$rt$intFromRef(p$x) == 0)) ?
           df$rt$intToRef(-1) :
-          l5$z$0))))
+          null)) in
+        (let l5$z$0 ==
+          ((!(df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
+          (!(df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0) &&
+          !(df$rt$intFromRef(p$x) == 0)) ?
+            df$rt$intToRef(5) :
+            null)) in
+          (let anon$3$0 ==
+            ((!(df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
+            (!(df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0) &&
+            !(df$rt$intFromRef(p$x) == 0)) ?
+              l5$z$0 :
+              null)) in
+            (df$rt$intFromRef(p$x) == 0 ?
+              anon$0$0 :
+              (df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0 &&
+              !(df$rt$intFromRef(p$x) == 0) ?
+                anon$1$0 :
+                ((df$rt$intFromRef(p$x) < 0 || df$rt$intFromRef(p$y) < 0) &&
+                (!(df$rt$intFromRef(p$x) > 0 && df$rt$intFromRef(p$y) > 0) &&
+                !(df$rt$intFromRef(p$x) == 0)) ?
+                  anon$2$0 :
+                  anon$3$0))))))))
 }
 
 /pure_function_with_branching.kt:(1299,1322): info: Generated Viper text for stringEqualityBranching:
@@ -132,27 +164,34 @@ function f$stringEqualityBranching$TF$T$String$T$Boolean(p$input: Ref): Ref
 {
   (let l0$isValid$0 ==
     (df$rt$boolToRef(false)) in
-    (let l0$isValid$1 ==
-      ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) &&
-      !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+    (let anon$0$0 ==
+      ((df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
         df$rt$boolToRef(true) :
         null)) in
-      (let l0$isValid$2 ==
-        ((!(df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114)) &&
+      (let l0$isValid$1 ==
+        ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) &&
         !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
-          df$rt$boolToRef(false) :
+          df$rt$boolToRef(true) :
           null)) in
-        (let l0$isValid$3 ==
-          ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) ?
-            l0$isValid$1 :
-            l0$isValid$2)) in
-          (let l0$isValid$4 ==
-            ((df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
-              l0$isValid$0 :
-              l0$isValid$3)) in
-            (df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
-              df$rt$boolToRef(true) :
-              l0$isValid$4))))))
+        (let l0$isValid$2 ==
+          ((!(df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114)) &&
+          !(df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110)) ?
+            df$rt$boolToRef(false) :
+            null)) in
+          (let l0$isValid$3 ==
+            ((df$rt$stringFromRef(p$input) == Seq(117, 115, 101, 114) ?
+              l0$isValid$1 :
+              l0$isValid$2)) in
+            (let l0$isValid$4 ==
+              ((df$rt$stringFromRef(p$input) == Seq(97, 100, 109, 105, 110) ?
+                l0$isValid$0 :
+                l0$isValid$3)) in
+              (let anon$1$0 ==
+                (l0$isValid$4) in
+                (df$rt$stringFromRef(p$input) ==
+                Seq(97, 100, 109, 105, 110) ?
+                  anon$0$0 :
+                  anon$1$0))))))))
 }
 
 /pure_function_with_branching.kt:(1585,1609): info: Generated Viper text for sequentialIfWithMutation:
@@ -167,9 +206,11 @@ function f$sequentialIfWithMutation$TF$T$Int(): Ref
         ((!(df$rt$intFromRef(l0$x$0) > 5) ? df$rt$intToRef(20) : null)) in
         (let l0$x$3 ==
           ((df$rt$intFromRef(l0$x$0) > 5 ? l0$x$1 : l0$x$2)) in
-          (df$rt$intFromRef(l0$x$3) == 2 ?
-            df$rt$intToRef(100) :
-            df$rt$intToRef(0))))))
+          (let anon$0$0 ==
+            ((df$rt$intFromRef(l0$x$3) == 2 ? df$rt$intToRef(100) : null)) in
+            (let anon$1$0 ==
+              (df$rt$intToRef(0)) in
+              (df$rt$intFromRef(l0$x$3) == 2 ? anon$0$0 : anon$1$0)))))))
 }
 
 /pure_function_with_branching.kt:(1768,1788): info: Generated Viper text for complexBooleanReturn:
@@ -177,19 +218,34 @@ function f$complexBooleanReturn$TF$T$Int$T$Boolean(p$x: Ref): Ref
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
-  (let l0$result$0 ==
-    (df$rt$boolToRef(false)) in
-    (let l0$result$1 ==
-      ((df$rt$intFromRef(p$x) > 50 ? df$rt$boolToRef(true) : null)) in
-      (let l0$result$2 ==
-        ((!(df$rt$intFromRef(p$x) > 50) ? df$rt$boolToRef(true) : null)) in
-        (let l0$result$3 ==
-          ((df$rt$intFromRef(p$x) > 50 ? l0$result$1 : l0$result$2)) in
-          (df$rt$intFromRef(p$x) > 100 ?
-            df$rt$boolToRef(true) :
-            (df$rt$intFromRef(p$x) < 0 && !(df$rt$intFromRef(p$x) > 50) ?
-              df$rt$boolToRef(false) :
-              (df$rt$boolFromRef(l0$result$3) ?
-                df$rt$boolToRef(false) :
-                df$rt$boolToRef(true))))))))
+  (let anon$0$0 ==
+    ((df$rt$intFromRef(p$x) > 100 ? df$rt$boolToRef(true) : null)) in
+    (let l0$result$0 ==
+      (df$rt$boolToRef(false)) in
+      (let l0$result$1 ==
+        ((df$rt$intFromRef(p$x) > 50 ? df$rt$boolToRef(true) : null)) in
+        (let anon$1$0 ==
+          ((df$rt$intFromRef(p$x) < 0 && !(df$rt$intFromRef(p$x) > 50) ?
+            df$rt$boolToRef(false) :
+            null)) in
+          (let l0$result$2 ==
+            ((!(df$rt$intFromRef(p$x) > 50) ? df$rt$boolToRef(true) : null)) in
+            (let l0$result$3 ==
+              ((df$rt$intFromRef(p$x) > 50 ? l0$result$1 : l0$result$2)) in
+              (let anon$2$0 ==
+                ((df$rt$boolFromRef(l0$result$3) ?
+                  df$rt$boolToRef(false) :
+                  null)) in
+                (let anon$3$0 ==
+                  ((!df$rt$boolFromRef(l0$result$3) ?
+                    df$rt$boolToRef(true) :
+                    null)) in
+                  (df$rt$intFromRef(p$x) > 100 ?
+                    anon$0$0 :
+                    (df$rt$intFromRef(p$x) < 0 &&
+                    !(df$rt$intFromRef(p$x) > 50) ?
+                      anon$1$0 :
+                      (df$rt$boolFromRef(l0$result$3) ?
+                        anon$2$0 :
+                        anon$3$0)))))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
@@ -8,7 +8,9 @@ function f$doubleIncrement$TF$T$Int(): Ref
       (sp$plusInts(l0$x$0, df$rt$intToRef(1))) in
       (let l0$x$2 ==
         (sp$plusInts(l0$x$1, df$rt$intToRef(1))) in
-        l0$x$2)))
+        (let anon$0$0 ==
+          (l0$x$2) in
+          anon$0$0))))
 }
 
 /pure_function_with_reassignments.kt:(171,194): info: Generated Viper text for updateThenReadIntoOther:
@@ -21,7 +23,9 @@ function f$updateThenReadIntoOther$TF$T$Int(): Ref
       (sp$plusInts(l0$x$0, df$rt$intToRef(4))) in
       (let l0$y$0 ==
         (sp$plusInts(l0$x$1, df$rt$intToRef(1))) in
-        l0$y$0)))
+        (let anon$0$0 ==
+          (l0$y$0) in
+          anon$0$0))))
 }
 
 /pure_function_with_reassignments.kt:(276,300): info: Generated Viper text for readOldValueBeforeUpdate:
@@ -36,7 +40,9 @@ function f$readOldValueBeforeUpdate$TF$T$Int(): Ref
         (sp$plusInts(l0$x$0, df$rt$intToRef(5))) in
         (let l0$x$2 ==
           (sp$plusInts(l0$y$0, l0$x$1)) in
-          l0$x$2))))
+          (let anon$0$0 ==
+            (l0$x$2) in
+            anon$0$0)))))
 }
 
 /pure_function_with_reassignments.kt:(397,413): info: Generated Viper text for chainThroughTemp:
@@ -49,7 +55,9 @@ function f$chainThroughTemp$TF$T$Int(): Ref
       (sp$plusInts(l0$x$0, df$rt$intToRef(3))) in
       (let l0$x$1 ==
         (sp$plusInts(l0$t$0, df$rt$intToRef(4))) in
-        l0$x$1)))
+        (let anon$0$0 ==
+          (l0$x$1) in
+          anon$0$0))))
 }
 
 /pure_function_with_reassignments.kt:(495,522): info: Generated Viper text for overwriteNotSelfReferential:
@@ -60,7 +68,9 @@ function f$overwriteNotSelfReferential$TF$T$Int(): Ref
     (df$rt$intToRef(7)) in
     (let l0$x$1 ==
       (df$rt$intToRef(100)) in
-      l0$x$1))
+      (let anon$0$0 ==
+        (l0$x$1) in
+        anon$0$0)))
 }
 
 /pure_function_with_reassignments.kt:(584,611): info: Generated Viper text for nestedConditionalAssignment:
@@ -70,33 +80,53 @@ function f$nestedConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
   requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let anon$1$0 ==
+  (let anon$3$0 ==
     ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
       df$rt$intToRef(4) :
       null)) in
     (let anon$2$0 ==
-      ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
-        df$rt$intToRef(3) :
-        null)) in
-      (let anon$0$0 ==
-        ((df$rt$boolFromRef(p$a) ?
-          (df$rt$boolFromRef(p$b) ? anon$1$0 : anon$2$0) :
+      ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ? anon$3$0 : null)) in
+      (let anon$5$0 ==
+        ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+          df$rt$intToRef(3) :
           null)) in
         (let anon$4$0 ==
-          ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
-            df$rt$intToRef(2) :
+          ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+            anon$5$0 :
             null)) in
-          (let anon$5$0 ==
-            ((!df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
-              df$rt$intToRef(1) :
+          (let anon$1$0 ==
+            ((df$rt$boolFromRef(p$a) ?
+              (df$rt$boolFromRef(p$b) ? anon$2$0 : anon$4$0) :
               null)) in
-            (let anon$3$0 ==
-              ((!df$rt$boolFromRef(p$a) ?
-                (df$rt$boolFromRef(p$b) ? anon$4$0 : anon$5$0) :
-                null)) in
-              (let l0$x$0 ==
-                ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0)) in
-                l0$x$0)))))))
+            (let anon$0$0 ==
+              ((df$rt$boolFromRef(p$a) ? anon$1$0 : null)) in
+              (let anon$9$0 ==
+                ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+                  df$rt$intToRef(2) :
+                  null)) in
+                (let anon$8$0 ==
+                  ((df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+                    anon$9$0 :
+                    null)) in
+                  (let anon$11$0 ==
+                    ((!df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+                      df$rt$intToRef(1) :
+                      null)) in
+                    (let anon$10$0 ==
+                      ((!df$rt$boolFromRef(p$b) && !df$rt$boolFromRef(p$a) ?
+                        anon$11$0 :
+                        null)) in
+                      (let anon$7$0 ==
+                        ((!df$rt$boolFromRef(p$a) ?
+                          (df$rt$boolFromRef(p$b) ? anon$8$0 : anon$10$0) :
+                          null)) in
+                        (let anon$6$0 ==
+                          ((!df$rt$boolFromRef(p$a) ? anon$7$0 : null)) in
+                          (let l0$x$0 ==
+                            ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$6$0)) in
+                            (let anon$12$0 ==
+                              (l0$x$0) in
+                              anon$12$0))))))))))))))
 }
 
 /pure_function_with_reassignments.kt:(729,755): info: Generated Viper text for blockConditionalAssignment:
@@ -106,27 +136,39 @@ function f$blockConditionalAssignment$TF$T$Boolean$T$Boolean$T$Int(p$a: Ref,
   requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let anon$1$0 ==
+  (let anon$3$0 ==
     ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
       df$rt$intToRef(10) :
       null)) in
     (let anon$2$0 ==
-      ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
-        df$rt$intToRef(20) :
-        null)) in
-      (let l2$y$0 ==
-        ((df$rt$boolFromRef(p$a) ?
-          (df$rt$boolFromRef(p$b) ? anon$1$0 : anon$2$0) :
+      ((df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ? anon$3$0 : null)) in
+      (let anon$5$0 ==
+        ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+          df$rt$intToRef(20) :
           null)) in
-        (let anon$0$0 ==
-          ((df$rt$boolFromRef(p$a) ?
-            sp$plusInts(l2$y$0, df$rt$intToRef(1)) :
+        (let anon$4$0 ==
+          ((!df$rt$boolFromRef(p$b) && df$rt$boolFromRef(p$a) ?
+            anon$5$0 :
             null)) in
-          (let anon$3$0 ==
-            ((!df$rt$boolFromRef(p$a) ? df$rt$intToRef(30) : null)) in
-            (let l0$x$0 ==
-              ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$3$0)) in
-              l0$x$0))))))
+          (let l2$y$0 ==
+            ((df$rt$boolFromRef(p$a) ?
+              (df$rt$boolFromRef(p$b) ? anon$2$0 : anon$4$0) :
+              null)) in
+            (let anon$1$0 ==
+              ((df$rt$boolFromRef(p$a) ?
+                sp$plusInts(l2$y$0, df$rt$intToRef(1)) :
+                null)) in
+              (let anon$0$0 ==
+                ((df$rt$boolFromRef(p$a) ? anon$1$0 : null)) in
+                (let anon$7$0 ==
+                  ((!df$rt$boolFromRef(p$a) ? df$rt$intToRef(30) : null)) in
+                  (let anon$6$0 ==
+                    ((!df$rt$boolFromRef(p$a) ? anon$7$0 : null)) in
+                    (let l0$x$0 ==
+                      ((df$rt$boolFromRef(p$a) ? anon$0$0 : anon$6$0)) in
+                      (let anon$8$0 ==
+                        (l0$x$0) in
+                        anon$8$0)))))))))))
 }
 
 /pure_function_with_reassignments.kt:(912,926): info: Generated Viper text for whenAssignment:
@@ -137,33 +179,63 @@ function f$whenAssignment$TF$T$Int$T$Boolean$T$Int(p$a: Ref, p$b: Ref): Ref
 {
   (let anon$0$0 ==
     (p$a) in
-    (let anon$2$0 ==
+    (let anon$4$0 ==
       ((df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
         df$rt$intToRef(2) :
         null)) in
       (let anon$3$0 ==
-        ((!df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
-          df$rt$intToRef(3) :
+        ((df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
+          anon$4$0 :
           null)) in
-        (let anon$1$0 ==
-          ((df$rt$intFromRef(anon$0$0) == 1 ?
-            (df$rt$boolFromRef(p$b) ? anon$2$0 : anon$3$0) :
+        (let anon$6$0 ==
+          ((!df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
+            df$rt$intToRef(3) :
             null)) in
           (let anon$5$0 ==
-            ((df$rt$intFromRef(anon$0$0) == 2 &&
-            !(df$rt$intFromRef(anon$0$0) == 1) ?
-              df$rt$intToRef(4) :
+            ((!df$rt$boolFromRef(p$b) && df$rt$intFromRef(anon$0$0) == 1 ?
+              anon$6$0 :
               null)) in
-            (let anon$6$0 ==
-              ((!(df$rt$intFromRef(anon$0$0) == 2) &&
-              !(df$rt$intFromRef(anon$0$0) == 1) ?
-                df$rt$intToRef(5) :
+            (let anon$2$0 ==
+              ((df$rt$intFromRef(anon$0$0) == 1 ?
+                (df$rt$boolFromRef(p$b) ? anon$3$0 : anon$5$0) :
                 null)) in
-              (let anon$4$0 ==
-                ((!(df$rt$intFromRef(anon$0$0) == 1) ?
-                  (df$rt$intFromRef(anon$0$0) == 2 ? anon$5$0 : anon$6$0) :
-                  null)) in
-                (let l0$x$0 ==
-                  ((df$rt$intFromRef(anon$0$0) == 1 ? anon$1$0 : anon$4$0)) in
-                  l0$x$0))))))))
+              (let anon$1$0 ==
+                ((df$rt$intFromRef(anon$0$0) == 1 ? anon$2$0 : null)) in
+                (let anon$10$0 ==
+                  ((df$rt$intFromRef(anon$0$0) == 2 &&
+                  !(df$rt$intFromRef(anon$0$0) == 1) ?
+                    df$rt$intToRef(4) :
+                    null)) in
+                  (let anon$9$0 ==
+                    ((df$rt$intFromRef(anon$0$0) == 2 &&
+                    !(df$rt$intFromRef(anon$0$0) == 1) ?
+                      anon$10$0 :
+                      null)) in
+                    (let anon$12$0 ==
+                      ((!(df$rt$intFromRef(anon$0$0) == 2) &&
+                      !(df$rt$intFromRef(anon$0$0) == 1) ?
+                        df$rt$intToRef(5) :
+                        null)) in
+                      (let anon$11$0 ==
+                        ((!(df$rt$intFromRef(anon$0$0) == 2) &&
+                        !(df$rt$intFromRef(anon$0$0) == 1) ?
+                          anon$12$0 :
+                          null)) in
+                        (let anon$8$0 ==
+                          ((!(df$rt$intFromRef(anon$0$0) == 1) ?
+                            (df$rt$intFromRef(anon$0$0) == 2 ?
+                              anon$9$0 :
+                              anon$11$0) :
+                            null)) in
+                          (let anon$7$0 ==
+                            ((!(df$rt$intFromRef(anon$0$0) == 1) ?
+                              anon$8$0 :
+                              null)) in
+                            (let l0$x$0 ==
+                              ((df$rt$intFromRef(anon$0$0) == 1 ?
+                                anon$1$0 :
+                                anon$7$0)) in
+                              (let anon$13$0 ==
+                                (l0$x$0) in
+                                anon$13$0)))))))))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
@@ -16,35 +16,45 @@ method f$emptyFunction$TF$T$Unit() returns (ret$0: Ref)
 function f$emptyAnnotatedFunction$TF$NT$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$intType()))
 {
-  df$rt$nullValue()
+  (let anon$0$0 ==
+    (df$rt$nullValue()) in
+    anon$0$0)
 }
 
 /pure_literal_function.kt:(194,215): info: Generated Viper text for annotatedIntLitReturn:
 function f$annotatedIntLitReturn$TF$T$Int(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  df$rt$intToRef(42)
+  (let anon$0$0 ==
+    (df$rt$intToRef(42)) in
+    anon$0$0)
 }
 
 /pure_literal_function.kt:(248,270): info: Generated Viper text for annotatedBoolLitReturn:
 function f$annotatedBoolLitReturn$TF$T$Boolean(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
-  df$rt$boolToRef(true)
+  (let anon$0$0 ==
+    (df$rt$boolToRef(true)) in
+    anon$0$0)
 }
 
 /pure_literal_function.kt:(309,331): info: Generated Viper text for annotatedCharLitReturn:
 function f$annotatedCharLitReturn$TF$T$Char(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
 {
-  df$rt$charToRef(65)
+  (let anon$0$0 ==
+    (df$rt$charToRef(65)) in
+    anon$0$0)
 }
 
 /pure_literal_function.kt:(366,390): info: Generated Viper text for annotatedStringLitReturn:
 function f$annotatedStringLitReturn$TF$T$String(): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$stringType())
 {
-  df$rt$stringToRef(Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116))
+  (let anon$0$0 ==
+    (df$rt$stringToRef(Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116))) in
+    anon$0$0)
 }
 
 /pure_literal_function.kt:(474,498): info: Generated Viper text for annotatedReferenceReturn:
@@ -53,9 +63,11 @@ field bf$a: Ref
 field bf$b: Ref
 
 function f$annotatedReferenceReturn$TF$T$X$T$X(p$x: Ref): Ref
-  requires acc(p$c$X$shared(p$x), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
+  requires acc(p$c$X$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$c$X())
 {
-  p$x
+  (let anon$0$0 ==
+    (p$x) in
+    anon$0$0)
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
@@ -19,9 +19,9 @@ field bf$value: Ref
 method f$impureExtension$TF$T$Field$T$Unit(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Field())
+  requires acc(p$c$Field$shared(this$extension), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$Field$shared(this$extension), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
@@ -4,10 +4,10 @@ field bf$t: Ref
 method f$c$Box$genericMethod$TF$T$Box$NT$Any$NT$Any(this$dispatch: Ref, p$x: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Box())
+  requires acc(p$c$Box$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$anyType()))
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$anyType()))
 {
-  inhale acc(p$c$Box$shared(this$dispatch), wildcard)
   ret$0 := p$x
   goto lbl$ret$0
   label lbl$ret$0
@@ -96,11 +96,11 @@ field bf$t: Ref
 method f$genericAsIfCondition$TF$T$Box$T$Int(p$box: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
+  requires acc(p$c$Box$shared(p$box), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$Box$shared(p$box), wildcard)
   anon$1 := havoc$NT$Any()
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$boolType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
@@ -15,10 +15,10 @@ method f$smartcastReturn$TF$NT$Int$T$Int(p$n: Ref) returns (ret$0: Ref)
 method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
+  requires p$seq != df$rt$nullValue() ==>
+    acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
-  inhale p$seq != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   if (p$seq == df$rt$nullValue()) {
     var anon$0: Ref
     if (p$seq != df$rt$nullValue()) {
@@ -38,3 +38,4 @@ method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
 }
 
 method pg$public$length(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
@@ -6,6 +6,7 @@ method f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -15,7 +16,6 @@ method f$mid_increased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -57,6 +57,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -73,6 +74,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -90,6 +92,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
@@ -118,6 +121,7 @@ method f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -127,7 +131,6 @@ method f$mid_decreased_by_one$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Re
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -169,6 +172,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -185,6 +189,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -202,6 +207,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
@@ -231,6 +237,7 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(p$arr: Ref,
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -240,7 +247,6 @@ method f$mid_decreased_by_one_in_rec_call$TF$T$List$T$Int$T$Boolean(p$arr: Ref,
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -284,6 +290,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -300,6 +307,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -317,6 +325,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
@@ -346,6 +355,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -363,6 +373,7 @@ method f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr: Ref,
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
@@ -372,7 +383,6 @@ method f$unsafe_binary_search$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr: Ref,
 {
   var l0$mid: Ref
   var anon$0: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   if (df$rt$intFromRef(p$left) > df$rt$intFromRef(p$right)) {
     ret$0 := df$rt$boolToRef(false)
     goto lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
@@ -5,11 +5,11 @@ field bf$z: Ref
 
 method f$cascadeGet$TF$T$X$T$Z(p$x: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$X())
+  requires acc(p$c$X$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Z())
   ensures acc(p$c$Z$shared(ret$0), wildcard)
 {
   var anon$0: Ref
-  inhale acc(p$c$X$shared(p$x), wildcard)
   unfold acc(p$c$X$shared(p$x), wildcard)
   anon$0 := p$x.bf$y
   unfold acc(p$c$Y$shared(anon$0), wildcard)
@@ -26,11 +26,11 @@ field bf$z: Ref
 method f$receiverNotNullProved$TF$NT$X$T$Boolean(p$x: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$X()))
+  requires p$x != df$rt$nullValue() ==> acc(p$c$X$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==> p$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale p$x != df$rt$nullValue() ==> acc(p$c$X$shared(p$x), wildcard)
   if (p$x != df$rt$nullValue()) {
     var anon$1: Ref
     unfold acc(p$c$X$shared(p$x), wildcard)
@@ -51,13 +51,13 @@ field bf$z: Ref
 method f$cascadeNullableGet$TF$NT$NullableX$NT$Z(p$x: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
+  requires p$x != df$rt$nullValue() ==>
+    acc(p$c$NullableX$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
 {
   var anon$0: Ref
-  inhale p$x != df$rt$nullValue() ==>
-    acc(p$c$NullableX$shared(p$x), wildcard)
   if (p$x != df$rt$nullValue()) {
     unfold acc(p$c$NullableX$shared(p$x), wildcard)
     anon$0 := p$x.bf$y
@@ -80,12 +80,12 @@ field bf$z: Ref
 method f$cascadeNullableSmartcastGet$TF$NT$NullableX$NT$Z(p$x: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$c$NullableX()))
+  requires p$x != df$rt$nullValue() ==>
+    acc(p$c$NullableX$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Z()))
   ensures ret$0 != df$rt$nullValue() ==> acc(p$c$Z$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==> p$x != df$rt$nullValue()
 {
-  inhale p$x != df$rt$nullValue() ==>
-    acc(p$c$NullableX$shared(p$x), wildcard)
   if (p$x == df$rt$nullValue()) {
     var anon$0: Ref
     anon$0 := df$rt$nullValue()
@@ -225,6 +225,7 @@ method con$c$ClassI$T$Int$T$Int$T$ClassI(p$x: Ref, p$y: Ref)
 
 method con$c$ClassII$T$Z$T$ClassII(p$z: Ref) returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$z), df$rt$c$Z())
+  requires acc(p$c$Z$shared(p$z), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$ClassII())
   ensures acc(p$c$ClassII$shared(ret), wildcard)
   ensures acc(p$c$ClassII$unique(ret), write)
@@ -275,3 +276,4 @@ method f$checkPrimary$TF$T$Int$T$Int$T$Unit(p$x: Ref, p$y: Ref)
 }
 
 method pg$public$z(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
@@ -7,6 +7,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -23,6 +24,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -40,6 +42,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
@@ -63,6 +66,7 @@ method f$safe_binary_search$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   ensures acc(p$arr.sp$size, write)
   ensures df$rt$intFromRef(p$arr.sp$size) >= 0
@@ -72,7 +76,6 @@ method f$safe_binary_search$TF$T$List$T$Int$T$Boolean(p$arr: Ref, p$target: Ref)
   var l0$mid: Ref
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   l0$size := p$arr.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   anon$0 := p$arr.sp$size
@@ -117,6 +120,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -134,6 +138,7 @@ method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr:
   requires acc(p$arr.sp$size, write)
   requires df$rt$intFromRef(p$arr.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$arr), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$target), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$intType())
@@ -145,7 +150,6 @@ method f$unsafe_binary_search_fixed$TF$T$List$T$Int$T$Int$T$Int$T$Boolean(p$arr:
   var anon$1: Ref
   var l0$mid: Ref
   var anon$3: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$arr), wildcard)
   if (df$rt$intFromRef(p$left) > df$rt$intFromRef(p$right)) {
     anon$1 := df$rt$boolToRef(true)
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
@@ -8,6 +8,7 @@ method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$inde
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
+  requires acc(p$c$CustomList$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -18,7 +19,6 @@ method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$inde
   ensures df$rt$intFromRef(this$dispatch.sp$size) ==
     old(df$rt$intFromRef(this$dispatch.sp$size))
 {
-  inhale acc(p$c$CustomList$shared(this$dispatch), wildcard)
   unfold acc(p$c$CustomList$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$c$CustomList$private$value
   goto lbl$ret$0
@@ -46,6 +46,7 @@ method f$c$CustomList$get$TF$T$CustomList$T$Int$T$Int(this$dispatch: Ref, p$inde
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
+  requires acc(p$c$CustomList$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -62,6 +63,7 @@ method f$c$CustomList$isEmpty$TF$T$CustomList$T$Boolean(this$dispatch: Ref)
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$CustomList())
+  requires acc(p$c$CustomList$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
@@ -18,13 +18,13 @@ method f$initialization$TF$T$List$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$myList: Ref
   var l0$myEmptyList: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   l0$myList := p$l
   l0$myEmptyList := f$pkg$kotlin_collections$emptyList$TF$T$List()
   label lbl$ret$0
@@ -46,13 +46,13 @@ method f$add_get$TF$T$MutableList$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
   anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(p$l,
     df$rt$intToRef(1))
   l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(p$l,
@@ -67,6 +67,7 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boole
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires acc(p$pkg$kotlin_collections$c$MutableList$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$element), df$rt$intType())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -81,6 +82,7 @@ method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(t
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires acc(p$pkg$kotlin_collections$c$MutableList$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -99,12 +101,12 @@ method f$last_or_null$TF$T$List$NT$Int(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var l0$size: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   l0$size := p$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(l0$size), df$rt$intType())
   if (!(df$rt$intFromRef(l0$size) == 0)) {
@@ -126,6 +128,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -144,12 +147,12 @@ method f$is_empty$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   anon$0 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$l)
   if (!df$rt$boolFromRef(anon$0)) {
     ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$l,
@@ -166,6 +169,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -182,6 +186,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -200,13 +205,13 @@ method f$nullable_list$TF$NT$List$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
   requires p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$nullable(df$rt$c$pkg$kotlin_collections$List()))
+  requires p$l != df$rt$nullValue() ==>
+    acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   ensures p$l != df$rt$nullValue() ==> acc(p$l.sp$size, write)
   ensures p$l != df$rt$nullValue() ==> df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
-  inhale p$l != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   if (!(p$l == df$rt$nullValue())) {
     var anon$1: Ref
     anon$1 := f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(p$l)
@@ -231,6 +236,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -247,6 +253,7 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -256,3 +263,4 @@ method f$pkg$kotlin_collections$c$List$isEmpty$TF$T$List$T$Boolean(this$dispatch
     df$rt$intFromRef(this$dispatch.sp$size) == 0
   ensures !df$rt$boolFromRef(ret) ==>
     df$rt$intFromRef(this$dispatch.sp$size) > 0
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
@@ -2,11 +2,11 @@
 method f$take1$TF$T$InterfaceWithImplementation1$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
+  requires acc(p$c$InterfaceWithImplementation1$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$InterfaceWithImplementation1$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -21,11 +21,11 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 method f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
+  requires acc(p$c$InterfaceWithoutImplementation2$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$InterfaceWithoutImplementation2$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -42,9 +42,9 @@ field bf$field: Ref
 method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
+  requires acc(p$c$AbstractWithFinalImplementation3$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
-  inhale acc(p$c$AbstractWithFinalImplementation3$shared(p$obj), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -53,11 +53,11 @@ method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
 method f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(p$obj: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
+  requires acc(p$c$AbstractWithOpenImplementation4$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var anon$1: Ref
-  inhale acc(p$c$AbstractWithOpenImplementation4$shared(p$obj), wildcard)
   anon$1 := pg$public$field(p$obj)
   anon$0 := anon$1
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
@@ -154,33 +154,43 @@ method f$createImpls$TF$T$Unit() returns (ret$0: Ref)
   unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
   anon$0 := l0$impl12.bf$field
   l0$start12 := sp$minusInts(sp$plusInts(anon$0, df$rt$intToRef(1)), df$rt$intToRef(1))
+  unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
   anon$1 := f$take1$TF$T$InterfaceWithImplementation1$T$Unit(l0$impl12)
+  unfold acc(p$c$Impl12$shared(l0$impl12), wildcard)
   anon$2 := f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(l0$impl12)
   l0$impl23 := con$c$Impl23$T$Impl23()
   unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl23), wildcard)
   anon$3 := l0$impl23.bf$field
   l0$start23 := sp$minusInts(sp$plusInts(anon$3, df$rt$intToRef(1)), df$rt$intToRef(1))
+  unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
+  unfold acc(p$c$InheritingInterfaceWithoutImplementation6$shared(l0$impl23), wildcard)
   anon$4 := f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(l0$impl23)
+  unfold acc(p$c$Impl23$shared(l0$impl23), wildcard)
   anon$5 := f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(l0$impl23)
   l0$impl3 := con$c$Impl3$T$Impl3()
   unfold acc(p$c$Impl3$shared(l0$impl3), wildcard)
   unfold acc(p$c$AbstractWithFinalImplementation3$shared(l0$impl3), wildcard)
   anon$6 := l0$impl3.bf$field
   l0$start3 := sp$minusInts(sp$plusInts(anon$6, df$rt$intToRef(1)), df$rt$intToRef(1))
+  unfold acc(p$c$Impl3$shared(l0$impl3), wildcard)
   anon$7 := f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(l0$impl3)
   l0$impl24 := con$c$Impl24$T$Impl24()
   anon$9 := pg$public$field(l0$impl24)
   anon$8 := anon$9
   inhale df$rt$isSubtype(df$rt$typeOf(anon$8), df$rt$intType())
   l0$start24 := sp$minusInts(sp$plusInts(anon$8, df$rt$intToRef(1)), df$rt$intToRef(1))
+  unfold acc(p$c$Impl24$shared(l0$impl24), wildcard)
   anon$10 := f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(l0$impl24)
+  unfold acc(p$c$Impl24$shared(l0$impl24), wildcard)
   anon$11 := f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(l0$impl24)
   l0$impl14 := con$c$Impl14$T$Impl14()
   unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
   anon$12 := l0$impl14.bf$field
   l0$start14 := sp$minusInts(sp$plusInts(anon$12, df$rt$intToRef(1)), df$rt$intToRef(1))
+  unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
   anon$13 := f$take1$TF$T$InterfaceWithImplementation1$T$Unit(l0$impl14)
+  unfold acc(p$c$Impl14$shared(l0$impl14), wildcard)
   anon$14 := f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(l0$impl14)
   l0$impl6 := f$create6$TF$T$InheritingInterfaceWithoutImplementation6()
   anon$16 := pg$public$field(l0$impl6)
@@ -218,25 +228,30 @@ method f$createImpls$TF$T$Unit() returns (ret$0: Ref)
 method f$take1$TF$T$InterfaceWithImplementation1$T$Unit(p$obj: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithImplementation1())
+  requires acc(p$c$InterfaceWithImplementation1$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$take2$TF$T$InterfaceWithoutImplementation2$T$Unit(p$obj: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$InterfaceWithoutImplementation2())
+  requires acc(p$c$InterfaceWithoutImplementation2$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$take3$TF$T$AbstractWithFinalImplementation3$T$Unit(p$obj: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithFinalImplementation3())
+  requires acc(p$c$AbstractWithFinalImplementation3$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method f$take4$TF$T$AbstractWithOpenImplementation4$T$Unit(p$obj: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$c$AbstractWithOpenImplementation4())
+  requires acc(p$c$AbstractWithOpenImplementation4$shared(p$obj), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
 
 method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
@@ -4,11 +4,11 @@ field bf$field: Ref
 method f$extractInt$TF$T$Base$T$Boolean$NT$Int(p$base: Ref, p$returnNull: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$base), df$rt$c$Base())
+  requires acc(p$c$Base$shared(p$base), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$returnNull), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
   ensures ret$0 == df$rt$nullValue() ==> df$rt$boolFromRef(p$returnNull)
 {
-  inhale acc(p$c$Base$shared(p$base), wildcard)
   if (df$rt$boolFromRef(p$returnNull)) {
     var anon$0: Ref
     anon$0 := df$rt$nullValue()
@@ -43,3 +43,4 @@ method pg$public$field(this$dispatch: Ref) returns (ret: Ref)
 
 
 method ps$public$field(this$dispatch: Ref, anon$0: Ref) returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
@@ -2,10 +2,10 @@
 method f$c$A$getBooleanField$TF$T$A$T$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$A())
+  requires acc(p$c$A$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
 {
   var anon$0: Ref
-  inhale acc(p$c$A$shared(this$dispatch), wildcard)
   anon$0 := pg$c$A$private$field(this$dispatch)
   ret$0 := anon$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
@@ -26,9 +26,9 @@ field bf$c$B$private$field: Ref
 method f$c$B$getStringField$TF$T$B$T$String(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$B())
+  requires acc(p$c$B$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$stringType())
 {
-  inhale acc(p$c$B$shared(this$dispatch), wildcard)
   unfold acc(p$c$B$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$c$B$private$field
   goto lbl$ret$0
@@ -88,3 +88,4 @@ method pg$c$A$private$field(this$dispatch: Ref) returns (ret: Ref)
 
 method ps$c$A$private$field(this$dispatch: Ref, anon$0: Ref)
   returns (ret: Ref)
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
@@ -43,11 +43,11 @@ method f$mayReturnNull$TF$NT$Any$NT$Any(p$x: Ref) returns (ret$0: Ref)
 method f$isNullOrEmptyWrong$TF$NT$CharSequence$T$Boolean(p$seq: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$seq), df$rt$nullable(df$rt$c$pkg$kotlin$CharSequence()))
+  requires p$seq != df$rt$nullValue() ==>
+    acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == false ==> p$seq != df$rt$nullValue()
 {
-  inhale p$seq != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin$c$CharSequence$shared(p$seq), wildcard)
   if (!(p$seq == df$rt$nullValue())) {
     var anon$0: Ref
     var anon$1: Ref

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
@@ -2,11 +2,11 @@
 method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl1())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -19,13 +19,13 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
   this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$extension), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -36,11 +36,11 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
 method f$is1$TF$T$Class$T$Boolean(this$extension: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$extension), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl2())
 {
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
@@ -19,6 +19,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -61,6 +62,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -91,6 +93,7 @@ method f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(this$dispatch: 
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -106,12 +109,12 @@ method f$unsafe_last$TF$T$List$T$Int(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
   var anon$0: Ref
-  inhale acc(p$pkg$kotlin_collections$c$List$shared(p$l), wildcard)
   anon$0 := p$l.sp$size
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
   ret$0 := f$pkg$kotlin_collections$c$List$get$TF$T$List$T$Int$T$Int(p$l, sp$minusInts(anon$0,
@@ -129,13 +132,13 @@ method f$add_get$TF$T$MutableList$T$Unit(p$l: Ref) returns (ret$0: Ref)
   requires acc(p$l.sp$size, write)
   requires df$rt$intFromRef(p$l.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
   ensures acc(p$l.sp$size, write)
   ensures df$rt$intFromRef(p$l.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$0: Ref
   var l0$n: Ref
-  inhale acc(p$pkg$kotlin_collections$c$MutableList$shared(p$l), wildcard)
   anon$0 := f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boolean(p$l,
     df$rt$intToRef(1))
   l0$n := f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(p$l,
@@ -150,6 +153,7 @@ method f$pkg$kotlin_collections$c$MutableList$add$TF$T$MutableList$T$Int$T$Boole
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires acc(p$pkg$kotlin_collections$c$MutableList$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$element), df$rt$intType())
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
@@ -164,6 +168,7 @@ method f$pkg$kotlin_collections$c$MutableList$get$TF$T$MutableList$T$Int$T$Int(t
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$MutableList())
+  requires acc(p$pkg$kotlin_collections$c$MutableList$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$index), df$rt$intType())
   requires df$rt$intFromRef(p$index) >= 0
   requires df$rt$intFromRef(this$dispatch.sp$size) >
@@ -198,6 +203,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)
@@ -247,6 +253,7 @@ method f$pkg$kotlin_collections$c$List$subList$TF$T$List$T$Int$T$Int$T$List(this
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$List())
+  requires acc(p$pkg$kotlin_collections$c$List$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$fromIndex), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$toIndex), df$rt$intType())
   requires df$rt$intFromRef(p$fromIndex) <= df$rt$intFromRef(p$toIndex)

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
@@ -1,11 +1,11 @@
 /as_type_contract.kt:(152,162): info: Generated Viper text for asOperator:
 method f$asOperator$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$c$Bar())
   ensures acc(p$c$Bar$shared(ret$0), wildcard)
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
   inhale acc(p$c$Bar$shared(p$foo), wildcard)
   ret$0 := p$foo
@@ -16,13 +16,13 @@ method f$asOperator$TF$T$Foo$T$Bar(p$foo: Ref) returns (ret$0: Ref)
 /as_type_contract.kt:(307,321): info: Generated Viper text for safeAsOperator:
 method f$safeAsOperator$TF$T$Foo$NT$Bar(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$c$Bar()))
   ensures ret$0 != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(ret$0), wildcard)
   ensures ret$0 != df$rt$nullValue() ==>
     df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Bar())
 {
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Bar()))
   inhale p$foo != df$rt$nullValue() ==>
     acc(p$c$Bar$shared(p$foo), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
@@ -2,11 +2,11 @@
 method f$c$Class$is2$TF$T$Class$T$Boolean(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Impl2()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -17,13 +17,13 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
   this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$extension), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale acc(p$c$Class$shared(this$dispatch), wildcard)
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0
@@ -32,11 +32,11 @@ method f$c$Class$is1butWithDispatch$TF$T$Class$T$Class$T$Boolean(this$dispatch: 
 /contracts_with_receivers.kt:(618,621): info: Generated Viper text for is1:
 method f$is1$TF$T$Class$T$Boolean(this$extension: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Class())
+  requires acc(p$c$Class$shared(this$extension), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true ==>
     df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1())
 {
-  inhale acc(p$c$Class$shared(this$extension), wildcard)
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$Impl1()))
   goto lbl$ret$0
   label lbl$ret$0

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -59,10 +59,10 @@ field bf$bar: Ref
 
 method f$subtypeSuperType$TF$T$Bar$T$Unit(p$bar: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Bar())
+  requires acc(p$c$Bar$shared(p$bar), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
   ensures true ==> df$rt$isSubtype(df$rt$typeOf(p$bar), df$rt$c$Foo())
 {
-  inhale acc(p$c$Bar$shared(p$bar), wildcard)
   label lbl$ret$0
   inhale df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 }
@@ -72,11 +72,11 @@ field bf$bar: Ref
 
 method f$typeOfField$TF$T$Foo$T$Boolean(p$foo: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$c$Foo())
+  requires acc(p$c$Foo$shared(p$foo), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
   var anon$0: Ref
-  inhale acc(p$c$Foo$shared(p$foo), wildcard)
   unfold acc(p$c$Foo$shared(p$foo), wildcard)
   anon$0 := p$foo.bf$bar
   ret$0 := df$rt$boolToRef(df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$Bar()))

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
@@ -100,6 +100,8 @@ method f$isNullOrEmpty$TF$NT$Collection$T$Boolean(this$extension: Ref)
   requires this$extension != df$rt$nullValue() ==>
     df$rt$intFromRef(this$extension.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$nullable(df$rt$c$pkg$kotlin_collections$Collection()))
+  requires this$extension != df$rt$nullValue() ==>
+    acc(p$pkg$kotlin_collections$c$Collection$shared(this$extension), wildcard)
   ensures this$extension != df$rt$nullValue() ==>
     acc(this$extension.sp$size, write)
   ensures this$extension != df$rt$nullValue() ==>
@@ -108,8 +110,6 @@ method f$isNullOrEmpty$TF$NT$Collection$T$Boolean(this$extension: Ref)
   ensures df$rt$boolFromRef(ret$0) == false ==>
     this$extension != df$rt$nullValue()
 {
-  inhale this$extension != df$rt$nullValue() ==>
-    acc(p$pkg$kotlin_collections$c$Collection$shared(this$extension), wildcard)
   if (this$extension == df$rt$nullValue()) {
     ret$0 := df$rt$boolToRef(true)
   } else {
@@ -123,6 +123,7 @@ method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection$T$Boolean(t
   requires acc(this$dispatch.sp$size, write)
   requires df$rt$intFromRef(this$dispatch.sp$size) >= 0
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$pkg$kotlin_collections$Collection())
+  requires acc(p$pkg$kotlin_collections$c$Collection$shared(this$dispatch), wildcard)
   ensures acc(this$dispatch.sp$size, write)
   ensures df$rt$intFromRef(this$dispatch.sp$size) >= 0
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
@@ -132,3 +133,4 @@ method f$pkg$kotlin_collections$c$Collection$isEmpty$TF$T$Collection$T$Boolean(t
     df$rt$intFromRef(this$dispatch.sp$size) == 0
   ensures !df$rt$boolFromRef(ret) ==>
     df$rt$intFromRef(this$dispatch.sp$size) > 0
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -103,6 +103,7 @@ method con$c$Box$NT$Any$T$Box(p$wrapped: Ref) returns (ret: Ref)
 method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$c$Box())
+  requires acc(p$c$Box$shared(p$box), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$boolType())
   ensures df$rt$boolFromRef(ret$0) == true
 {
@@ -122,7 +123,6 @@ method f$checkGenericMemberAccess$TF$T$Box$T$Boolean(p$box: Ref)
   var anon$3: Ref
   var anon$10: Ref
   var anon$11: Ref
-  inhale acc(p$c$Box$shared(p$box), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$box), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$box
   anon$4 := f$idFun$TF$NT$Any$NT$Any(anon$0)
@@ -173,6 +173,7 @@ field bf$a: Ref
 method f$checkArgumentIsCopied$TF$T$ClassWithVar$T$Unit(p$x: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$c$ClassWithVar())
+  requires acc(p$c$ClassWithVar$shared(p$x), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -183,7 +184,6 @@ method f$checkArgumentIsCopied$TF$T$ClassWithVar$T$Unit(p$x: Ref)
   var anon$5: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale acc(p$c$ClassWithVar$shared(p$x), wildcard)
   anon$4 := havoc$T$Int()
   anon$0 := anon$4
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$nullable(df$rt$anyType()))
@@ -216,6 +216,7 @@ field bf$i: Ref
 method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$c$ManyMembers())
+  requires acc(p$c$ManyMembers$shared(p$m), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$4: Ref
@@ -245,7 +246,6 @@ method f$accessManyMembers$TF$T$ManyMembers$T$Unit(p$m: Ref)
   var anon$20: Ref
   var anon$21: Ref
   var anon$22: Ref
-  inhale acc(p$c$ManyMembers$shared(p$m), wildcard)
   inhale df$rt$isSubtype(df$rt$typeOf(p$m), df$rt$nullable(df$rt$anyType()))
   anon$0 := p$m
   inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$c$ManyMembers())
@@ -325,6 +325,7 @@ method f$checkEvaluatedOnce$TF$T$Int$T$ManyMembers$T$Unit(p$i: Ref, p$mm: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$i), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$mm), df$rt$c$ManyMembers())
+  requires acc(p$c$ManyMembers$shared(p$mm), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var anon$2: Ref
@@ -336,7 +337,6 @@ method f$checkEvaluatedOnce$TF$T$Int$T$ManyMembers$T$Unit(p$i: Ref, p$mm: Ref)
   var anon$6: Ref
   var ret$2: Ref
   var anon$1: Ref
-  inhale acc(p$c$ManyMembers$shared(p$mm), wildcard)
   anon$5 := havoc$T$Boolean()
   if (df$rt$boolFromRef(anon$5)) {
     anon$4 := df$rt$intToRef(1)

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -7,6 +7,7 @@ method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(th
   this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
+  requires acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
@@ -14,7 +15,6 @@ method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(th
   var anon$0: Ref
   var l0$withLabels: Ref
   var anon$1: Ref
-  inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   anon$0 := this$dispatch.bf$delta
   l0$withoutLabels := sp$plusInts(this$extension, anon$0)
@@ -33,9 +33,9 @@ field bf$delta: Ref
 method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
+  requires acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   unfold acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   ret$0 := this$dispatch.bf$delta
   goto lbl$ret$0
@@ -48,9 +48,9 @@ field bf$delta: Ref
 method f$extensionReturnDelta$TF$T$ClassWithExtension$T$Int(this$extension: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
+  requires acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
 {
-  inhale acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   unfold acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   ret$0 := this$extension.bf$delta
   goto lbl$ret$0
@@ -77,6 +77,7 @@ method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(th
   this$extension: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
+  requires acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$intType())
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$unitType())
 
@@ -84,6 +85,7 @@ method f$c$ClassWithExtension$applyDelta$TF$T$ClassWithExtension$T$Int$T$Unit(th
 method f$c$ClassWithExtension$returnDelta$TF$T$ClassWithExtension$T$Int(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$ClassWithExtension())
+  requires acc(p$c$ClassWithExtension$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
 
 
@@ -140,4 +142,6 @@ method f$checkClassWithExtension$TF$T$Unit() returns (ret$0: Ref)
 method f$extensionReturnDelta$TF$T$ClassWithExtension$T$Int(this$extension: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$extension), df$rt$c$ClassWithExtension())
+  requires acc(p$c$ClassWithExtension$shared(this$extension), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$intType())
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -4,50 +4,66 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$isAlternating$TF$T$Node$T$Boolean$T$Boolean(p$node: Ref, p$expectsPositive: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$expectsPositive), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
-  (let anon$1$0 ==
+  (let anon$2$0 ==
     ((df$rt$boolFromRef(p$expectsPositive) ?
       (unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$value) :
       null)) in
-    (let anon$0$0 ==
+    (let anon$1$0 ==
       ((df$rt$boolFromRef(p$expectsPositive) ?
         (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-          sp$gtInts(anon$1$0, df$rt$intToRef(0))) :
+          sp$gtInts(anon$2$0, df$rt$intToRef(0))) :
         null)) in
-      (let anon$3$0 ==
-        ((!df$rt$boolFromRef(p$expectsPositive) ?
-          (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-            p$node.bf$value) :
-          null)) in
-        (let anon$2$0 ==
+      (let anon$0$0 ==
+        ((df$rt$boolFromRef(p$expectsPositive) ? anon$1$0 : null)) in
+        (let anon$5$0 ==
           ((!df$rt$boolFromRef(p$expectsPositive) ?
             (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              sp$ltInts(anon$3$0, df$rt$intToRef(0))) :
+              p$node.bf$value) :
             null)) in
-          (let l0$isCurrentValid$0 ==
-            ((df$rt$boolFromRef(p$expectsPositive) ? anon$0$0 : anon$2$0)) in
-            (let l0$nextNode$0 ==
-              ((unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                p$node.bf$next)) in
-              (let anon$5$0 ==
-                ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                  (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                    f$isAlternating$TF$T$Node$T$Boolean$T$Boolean(l0$nextNode$0,
-                    sp$notBool(p$expectsPositive))) :
-                  null)) in
-                (let anon$6$0 ==
-                  ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
-                    df$rt$boolToRef(true) :
-                    null)) in
-                  (let anon$4$0 ==
+          (let anon$4$0 ==
+            ((!df$rt$boolFromRef(p$expectsPositive) ?
+              (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                sp$ltInts(anon$5$0, df$rt$intToRef(0))) :
+              null)) in
+            (let anon$3$0 ==
+              ((!df$rt$boolFromRef(p$expectsPositive) ? anon$4$0 : null)) in
+              (let l0$isCurrentValid$0 ==
+                ((df$rt$boolFromRef(p$expectsPositive) ?
+                  anon$0$0 :
+                  anon$3$0)) in
+                (let l0$nextNode$0 ==
+                  ((unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                    p$node.bf$next)) in
+                  (let anon$9$0 ==
                     ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                      anon$5$0 :
-                      anon$6$0)) in
-                    sp$andBools(l0$isCurrentValid$0, anon$4$0))))))))))
+                      (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                        f$isAlternating$TF$T$Node$T$Boolean$T$Boolean(l0$nextNode$0,
+                        sp$notBool(p$expectsPositive))) :
+                      null)) in
+                    (let anon$8$0 ==
+                      ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                        anon$9$0 :
+                        null)) in
+                      (let anon$11$0 ==
+                        ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+                          df$rt$boolToRef(true) :
+                          null)) in
+                        (let anon$10$0 ==
+                          ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+                            anon$11$0 :
+                            null)) in
+                          (let anon$7$0 ==
+                            ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                              anon$8$0 :
+                              anon$10$0)) in
+                            (let anon$6$0 ==
+                              (sp$andBools(l0$isCurrentValid$0, anon$7$0)) in
+                              anon$6$0))))))))))))))
 }
 
 /heap_dependent_specifications.kt:(482,512): info: Generated Viper text for isStrictlyAscendingAndPositive:
@@ -56,8 +72,8 @@ field bf$next: Ref
 field bf$value: Ref
 
 function f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(p$node: Ref): Ref
-  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$node), wildcard)
   requires df$rt$intFromRef((unfolding acc(p$c$Node$shared(p$node), wildcard) in
       p$node.bf$value)) >=
     0
@@ -65,51 +81,73 @@ function f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(p$node: Ref): Ref
 {
   (let l0$nextNode$0 ==
     ((unfolding acc(p$c$Node$shared(p$node), wildcard) in p$node.bf$next)) in
-    (let anon$2$0 ==
+    (let anon$4$0 ==
       ((!(l0$nextNode$0 == df$rt$nullValue()) ?
         (unfolding acc(p$c$Node$shared(p$node), wildcard) in
           (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
             l0$nextNode$0.bf$value)) :
         null)) in
-      (let anon$3$0 ==
-        ((df$rt$intFromRef(anon$2$0) < 0 &&
+      (let anon$6$0 ==
+        ((df$rt$intFromRef(anon$4$0) < 0 &&
         !(l0$nextNode$0 == df$rt$nullValue()) ?
           df$rt$boolToRef(false) :
           null)) in
         (let anon$5$0 ==
-          ((!(df$rt$intFromRef(anon$2$0) < 0) &&
+          ((df$rt$intFromRef(anon$4$0) < 0 &&
           !(l0$nextNode$0 == df$rt$nullValue()) ?
-            (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-              (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
-                l0$nextNode$0.bf$value)) :
+            anon$6$0 :
             null)) in
-          (let anon$6$0 ==
-            ((!(df$rt$intFromRef(anon$2$0) < 0) &&
+          (let anon$9$0 ==
+            ((!(df$rt$intFromRef(anon$4$0) < 0) &&
             !(l0$nextNode$0 == df$rt$nullValue()) ?
               (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                p$node.bf$value) :
+                (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
+                  l0$nextNode$0.bf$value)) :
               null)) in
-            (let anon$4$0 ==
-              ((!(df$rt$intFromRef(anon$2$0) < 0) &&
+            (let anon$10$0 ==
+              ((!(df$rt$intFromRef(anon$4$0) < 0) &&
               !(l0$nextNode$0 == df$rt$nullValue()) ?
                 (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                  (unfolding acc(p$c$Node$shared(p$node), wildcard) in
-                    (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
-                      sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(l0$nextNode$0))))) :
+                  p$node.bf$value) :
                 null)) in
-              (let anon$1$0 ==
-                ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                  (df$rt$intFromRef(anon$2$0) < 0 ? anon$3$0 : anon$4$0) :
+              (let anon$8$0 ==
+                ((!(df$rt$intFromRef(anon$4$0) < 0) &&
+                !(l0$nextNode$0 == df$rt$nullValue()) ?
+                  (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                    (unfolding acc(p$c$Node$shared(p$node), wildcard) in
+                      (unfolding acc(p$c$Node$shared(l0$nextNode$0), wildcard) in
+                        sp$andBools(sp$gtInts(anon$9$0, anon$10$0), f$isStrictlyAscendingAndPositive$TF$T$Node$T$Boolean(l0$nextNode$0))))) :
                   null)) in
                 (let anon$7$0 ==
-                  ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
-                    df$rt$boolToRef(true) :
+                  ((!(df$rt$intFromRef(anon$4$0) < 0) &&
+                  !(l0$nextNode$0 == df$rt$nullValue()) ?
+                    anon$8$0 :
                     null)) in
-                  (let anon$0$0 ==
+                  (let anon$3$0 ==
                     ((!(l0$nextNode$0 == df$rt$nullValue()) ?
-                      anon$1$0 :
-                      anon$7$0)) in
-                    anon$0$0)))))))))
+                      (df$rt$intFromRef(anon$4$0) < 0 ?
+                        anon$5$0 :
+                        anon$7$0) :
+                      null)) in
+                    (let anon$2$0 ==
+                      ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                        anon$3$0 :
+                        null)) in
+                      (let anon$12$0 ==
+                        ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+                          df$rt$boolToRef(true) :
+                          null)) in
+                        (let anon$11$0 ==
+                          ((!!(l0$nextNode$0 == df$rt$nullValue()) ?
+                            anon$12$0 :
+                            null)) in
+                          (let anon$1$0 ==
+                            ((!(l0$nextNode$0 == df$rt$nullValue()) ?
+                              anon$2$0 :
+                              anon$11$0)) in
+                            (let anon$0$0 ==
+                              (anon$1$0) in
+                              anon$0$0))))))))))))))
 }
 
 /heap_dependent_specifications.kt:(948,965): info: Generated Viper text for isLocallyValidBST:
@@ -120,67 +158,82 @@ field bf$right: Ref
 field bf$value: Ref
 
 function f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(p$node: Ref): Ref
-  requires acc(p$c$TreeNode$shared(p$node), wildcard)
   requires df$rt$isSubtype(df$rt$typeOf(p$node), df$rt$c$TreeNode())
+  requires acc(p$c$TreeNode$shared(p$node), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$boolType())
 {
   (let l0$leftNode$0 ==
     ((unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
       p$node.bf$left)) in
-    (let anon$1$0 ==
+    (let anon$2$0 ==
       ((!(l0$leftNode$0 == df$rt$nullValue()) ?
         (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
           (unfolding acc(p$c$TreeNode$shared(l0$leftNode$0), wildcard) in
             l0$leftNode$0.bf$value)) :
         null)) in
-      (let anon$2$0 ==
+      (let anon$3$0 ==
         ((!(l0$leftNode$0 == df$rt$nullValue()) ?
           (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
             p$node.bf$value) :
           null)) in
-        (let anon$0$0 ==
+        (let anon$1$0 ==
           ((!(l0$leftNode$0 == df$rt$nullValue()) ?
             (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
               (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
                 (unfolding acc(p$c$TreeNode$shared(l0$leftNode$0), wildcard) in
-                  sp$andBools(sp$ltInts(anon$1$0, anon$2$0), f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(l0$leftNode$0))))) :
+                  sp$andBools(sp$ltInts(anon$2$0, anon$3$0), f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(l0$leftNode$0))))) :
             null)) in
-          (let anon$3$0 ==
-            ((!!(l0$leftNode$0 == df$rt$nullValue()) ?
-              df$rt$boolToRef(true) :
-              null)) in
-            (let l0$leftValid$0 ==
-              ((!(l0$leftNode$0 == df$rt$nullValue()) ?
-                anon$0$0 :
-                anon$3$0)) in
-              (let l0$rightNode$0 ==
-                ((unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                  p$node.bf$right)) in
-                (let anon$5$0 ==
-                  ((!(l0$rightNode$0 == df$rt$nullValue()) ?
-                    (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                      (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
-                        l0$rightNode$0.bf$value)) :
-                    null)) in
-                  (let anon$6$0 ==
-                    ((!(l0$rightNode$0 == df$rt$nullValue()) ?
-                      (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                        p$node.bf$value) :
-                      null)) in
-                    (let anon$4$0 ==
+          (let anon$0$0 ==
+            ((!(l0$leftNode$0 == df$rt$nullValue()) ? anon$1$0 : null)) in
+            (let anon$5$0 ==
+              ((!!(l0$leftNode$0 == df$rt$nullValue()) ?
+                df$rt$boolToRef(true) :
+                null)) in
+              (let anon$4$0 ==
+                ((!!(l0$leftNode$0 == df$rt$nullValue()) ? anon$5$0 : null)) in
+                (let l0$leftValid$0 ==
+                  ((!(l0$leftNode$0 == df$rt$nullValue()) ?
+                    anon$0$0 :
+                    anon$4$0)) in
+                  (let l0$rightNode$0 ==
+                    ((unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
+                      p$node.bf$right)) in
+                    (let anon$8$0 ==
                       ((!(l0$rightNode$0 == df$rt$nullValue()) ?
                         (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                          (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
-                            (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
-                              sp$andBools(sp$gtInts(anon$5$0, anon$6$0), f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(l0$rightNode$0))))) :
+                          (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
+                            l0$rightNode$0.bf$value)) :
                         null)) in
-                      (let anon$7$0 ==
-                        ((!!(l0$rightNode$0 == df$rt$nullValue()) ?
-                          df$rt$boolToRef(true) :
+                      (let anon$9$0 ==
+                        ((!(l0$rightNode$0 == df$rt$nullValue()) ?
+                          (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
+                            p$node.bf$value) :
                           null)) in
-                        (let l0$rightValid$0 ==
+                        (let anon$7$0 ==
                           ((!(l0$rightNode$0 == df$rt$nullValue()) ?
-                            anon$4$0 :
-                            anon$7$0)) in
-                          sp$andBools(l0$leftValid$0, l0$rightValid$0)))))))))))))
+                            (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
+                              (unfolding acc(p$c$TreeNode$shared(p$node), wildcard) in
+                                (unfolding acc(p$c$TreeNode$shared(l0$rightNode$0), wildcard) in
+                                  sp$andBools(sp$gtInts(anon$8$0, anon$9$0),
+                                  f$isLocallyValidBST$TF$T$TreeNode$T$Boolean(l0$rightNode$0))))) :
+                            null)) in
+                          (let anon$6$0 ==
+                            ((!(l0$rightNode$0 == df$rt$nullValue()) ?
+                              anon$7$0 :
+                              null)) in
+                            (let anon$11$0 ==
+                              ((!!(l0$rightNode$0 == df$rt$nullValue()) ?
+                                df$rt$boolToRef(true) :
+                                null)) in
+                              (let anon$10$0 ==
+                                ((!!(l0$rightNode$0 == df$rt$nullValue()) ?
+                                  anon$11$0 :
+                                  null)) in
+                                (let l0$rightValid$0 ==
+                                  ((!(l0$rightNode$0 == df$rt$nullValue()) ?
+                                    anon$6$0 :
+                                    anon$10$0)) in
+                                  (let anon$12$0 ==
+                                    (sp$andBools(l0$leftValid$0, l0$rightValid$0)) in
+                                    anon$12$0)))))))))))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
@@ -10,7 +10,9 @@ function f$safeDivide$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
       ((!(df$rt$intFromRef(p$y) == 0) ? sp$divInts(p$x, p$y) : null)) in
       (let l0$res$2 ==
         ((!(df$rt$intFromRef(p$y) == 0) ? l0$res$1 : l0$res$0)) in
-        l0$res$2)))
+        (let anon$0$0 ==
+          (l0$res$2) in
+          anon$0$0))))
 }
 
 /pure_function_rely_on_branch.kt:(206,221): info: Generated Viper text for getStringLength:
@@ -28,7 +30,9 @@ function f$getStringLength$TF$T$Any$T$Int(p$obj: Ref): Ref
         ((df$rt$isSubtype(df$rt$typeOf(p$obj), df$rt$stringType()) ?
           l0$len$1 :
           l0$len$0)) in
-        l0$len$2)))
+        (let anon$0$0 ==
+          (l0$len$2) in
+          anon$0$0))))
 }
 
 /pure_function_rely_on_branch.kt:(354,370): info: Generated Viper text for safeNestedDivide:
@@ -48,7 +52,9 @@ function f$safeNestedDivide$TF$T$Int$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref, p$z: 
         ((!(df$rt$intFromRef(p$z) == 0) ? l0$res$1 : l0$res$0)) in
         (let l0$res$3 ==
           ((!(df$rt$intFromRef(p$y) == 0) ? l0$res$2 : l0$res$0)) in
-          l0$res$3))))
+          (let anon$0$0 ==
+            (l0$res$3) in
+            anon$0$0)))))
 }
 
 /pure_function_rely_on_branch.kt:(546,567): info: Generated Viper text for safeInverseDifference:
@@ -67,5 +73,7 @@ function f$safeInverseDifference$TF$T$Int$T$Int$T$Int(p$x: Ref, p$y: Ref): Ref
         ((!(df$rt$intFromRef(p$x) == df$rt$intFromRef(p$y)) ?
           l0$res$1 :
           l0$res$0)) in
-        l0$res$2)))
+        (let anon$0$0 ==
+          (l0$res$2) in
+          anon$0$0))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_upcast.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_upcast.fir.diag.txt
@@ -1,6 +1,19 @@
-/pure_upcast.kt:(255,298): error: Impure function body detected in pure function
+/pure_upcast.kt:(221,230): info: Generated Viper text for readValue:
+field bf$value: Ref
 
-/pure_upcast.kt:(405,415): info: Generated Viper text for pureUpcast:
+function f$readValue$TF$T$Base$T$Int(p$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$c$Base())
+  requires acc(p$c$Base$shared(p$b), wildcard)
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
+{
+  (let anon$1$0 ==
+    ((unfolding acc(p$c$Base$shared(p$b), wildcard) in p$b.bf$value)) in
+    (let anon$0$0 ==
+      (anon$1$0) in
+      anon$0$0))
+}
+
+/pure_upcast.kt:(361,371): info: Generated Viper text for pureUpcast:
 field bf$value: Ref
 
 function f$pureUpcast$TF$T$Sub$T$Int(p$s: Ref): Ref
@@ -8,9 +21,12 @@ function f$pureUpcast$TF$T$Sub$T$Int(p$s: Ref): Ref
   requires acc(p$c$Sub$shared(p$s), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let anon$0$0 ==
+  (let anon$1$0 ==
     (p$s) in
-    f$readValue$TF$T$Base$T$Int(anon$0$0))
+    (let anon$0$0 ==
+      ((unfolding acc(p$c$Sub$shared(p$s), wildcard) in
+        f$readValue$TF$T$Base$T$Int(anon$1$0))) in
+      anon$0$0))
 }
 
 function f$readValue$TF$T$Base$T$Int(p$b: Ref): Ref
@@ -19,12 +35,7 @@ function f$readValue$TF$T$Base$T$Int(p$b: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 
 
-method pg$public$value(this$dispatch: Ref) returns (ret: Ref)
-
-
-/pure_upcast.kt:(431,443): warning: Viper verification error: Precondition of function f$readValue$TF$T$Base$T$Int might not hold. There might be insufficient permission to access p$c$Base$shared(anon$0$0)
-
-/pure_upcast.kt:(554,575): info: Generated Viper text for pureConditionalUpcast:
+/pure_upcast.kt:(510,531): info: Generated Viper text for pureConditionalUpcast:
 field bf$value: Ref
 
 function f$pureConditionalUpcast$TF$T$Sub$T$Sub2$T$Boolean$T$Int(p$s1: Ref,
@@ -36,13 +47,19 @@ function f$pureConditionalUpcast$TF$T$Sub$T$Sub2$T$Boolean$T$Int(p$s1: Ref,
   requires df$rt$isSubtype(df$rt$typeOf(p$flag), df$rt$boolType())
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  (let anon$1$0 ==
+  (let anon$3$0 ==
     ((df$rt$boolFromRef(p$flag) ? p$s1 : null)) in
     (let anon$2$0 ==
-      ((!df$rt$boolFromRef(p$flag) ? p$s2 : null)) in
-      (let anon$0$0 ==
-        ((df$rt$boolFromRef(p$flag) ? anon$1$0 : anon$2$0)) in
-        f$readValue$TF$T$Base$T$Int(anon$0$0))))
+      ((df$rt$boolFromRef(p$flag) ? anon$3$0 : null)) in
+      (let anon$5$0 ==
+        ((!df$rt$boolFromRef(p$flag) ? p$s2 : null)) in
+        (let anon$4$0 ==
+          ((!df$rt$boolFromRef(p$flag) ? anon$5$0 : null)) in
+          (let anon$1$0 ==
+            ((df$rt$boolFromRef(p$flag) ? anon$2$0 : anon$4$0)) in
+            (let anon$0$0 ==
+              (f$readValue$TF$T$Base$T$Int(anon$1$0)) in
+              anon$0$0))))))
 }
 
 function f$readValue$TF$T$Base$T$Int(p$b: Ref): Ref
@@ -51,16 +68,54 @@ function f$readValue$TF$T$Base$T$Int(p$b: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 
 
-method pg$public$value(this$dispatch: Ref) returns (ret: Ref)
+/pure_upcast.kt:(577,608): warning: Viper verification error: Precondition of function f$readValue$TF$T$Base$T$Int might not hold. There might be insufficient permission to access p$c$Base$shared(anon$1$0)
 
+/pure_upcast.kt:(690,791): warning: Viper verification error: Function might not be well-formed. There might be insufficient permission to access p$c$Base$shared(l0$b$0)
 
-/pure_upcast.kt:(621,652): warning: Viper verification error: Precondition of function f$readValue$TF$T$Base$T$Int might not hold. There might be insufficient permission to access p$c$Base$shared(anon$0$0)
+/pure_upcast.kt:(714,735): info: Generated Viper text for pureUpcastViaVariable:
+field bf$value: Ref
 
-/pure_upcast.kt:(734,835): error: Impure function body detected in pure function
+function f$pureUpcastViaVariable$TF$T$Sub$T$Int(p$s: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$s), df$rt$c$Sub())
+  requires acc(p$c$Sub$shared(p$s), wildcard)
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
+{
+  (let l0$b$0 ==
+    (p$s) in
+    (let anon$1$0 ==
+      ((unfolding acc(p$c$Base$shared(l0$b$0), wildcard) in
+        l0$b$0.bf$value)) in
+      (let anon$0$0 ==
+        (anon$1$0) in
+        anon$0$0)))
+}
 
-/pure_upcast.kt:(907,982): error: Impure function body detected in pure function
+/pure_upcast.kt:(873,890): info: Generated Viper text for readValueNullable:
+field bf$value: Ref
 
-/pure_upcast.kt:(1008,1026): info: Generated Viper text for pureNullableUpcast:
+function f$readValueNullable$TF$NT$Base$T$Int(p$b: Ref): Ref
+  requires df$rt$isSubtype(df$rt$typeOf(p$b), df$rt$nullable(df$rt$c$Base()))
+  requires p$b != df$rt$nullValue() ==> acc(p$c$Base$shared(p$b), wildcard)
+  ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
+{
+  (let anon$3$0 ==
+    ((!(p$b == df$rt$nullValue()) ?
+      (unfolding acc(p$c$Base$shared(p$b), wildcard) in p$b.bf$value) :
+      null)) in
+    (let anon$2$0 ==
+      ((!(p$b == df$rt$nullValue()) ? anon$3$0 : null)) in
+      (let anon$5$0 ==
+        ((!!(p$b == df$rt$nullValue()) ? df$rt$intToRef(-1) : null)) in
+        (let anon$4$0 ==
+          ((!!(p$b == df$rt$nullValue()) ? anon$5$0 : null)) in
+          (let anon$1$0 ==
+            ((!(p$b == df$rt$nullValue()) ? anon$2$0 : anon$4$0)) in
+            (let anon$0$0 ==
+              (anon$1$0) in
+              anon$0$0))))))
+}
+
+/pure_upcast.kt:(964,982): info: Generated Viper text for pureNullableUpcast:
 field bf$value: Ref
 
 function f$pureNullableUpcast$TF$NT$Sub$T$Int(p$s: Ref): Ref
@@ -68,7 +123,9 @@ function f$pureNullableUpcast$TF$NT$Sub$T$Int(p$s: Ref): Ref
   requires p$s != df$rt$nullValue() ==> acc(p$c$Sub$shared(p$s), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 {
-  f$readValueNullable$TF$NT$Base$T$Int(p$s)
+  (let anon$0$0 ==
+    (f$readValueNullable$TF$NT$Base$T$Int(p$s)) in
+    anon$0$0)
 }
 
 function f$readValueNullable$TF$NT$Base$T$Int(p$b: Ref): Ref
@@ -77,7 +134,4 @@ function f$readValueNullable$TF$NT$Base$T$Int(p$b: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$intType())
 
 
-method pg$public$value(this$dispatch: Ref) returns (ret: Ref)
-
-
-/pure_upcast.kt:(1043,1063): warning: Viper verification error: Precondition of function f$readValueNullable$TF$NT$Base$T$Int might not hold. There might be insufficient permission to access p$c$Base$shared(p$s)
+/pure_upcast.kt:(999,1019): warning: Viper verification error: Precondition of function f$readValueNullable$TF$NT$Base$T$Int might not hold. There might be insufficient permission to access p$c$Base$shared(p$s)

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_upcast.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_upcast.kt
@@ -17,15 +17,15 @@ fun <!VIPER_TEXT!>pureUpcast<!>(s: Sub): Int = readValue(s)
 @Pure
 @AlwaysVerify
 fun <!VIPER_TEXT!>pureConditionalUpcast<!>(s1: Sub, s2: Sub2, flag: Boolean): Int =
-    readValue(if (flag) s1 else s2)
+    <!VIPER_VERIFICATION_ERROR!>readValue(if (flag) s1 else s2)<!>
 
 // Test 3: pure function stores the upcast result in a variable, then reads it.
-@Pure
+<!VIPER_VERIFICATION_ERROR!>@Pure
 @AlwaysVerify
 fun <!VIPER_TEXT!>pureUpcastViaVariable<!>(s: Sub): Int {
     val b: Base = s
     return b.value
-}
+}<!>
 
 // Test 4: nullable subtype passed to a nullable supertype parameter.
 @Pure
@@ -33,4 +33,4 @@ fun <!VIPER_TEXT!>readValueNullable<!>(b: Base?): Int = if (b != null) b.value e
 
 @Pure
 @AlwaysVerify
-fun <!VIPER_TEXT!>pureNullableUpcast<!>(s: Sub?): Int = readValueNullable(s)
+fun <!VIPER_TEXT!>pureNullableUpcast<!>(s: Sub?): Int = <!VIPER_VERIFICATION_ERROR!>readValueNullable(s)<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
@@ -35,11 +35,11 @@ predicate p$c$Node$unique(this$dispatch: Ref) {
 
 method f$get_left_val$TF$T$Node$NT$Int(p$n: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$c$Node())
+  requires acc(p$c$Node$shared(p$n), wildcard)
   requires acc(p$c$Node$unique(p$n), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  inhale acc(p$c$Node$shared(p$n), wildcard)
   unfold acc(p$c$Node$shared(p$n), wildcard)
   anon$0 := p$n.bf$left
   if (anon$0 != df$rt$nullValue()) {
@@ -124,8 +124,12 @@ method con$c$Node$T$Int$NT$Node$NT$Node$T$Node(p$data: Ref, p$left: Ref, p$right
   requires df$rt$isSubtype(df$rt$typeOf(p$data), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$left), df$rt$nullable(df$rt$c$Node()))
   requires p$left != df$rt$nullValue() ==>
+    acc(p$c$Node$shared(p$left), wildcard)
+  requires p$left != df$rt$nullValue() ==>
     acc(p$c$Node$unique(p$left), write)
   requires df$rt$isSubtype(df$rt$typeOf(p$right), df$rt$nullable(df$rt$c$Node()))
+  requires p$right != df$rt$nullValue() ==>
+    acc(p$c$Node$shared(p$right), wildcard)
   requires p$right != df$rt$nullValue() ==>
     acc(p$c$Node$unique(p$right), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Node())

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
@@ -23,11 +23,11 @@ predicate p$c$Link$unique(this$dispatch: Ref) {
 
 method f$getVal$TF$T$Link$NT$Int(p$l: Ref) returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$l), df$rt$c$Link())
+  requires acc(p$c$Link$shared(p$l), wildcard)
   requires acc(p$c$Link$unique(p$l), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
 {
   var anon$0: Ref
-  inhale acc(p$c$Link$shared(p$l), wildcard)
   unfold acc(p$c$Link$shared(p$l), wildcard)
   anon$0 := p$l.bf$next
   if (anon$0 != df$rt$nullValue()) {
@@ -99,6 +99,8 @@ method con$c$Link$T$Int$NT$Link$T$Link(p$data: Ref, p$next: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$data), df$rt$intType())
   requires df$rt$isSubtype(df$rt$typeOf(p$next), df$rt$nullable(df$rt$c$Link()))
+  requires p$next != df$rt$nullValue() ==>
+    acc(p$c$Link$shared(p$next), wildcard)
   requires p$next != df$rt$nullValue() ==>
     acc(p$c$Link$unique(p$next), write)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$c$Link())

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/pure_function_with_literal_return.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/pure_function_with_literal_return.fir.diag.txt
@@ -11,7 +11,9 @@ function f$annotatedIntLitReturn$TF$T$Int$T$Int(p$arg: Ref): Ref
       anon$builtin$1 == df$rt$intFromRef(result) ==>
       anon$builtin$1 == df$rt$intFromRef(p$arg))
 {
-  df$rt$intToRef(42)
+  (let anon$0$0 ==
+    (df$rt$intToRef(42)) in
+    anon$0$0)
 }
 
 /pure_function_with_literal_return.kt:(403,425): info: Generated Viper text for annotatedBoolLitReturn:
@@ -23,7 +25,9 @@ function f$annotatedBoolLitReturn$TF$T$Int$T$Boolean(p$arg: Ref): Ref
   ensures df$rt$boolFromRef(result)
   ensures df$rt$intFromRef(p$arg) == 0
 {
-  df$rt$boolToRef(true)
+  (let anon$0$0 ==
+    (df$rt$boolToRef(true)) in
+    anon$0$0)
 }
 
 /pure_function_with_literal_return.kt:(628,650): info: Generated Viper text for annotatedCharLitReturn:
@@ -34,7 +38,9 @@ function f$annotatedCharLitReturn$TF$T$String$T$Char(p$arg: Ref): Ref
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$charType())
   ensures df$rt$charFromRef(result) == 65
 {
-  df$rt$charToRef(65)
+  (let anon$0$0 ==
+    (df$rt$charToRef(65)) in
+    anon$0$0)
 }
 
 /pure_function_with_literal_return.kt:(834,858): info: Generated Viper text for annotatedStringLitReturn:
@@ -45,5 +51,7 @@ function f$annotatedStringLitReturn$TF$T$Boolean$T$String(p$arg: Ref): Ref
   ensures df$rt$stringFromRef(result) ==
     Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116)
 {
-  df$rt$stringToRef(Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116))
+  (let anon$0$0 ==
+    (df$rt$stringToRef(Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116))) in
+    anon$0$0)
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
@@ -135,6 +135,7 @@ method con$c$WithVar$T$Int$T$WithVar(p$e: Ref) returns (ret: Ref)
 method f$c$WithVar$doSomething$TF$T$WithVar$T$Boolean(this$dispatch: Ref)
   returns (ret: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(this$dispatch), df$rt$c$WithVar())
+  requires acc(p$c$WithVar$shared(this$dispatch), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret), df$rt$boolType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
@@ -17,6 +17,7 @@ method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
 method f$test_while$TF$T$ClassWithField$T$Unit(p$param: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
+  requires acc(p$c$ClassWithField$shared(p$param), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$c: Ref
@@ -27,7 +28,6 @@ method f$test_while$TF$T$ClassWithField$T$Unit(p$param: Ref)
   var anon$1: Ref
   var l0$cond2: Ref
   var anon$2: Ref
-  inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
   l0$c := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(13))
   unfold acc(p$c$ClassWithField$shared(p$param), wildcard)
   l0$initParamField := p$param.bf$field
@@ -95,6 +95,7 @@ method con$c$ClassWithField$T$Int$T$ClassWithField(p$field: Ref)
 method f$test_while_with_inlining$TF$T$ClassWithField$T$Unit(p$param: Ref)
   returns (ret$0: Ref)
   requires df$rt$isSubtype(df$rt$typeOf(p$param), df$rt$c$ClassWithField())
+  requires acc(p$c$ClassWithField$shared(p$param), wildcard)
   ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$unitType())
 {
   var l0$local: Ref
@@ -110,7 +111,6 @@ method f$test_while_with_inlining$TF$T$ClassWithField$T$Unit(p$param: Ref)
   var anon$6: Ref
   var anon$7: Ref
   var anon$8: Ref
-  inhale acc(p$c$ClassWithField$shared(p$param), wildcard)
   l0$local := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(13))
   anon$4 := con$c$ClassWithField$T$Int$T$ClassWithField(df$rt$intToRef(42))
   anon$0 := anon$4


### PR DESCRIPTION
## Summary

This PR was extracted from #92 and is based on #106. It concerns moving the `sharedPredicateAccessInvariant` for method parameters from being expressed inside function bodies to being declared as `requires` clauses in method preconditions.

Shared-access predicate invariants ensure that an access to an object on the heap is permitted. Previously, these were only inhaled before the access occurred and it was not verified that the individual function actually has enough permissions to access the object. Implementing this change demonstrated that functions expecting a super type of the provided type did not have enough permissions to access it, leading to failures in the test cases.

> **Draft — the correctness of this implementation depends on the previous two PR requests.**

## Changes

- `ProgramConverter`: adds `sharedPredicateAccessInvariant` to method preconditions for each
  formal argument, so that the `requires acc(Type_shared(param), wildcard)` clause appears in
  the generated Viper method signature.
- `FullNamedFunctionSignature.toViperFunction`: removes the `formalArgs.mapNotNull { it.sharedPredicateAccessInvariant() }`
  that was previously prepended to pure-function preconditions; `getPreconditions()` is now
  used directly, which picks up the invariant from the method level.
- `ControlFlow` (`FunctionExp.toViperMaybeStoringIn`): removes the inline `Stmt.Inhale` of
  `sharedPredicateAccessInvariant` for each formal argument of an inline function body, which
  was a workaround that is no longer needed.

## Remaining tasks

- Update all `.fir.diag.txt` golden files to reflect the new `requires acc(...)` lines in
  method preconditions.
- Verify that the moved permission does not introduce inconsistencies for callers that
  previously relied on the inhale.
- Decide whether `uniquePredicateAccessInvariant` should be moved to preconditions in the
  same way; currently only the shared predicate is moved.

## Limitations

This strategy is not capable of handling casts to a subtype. Currently, when we explicitly or implicitly cast to a subtype, the permissions of this subtype are assumed. Our access predicate logic does not support an easy fix for this.