### PR TITLE
Add dump-test-diff.sh for viewing golden file assertion diffs

### DIFF
--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/DumpAssertionDiffExtension.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/DumpAssertionDiffExtension.kt
@@ -1,0 +1,74 @@
+package org.jetbrains.kotlin.formver.plugin
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestWatcher
+import org.opentest4j.AssertionFailedError
+import java.io.File
+
+// Dumps expected vs actual content from golden-file assertion failures to
+// /tmp/test-assertion-dump-*.txt. Inert unless registered via
+// META-INF/services and enabled via junit-platform.properties autodetection;
+// scripts/dump-test-diff.sh manages that registration transiently.
+class DumpAssertionDiffExtension : TestWatcher {
+    override fun testFailed(context: ExtensionContext, cause: Throwable) {
+        val baseName = context.displayName.replace(Regex("[^a-zA-Z0-9_]"), "_")
+        val assertions = collectAssertionErrors(cause)
+        for ((index, error) in assertions.withIndex()) {
+            val suffix = if (assertions.size > 1) "_$index" else ""
+            val name = "$baseName$suffix"
+            val expected = resolveValue(error.expected)
+            val actual = resolveValue(error.actual)
+            File("/tmp/test-assertion-dump-$name.txt").writeText(buildString {
+                appendLine("=== EXPECTED ===")
+                appendLine(expected)
+                appendLine()
+                appendLine("=== ACTUAL ===")
+                appendLine(actual)
+            })
+            System.err.println(">>> Assertion diff dumped to /tmp/test-assertion-dump-$name.txt")
+        }
+    }
+
+    private fun collectAssertionErrors(throwable: Throwable): List<AssertionFailedError> {
+        if (throwable is AssertionFailedError && throwable.isExpectedDefined && throwable.isActualDefined) {
+            return listOf(throwable)
+        }
+        // MultipleFailuresError (opentest4j, Assertions.assertAll) exposes getFailures();
+        // Gradle's DefaultMultiCauseException exposes getCauses(). Both give a List<Throwable>.
+        for (methodName in listOf("getFailures", "getCauses")) {
+            try {
+                val method = throwable.javaClass.getMethod(methodName)
+                @Suppress("UNCHECKED_CAST")
+                val children = method.invoke(throwable) as? List<Throwable>
+                if (children != null && children.isNotEmpty()) {
+                    return children.flatMap { collectAssertionErrors(it) }
+                }
+            } catch (_: Exception) {}
+        }
+        val fromSuppressed = throwable.suppressed.flatMap { collectAssertionErrors(it) }
+        if (fromSuppressed.isNotEmpty()) return fromSuppressed
+        val inner = throwable.cause
+        if (inner != null && inner !== throwable) {
+            return collectAssertionErrors(inner)
+        }
+        return emptyList()
+    }
+
+    private fun resolveValue(wrapper: org.opentest4j.ValueWrapper): String {
+        val value = wrapper.value
+        if (value != null && value !is String) {
+            try {
+                val m = value.javaClass.getMethod("getContentsAsString")
+                return m.invoke(value) as String
+            } catch (_: Exception) {}
+        }
+        val str = (value as? String) ?: wrapper.stringRepresentation
+        // FileInfo.toString() embeds the path; read the file directly when we see it.
+        val match = Regex("""FileInfo\[path='(.+?)',""").find(str)
+        if (match != null) {
+            val path = match.groupValues[1]
+            try { return File(path).readText() } catch (_: Exception) {}
+        }
+        return str
+    }
+}

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/DumpAssertionDiffExtension.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/DumpAssertionDiffExtension.kt
@@ -6,10 +6,13 @@ import org.opentest4j.AssertionFailedError
 import java.io.File
 
 // Dumps expected vs actual content from golden-file assertion failures to
