### PR TITLE
Fixed recently-introduced failing test case

### DIFF
--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -281,7 +281,7 @@ function f$id$t$F$t$N$Node$t$N$Node(par$node: Ref): Ref
   requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 {
-  p$node
+  par$node
 }
 
 function f$useIdentityFunction$t$F$t$Node$t$Int(par$node: Ref): Ref
@@ -340,5 +340,5 @@ function f$id$t$F$t$N$Node$t$N$Node(par$node: Ref): Ref
   requires df$rt$isSubtype(df$rt$typeOf(par$node), df$rt$nullable(df$rt$c$Node()))
   ensures df$rt$isSubtype(df$rt$typeOf(result), df$rt$nullable(df$rt$c$Node()))
 {
-  p$node
+  par$node
 }


### PR DESCRIPTION
This PR fixes an issue with the _pure_function_with_heap_dependent_expressions_ test case, which was introduced into main by a recent PR and not yet updated to the new naming standards.