### PR TITLE
Add dump-test-diff.sh for viewing golden file assertion diffs

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,12 @@
+# Scripts
+
+Use `dump-test-diff.sh` to debug golden file test failures. It runs a single test and dumps the expected vs actual content when an assertion fails, working around Gradle's cross-JVM serialization which strips diff details.
+
+When both `.kt` and `.fir.diag.txt` golden files are broken, it captures each diff in a separate numbered file.
+
+Usage:
+```
+./scripts/dump-test-diff.sh "testName"
+```
+
+Output appears at `/tmp/test-assertion-dump-*.txt`.

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# dump-test-diff.sh — Run a single failing test and dump the assertion diff.
+#
+# The Kotlin compiler test framework compares golden files (.fir.diag.txt, .kt
+# with diagnostic markers) inside a forked test JVM. Gradle's cross-JVM
+# serialization strips AssertionFailedError expected/actual values, so you
+# never see the diff in normal test output.
+#
+# This script works around that by temporarily injecting a JUnit 5 TestWatcher
+# extension that catches failures inside the test JVM and writes the diff to
+# /tmp/test-assertion-dump-*.txt files.
+#
+# Usage:
+#   ./scripts/dump-test-diff.sh "testIs_type_contract"
+#   ./scripts/dump-test-diff.sh "testFull_viper_dump"
+#
+# After the run, look at /tmp/test-assertion-dump-*.txt for the expected vs
+# actual content.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <test-method-name-pattern>"
+    echo "Example: $0 'testIs_type_contract'"
+    exit 1
+fi
+
+TEST_PATTERN="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+EXTENSION_FILE="$ROOT_DIR/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/DumpAssertionDiffExtension.kt"
+SERVICES_DIR="$ROOT_DIR/formver.compiler-plugin/testData/META-INF/services"
+SERVICES_FILE="$SERVICES_DIR/org.junit.jupiter.api.extension.Extension"
+PLATFORM_PROPS="$ROOT_DIR/formver.compiler-plugin/testData/junit-platform.properties"
+
+# Clean up old dumps
+rm -f /tmp/test-assertion-dump-*.txt
+
+# Write the JUnit 5 extension
+mkdir -p "$(dirname "$EXTENSION_FILE")"
+cat > "$EXTENSION_FILE" << 'KOTLIN'
+package org.jetbrains.kotlin.formver.plugin
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestWatcher
+import org.opentest4j.AssertionFailedError
+import java.io.File
+
+class DumpAssertionDiffExtension : TestWatcher {
+    override fun testFailed(context: ExtensionContext, cause: Throwable) {
+        val baseName = context.displayName.replace(Regex("[^a-zA-Z0-9_]"), "_")
+        val assertions = collectAssertionErrors(cause)
+        for ((index, error) in assertions.withIndex()) {
+            val suffix = if (assertions.size > 1) "_$index" else ""
+            val name = "$baseName$suffix"
+            val expected = resolveValue(error.expected)
+            val actual = resolveValue(error.actual)
+            File("/tmp/test-assertion-dump-$name.txt").writeText(buildString {
+                appendLine("=== EXPECTED ===")
+                appendLine(expected)
+                appendLine()
+                appendLine("=== ACTUAL ===")
+                appendLine(actual)
+            })
+            System.err.println(">>> Assertion diff dumped to /tmp/test-assertion-dump-$name.txt")
+        }
+    }
+
+    private fun collectAssertionErrors(throwable: Throwable): List<AssertionFailedError> {
+        // Direct assertion error with expected/actual values
+        if (throwable is AssertionFailedError && throwable.isExpectedDefined && throwable.isActualDefined) {
+            return listOf(throwable)
+        }
+        // MultipleFailuresError (opentest4j, thrown by Assertions.assertAll) — has getFailures(): List<Throwable>
+        // Also covers DefaultMultiCauseException (Gradle) which has getCauses(): List<Throwable>
+        for (methodName in listOf("getFailures", "getCauses")) {
+            try {
+                val method = throwable.javaClass.getMethod(methodName)
+                @Suppress("UNCHECKED_CAST")
+                val children = method.invoke(throwable) as? List<Throwable>
+                if (children != null && children.isNotEmpty()) {
+                    return children.flatMap { collectAssertionErrors(it) }
+                }
+            } catch (_: Exception) {}
+        }
+        // Walk suppressed exceptions
+        val fromSuppressed = throwable.suppressed.flatMap { collectAssertionErrors(it) }
+        if (fromSuppressed.isNotEmpty()) return fromSuppressed
+        // Walk standard cause chain
+        val inner = throwable.cause
+        if (inner != null && inner !== throwable) {
+            return collectAssertionErrors(inner)
+        }
+        return emptyList()
+    }
+
+    private fun resolveValue(wrapper: org.opentest4j.ValueWrapper): String {
+        // First try the raw value — may be a FileInfo with getContentsAsString()
+        val value = wrapper.value
+        if (value != null && value !is String) {
+            try {
+                val m = value.javaClass.getMethod("getContentsAsString")
+                return m.invoke(value) as String
+            } catch (_: Exception) {}
+        }
+        val str = (value as? String) ?: wrapper.stringRepresentation
+        // If it looks like a FileInfo toString, read the file directly
+        val match = Regex("""FileInfo\[path='(.+?)',""").find(str)
+        if (match != null) {
+            val path = match.groupValues[1]
+            try { return File(path).readText() } catch (_: Exception) {}
+        }
+        return str
+    }
+}
+KOTLIN
+
+# Register as auto-detected extension
+mkdir -p "$SERVICES_DIR"
+echo "org.jetbrains.kotlin.formver.plugin.DumpAssertionDiffExtension" > "$SERVICES_FILE"
+
+# Enable JUnit 5 extension autodetection (disabled by default)
+echo "junit.jupiter.extensions.autodetection.enabled=true" > "$PLATFORM_PROPS"
+
+cleanup() {
+    rm -f "$EXTENSION_FILE"
+    rm -f "$SERVICES_FILE"
+    rm -f "$PLATFORM_PROPS"
+    rmdir "$SERVICES_DIR" 2>/dev/null || true
+    rmdir "$(dirname "$SERVICES_DIR")" 2>/dev/null || true
+    # Also clean up the build copy so it doesn't persist across runs
+    rm -f "$ROOT_DIR/formver.compiler-plugin/build/resources/test/junit-platform.properties"
+    rm -rf "$ROOT_DIR/formver.compiler-plugin/build/resources/test/META-INF/services"
+}
+trap cleanup EXIT
+
+echo "Running test: $TEST_PATTERN"
+echo "Diff files will appear at /tmp/test-assertion-dump-*.txt"
+echo
+
+# --rerun-tasks forces recompilation of test-fixtures with the extension
+cd "$ROOT_DIR"
+./gradlew :formver.compiler-plugin:test \
+    --tests "*$TEST_PATTERN*" \
+    --rerun-tasks \
+    --no-daemon \
+    2>&1 || true
+
+echo
+echo "=== Assertion diffs ==="
+for f in /tmp/test-assertion-dump-*.txt; do
+    if [[ -f "$f" ]]; then
+        echo
+        echo "--- $(basename "$f") ---"
+        cat "$f"
+    fi
+done
+
+if ! ls /tmp/test-assertion-dump-*.txt &>/dev/null; then
+    echo "(no diffs captured — test may have passed or failed with a non-assertion error)"
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/dump-test-diff.sh` — a helper that runs a single test and dumps the expected vs actual content when a golden file assertion fails.
- Gradle's cross-JVM serialization strips `AssertionFailedError` expected/actual values, so you never see the diff in normal test output. This script works around that by temporarily injecting a JUnit 5 `TestWatcher` extension that catches failures inside the test JVM and writes both sides to `/tmp/test-assertion-dump-*.txt`.
- Handles the Kotlin test framework's `FileInfo` wrapper by extracting the file path and reading the golden file content directly.

Usage:
```
./scripts/dump-test-diff.sh "testArithmetic"
```

## Test plan
- [x] Intentionally broke a golden file (`sp$BROKEN` vs `sp$plusInts`), ran the script, confirmed both expected and actual content appear in the dump with the correct diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)