-// /tmp/test-assertion-dump-*.txt. Inert unless registered via
-// META-INF/services and enabled via junit-platform.properties autodetection;
-// scripts/dump-test-diff.sh manages that registration transiently.
+// $SNAKT_TEST_DUMP_DIR/test-assertion-dump-*.txt (default /tmp). Inert unless
+// registered via META-INF/services and enabled via junit-platform.properties
+// autodetection; scripts/dump-test-diff.sh manages that registration
+// transiently.
 class DumpAssertionDiffExtension : TestWatcher {
+    private val dumpDir: File = File(System.getenv("SNAKT_TEST_DUMP_DIR") ?: "/tmp")
+
     override fun testFailed(context: ExtensionContext, cause: Throwable) {
         val baseName = context.displayName.replace(Regex("[^a-zA-Z0-9_]"), "_")
         val assertions = collectAssertionErrors(cause)
@@ -18,14 +21,15 @@ class DumpAssertionDiffExtension : TestWatcher {
             val name = "$baseName$suffix"
             val expected = resolveValue(error.expected)
             val actual = resolveValue(error.actual)
-            File("/tmp/test-assertion-dump-$name.txt").writeText(buildString {
+            val out = File(dumpDir, "test-assertion-dump-$name.txt")
+            out.writeText(buildString {
                 appendLine("=== EXPECTED ===")
                 appendLine(expected)
                 appendLine()
                 appendLine("=== ACTUAL ===")
                 appendLine(actual)
             })
-            System.err.println(">>> Assertion diff dumped to /tmp/test-assertion-dump-$name.txt")
+            System.err.println(">>> Assertion diff dumped to ${out.absolutePath}")
         }
     }
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,12 @@
+# Scripts
+
+Use `dump-test-diff.sh` to debug golden file test failures. It runs a single test and dumps the expected vs actual content when an assertion fails, working around Gradle's cross-JVM serialization which strips diff details.
+
+When both `.kt` and `.fir.diag.txt` golden files are broken, it captures each diff in a separate numbered file.
+
+Usage:
+```
+./scripts/dump-test-diff.sh "testName"
+```
+
+Raw expected/actual content lands at `/tmp/test-assertion-dump-*.txt`. The script also writes a normalized unified diff to `/tmp/test-assertion-diff-*.txt` with source-position offsets (e.g. `/foo.kt:(23,31):`) stripped, so methods that only had their offsets shifted by unrelated edits do not show up as spurious changes — read the normalized diff first; fall back to the raw dump only if you need original offsets.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,12 @@
+# Scripts
+
+Use `dump-test-diff.sh` to debug golden file test failures. It runs a single test and dumps the expected vs actual content when an assertion fails, working around Gradle's cross-JVM serialization which strips diff details.
+
+When both `.kt` and `.fir.diag.txt` golden files are broken, it captures each diff in a separate numbered file.
+
+Usage:
+```
+./scripts/dump-test-diff.sh "testName"
+```
+
+Output appears at `/tmp/test-assertion-dump-*.txt`.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,12 +1,14 @@
 # Scripts
 
-Use `dump-test-diff.sh` to debug golden file test failures. It runs a single test and dumps the expected vs actual content when an assertion fails, working around Gradle's cross-JVM serialization which strips diff details.
+`dump-test-diff.sh` debugs golden-file test failures by surfacing the expected/actual diff that Gradle's cross-JVM serialization normally strips.
 
-When both `.kt` and `.fir.diag.txt` golden files are broken, it captures each diff in a separate numbered file.
-
-Usage:
 ```
 ./scripts/dump-test-diff.sh "testName"
 ```
 
-Raw expected/actual content lands at `/tmp/test-assertion-dump-*.txt`. The script also writes a normalized unified diff to `/tmp/test-assertion-diff-*.txt` with source-position offsets (e.g. `/foo.kt:(23,31):`) stripped, so methods that only had their offsets shifted by unrelated edits do not show up as spurious changes — read the normalized diff first; fall back to the raw dump only if you need original offsets.
+Output lands in `$SNAKT_TEST_DUMP_DIR` (default `/tmp`):
+
+- `test-assertion-diff-*.txt` — unified diff with source-position offsets (`/foo.kt:(23,31):`) collapsed to `:(_,_):` so unrelated offset shifts don't show as changes. Read this first.
+- `test-assertion-dump-*.txt` — raw expected/actual content. Fall back to this when you need the original offsets.
+
+Multiple failing assertions (e.g. both `.kt` and `.fir.diag.txt` broken) get separate numbered files.

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# dump-test-diff.sh — Run a single failing test and dump the assertion diff.
+#
+# The Kotlin compiler test framework compares golden files (.fir.diag.txt, .kt
+# with diagnostic markers) inside a forked test JVM. Gradle's cross-JVM
+# serialization strips AssertionFailedError expected/actual values, so you
+# never see the diff in normal test output.
+#
+# This script works around that by temporarily injecting a JUnit 5 TestWatcher
+# extension that catches failures inside the test JVM and writes the diff to
+# /tmp/test-assertion-dump-*.txt files.
+#
+# Usage:
+#   ./scripts/dump-test-diff.sh "testIs_type_contract"
+#   ./scripts/dump-test-diff.sh "testFull_viper_dump"
+#
+# After the run, look at /tmp/test-assertion-dump-*.txt for the expected vs
+# actual content.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <test-method-name-pattern>"
+    echo "Example: $0 'testIs_type_contract'"
+    exit 1
+fi
+
+TEST_PATTERN="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+EXTENSION_FILE="$ROOT_DIR/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/DumpAssertionDiffExtension.kt"
+SERVICES_DIR="$ROOT_DIR/formver.compiler-plugin/testData/META-INF/services"
+SERVICES_FILE="$SERVICES_DIR/org.junit.jupiter.api.extension.Extension"
+PLATFORM_PROPS="$ROOT_DIR/formver.compiler-plugin/testData/junit-platform.properties"
+
+# Clean up old dumps
+rm -f /tmp/test-assertion-dump-*.txt
+
+# Write the JUnit 5 extension
+mkdir -p "$(dirname "$EXTENSION_FILE")"
+cat > "$EXTENSION_FILE" << 'KOTLIN'
+package org.jetbrains.kotlin.formver.plugin
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestWatcher
+import org.opentest4j.AssertionFailedError
+import java.io.File
+
+class DumpAssertionDiffExtension : TestWatcher {
+    override fun testFailed(context: ExtensionContext, cause: Throwable) {
+        val baseName = context.displayName.replace(Regex("[^a-zA-Z0-9_]"), "_")
+        val assertions = collectAssertionErrors(cause)
+        for ((index, error) in assertions.withIndex()) {
+            val suffix = if (assertions.size > 1) "_$index" else ""
+            val name = "$baseName$suffix"
+            val expected = resolveValue(error.expected)
+            val actual = resolveValue(error.actual)
+            File("/tmp/test-assertion-dump-$name.txt").writeText(buildString {
+                appendLine("=== EXPECTED ===")
+                appendLine(expected)
+                appendLine()
+                appendLine("=== ACTUAL ===")
+                appendLine(actual)
+            })
+            System.err.println(">>> Assertion diff dumped to /tmp/test-assertion-dump-$name.txt")
+        }
+    }
+
+    private fun collectAssertionErrors(throwable: Throwable): List<AssertionFailedError> {
+        // Direct assertion error with expected/actual values
+        if (throwable is AssertionFailedError && throwable.isExpectedDefined && throwable.isActualDefined) {
+            return listOf(throwable)
+        }
+        // MultipleFailuresError (opentest4j, thrown by Assertions.assertAll) — has getFailures(): List<Throwable>
+        // Also covers DefaultMultiCauseException (Gradle) which has getCauses(): List<Throwable>
+        for (methodName in listOf("getFailures", "getCauses")) {
+            try {
+                val method = throwable.javaClass.getMethod(methodName)
+                @Suppress("UNCHECKED_CAST")
+                val children = method.invoke(throwable) as? List<Throwable>
+                if (children != null && children.isNotEmpty()) {
+                    return children.flatMap { collectAssertionErrors(it) }
+                }
+            } catch (_: Exception) {}
+        }
+        // Walk suppressed exceptions
+        val fromSuppressed = throwable.suppressed.flatMap { collectAssertionErrors(it) }
+        if (fromSuppressed.isNotEmpty()) return fromSuppressed
+        // Walk standard cause chain
+        val inner = throwable.cause
+        if (inner != null && inner !== throwable) {
+            return collectAssertionErrors(inner)
+        }
+        return emptyList()
+    }
+
+    private fun resolveValue(wrapper: org.opentest4j.ValueWrapper): String {
+        // First try the raw value — may be a FileInfo with getContentsAsString()
+        val value = wrapper.value
+        if (value != null && value !is String) {
+            try {
+                val m = value.javaClass.getMethod("getContentsAsString")
+                return m.invoke(value) as String
+            } catch (_: Exception) {}
+        }
+        val str = (value as? String) ?: wrapper.stringRepresentation
+        // If it looks like a FileInfo toString, read the file directly
+        val match = Regex("""FileInfo\[path='(.+?)',""").find(str)
+        if (match != null) {
+            val path = match.groupValues[1]
+            try { return File(path).readText() } catch (_: Exception) {}
+        }
+        return str
+    }
+}
+KOTLIN
+
+# Register as auto-detected extension
+mkdir -p "$SERVICES_DIR"
+echo "org.jetbrains.kotlin.formver.plugin.DumpAssertionDiffExtension" > "$SERVICES_FILE"
+
+# Enable JUnit 5 extension autodetection (disabled by default)
+echo "junit.jupiter.extensions.autodetection.enabled=true" > "$PLATFORM_PROPS"
+
+cleanup() {
+    rm -f "$EXTENSION_FILE"
+    rm -f "$SERVICES_FILE"
+    rm -f "$PLATFORM_PROPS"
+    rmdir "$SERVICES_DIR" 2>/dev/null || true
+    rmdir "$(dirname "$SERVICES_DIR")" 2>/dev/null || true
+    # Also clean up the build copy so it doesn't persist across runs
+    rm -f "$ROOT_DIR/formver.compiler-plugin/build/resources/test/junit-platform.properties"
+    rm -rf "$ROOT_DIR/formver.compiler-plugin/build/resources/test/META-INF/services"
+}
+trap cleanup EXIT
+
+echo "Running test: $TEST_PATTERN"
+echo "Diff files will appear at /tmp/test-assertion-dump-*.txt"
+echo
+
+# --rerun-tasks forces recompilation of test-fixtures with the extension
+cd "$ROOT_DIR"
+./gradlew :formver.compiler-plugin:test \
+    --tests "*$TEST_PATTERN*" \
+    --rerun-tasks \
+    --no-daemon \
+    2>&1 || true
+
+echo
+echo "=== Assertion diffs ==="
+for f in /tmp/test-assertion-dump-*.txt; do
+    if [[ -f "$f" ]]; then
+        echo
+        echo "--- $(basename "$f") ---"
+        cat "$f"
+    fi
+done
+
+if ! ls /tmp/test-assertion-dump-*.txt &>/dev/null; then
+    echo "(no diffs captured — test may have passed or failed with a non-assertion error)"
+fi

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# dump-test-diff.sh — Run a single failing test and dump the assertion diff.
+#
+# The Kotlin compiler test framework compares golden files (.fir.diag.txt, .kt
+# with diagnostic markers) inside a forked test JVM. Gradle's cross-JVM
+# serialization strips AssertionFailedError expected/actual values, so you
+# never see the diff in normal test output.
+#
+# This script works around that by temporarily registering a JUnit 5
+# TestWatcher extension (DumpAssertionDiffExtension, in test-fixtures) that
+# catches failures inside the test JVM and writes the diff to
+# /tmp/test-assertion-dump-*.txt files.
+#
+# It then post-processes each dump into /tmp/test-assertion-diff-*.txt — a
+# unified diff with source-position prefixes (e.g. "/foo.kt:(23,31):")
+# replaced by ":(_,_):" so methods that only had their offsets shifted by
+# unrelated edits do not appear as spurious changes. The raw dumps are kept
+# alongside in case the original offsets matter.
+#
+# Usage:
+#   ./scripts/dump-test-diff.sh "testIs_type_contract"
+#   ./scripts/dump-test-diff.sh "testFull_viper_dump"
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <test-method-name-pattern>"
+    echo "Example: $0 'testIs_type_contract'"
+    exit 1
+fi
+
+TEST_PATTERN="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SERVICES_DIR="$ROOT_DIR/formver.compiler-plugin/testData/META-INF/services"
+SERVICES_FILE="$SERVICES_DIR/org.junit.jupiter.api.extension.Extension"
+PLATFORM_PROPS="$ROOT_DIR/formver.compiler-plugin/testData/junit-platform.properties"
+
+rm -f /tmp/test-assertion-dump-*.txt /tmp/test-assertion-diff-*.txt
+
+# Register the extension via auto-detection. The DumpAssertionDiffExtension
+# class itself lives in test-fixtures and is inert unless both of these files
+# are present at test time.
+mkdir -p "$SERVICES_DIR"
+echo "org.jetbrains.kotlin.formver.plugin.DumpAssertionDiffExtension" > "$SERVICES_FILE"
+echo "junit.jupiter.extensions.autodetection.enabled=true" > "$PLATFORM_PROPS"
+
+cleanup() {
+    rm -f "$SERVICES_FILE"
+    rm -f "$PLATFORM_PROPS"
+    rmdir "$SERVICES_DIR" 2>/dev/null || true
+    rmdir "$(dirname "$SERVICES_DIR")" 2>/dev/null || true
+    # Also clean up the build copy so it doesn't persist across runs
+    rm -f "$ROOT_DIR/formver.compiler-plugin/build/resources/test/junit-platform.properties"
+    rm -rf "$ROOT_DIR/formver.compiler-plugin/build/resources/test/META-INF/services"
+}
+trap cleanup EXIT
+
+echo "Running test: $TEST_PATTERN"
+echo "Raw dumps at /tmp/test-assertion-dump-*.txt; normalized diffs at /tmp/test-assertion-diff-*.txt"
+echo
+
+# --rerun-tasks forces recompilation of test resources with the registration
+cd "$ROOT_DIR"
+./gradlew :formver.compiler-plugin:test \
+    --tests "*$TEST_PATTERN*" \
+    --rerun-tasks \
+    --no-daemon \
+    2>&1 || true
+
+# Replace source-position offsets like ":(23,31):" with ":(_,_):" so methods
+# that only shifted by edits to earlier code drop out of the diff. Restricted
+# to lines starting with a "/path:" prefix to avoid false matches.
+normalize_positions() {
+    sed -E 's#^(/[^:]+):\([0-9]+,[0-9]+\):#\1:(_,_):#'
+}
+
+# Split a dump file at the "=== ACTUAL ===" marker into two files.
+split_dump() {
+    local dump="$1" expected_path="$2" actual_path="$3"
+    awk -v exp_out="$expected_path" -v act_out="$actual_path" '
+        /^=== EXPECTED ===$/ { side = "expected"; next }
+        /^=== ACTUAL ===$/   { side = "actual";   next }
+        side == "expected" { print > exp_out }
+        side == "actual"   { print > act_out }
+    ' "$dump"
+}
+
+shopt -s nullglob
+for dump in /tmp/test-assertion-dump-*.txt; do
+    base="$(basename "$dump" .txt)"
+    base="${base#test-assertion-dump-}"
+    exp_file="$(mktemp)"; act_file="$(mktemp)"
+    exp_norm="$(mktemp)"; act_norm="$(mktemp)"
+    split_dump "$dump" "$exp_file" "$act_file"
+    normalize_positions < "$exp_file" > "$exp_norm"
+    normalize_positions < "$act_file" > "$act_norm"
+    diff -u --label "expected (positions normalized)" --label "actual (positions normalized)" \
+        "$exp_norm" "$act_norm" > "/tmp/test-assertion-diff-$base.txt" || true
+    rm -f "$exp_file" "$act_file" "$exp_norm" "$act_norm"
+done
+
+echo
+echo "=== Normalized diffs (source-position offsets stripped) ==="
+shown=0
+for f in /tmp/test-assertion-diff-*.txt; do
+    if [[ -s "$f" ]]; then
+        echo
+        echo "--- $(basename "$f") ---"
+        cat "$f"
+        shown=1
+    fi
+done
+
+if [[ $shown -eq 0 ]]; then
+    if compgen -G "/tmp/test-assertion-dump-*.txt" >/dev/null; then
+        echo "(no real differences after normalizing positions — all changes were just offset shifts)"
+        echo "Raw dumps remain at /tmp/test-assertion-dump-*.txt"
+    else
+        echo "(no diffs captured — test may have passed or failed with a non-assertion error)"
+    fi
+fi

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -6,8 +6,9 @@
 # serialization strips AssertionFailedError expected/actual values, so you
 # never see the diff in normal test output.
 #
-# This script works around that by temporarily injecting a JUnit 5 TestWatcher
-# extension that catches failures inside the test JVM and writes the diff to
+# This script works around that by temporarily registering a JUnit 5
+# TestWatcher extension (DumpAssertionDiffExtension, in test-fixtures) that
+# catches failures inside the test JVM and writes the diff to
 # /tmp/test-assertion-dump-*.txt files.
 #
 # Usage:
@@ -29,102 +30,20 @@ TEST_PATTERN="$1"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-EXTENSION_FILE="$ROOT_DIR/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/DumpAssertionDiffExtension.kt"
 SERVICES_DIR="$ROOT_DIR/formver.compiler-plugin/testData/META-INF/services"
 SERVICES_FILE="$SERVICES_DIR/org.junit.jupiter.api.extension.Extension"
 PLATFORM_PROPS="$ROOT_DIR/formver.compiler-plugin/testData/junit-platform.properties"
 
-# Clean up old dumps
 rm -f /tmp/test-assertion-dump-*.txt
 
-# Write the JUnit 5 extension
-mkdir -p "$(dirname "$EXTENSION_FILE")"
-cat > "$EXTENSION_FILE" << 'KOTLIN'
-package org.jetbrains.kotlin.formver.plugin
-
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.api.extension.TestWatcher
-import org.opentest4j.AssertionFailedError
-import java.io.File
-
-class DumpAssertionDiffExtension : TestWatcher {
-    override fun testFailed(context: ExtensionContext, cause: Throwable) {
-        val baseName = context.displayName.replace(Regex("[^a-zA-Z0-9_]"), "_")
-        val assertions = collectAssertionErrors(cause)
-        for ((index, error) in assertions.withIndex()) {
-            val suffix = if (assertions.size > 1) "_$index" else ""
-            val name = "$baseName$suffix"
-            val expected = resolveValue(error.expected)
-            val actual = resolveValue(error.actual)
-            File("/tmp/test-assertion-dump-$name.txt").writeText(buildString {
-                appendLine("=== EXPECTED ===")
-                appendLine(expected)
-                appendLine()
-                appendLine("=== ACTUAL ===")
-                appendLine(actual)
-            })
-            System.err.println(">>> Assertion diff dumped to /tmp/test-assertion-dump-$name.txt")
-        }
-    }
-
-    private fun collectAssertionErrors(throwable: Throwable): List<AssertionFailedError> {
-        // Direct assertion error with expected/actual values
-        if (throwable is AssertionFailedError && throwable.isExpectedDefined && throwable.isActualDefined) {
-            return listOf(throwable)
-        }
-        // MultipleFailuresError (opentest4j, thrown by Assertions.assertAll) — has getFailures(): List<Throwable>
-        // Also covers DefaultMultiCauseException (Gradle) which has getCauses(): List<Throwable>
-        for (methodName in listOf("getFailures", "getCauses")) {
-            try {
-                val method = throwable.javaClass.getMethod(methodName)
-                @Suppress("UNCHECKED_CAST")
-                val children = method.invoke(throwable) as? List<Throwable>
-                if (children != null && children.isNotEmpty()) {
-                    return children.flatMap { collectAssertionErrors(it) }
-                }
-            } catch (_: Exception) {}
-        }
-        // Walk suppressed exceptions
-        val fromSuppressed = throwable.suppressed.flatMap { collectAssertionErrors(it) }
-        if (fromSuppressed.isNotEmpty()) return fromSuppressed
-        // Walk standard cause chain
-        val inner = throwable.cause
-        if (inner != null && inner !== throwable) {
-            return collectAssertionErrors(inner)
-        }
-        return emptyList()
-    }
-
-    private fun resolveValue(wrapper: org.opentest4j.ValueWrapper): String {
-        // First try the raw value — may be a FileInfo with getContentsAsString()
-        val value = wrapper.value
-        if (value != null && value !is String) {
-            try {
-                val m = value.javaClass.getMethod("getContentsAsString")
-                return m.invoke(value) as String
-            } catch (_: Exception) {}
-        }
-        val str = (value as? String) ?: wrapper.stringRepresentation
-        // If it looks like a FileInfo toString, read the file directly
-        val match = Regex("""FileInfo\[path='(.+?)',""").find(str)
-        if (match != null) {
-            val path = match.groupValues[1]
-            try { return File(path).readText() } catch (_: Exception) {}
-        }
-        return str
-    }
-}
-KOTLIN
-
-# Register as auto-detected extension
+# Register the extension via auto-detection. The DumpAssertionDiffExtension
+# class itself lives in test-fixtures and is inert unless both of these files
+# are present at test time.
 mkdir -p "$SERVICES_DIR"
 echo "org.jetbrains.kotlin.formver.plugin.DumpAssertionDiffExtension" > "$SERVICES_FILE"
-
-# Enable JUnit 5 extension autodetection (disabled by default)
 echo "junit.jupiter.extensions.autodetection.enabled=true" > "$PLATFORM_PROPS"
 
 cleanup() {
-    rm -f "$EXTENSION_FILE"
     rm -f "$SERVICES_FILE"
     rm -f "$PLATFORM_PROPS"
     rmdir "$SERVICES_DIR" 2>/dev/null || true
@@ -139,7 +58,7 @@ echo "Running test: $TEST_PATTERN"
 echo "Diff files will appear at /tmp/test-assertion-dump-*.txt"
 echo
 
-# --rerun-tasks forces recompilation of test-fixtures with the extension
+# --rerun-tasks forces recompilation of test resources with the registration
 cd "$ROOT_DIR"
 ./gradlew :formver.compiler-plugin:test \
     --tests "*$TEST_PATTERN*" \

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -9,23 +9,24 @@
 # This script works around that by temporarily registering a JUnit 5
 # TestWatcher extension (DumpAssertionDiffExtension, in test-fixtures) that
 # catches failures inside the test JVM and writes the diff to
-# /tmp/test-assertion-dump-*.txt files.
+# $SNAKT_TEST_DUMP_DIR/test-assertion-dump-*.txt (default /tmp).
 #
-# It then post-processes each dump into /tmp/test-assertion-diff-*.txt — a
-# unified diff with source-position prefixes (e.g. "/foo.kt:(23,31):")
-# replaced by ":(_,_):" so methods that only had their offsets shifted by
-# unrelated edits do not appear as spurious changes. The raw dumps are kept
-# alongside in case the original offsets matter.
+# It then post-processes each dump into test-assertion-diff-*.txt in the same
+# directory — a unified diff with source-position prefixes (e.g.
+# "/foo.kt:(23,31):") replaced by ":(_,_):" so methods that only had their
+# offsets shifted by unrelated edits do not appear as spurious changes. The
+# raw dumps are kept alongside in case the original offsets matter.
 #
 # Usage:
 #   ./scripts/dump-test-diff.sh "testIs_type_contract"
-#   ./scripts/dump-test-diff.sh "testFull_viper_dump"
+#   SNAKT_TEST_DUMP_DIR=/var/tmp/snakt ./scripts/dump-test-diff.sh "testFoo"
 
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
     echo "Usage: $0 <test-method-name-pattern>"
     echo "Example: $0 'testIs_type_contract'"
+    echo "Set SNAKT_TEST_DUMP_DIR to override the output directory (default /tmp)."
     exit 1
 fi
 
@@ -33,11 +34,15 @@ TEST_PATTERN="$1"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+DUMP_DIR="${SNAKT_TEST_DUMP_DIR:-/tmp}"
+mkdir -p "$DUMP_DIR"
+export SNAKT_TEST_DUMP_DIR="$DUMP_DIR"
+
 SERVICES_DIR="$ROOT_DIR/formver.compiler-plugin/testData/META-INF/services"
 SERVICES_FILE="$SERVICES_DIR/org.junit.jupiter.api.extension.Extension"
 PLATFORM_PROPS="$ROOT_DIR/formver.compiler-plugin/testData/junit-platform.properties"
 
-rm -f /tmp/test-assertion-dump-*.txt /tmp/test-assertion-diff-*.txt
+rm -f "$DUMP_DIR"/test-assertion-dump-*.txt "$DUMP_DIR"/test-assertion-diff-*.txt
 
 # Register the extension via auto-detection. The DumpAssertionDiffExtension
 # class itself lives in test-fixtures and is inert unless both of these files
@@ -58,7 +63,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Running test: $TEST_PATTERN"
-echo "Raw dumps at /tmp/test-assertion-dump-*.txt; normalized diffs at /tmp/test-assertion-diff-*.txt"
+echo "Raw dumps at $DUMP_DIR/test-assertion-dump-*.txt; normalized diffs at $DUMP_DIR/test-assertion-diff-*.txt"
 echo
 
 # --rerun-tasks forces recompilation of test resources with the registration
@@ -88,7 +93,7 @@ split_dump() {
 }
 
 shopt -s nullglob
-for dump in /tmp/test-assertion-dump-*.txt; do
+for dump in "$DUMP_DIR"/test-assertion-dump-*.txt; do
     base="$(basename "$dump" .txt)"
     base="${base#test-assertion-dump-}"
     exp_file="$(mktemp)"; act_file="$(mktemp)"
@@ -97,14 +102,14 @@ for dump in /tmp/test-assertion-dump-*.txt; do
     normalize_positions < "$exp_file" > "$exp_norm"
     normalize_positions < "$act_file" > "$act_norm"
     diff -u --label "expected (positions normalized)" --label "actual (positions normalized)" \
-        "$exp_norm" "$act_norm" > "/tmp/test-assertion-diff-$base.txt" || true
+        "$exp_norm" "$act_norm" > "$DUMP_DIR/test-assertion-diff-$base.txt" || true
     rm -f "$exp_file" "$act_file" "$exp_norm" "$act_norm"
 done
 
 echo
 echo "=== Normalized diffs (source-position offsets stripped) ==="
 shown=0
-for f in /tmp/test-assertion-diff-*.txt; do
+for f in "$DUMP_DIR"/test-assertion-diff-*.txt; do
     if [[ -s "$f" ]]; then
         echo
         echo "--- $(basename "$f") ---"
@@ -114,9 +119,9 @@ for f in /tmp/test-assertion-diff-*.txt; do
 done
 
 if [[ $shown -eq 0 ]]; then
-    if compgen -G "/tmp/test-assertion-dump-*.txt" >/dev/null; then
+    if compgen -G "$DUMP_DIR/test-assertion-dump-*.txt" >/dev/null; then
         echo "(no real differences after normalizing positions — all changes were just offset shifts)"
-        echo "Raw dumps remain at /tmp/test-assertion-dump-*.txt"
+        echo "Raw dumps remain at $DUMP_DIR/test-assertion-dump-*.txt"
     else
         echo "(no diffs captured — test may have passed or failed with a non-assertion error)"
     fi

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -66,14 +66,17 @@ echo "Running test: $TEST_PATTERN"
 echo "Raw dumps at $DUMP_DIR/test-assertion-dump-*.txt; normalized diffs at $DUMP_DIR/test-assertion-diff-*.txt"
 echo
 
-# --rerun-tasks forces recompilation of test resources with the registration.
+# --rerun forces the test task to run even on identical inputs (so re-running
+# the script always captures a fresh assertion); upstream tasks like
+# processTestResources still honor input tracking and stay UP-TO-DATE when
+# they can, which keeps repeat runs cheap.
 # -q suppresses per-task lifecycle logs; we expect a failing test, and the
 # captured diff is the interesting output. Compile/configuration errors still
 # print at ERROR level.
 cd "$ROOT_DIR"
 ./gradlew :formver.compiler-plugin:test \
     --tests "*$TEST_PATTERN*" \
-    --rerun-tasks \
+    --rerun \
     --no-daemon \
     -q \
     2>&1 || true

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -101,7 +101,10 @@ for dump in "$DUMP_DIR"/test-assertion-dump-*.txt; do
     split_dump "$dump" "$exp_file" "$act_file"
     normalize_positions < "$exp_file" > "$exp_norm"
     normalize_positions < "$act_file" > "$act_norm"
-    diff -u --label "expected (positions normalized)" --label "actual (positions normalized)" \
+    # -B drops hunks that are pure blank-line drift (golden files don't always
+    # end in exactly the same number of newlines); real whitespace differences
+    # inside content lines are still reported.
+    diff -u -B --label "expected (positions normalized)" --label "actual (positions normalized)" \
         "$exp_norm" "$act_norm" > "$DUMP_DIR/test-assertion-diff-$base.txt" || true
     rm -f "$exp_file" "$act_file" "$exp_norm" "$act_norm"
 done

--- a/scripts/dump-test-diff.sh
+++ b/scripts/dump-test-diff.sh
@@ -66,12 +66,16 @@ echo "Running test: $TEST_PATTERN"
 echo "Raw dumps at $DUMP_DIR/test-assertion-dump-*.txt; normalized diffs at $DUMP_DIR/test-assertion-diff-*.txt"
 echo
 
-# --rerun-tasks forces recompilation of test resources with the registration
+# --rerun-tasks forces recompilation of test resources with the registration.
+# -q suppresses per-task lifecycle logs; we expect a failing test, and the
+# captured diff is the interesting output. Compile/configuration errors still
+# print at ERROR level.
 cd "$ROOT_DIR"
 ./gradlew :formver.compiler-plugin:test \
     --tests "*$TEST_PATTERN*" \
     --rerun-tasks \
     --no-daemon \
+    -q \
     2>&1 || true
 
 # Replace source-position offsets like ":(23,31):" with ":(_,_):" so methods


### PR DESCRIPTION
## Summary
- Adds `scripts/dump-test-diff.sh` — a helper that runs a single test and dumps the expected vs actual content when a golden file assertion fails.
- Gradle's cross-JVM serialization strips `AssertionFailedError` expected/actual values, so you never see the diff in normal test output. This script works around that by registering a JUnit 5 `TestWatcher` extension that catches failures inside the test JVM and writes both sides to `$SNAKT_TEST_DUMP_DIR/test-assertion-dump-*.txt` (default `/tmp`; override the env var to redirect).
- Handles the Kotlin test framework's `FileInfo` wrapper by extracting the file path and reading the golden file content directly.

The extension itself (`DumpAssertionDiffExtension`) lives in `test-fixtures` as a normal `.kt` file. It is inert unless the `META-INF/services` registration and `junit-platform.properties` autodetection flag are present, so leaving it on disk has no effect on normal test runs — the script only creates and cleans up those two registration files.

This supersedes #110, which emitted the extension source via a heredoc in the shell script; pulling it into a real file makes it reviewable/editable with IDE support and shrinks the script considerably.

Usage:
```
./scripts/dump-test-diff.sh "testArithmetic"
SNAKT_TEST_DUMP_DIR=/var/tmp/snakt ./scripts/dump-test-diff.sh "testArithmetic"
```

## Test plan
- [x] Intentionally broke a golden file, ran the script, confirmed both expected and actual content appear in the dump with the correct diff
- [x] Verified `./gradlew :formver.compiler-plugin:compileTestFixturesKotlin` succeeds with the new file
- [x] Verified `SNAKT_TEST_DUMP_DIR` override lands the files in the requested directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)