### PR TITLE
Unify ListSizeFieldEmbedding with SpecialField

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SpecialFields.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SpecialFields.kt
@@ -7,14 +7,21 @@ package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeInvariantEmbedding
 import org.jetbrains.kotlin.formver.core.names.SpecialFieldName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
-class SpecialField(baseName: String, override val type: TypeEmbedding, override val viperType: Type) : FieldEmbedding {
+class SpecialField(
+    baseName: String,
+    override val type: TypeEmbedding,
+    override val viperType: Type,
+    override val includeInShortDump: Boolean = false,
+    private val extraInvariantsBuilder: (FieldEmbedding) -> List<TypeInvariantEmbedding> = { listOf() },
+) : FieldEmbedding {
     override val name: SymbolicName = SpecialFieldName(baseName)
     override val accessPolicy: AccessPolicy = AccessPolicy.ALWAYS_WRITEABLE
-    override val includeInShortDump: Boolean = false
+    override fun extraAccessInvariantsForParameter(): List<TypeInvariantEmbedding> = extraInvariantsBuilder(this)
 }
 
 object SpecialFields {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.core.embeddings.properties
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
+import org.jetbrains.kotlin.formver.core.conversion.SpecialField
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.FieldAccess
@@ -16,7 +17,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.embeddings.types.*
 import org.jetbrains.kotlin.formver.core.names.NameMatcher
 import org.jetbrains.kotlin.formver.core.names.ScopedName
-import org.jetbrains.kotlin.formver.core.names.SpecialFieldName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Field
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -80,19 +80,16 @@ class UserFieldEmbedding(
 }
 
 
-object ListSizeFieldEmbedding : FieldEmbedding {
-    override val name = SpecialFieldName("size")
-    override val type = buildType { int() }
-    override val viperType = Type.Ref
-    override val accessPolicy = AccessPolicy.ALWAYS_WRITEABLE
-    override val includeInShortDump: Boolean = true
-    override fun extraAccessInvariantsForParameter(): List<TypeInvariantEmbedding> =
-        listOf(NonNegativeSizeTypeInvariantEmbedding)
-
-    object NonNegativeSizeTypeInvariantEmbedding : TypeInvariantEmbedding {
+val ListSizeFieldEmbedding: FieldEmbedding = SpecialField(
+    baseName = "size",
+    type = buildType { int() },
+    viperType = Type.Ref,
+    includeInShortDump = true,
+) { field ->
+    listOf(object : TypeInvariantEmbedding {
         override fun fillHole(exp: ExpEmbedding): ExpEmbedding =
-            OperatorExpEmbeddings.GeIntInt(FieldAccess(exp, ListSizeFieldEmbedding), IntLit(0))
-    }
+            OperatorExpEmbeddings.GeIntInt(FieldAccess(exp, field), IntLit(0))
+    })
 }
 
 fun ScopedName.specialEmbedding(embedding: ClassTypeEmbedding, ctx: TypeResolver): FieldEmbedding? =


### PR DESCRIPTION
## Summary

`ListSizeFieldEmbedding` and `SpecialField` were two near-duplicate `FieldEmbedding` shapes — both used `SpecialFieldName`, both had `ALWAYS_WRITEABLE` access policy, and the only structural differences were `includeInShortDump` and the optional non-negative-size invariant.

This PR extends `SpecialField` with two optional constructor parameters and re-expresses `ListSizeFieldEmbedding` as a `SpecialField` instance:

- `includeInShortDump: Boolean = false`
- `extraInvariantsBuilder: (FieldEmbedding) -> List<TypeInvariantEmbedding> = { listOf() }` — receives `this` so an invariant can refer to the field it lives on without a singleton self-reference.

The non-negative-size invariant is now an inline anonymous `TypeInvariantEmbedding` that closes over the `field` argument rather than referencing `ListSizeFieldEmbedding` by name.

## Test plan

- [x] `:formver.compiler-plugin:core:compileKotlin` succeeds.
- [x] `./gradlew :formver.compiler-plugin:test` passes (with `Z3_EXE` set).
- [x] `./gradlew :formver.compiler-plugin:testNoVerification` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)