### PR TITLE
Fix @AlwaysVerify bypassing conversion-only mode

### DIFF
--- a/formver.common/src/org/jetbrains/kotlin/formver/common/TargetsSelection.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/TargetsSelection.kt
@@ -6,7 +6,7 @@
 package org.jetbrains.kotlin.formver.common
 
 enum class TargetsSelection {
-    NO_TARGETS, TARGETS_WITH_CONTRACT, ALL_TARGETS;
+    FORCE_DISABLE, NO_TARGETS, TARGETS_WITH_CONTRACT, ALL_TARGETS;
 
 
     companion object {

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -39,6 +39,7 @@ private fun TargetsSelection.applicable(declaration: FirSimpleFunction): Boolean
     TargetsSelection.ALL_TARGETS -> true
     TargetsSelection.TARGETS_WITH_CONTRACT -> declaration.hasContract
     TargetsSelection.NO_TARGETS -> false
+    TargetsSelection.FORCE_DISABLE -> false
 }
 
 class ViperPoweredDeclarationChecker(private val session: FirSession, private val config: PluginConfiguration) :
@@ -130,6 +131,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
     }
 
     private fun PluginConfiguration.shouldVerify(declaration: FirSimpleFunction): Boolean = when {
+        verificationSelection == TargetsSelection.FORCE_DISABLE -> false
         declaration.hasAnnotation(neverConvertId, session) -> false
         declaration.hasAnnotation(neverVerifyId, session) -> false
         declaration.hasAnnotation(alwaysVerifyId, session) -> true

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -48,7 +48,7 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
         val uniquenessOnly = UNIQUE_CHECK_ONLY in module.directives
         val dumpUniquenessCFG = DUMP_UNIQUENESS_CFG in module.directives
         val verificationSelection = when {
-            conversionOnly -> TargetsSelection.NO_TARGETS
+            conversionOnly -> TargetsSelection.FORCE_DISABLE
             ALWAYS_VALIDATE in module.directives -> TargetsSelection.ALL_TARGETS
             uniquenessOnly -> TargetsSelection.NO_TARGETS
             else -> TargetsSelection.TARGETS_WITH_CONTRACT


### PR DESCRIPTION
## Summary

- `shouldVerify()` in `ViperPoweredDeclarationChecker` checked `@AlwaysVerify` annotations before consulting `verificationSelection`, so functions with `@AlwaysVerify` still invoked z3 in conversion-only mode (`NEVER_VALIDATE` / `formver.conversionOnly=true`)
- Added `FORCE_DISABLE` to `TargetsSelection` which unconditionally prevents verification, including for `@AlwaysVerify` functions. Conversion-only mode now uses `FORCE_DISABLE` instead of `NO_TARGETS`
- `NO_TARGETS` remains available for cases where `@AlwaysVerify` should still be able to opt in to verification for specific functions

## Test plan

- [x] `./gradlew testNoVerification` passes with `Z3_EXE=/bin/false` (all 150 tests — previously 32 failures)
- [x] `./gradlew test` still passes with real z3 (no regression for normal verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)