### PR TITLE
Property Name Update

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -89,12 +89,12 @@ class ProgramConverter(
             // We need to deduplicate fields since public fields with the same name are represented differently
             // at `FieldEmbedding` level but map to the same Viper.
             fields = SpecialFields.all.map { it.toViper() } +
-                    fields.distinctBy { it.name.debugMangled }.map { it.toViper() },
+                    fields.distinctBy { it.name }.map { it.toViper() },
             functions = SpecialFunctions.all +
-                    functions.values.mapNotNull { it.viperFunction }.distinctBy { it.name.debugMangled },
+                    functions.values.mapNotNull { it.viperFunction }.distinctBy { it.name },
             methods = SpecialMethods.all +
                     methods.values.mapNotNull { it.viperMethod }
-                        .distinctBy { it.name.debugMangled } + havocMethods.values,
+                        .distinctBy { it.name } + havocMethods.values,
             predicates = classes.values.flatMap {
                 listOf(
                     it.details.sharedPredicate,

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.utils.addToStdlib.ifFalse
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 
-typealias PropertyName = Pair<ScopedName, ScopedName>
+typealias ClassPropertyPair = Pair<ScopedName, ScopedName>
 
 /**
  * Tracks the top-level information about the program.
@@ -66,7 +66,7 @@ class ProgramConverter(
      * [properties] contains all the properties. This includes properties defined on interfaces etc.
      * They are stored in a map. The key is the pair of the name of the class and the field.
      **/
-    private val properties: MutableMap<PropertyName, PropertyEmbedding> = mutableMapOf()
+    private val properties: MutableMap<ClassPropertyPair, PropertyEmbedding> = mutableMapOf()
 
     /** [fields] contain the properties that actually have backing fields. **/
     private val fields: MutableSet<FieldEmbedding> = mutableSetOf()

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -39,6 +39,9 @@ import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.utils.addToStdlib.ifFalse
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
+
+typealias PropertyName = Pair<ScopedName, ScopedName>
+
 /**
  * Tracks the top-level information about the program.
  * Conversions for global entities like types should generally be
@@ -63,7 +66,7 @@ class ProgramConverter(
      * [properties] contains all the properties. This includes properties defined on interfaces etc.
      * They are stored in a map. The key is the pair of the name of the class and the field.
      **/
-    private val properties: MutableMap<Pair<SymbolicName, SymbolicName>, PropertyEmbedding> = mutableMapOf()
+    private val properties: MutableMap<PropertyName, PropertyEmbedding> = mutableMapOf()
 
     /** [fields] contain the properties that actually have backing fields. **/
     private val fields: MutableSet<FieldEmbedding> = mutableSetOf()

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -58,7 +58,14 @@ class ProgramConverter(
         }.toMutableMap()
     private val functions: MutableMap<SymbolicName, PureFunctionEmbedding> = mutableMapOf()
     private val classes: MutableMap<SymbolicName, ClassTypeEmbedding> = mutableMapOf()
-    private val properties: MutableMap<SymbolicName, PropertyEmbedding> = mutableMapOf()
+
+    /**
+     * [properties] contains all the properties. This includes properties defined on interfaces etc.
+     * They are stored in a map. The key is the pair of the name of the class and the field.
+     **/
+    private val properties: MutableMap<Pair<SymbolicName, SymbolicName>, PropertyEmbedding> = mutableMapOf()
+
+    /** [fields] contain the properties that actually have backing fields. **/
     private val fields: MutableSet<FieldEmbedding> = mutableSetOf()
     private val havocMethods: MutableMap<SymbolicName, Method> = mutableMapOf()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -32,7 +32,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.properties.*
 import org.jetbrains.kotlin.formver.core.embeddings.types.*
 import org.jetbrains.kotlin.formver.core.names.*
 import org.jetbrains.kotlin.formver.names.SimpleNameResolver
-import org.jetbrains.kotlin.formver.names.debugMangled
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Method
 import org.jetbrains.kotlin.formver.viper.ast.Program

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/MemberEmbeddingPolicy.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/MemberEmbeddingPolicy.kt
@@ -18,4 +18,4 @@ fun onlyPrivateScopedPolicy(isPrivate: Boolean): MemberEmbeddingPolicy =
     if (isPrivate) MemberEmbeddingPolicy.PRIVATE else MemberEmbeddingPolicy.UNSCOPED
 
 val MemberEmbeddingPolicy.isScoped: Boolean
-    get() = this == MemberEmbeddingPolicy.PRIVATE || this == MemberEmbeddingPolicy.PUBLIC
+    get() = this == MemberEmbeddingPolicy.PRIVATE

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/MemberEmbeddingPolicy.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/MemberEmbeddingPolicy.kt
@@ -17,5 +17,3 @@ fun alwaysScopedPolicy(isPrivate: Boolean): MemberEmbeddingPolicy =
 fun onlyPrivateScopedPolicy(isPrivate: Boolean): MemberEmbeddingPolicy =
     if (isPrivate) MemberEmbeddingPolicy.PRIVATE else MemberEmbeddingPolicy.UNSCOPED
 
-val MemberEmbeddingPolicy.isScoped: Boolean
-    get() = this == MemberEmbeddingPolicy.PRIVATE

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameEmbeddings.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameEmbeddings.kt
@@ -9,8 +9,8 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
+import org.jetbrains.kotlin.formver.core.conversion.ClassPropertyPair
 import org.jetbrains.kotlin.formver.core.conversion.ProgramConversionContext
-import org.jetbrains.kotlin.formver.core.conversion.PropertyName
 import org.jetbrains.kotlin.formver.core.conversion.ScopeIndex
 import org.jetbrains.kotlin.formver.core.embeddings.types.FunctionTypeEmbedding
 import org.jetbrains.kotlin.name.CallableId
@@ -129,10 +129,11 @@ fun FirPropertySymbol.embedSetterName(ctx: ProgramConversionContext): ScopedName
  * Returns a pair that uniquely identifies the property.
  * The first element is the name of the class that contains the property, and the second is the name of the property itself.
  */
-fun FirPropertySymbol.embedMemberPropertyName(): PropertyName {
+fun FirPropertySymbol.embedMemberPropertyName(): ClassPropertyPair {
+    val callable = callableId
     val className =
-        callableId?.classId?.embedName() ?: throw SnaktInternalException(source, "Property is not part of a class")
-    val propertyName = callableId!!.embedMemberPropertyName(Visibilities.isPrivate(this.visibility))
+        callable?.classId?.embedName() ?: throw SnaktInternalException(source, "Property is not part of a class")
+    val propertyName = callable.embedMemberPropertyName(Visibilities.isPrivate(this.visibility))
     return Pair(className, propertyName)
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameEmbeddings.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameEmbeddings.kt
@@ -8,9 +8,11 @@ package org.jetbrains.kotlin.formver.core.names
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.symbols.impl.*
+import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.conversion.ProgramConversionContext
 import org.jetbrains.kotlin.formver.core.conversion.ScopeIndex
 import org.jetbrains.kotlin.formver.core.embeddings.types.FunctionTypeEmbedding
+import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
@@ -122,9 +124,17 @@ fun FirPropertySymbol.embedSetterName(ctx: ProgramConversionContext): ScopedName
         callableId!!.embedMemberSetterName(Visibilities.isPrivate(visibility))
     }
 
-fun FirPropertySymbol.embedMemberPropertyName() = callableId!!.embedMemberPropertyName(
-    Visibilities.isPrivate(this.visibility)
-)
+/**
+ * Returns a pair that uniquely identifies the property.
+ * The first element is the name of the class that contains the property, and the second is the name of the property itself.
+ */
+fun FirPropertySymbol.embedMemberPropertyName(): Pair<SymbolicName, SymbolicName> {
+    val className =
+        callableId!!.classId?.embedName() ?: throw SnaktInternalException(null, "Property is not part of a class")
+    val propertyName = callableId!!.embedMemberPropertyName(Visibilities.isPrivate(this.visibility))
+    return Pair(className, propertyName)
+}
+
 
 fun FirConstructorSymbol.embedName(ctx: ProgramConversionContext): ScopedName = buildName {
     embedScope(callableId)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameEmbeddings.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameEmbeddings.kt
@@ -10,9 +10,9 @@ import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.conversion.ProgramConversionContext
+import org.jetbrains.kotlin.formver.core.conversion.PropertyName
 import org.jetbrains.kotlin.formver.core.conversion.ScopeIndex
 import org.jetbrains.kotlin.formver.core.embeddings.types.FunctionTypeEmbedding
-import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
@@ -56,12 +56,13 @@ private fun CallableId.embedMemberPropertyNameBase(
 ): ScopedName {
     val id = classId ?: error("Embedding non-member property $callableName as a member.")
     return buildName {
-        if (scopePolicy.isScoped) {
-            embedScope(id)
-        }
         when (scopePolicy) {
             MemberEmbeddingPolicy.PUBLIC -> publicScope()
-            MemberEmbeddingPolicy.PRIVATE -> privateScope()
+            MemberEmbeddingPolicy.PRIVATE -> {
+                // When the field is private, we want to have the class scope as the parent.
+                embedScope(id)
+                privateScope()
+            }
             MemberEmbeddingPolicy.UNSCOPED -> fakeScope()
         }
         withAction(callableName)
@@ -128,9 +129,9 @@ fun FirPropertySymbol.embedSetterName(ctx: ProgramConversionContext): ScopedName
  * Returns a pair that uniquely identifies the property.
  * The first element is the name of the class that contains the property, and the second is the name of the property itself.
  */
-fun FirPropertySymbol.embedMemberPropertyName(): Pair<SymbolicName, SymbolicName> {
+fun FirPropertySymbol.embedMemberPropertyName(): PropertyName {
     val className =
-        callableId!!.classId?.embedName() ?: throw SnaktInternalException(null, "Property is not part of a class")
+        callableId?.classId?.embedName() ?: throw SnaktInternalException(source, "Property is not part of a class")
     val propertyName = callableId!!.embedMemberPropertyName(Visibilities.isPrivate(this.visibility))
     return Pair(className, propertyName)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
@@ -10,19 +10,13 @@ import org.jetbrains.kotlin.name.FqName
 
 sealed interface NameScope : AnyName {
     val parent: NameScope?
-
-    // Determines whether the parent should be part of the name.
-    // This is a hack required by how we deal with public names.
-    // We use only accessible scopes when generating the names, but all scopes when doing lookups
-    // for things like package and class names.
-    val parentAccessible: Boolean
-        get() = true
+        get() = null
 }
 
 // Includes the scope itself.
 val NameScope.parentScopes: Sequence<NameScope>
     get() = sequence {
-        if (parentAccessible) parent?.parentScopes?.let { yieldAll(it) }
+        parent?.parentScopes?.let { yieldAll(it) }
         yield(this@parentScopes)
     }
 
@@ -35,41 +29,22 @@ val NameScope.allParentScopes: Sequence<NameScope>
 val NameScope.packageNameIfAny: FqName?
     get() = allParentScopes.filterIsInstance<PackageScope>().lastOrNull()?.packageName
 
-val NameScope.classNameIfAny: ClassKotlinName?
-    get() = allParentScopes.filterIsInstance<ClassScope>().lastOrNull()?.className
 
-data class PackageScope(val packageName: FqName) : NameScope {
-    override val parent = null
-}
+data class PackageScope(val packageName: FqName) : NameScope
 
 data class ClassScope(override val parent: NameScope, val className: ClassKotlinName) : NameScope
 
-/**
- * We do not want to mangle field names with class and package, hence introducing
- * this special `NameScope`. Note that it still needs package and class for other purposes.
- */
-data object PublicScope : NameScope {
-    override val parent: NameScope? = null
-    override val parentAccessible: Boolean
-        get() = false
-}
+data object PublicScope : NameScope
 
 data class PrivateScope(override val parent: NameScope) : NameScope
-data object ParameterScope : NameScope {
-    override val parent: NameScope? = null
-}
 
-data object BadScope : NameScope {
-    override val parent: NameScope? = null
-}
+data object ParameterScope : NameScope
 
-data class LocalScope(val level: Int) : NameScope {
-    override val parent: NameScope? = null
-}
+data object BadScope : NameScope
+
+data class LocalScope(val level: Int) : NameScope
 
 /**
  * Scope to use in cases when we need a scoped name, but don't actually want to introduce one.
  */
-data object FakeScope : NameScope {
-    override val parent: NameScope? = null
-}
+data object FakeScope : NameScope

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
@@ -6,8 +6,6 @@
 package org.jetbrains.kotlin.formver.core.names
 
 import org.jetbrains.kotlin.formver.viper.AnyName
-import org.jetbrains.kotlin.formver.viper.NameResolver
-import org.jetbrains.kotlin.formver.viper.mangled
 import org.jetbrains.kotlin.name.FqName
 
 sealed interface NameScope : AnyName {
@@ -50,7 +48,8 @@ data class ClassScope(override val parent: NameScope, val className: ClassKotlin
  * We do not want to mangle field names with class and package, hence introducing
  * this special `NameScope`. Note that it still needs package and class for other purposes.
  */
-data class PublicScope(override val parent: NameScope) : NameScope {
+data object PublicScope : NameScope {
+    override val parent: NameScope? = null
     override val parentAccessible: Boolean
         get() = false
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedNameBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedNameBuilder.kt
@@ -31,8 +31,8 @@ class ScopedNameBuilder {
     }
 
     fun publicScope() {
-        require(scope is ClassScope) { "Public scope must be in a class scope." }
-        scope = PublicScope(scope!!)
+        require(scope == null) { "Public scope cannot be nested." }
+        scope = PublicScope
     }
 
     fun privateScope() {


### PR DESCRIPTION
This PR contains multiple changes on different things, but they are all related.


## Unique Program Parts
Before creating the viper programs, some structure of the "ExpEmbedding-Program" were made unique. For example this was done to only have one public field per name. This was performed in the following way:

```kotlin
fields.distinctBy { it.name.debugMangled }
```
The name of the fields get transformed to a string using the `DebugNameResolver`. But since our names are structurally unique, we should also use structural comparison instead of reliying on the NameResolver to translate them to strings.

Therefore we only use `it.name` to make the fields unique.


## Structurally Wrong Names
This change uncovered the problem on how we create the names for public fields. Since we want to merge all public fields  with the same name, the public name should have the form: `ScopedName(public, fieldName)`. But actually, the field name contained the name of the corresponding class. The class Name was included as a parent scope of the public scope. 
Before this was not an issue, because the `DebugNameResolver` ignored the parents scopes of the public scope. (So does the simple name resolver).
Therefore we changed the public scope to no longer hold a parent scope. (private field names, still have their corresponding class in their name)


## Embedding Problem
The previous change resulted in a follow up problem. In the situation where there are two public fields with the same name, but with different getters, we need to be able to decide which getter to use. The `ProgramConverter` used to look this up using the property name. This used because the property name contained the corresponding class. But now this is no longer possible.
We came up with the following solution: When embedding the name of a property we return a pair: The name of the corresponding class as well as the name of the property. This pair is then used to lookup the property.

