### PR TITLE
Optimized Short Name Resolver

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
@@ -103,7 +103,7 @@ data object ExtensionReceiverName : FreshName, NameTypeIsVariable {
 
     override val candidates: List<CandidateName> = buildCandidates {
         val shortName = "this"
-        val longName = listOf("this", "dispatch")
+        val longName = listOf("this", "extension")
         candidate {
             +shortName
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
@@ -101,7 +101,21 @@ data object DispatchReceiverName : FreshName, NameTypeIsVariable {
 data object ExtensionReceiverName : FreshName, NameTypeIsVariable {
     override val inViper: Boolean = true
 
-    override val candidates: List<CandidateName> = nameWithPrefixCandidates("this", nameType)
+    override val candidates: List<CandidateName> = buildCandidates {
+        val shortName = "this"
+        val longName = listOf("this", "dispatch")
+        candidate {
+            +shortName
+        }
+        candidate {
+            +nameType
+            +shortName
+        }
+        candidate {
+            +nameType
+            +longName
+        }
+    }
 
     override val children: List<AnyName> = listOf(nameType)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/KotlinName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/KotlinName.kt
@@ -178,9 +178,6 @@ data class TypeName(val pretype: PretypeEmbedding, val nullable: Boolean) : Symb
     override val inViper: Boolean = false
 
     override val candidates: List<CandidateName> = buildCandidates {
-        candidate {
-            +pretype.name
-        }
         candidateNoSeparator {
             if (nullable) +"N"
             +pretype.name

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
@@ -14,7 +14,7 @@ sealed interface NameScope : AnyName {
         get() = null
 
     override val inViper: Boolean
-        get() = true
+        get() = false
 }
 
 // Includes the scope itself.
@@ -36,7 +36,15 @@ val NameScope.packageNameIfAny: FqName?
 
 data class PackageScope(val packageName: FqName) : NameScope {
     override val candidates: List<CandidateName> = buildCandidates {
-        val split = packageName.asString().split(".")
+        val name = packageName.asString()
+
+        if (name.isEmpty()) {
+            candidate { +"pkg" }
+            return@buildCandidates
+        }
+
+        val split = name.split(".")
+
         split.indices.forEach { i -> candidate { +split.takeLast(i + 1) } }
         candidate {
             +"pkg"

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedName.kt
@@ -21,14 +21,13 @@ data class ScopedName(val scope: NameScope, val name: SymbolicName) : SymbolicNa
     override val inViper: Boolean = name !is ClassKotlinName
 
     override val candidates: List<CandidateName> = buildCandidates {
-        +nameWithDependentPrefixCandidates(name, scope)
-        if (nameType != null) {
+        if (scope is BadScope || scope is FakeScope) {
             candidate {
-                +nameType
-                +scope
                 +name
             }
+            return@buildCandidates
         }
+        +nameWithDependentPrefixCandidates(name, scope)
     }
 
     override val children: List<AnyName> = listOf(scope, name)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -79,7 +79,9 @@ class ShortNameResolver : NameResolver {
     /**
      * Stores all the names that exist in the system.
      */
-    private val elements: MutableSet<AnyName> = ViperKeywords.keywords.toMutableSet()
+    private val elements: MutableSet<AnyName> = sortedSetOf<AnyName>(compareBy { it.fullName() }).also {
+        it.addAll(ViperKeywords.keywords)
+    }
 
     fun elements() = elements.toList()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -79,9 +79,7 @@ class ShortNameResolver : NameResolver {
     /**
      * Stores all the names that exist in the system.
      */
-    private val elements: MutableSet<AnyName> = sortedSetOf<AnyName>(compareBy { it.fullName() }).also {
-        it.addAll(ViperKeywords.keywords)
-    }
+    private val elements: MutableSet<AnyName> = ViperKeywords.keywords.toMutableSet()
 
     fun elements() = elements.toList()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -146,9 +146,9 @@ class ShortNameResolver : NameResolver {
     override fun resolve() {
         var currentCollisions = collisions()
         while (currentCollisions.isNotEmpty()) {
-            val toResolve = currentCollisions.entries.first().value
+            val toResolve = currentCollisions.entries.minByOrNull { it.key }!!.value
 
-            val candidateToMove = toResolve.filter { canMove(it) }.ifNotEmpty { maxBy { priorityOrder(it) } }
+            val candidateToMove = toResolve.filter { canMove(it) }.sortedBy { it.hashCode() }.ifNotEmpty { maxBy { priorityOrder(it) } }
 
             assert(candidateToMove != null) { "Unable to make names unique" }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -118,6 +118,11 @@ class ShortNameResolver : NameResolver {
         val index = currentCandidate.getOrPut(name) { 0 }
         return name.candidates()[index + 1]
     }
+
+    private fun hasNextCandidate(name: AnyName): Boolean {
+        val currentIndex = currentCandidate[name] ?: 0
+        return currentIndex + 1 < name.candidates().size
+    }
     // END RESOLVE NAMES
 
 
@@ -195,11 +200,7 @@ class ShortNameResolver : NameResolver {
             val toMove = removeNonLeaves(allToMove)
             assert(toMove.isNotEmpty()) { "No moveable names found, unable to resolve collisions" }
 
-            toMove.forEach { name ->
-                move(name)
-            }
-
-
+            toMove.forEach(::move)
 
             currentCollisions = collisions()
 
@@ -238,13 +239,17 @@ class ShortNameResolver : NameResolver {
      * This function returns the move that results in the lowest cost. If the name cannot be moved, it returns null.
      */
     private fun findMoveableName(entity: AnyName): Pair<Int, AnyName>? {
-        val currentIndex = currentCandidate[entity] ?: 0
-        val options = currentCandidate(entity).moveableParts().mapNotNull { namePart ->
-            findMoveableName(namePart.name)
-        } + (if (currentIndex + 1 < entity.candidates().size) {
-            // entity can be moved, so it is added to the options
-            listOf(Pair(costOfMovingName(entity), entity))
-        } else emptyList())
+        val options = buildList {
+            val subOptions = currentCandidate(entity).moveableParts().mapNotNull { namePart ->
+                findMoveableName(namePart.name)
+            }
+
+            addAll(subOptions)
+
+            if (hasNextCandidate(entity)) {
+                add(Pair(costOfMovingName(entity), entity))
+            }
+        }
 
         return options.minByOrNull { it.first }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -123,14 +123,17 @@ class ShortNameResolver : NameResolver {
 
     // START MANGLE
 
-
-    private fun costOfName(name: AnyName) : Int = when(name) {
-        is NameScope -> when(name) {
+    /**
+     * The cost of having [name] in a viper name.
+     * Higher cost means that [name] is more likely to not be used in the final viper name.
+     */
+    private fun costOfName(name: AnyName): Int = when (name) {
+        is NameScope -> when (name) {
             BadScope -> 100
             is ClassScope -> 2
             FakeScope -> 50
             is LocalScope -> 3
-            is PackageScope -> 10
+            is PackageScope -> 20
             ParameterScope -> 3
             is PrivateScope -> 1
             PublicScope -> 3
@@ -138,6 +141,10 @@ class ShortNameResolver : NameResolver {
         else -> 1
     }
 
+    /**
+     * This function calculates the cost of adding [part] to a name.
+     * The cost is the sum of the cost of the names that are inside of [part] plus the cost of [part].
+     */
     private fun costOfNamePart(part: NamePart): Int = when (part) {
         is NamePart.Basic -> 1
         is NamePart.Dependent -> {
@@ -146,41 +153,35 @@ class ShortNameResolver : NameResolver {
             val subCost = subParts.sumOf { costOfNamePart(it) }
             subCost + costOfName(name)
         }
+
         NamePart.Separator -> 0
     }
 
     /**
-     * TODO: Update
-     * The higher the priority, the earlier it is chosen to move.
-     * There are no fundamental reasons for this priority order. These just resulted in "good" names.
+     * The cost of moving [name].
+     * The cost of moving is the sum of the costs of the **new** added parts
      */
     private fun costOfMovingName(name: AnyName): Int {
         val currentCandidate = currentCandidate(name)
         val nextCandidate = nextCandidate(name)
 
         val newParts = (nextCandidate.parts.toSet() - currentCandidate.parts.toSet())
-        return newParts.sumOf { costOfNamePart(it)}
+        return newParts.sumOf { costOfNamePart(it) }
     }
 
-    private fun buildGraph(name: AnyName): Map<AnyName, Set<AnyName>> {
-        val graph = mutableMapOf<AnyName, MutableSet<AnyName>>()
-        val queue = mutableListOf(name)
-        while (queue.isNotEmpty()) {
-            val current = queue.removeFirst()
-            val subNames = current.children
-            subNames.forEach {
-                graph.getOrPut(it) { mutableSetOf() }.add(current)
+    fun removeNonLeaves(toMove: Set<AnyName>): Set<AnyName> {
+        val numVisites = mutableMapOf<AnyName, Int>()
+
+        for (name in toMove) {
+            val queue = mutableListOf(name)
+            while (queue.isNotEmpty()) {
+                val current = queue.removeFirst()
+                numVisites[current] = (numVisites[current] ?: 0) + 1
+                queue.addAll(current.children)
             }
-            queue.addAll(subNames)
         }
-        return graph
-    }
 
-    private fun buildGraph(names: Set<AnyName>) : Map<AnyName, Set<AnyName>> {
-        return names.fold(emptyMap()
-        ) {
-            acc, name -> acc +  buildGraph(name)
-        }
+        return toMove.filter { numVisites.getOrDefault(it, 0) < 2 }.toSet()
     }
 
     /**
@@ -188,18 +189,14 @@ class ShortNameResolver : NameResolver {
      */
     override fun resolve() {
         var currentCollisions = collisions()
-        loop@ while (currentCollisions.isNotEmpty()) {
-            val toMove = currentCollisions.flatMap { it.value }.mapNotNull { findMoveableName(it)?.second }.toSet()
-            // outer name maps to inner name
-            val graph = buildGraph(toMove)
+        while (currentCollisions.isNotEmpty()) {
+            val allToMove = currentCollisions.flatMap { it.value }.mapNotNull { findMoveableName(it)?.second }.toSet()
+
+            val toMove = removeNonLeaves(allToMove)
             assert(toMove.isNotEmpty()) { "No moveable names found, unable to resolve collisions" }
 
             toMove.forEach { name ->
-                if (graph[name]?.isNotEmpty() != true) {
-//                    print(current(name))
-                    move(name)
-//                    println(" -> ${current(name)}")
-                }
+                move(name)
             }
 
 
@@ -236,18 +233,19 @@ class ShortNameResolver : NameResolver {
     private fun move(entity: AnyName) {
         currentCandidate[entity] = (currentCandidate[entity] ?: 0) + 1
     }
+
     /**
-     * Returns the name that will be moved. This can be the [entity] or a name on which [entity] depends.
-     * If no such name exists, it returns null.
+     * This function returns the move that results in the lowest cost. If the name cannot be moved, it returns null.
      */
     private fun findMoveableName(entity: AnyName): Pair<Int, AnyName>? {
         val currentIndex = currentCandidate[entity] ?: 0
         val options = currentCandidate(entity).moveableParts().mapNotNull { namePart ->
             findMoveableName(namePart.name)
-        } + (if (currentIndex + 1 < entity.candidates().size)  {
+        } + (if (currentIndex + 1 < entity.candidates().size) {
             // entity can be moved, so it is added to the options
             listOf(Pair(costOfMovingName(entity), entity))
         } else emptyList())
+
         return options.minByOrNull { it.first }
     }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlin.formver.core.names
 
 import org.jetbrains.kotlin.formver.viper.*
-import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 
 /**
  * Gives the current name.
@@ -114,44 +113,99 @@ class ShortNameResolver : NameResolver {
         val index = currentCandidate.getOrPut(name) { 0 }
         return name.candidates()[index]
     }
+
+    private fun nextCandidate(name: AnyName): CandidateName {
+        val index = currentCandidate.getOrPut(name) { 0 }
+        return name.candidates()[index + 1]
+    }
     // END RESOLVE NAMES
 
 
     // START MANGLE
 
+
+    private fun costOfName(name: AnyName) : Int = when(name) {
+        is NameScope -> when(name) {
+            BadScope -> 100
+            is ClassScope -> 2
+            FakeScope -> 50
+            is LocalScope -> 3
+            is PackageScope -> 10
+            ParameterScope -> 3
+            is PrivateScope -> 1
+            PublicScope -> 3
+        }
+        else -> 1
+    }
+
+    private fun costOfNamePart(part: NamePart): Int = when (part) {
+        is NamePart.Basic -> 1
+        is NamePart.Dependent -> {
+            val name = part.name
+            val subParts = currentCandidate(name).parts
+            val subCost = subParts.sumOf { costOfNamePart(it) }
+            subCost + costOfName(name)
+        }
+        NamePart.Separator -> 0
+    }
+
     /**
+     * TODO: Update
      * The higher the priority, the earlier it is chosen to move.
      * There are no fundamental reasons for this priority order. These just resulted in "good" names.
      */
-    private fun priorityOrder(name: AnyName): Int = when (name) {
-        is SymbolicName -> when (name) {
-            is FreshName -> when (name) {
-                is LabelName -> 5
-                else -> 1
-            }
-            is KotlinName -> 1
-            is ScopedName -> 2
-            is DomainName -> 4
-            else -> -1
-        }
-        else -> -1
+    private fun costOfMovingName(name: AnyName): Int {
+        val currentCandidate = currentCandidate(name)
+        val nextCandidate = nextCandidate(name)
+
+        val newParts = (nextCandidate.parts.toSet() - currentCandidate.parts.toSet())
+        return newParts.sumOf { costOfNamePart(it)}
     }
 
+    private fun buildGraph(name: AnyName): Map<AnyName, Set<AnyName>> {
+        val graph = mutableMapOf<AnyName, MutableSet<AnyName>>()
+        val queue = mutableListOf(name)
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            val subNames = current.children
+            subNames.forEach {
+                graph.getOrPut(it) { mutableSetOf() }.add(current)
+            }
+            queue.addAll(subNames)
+        }
+        return graph
+    }
+
+    private fun buildGraph(names: Set<AnyName>) : Map<AnyName, Set<AnyName>> {
+        return names.fold(emptyMap()
+        ) {
+            acc, name -> acc +  buildGraph(name)
+        }
+    }
 
     /**
      * Generates short human-readable names. Must be called before using [lookup].
      */
     override fun resolve() {
         var currentCollisions = collisions()
-        while (currentCollisions.isNotEmpty()) {
-            val toResolve = currentCollisions.entries.minByOrNull { it.key }!!.value
+        loop@ while (currentCollisions.isNotEmpty()) {
+            val toMove = currentCollisions.flatMap { it.value }.mapNotNull { findMoveableName(it)?.second }.toSet()
+            // outer name maps to inner name
+            val graph = buildGraph(toMove)
+            assert(toMove.isNotEmpty()) { "No moveable names found, unable to resolve collisions" }
 
-            val candidateToMove = toResolve.filter { canMove(it) }.sortedBy { it.hashCode() }.ifNotEmpty { maxBy { priorityOrder(it) } }
+            toMove.forEach { name ->
+                if (graph[name]?.isNotEmpty() != true) {
+//                    print(current(name))
+                    move(name)
+//                    println(" -> ${current(name)}")
+                }
+            }
 
-            assert(candidateToMove != null) { "Unable to make names unique" }
 
-            move(candidateToMove!!)
+
             currentCollisions = collisions()
+
         }
 
         // Fix the names
@@ -178,32 +232,22 @@ class ShortNameResolver : NameResolver {
 
     /**
      * Moves `name` one position.
-     * We generally try to move first the parts, and only if not successful do we move the `name`
-     *
-     * Returns true if the entity (or a dependent name) could be moved
      */
-    private fun move(entity: AnyName): Boolean {
-        val movableParts = currentCandidate(entity).moveableParts()
-
-        // Try to move the subparts first
-        for (part in movableParts) {
-            if (move(part.name)) return true
-        }
-
-        if (canMove(entity)) {
-            currentCandidate[entity] = (currentCandidate[entity] ?: 0) + 1
-            return true
-        }
-        return false
+    private fun move(entity: AnyName) {
+        currentCandidate[entity] = (currentCandidate[entity] ?: 0) + 1
     }
     /**
-     * Returns true if `name` can be moved or one of the parts of the current candidate can be moved
+     * Returns the name that will be moved. This can be the [entity] or a name on which [entity] depends.
+     * If no such name exists, it returns null.
      */
-    private fun canMove(entity: AnyName): Boolean {
+    private fun findMoveableName(entity: AnyName): Pair<Int, AnyName>? {
         val currentIndex = currentCandidate[entity] ?: 0
-        if (currentIndex + 1 < entity.candidates().size) return true
-        return currentCandidate(entity).moveableParts().any {
-            canMove(it.name)
-        }
+        val options = currentCandidate(entity).moveableParts().mapNotNull { namePart ->
+            findMoveableName(namePart.name)
+        } + (if (currentIndex + 1 < entity.candidates().size)  {
+            // entity can be moved, so it is added to the options
+            listOf(Pair(costOfMovingName(entity), entity))
+        } else emptyList())
+        return options.minByOrNull { it.first }
     }
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/adts/singleton.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/adts/singleton.fir.diag.txt
@@ -23,12 +23,12 @@
 /singleton.kt: error: Function 'triggerWithAssignment' used an invalid ADT
 
 /singleton.kt: info: Generated Viper text for validParameter:
-method validParameter(a: Ref) returns (ret: Ref)
+method validParameter(a: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), Valid())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 adt adt_Valid {
@@ -36,13 +36,13 @@ adt adt_Valid {
 }
 
 /singleton.kt: info: Generated Viper text for validLocalVariable:
-method validLocalVariable() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method validLocalVariable() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   x := ValidToRef(constr_Valid())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 adt adt_Valid {

--- a/formver.compiler-plugin/testData/diagnostics/conversion/basic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/basic.fir.diag.txt
@@ -1,67 +1,67 @@
 /basic.kt: info: Generated Viper text for returnUnit:
-method returnUnit() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method returnUnit() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /basic.kt: info: Generated Viper text for returnInt:
-method returnInt() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method returnInt() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  ret := intToRef(0)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(0)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /basic.kt: info: Generated Viper text for takeIntReturnUnit:
-method takeIntReturnUnit(x: Ref) returns (ret: Ref)
+method takeIntReturnUnit(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /basic.kt: info: Generated Viper text for takeIntReturnInt:
-method takeIntReturnInt(x: Ref) returns (ret: Ref)
+method takeIntReturnInt(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /basic.kt: info: Generated Viper text for takeIntReturnIntExpr:
-method takeIntReturnIntExpr(x: Ref) returns (ret: Ref)
+method takeIntReturnIntExpr(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /basic.kt: info: Generated Viper text for withIntDeclaration:
-method withIntDeclaration() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method withIntDeclaration() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var x: Ref
   x := intToRef(0)
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /basic.kt: info: Generated Viper text for intAssignment:
-method intAssignment() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method intAssignment() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   x := intToRef(0)
   x := intToRef(1)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
@@ -1,18 +1,18 @@
 /field_getters.kt: info: Generated Viper text for testPrimitiveFieldGetter:
-field bf_a: Ref
+field a: Ref
 
-field bf_b: Ref
+field b: Ref
 
 method testPrimitiveFieldGetter(pf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveFields())
+  requires isSubtype(typeOf(pf), c_PrimitiveFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var a: Ref
-  var b: Ref
+  var l0_a: Ref
+  var l0_b: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
-  a := pf.bf_a
-  b := havoc()
+  l0_a := pf.a
+  l0_b := havoc()
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -22,30 +22,30 @@ field a: Ref
 
 field b: Ref
 
-field bf_f: Ref
+field f: Ref
 
-field bf_g: Ref
+field g: Ref
 
 method testReferenceFieldGetter(rf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceFields())
+  requires isSubtype(typeOf(rf), c_ReferenceFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var f: Ref
-  var g: Ref
+  var l0_f: Ref
+  var l0_g: Ref
   var fa: Ref
   var fb: Ref
   var ga: Ref
   var gb: Ref
-  inhale acc(c_ReferenceFields_shared(rf), wildcard)
-  unfold acc(c_ReferenceFields_shared(rf), wildcard)
-  f := rf.bf_f
-  g := havoc__c_PrimitiveFields()
-  unfold acc(shared(f), wildcard)
-  fa := f.a
-  fb := havoc()
-  unfold acc(shared(g), wildcard)
-  ga := g.a
-  gb := havoc()
+  inhale acc(shared(rf), wildcard)
+  unfold acc(shared(rf), wildcard)
+  l0_f := rf.f
+  l0_g := havoc()
+  unfold acc(_c_PrimitiveFields_shared(l0_f), wildcard)
+  fa := l0_f.a
+  fb := havoc_Int()
+  unfold acc(_c_PrimitiveFields_shared(l0_g), wildcard)
+  ga := l0_g.a
+  gb := havoc_Int()
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -60,7 +60,7 @@ field f: Ref
 field g: Ref
 
 method testCascadingFieldGetter(rf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceFields())
+  requires isSubtype(typeOf(rf), c_ReferenceFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var fa: Ref
@@ -69,14 +69,14 @@ method testCascadingFieldGetter(rf: Ref) returns (ret_0: Ref)
   var ga: Ref
   var anon: Ref
   var gb: Ref
-  inhale acc(c_ReferenceFields_shared(rf), wildcard)
-  unfold acc(c_ReferenceFields_shared(rf), wildcard)
+  inhale acc(shared(rf), wildcard)
+  unfold acc(shared(rf), wildcard)
   anon_0 := rf.f
-  unfold acc(shared(anon_0), wildcard)
+  unfold acc(_c_PrimitiveFields_shared(anon_0), wildcard)
   fa := anon_0.a
   fb := havoc_Int()
   anon := havoc()
-  unfold acc(shared(anon), wildcard)
+  unfold acc(_c_PrimitiveFields_shared(anon), wildcard)
   ga := anon.a
   gb := havoc_Int()
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
@@ -1,20 +1,20 @@
 /field_getters.kt: info: Generated Viper text for testPrimitiveFieldGetter:
-field a: Ref
+field bf_a: Ref
 
-field b: Ref
+field bf_b: Ref
 
-method testPrimitiveFieldGetter(pf: Ref) returns (ret_0: Ref)
+method testPrimitiveFieldGetter(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  var l0_a: Ref
-  var l0_b: Ref
+  var a: Ref
+  var b: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
-  l0_a := pf.a
-  l0_b := havoc()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  a := pf.bf_a
+  b := havoc()
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_getters.kt: info: Generated Viper text for testReferenceFieldGetter:
@@ -22,32 +22,32 @@ field a: Ref
 
 field b: Ref
 
-field f: Ref
+field bf_f: Ref
 
-field g: Ref
+field bf_g: Ref
 
-method testReferenceFieldGetter(rf: Ref) returns (ret_0: Ref)
+method testReferenceFieldGetter(rf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  var l0_f: Ref
-  var l0_g: Ref
+  var f: Ref
+  var g: Ref
   var fa: Ref
   var fb: Ref
   var ga: Ref
   var gb: Ref
   inhale acc(shared(rf), wildcard)
   unfold acc(shared(rf), wildcard)
-  l0_f := rf.f
-  l0_g := havoc()
-  unfold acc(_c_PrimitiveFields_shared(l0_f), wildcard)
-  fa := l0_f.a
+  f := rf.bf_f
+  g := havoc()
+  unfold acc(_c_PrimitiveFields_shared(f), wildcard)
+  fa := f.a
   fb := havoc_Int()
-  unfold acc(_c_PrimitiveFields_shared(l0_g), wildcard)
-  ga := l0_g.a
+  unfold acc(_c_PrimitiveFields_shared(g), wildcard)
+  ga := g.a
   gb := havoc_Int()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_getters.kt: info: Generated Viper text for testCascadingFieldGetter:
@@ -59,9 +59,9 @@ field f: Ref
 
 field g: Ref
 
-method testCascadingFieldGetter(rf: Ref) returns (ret_0: Ref)
+method testCascadingFieldGetter(rf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var fa: Ref
   var anon_0: Ref
@@ -79,6 +79,6 @@ method testCascadingFieldGetter(rf: Ref) returns (ret_0: Ref)
   unfold acc(_c_PrimitiveFields_shared(anon), wildcard)
   ga := anon.a
   gb := havoc_Int()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters.fir.diag.txt
@@ -3,18 +3,18 @@ field bf_a: Ref
 
 field bf_b: Ref
 
-method testPrimitiveFieldGetter(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testPrimitiveFieldGetter(pf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var a: Ref
-  var b: Ref
+  var l0_a: Ref
+  var l0_b: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
-  a := pf.bf_a
-  b := havoc()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  l0_a := pf.bf_a
+  l0_b := havoc()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_getters.kt: info: Generated Viper text for testReferenceFieldGetter:
@@ -26,28 +26,28 @@ field bf_f: Ref
 
 field bf_g: Ref
 
-method testReferenceFieldGetter(rf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferenceFieldGetter(rf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var f: Ref
-  var g: Ref
+  var l0_f: Ref
+  var l0_g: Ref
   var fa: Ref
   var fb: Ref
   var ga: Ref
   var gb: Ref
-  inhale acc(shared(rf), wildcard)
-  unfold acc(shared(rf), wildcard)
-  f := rf.bf_f
-  g := havoc()
-  unfold acc(_c_PrimitiveFields_shared(f), wildcard)
-  fa := f.a
+  inhale acc(ReferenceFields_shared(rf), wildcard)
+  unfold acc(ReferenceFields_shared(rf), wildcard)
+  l0_f := rf.bf_f
+  l0_g := havoc_PrimitiveFields()
+  unfold acc(PrimitiveFields_shared(l0_f), wildcard)
+  fa := l0_f.a
   fb := havoc_Int()
-  unfold acc(_c_PrimitiveFields_shared(g), wildcard)
-  ga := g.a
+  unfold acc(PrimitiveFields_shared(l0_g), wildcard)
+  ga := l0_g.a
   gb := havoc_Int()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_getters.kt: info: Generated Viper text for testCascadingFieldGetter:
@@ -59,26 +59,26 @@ field f: Ref
 
 field g: Ref
 
-method testCascadingFieldGetter(rf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testCascadingFieldGetter(rf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var fa: Ref
   var anon_0: Ref
   var fb: Ref
   var ga: Ref
-  var anon: Ref
+  var anon_1: Ref
   var gb: Ref
-  inhale acc(shared(rf), wildcard)
-  unfold acc(shared(rf), wildcard)
+  inhale acc(ReferenceFields_shared(rf), wildcard)
+  unfold acc(ReferenceFields_shared(rf), wildcard)
   anon_0 := rf.f
-  unfold acc(_c_PrimitiveFields_shared(anon_0), wildcard)
+  unfold acc(PrimitiveFields_shared(anon_0), wildcard)
   fa := anon_0.a
   fb := havoc_Int()
-  anon := havoc()
-  unfold acc(_c_PrimitiveFields_shared(anon), wildcard)
-  ga := anon.a
+  anon_1 := havoc_PrimitiveFields()
+  unfold acc(PrimitiveFields_shared(anon_1), wildcard)
+  ga := anon_1.a
   gb := havoc_Int()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
@@ -1,113 +1,113 @@
 /field_getters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldGetterUnique:
-field bf_sharedVal: Ref
+field sharedVal: Ref
 
-field bf_sharedVar: Ref
+field sharedVar: Ref
 
-field bf_uniqueVal: Ref
+field uniqueVal: Ref
 
-field bf_uniqueVar: Ref
+field uniqueVar: Ref
 
 method testPrimitiveFieldGetterUnique(pf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveFields())
-  requires acc(c_PrimitiveFields_unique(pf), write)
+  requires isSubtype(typeOf(pf), c_PrimitiveFields())
+  requires acc(_c_PrimitiveFields_unique(pf), write)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var sharedVal: Ref
-  var sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
+  var l0_sharedVal: Ref
+  var l0_sharedVar: Ref
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
-  sharedVal := pf.bf_sharedVal
-  sharedVar := havoc()
+  l0_sharedVal := pf.sharedVal
+  l0_sharedVar := havoc()
   unfold acc(shared(pf), wildcard)
-  uniqueVal := pf.bf_uniqueVal
-  uniqueVar := havoc()
+  l0_uniqueVal := pf.uniqueVal
+  l0_uniqueVar := havoc()
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldGetterShared:
-field bf_sharedVal: Ref
+field sharedVal: Ref
 
-field bf_sharedVar: Ref
+field sharedVar: Ref
 
-field bf_uniqueVal: Ref
+field uniqueVal: Ref
 
-field bf_uniqueVar: Ref
+field uniqueVar: Ref
 
 method testPrimitiveFieldGetterShared(pf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveFields())
+  requires isSubtype(typeOf(pf), c_PrimitiveFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var sharedVal: Ref
-  var sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
+  var l0_sharedVal: Ref
+  var l0_sharedVar: Ref
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
-  sharedVal := pf.bf_sharedVal
-  sharedVar := havoc()
+  l0_sharedVal := pf.sharedVal
+  l0_sharedVar := havoc()
   unfold acc(shared(pf), wildcard)
-  uniqueVal := pf.bf_uniqueVal
-  uniqueVar := havoc()
+  l0_uniqueVal := pf.uniqueVal
+  l0_uniqueVar := havoc()
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testReferenceFieldGetterUnique:
-field bf_sharedVal: Ref
+field sharedVal: Ref
 
-field bf_sharedVar: Ref
+field sharedVar: Ref
 
-field bf_uniqueVal: Ref
+field uniqueVal: Ref
 
-field bf_uniqueVar: Ref
+field uniqueVar: Ref
 
 method testReferenceFieldGetterUnique(rf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceFields())
-  requires acc(c_ReferenceFields_unique(rf), write)
+  requires isSubtype(typeOf(rf), c_ReferenceFields())
+  requires acc(_c_ReferenceFields_unique(rf), write)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var sharedVal: Ref
-  var sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
-  inhale acc(c_ReferenceFields_shared(rf), wildcard)
-  unfold acc(c_ReferenceFields_shared(rf), wildcard)
-  sharedVal := rf.bf_sharedVal
-  sharedVar := havoc__c_PrimitiveFields()
-  unfold acc(c_ReferenceFields_shared(rf), wildcard)
-  uniqueVal := rf.bf_uniqueVal
-  uniqueVar := havoc__c_PrimitiveFields()
+  var l0_sharedVal: Ref
+  var l0_sharedVar: Ref
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
+  inhale acc(shared(rf), wildcard)
+  unfold acc(shared(rf), wildcard)
+  l0_sharedVal := rf.sharedVal
+  l0_sharedVar := havoc()
+  unfold acc(shared(rf), wildcard)
+  l0_uniqueVal := rf.uniqueVal
+  l0_uniqueVar := havoc()
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testReferenceFieldGetterShared:
-field bf_sharedVal: Ref
+field sharedVal: Ref
 
-field bf_sharedVar: Ref
+field sharedVar: Ref
 
-field bf_uniqueVal: Ref
+field uniqueVal: Ref
 
-field bf_uniqueVar: Ref
+field uniqueVar: Ref
 
 method testReferenceFieldGetterShared(rf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceFields())
+  requires isSubtype(typeOf(rf), c_ReferenceFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var sharedVal: Ref
-  var sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
-  inhale acc(c_ReferenceFields_shared(rf), wildcard)
-  unfold acc(c_ReferenceFields_shared(rf), wildcard)
-  sharedVal := rf.bf_sharedVal
-  sharedVar := havoc__c_PrimitiveFields()
-  unfold acc(c_ReferenceFields_shared(rf), wildcard)
-  uniqueVal := rf.bf_uniqueVal
-  uniqueVar := havoc__c_PrimitiveFields()
+  var l0_sharedVal: Ref
+  var l0_sharedVar: Ref
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
+  inhale acc(shared(rf), wildcard)
+  unfold acc(shared(rf), wildcard)
+  l0_sharedVal := rf.sharedVal
+  l0_sharedVar := havoc()
+  unfold acc(shared(rf), wildcard)
+  l0_uniqueVal := rf.uniqueVal
+  l0_uniqueVar := havoc()
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
@@ -1,113 +1,113 @@
 /field_getters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldGetterUnique:
+field bf_uniqueVal: Ref
+
+field bf_uniqueVar: Ref
+
 field sharedVal: Ref
 
 field sharedVar: Ref
 
-field uniqueVal: Ref
-
-field uniqueVar: Ref
-
-method testPrimitiveFieldGetterUnique(pf: Ref) returns (ret_0: Ref)
+method testPrimitiveFieldGetterUnique(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveFields())
   requires acc(_c_PrimitiveFields_unique(pf), write)
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var l0_uniqueVal: Ref
-  var l0_uniqueVar: Ref
+  var uniqueVal: Ref
+  var uniqueVar: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
   l0_sharedVal := pf.sharedVal
   l0_sharedVar := havoc()
   unfold acc(shared(pf), wildcard)
-  l0_uniqueVal := pf.uniqueVal
-  l0_uniqueVar := havoc()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  uniqueVal := pf.bf_uniqueVal
+  uniqueVar := havoc()
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldGetterShared:
+field bf_uniqueVal: Ref
+
+field bf_uniqueVar: Ref
+
 field sharedVal: Ref
 
 field sharedVar: Ref
 
-field uniqueVal: Ref
-
-field uniqueVar: Ref
-
-method testPrimitiveFieldGetterShared(pf: Ref) returns (ret_0: Ref)
+method testPrimitiveFieldGetterShared(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var l0_uniqueVal: Ref
-  var l0_uniqueVar: Ref
+  var uniqueVal: Ref
+  var uniqueVar: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
   l0_sharedVal := pf.sharedVal
   l0_sharedVar := havoc()
   unfold acc(shared(pf), wildcard)
-  l0_uniqueVal := pf.uniqueVal
-  l0_uniqueVar := havoc()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  uniqueVal := pf.bf_uniqueVal
+  uniqueVar := havoc()
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testReferenceFieldGetterUnique:
+field bf_uniqueVal: Ref
+
+field bf_uniqueVar: Ref
+
 field sharedVal: Ref
 
 field sharedVar: Ref
 
-field uniqueVal: Ref
-
-field uniqueVar: Ref
-
-method testReferenceFieldGetterUnique(rf: Ref) returns (ret_0: Ref)
+method testReferenceFieldGetterUnique(rf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceFields())
   requires acc(_c_ReferenceFields_unique(rf), write)
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var l0_uniqueVal: Ref
-  var l0_uniqueVar: Ref
+  var uniqueVal: Ref
+  var uniqueVar: Ref
   inhale acc(shared(rf), wildcard)
   unfold acc(shared(rf), wildcard)
   l0_sharedVal := rf.sharedVal
   l0_sharedVar := havoc()
   unfold acc(shared(rf), wildcard)
-  l0_uniqueVal := rf.uniqueVal
-  l0_uniqueVar := havoc()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  uniqueVal := rf.bf_uniqueVal
+  uniqueVar := havoc()
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testReferenceFieldGetterShared:
+field bf_uniqueVal: Ref
+
+field bf_uniqueVar: Ref
+
 field sharedVal: Ref
 
 field sharedVar: Ref
 
-field uniqueVal: Ref
-
-field uniqueVar: Ref
-
-method testReferenceFieldGetterShared(rf: Ref) returns (ret_0: Ref)
+method testReferenceFieldGetterShared(rf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var l0_uniqueVal: Ref
-  var l0_uniqueVar: Ref
+  var uniqueVal: Ref
+  var uniqueVar: Ref
   inhale acc(shared(rf), wildcard)
   unfold acc(shared(rf), wildcard)
   l0_sharedVal := rf.sharedVal
   l0_sharedVar := havoc()
   unfold acc(shared(rf), wildcard)
-  l0_uniqueVal := rf.uniqueVal
-  l0_uniqueVar := havoc()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  uniqueVal := rf.bf_uniqueVal
+  uniqueVar := havoc()
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_getters_unique_shared.fir.diag.txt
@@ -1,113 +1,113 @@
 /field_getters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldGetterUnique:
+field bf_sharedVal: Ref
+
+field bf_sharedVar: Ref
+
 field bf_uniqueVal: Ref
 
 field bf_uniqueVar: Ref
 
-field sharedVal: Ref
-
-field sharedVar: Ref
-
-method testPrimitiveFieldGetterUnique(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  requires acc(_c_PrimitiveFields_unique(pf), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method testPrimitiveFieldGetterUnique(pf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveFields())
+  requires acc(PrimitiveFields_unique(pf), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
-  l0_sharedVal := pf.sharedVal
+  l0_sharedVal := pf.bf_sharedVal
   l0_sharedVar := havoc()
   unfold acc(shared(pf), wildcard)
-  uniqueVal := pf.bf_uniqueVal
-  uniqueVar := havoc()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  l0_uniqueVal := pf.bf_uniqueVal
+  l0_uniqueVar := havoc()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldGetterShared:
+field bf_sharedVal: Ref
+
+field bf_sharedVar: Ref
+
 field bf_uniqueVal: Ref
 
 field bf_uniqueVar: Ref
 
-field sharedVal: Ref
-
-field sharedVar: Ref
-
-method testPrimitiveFieldGetterShared(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testPrimitiveFieldGetterShared(pf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
   inhale acc(shared(pf), wildcard)
   unfold acc(shared(pf), wildcard)
-  l0_sharedVal := pf.sharedVal
+  l0_sharedVal := pf.bf_sharedVal
   l0_sharedVar := havoc()
   unfold acc(shared(pf), wildcard)
-  uniqueVal := pf.bf_uniqueVal
-  uniqueVar := havoc()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  l0_uniqueVal := pf.bf_uniqueVal
+  l0_uniqueVar := havoc()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testReferenceFieldGetterUnique:
+field bf_sharedVal: Ref
+
+field bf_sharedVar: Ref
+
 field bf_uniqueVal: Ref
 
 field bf_uniqueVar: Ref
 
-field sharedVal: Ref
-
-field sharedVar: Ref
-
-method testReferenceFieldGetterUnique(rf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceFields())
-  requires acc(_c_ReferenceFields_unique(rf), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferenceFieldGetterUnique(rf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceFields())
+  requires acc(ReferenceFields_unique(rf), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
-  inhale acc(shared(rf), wildcard)
-  unfold acc(shared(rf), wildcard)
-  l0_sharedVal := rf.sharedVal
-  l0_sharedVar := havoc()
-  unfold acc(shared(rf), wildcard)
-  uniqueVal := rf.bf_uniqueVal
-  uniqueVar := havoc()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
+  inhale acc(ReferenceFields_shared(rf), wildcard)
+  unfold acc(ReferenceFields_shared(rf), wildcard)
+  l0_sharedVal := rf.bf_sharedVal
+  l0_sharedVar := havoc_PrimitiveFields()
+  unfold acc(ReferenceFields_shared(rf), wildcard)
+  l0_uniqueVal := rf.bf_uniqueVal
+  l0_uniqueVar := havoc_PrimitiveFields()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_getters_unique_shared.kt: info: Generated Viper text for testReferenceFieldGetterShared:
+field bf_sharedVal: Ref
+
+field bf_sharedVar: Ref
+
 field bf_uniqueVal: Ref
 
 field bf_uniqueVar: Ref
 
-field sharedVal: Ref
-
-field sharedVar: Ref
-
-method testReferenceFieldGetterShared(rf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferenceFieldGetterShared(rf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
-  var uniqueVal: Ref
-  var uniqueVar: Ref
-  inhale acc(shared(rf), wildcard)
-  unfold acc(shared(rf), wildcard)
-  l0_sharedVal := rf.sharedVal
-  l0_sharedVar := havoc()
-  unfold acc(shared(rf), wildcard)
-  uniqueVal := rf.bf_uniqueVal
-  uniqueVar := havoc()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  var l0_uniqueVal: Ref
+  var l0_uniqueVar: Ref
+  inhale acc(ReferenceFields_shared(rf), wildcard)
+  unfold acc(ReferenceFields_shared(rf), wildcard)
+  l0_sharedVal := rf.bf_sharedVal
+  l0_sharedVar := havoc_PrimitiveFields()
+  unfold acc(ReferenceFields_shared(rf), wildcard)
+  l0_uniqueVal := rf.bf_uniqueVal
+  l0_uniqueVar := havoc_PrimitiveFields()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
@@ -4,8 +4,8 @@ field bf_shared: Ref
 field bf_unique: Ref
 
 method testPrimitiveFieldSetterUnique(pf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveFields())
-  requires acc(c_PrimitiveFields_unique(pf), write)
+  requires isSubtype(typeOf(pf), c_PrimitiveFields())
+  requires acc(_c_PrimitiveFields_unique(pf), write)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   inhale acc(shared(pf), wildcard)
@@ -19,7 +19,7 @@ field bf_shared: Ref
 field bf_unique: Ref
 
 method testPrimitiveFieldSetterShared(pf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveFields())
+  requires isSubtype(typeOf(pf), c_PrimitiveFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   inhale acc(shared(pf), wildcard)
@@ -32,22 +32,22 @@ field bf_shared: Ref
 
 field bf_unique: Ref
 
-method con(shared: Ref, par_unique: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(shared), intType())
+method con(par_shared: Ref, par_unique: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(par_shared), intType())
   requires isSubtype(typeOf(par_unique), intType())
-  ensures isSubtype(typeOf(ret), _c_PrimitiveFields())
-  ensures acc(c_PrimitiveFields_shared(ret), wildcard)
-  ensures acc(c_PrimitiveFields_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
+  ensures acc(_c_PrimitiveFields_shared(ret), wildcard)
+  ensures acc(_c_PrimitiveFields_unique(ret), write)
 
 
 method testReferenceFieldSetterUnique(rf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceFields())
-  requires acc(c_ReferenceFields_unique(rf), write)
+  requires isSubtype(typeOf(rf), c_ReferenceFields())
+  requires acc(_c_ReferenceFields_unique(rf), write)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon: Ref
-  inhale acc(c_ReferenceFields_shared(rf), wildcard)
+  inhale acc(shared(rf), wildcard)
   anon_0 := con(intToRef(5), intToRef(6))
   anon := con(intToRef(7), intToRef(8))
   label lbl_ret_0
@@ -59,21 +59,21 @@ field bf_shared: Ref
 
 field bf_unique: Ref
 
-method con(shared: Ref, par_unique: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(shared), intType())
+method con(par_shared: Ref, par_unique: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(par_shared), intType())
   requires isSubtype(typeOf(par_unique), intType())
-  ensures isSubtype(typeOf(ret), _c_PrimitiveFields())
-  ensures acc(c_PrimitiveFields_shared(ret), wildcard)
-  ensures acc(c_PrimitiveFields_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
+  ensures acc(_c_PrimitiveFields_shared(ret), wildcard)
+  ensures acc(_c_PrimitiveFields_unique(ret), write)
 
 
 method testReferenceFieldSetterShared(rf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceFields())
+  requires isSubtype(typeOf(rf), c_ReferenceFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon: Ref
-  inhale acc(c_ReferenceFields_shared(rf), wildcard)
+  inhale acc(shared(rf), wildcard)
   anon_0 := con(intToRef(9), intToRef(10))
   anon := con(intToRef(11), intToRef(12))
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
@@ -1,30 +1,30 @@
 /field_setters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldSetterUnique:
-field bf_shared: Ref
-
 field bf_unique: Ref
 
-method testPrimitiveFieldSetterUnique(pf: Ref) returns (ret_0: Ref)
+field shared: Ref
+
+method testPrimitiveFieldSetterUnique(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveFields())
   requires acc(_c_PrimitiveFields_unique(pf), write)
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared(pf), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale acc(_c_PrimitiveFields_shared(pf), wildcard)
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_setters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldSetterShared:
-field bf_shared: Ref
-
 field bf_unique: Ref
 
-method testPrimitiveFieldSetterShared(pf: Ref) returns (ret_0: Ref)
+field shared: Ref
+
+method testPrimitiveFieldSetterShared(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared(pf), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale acc(_c_PrimitiveFields_shared(pf), wildcard)
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_setters_unique_shared.kt: info: Generated Viper text for testReferenceFieldSetterUnique:
@@ -32,26 +32,26 @@ field bf_shared: Ref
 
 field bf_unique: Ref
 
-method con(par_shared: Ref, par_unique: Ref) returns (ret: Ref)
+method con(par_shared: Ref, par_unique: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_shared), intType())
   requires isSubtype(typeOf(par_unique), intType())
-  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
-  ensures acc(_c_PrimitiveFields_shared(ret), wildcard)
-  ensures acc(_c_PrimitiveFields_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_PrimitiveFields())
+  ensures acc(_c_PrimitiveFields_shared(v_ret), wildcard)
+  ensures acc(_c_PrimitiveFields_unique(v_ret), write)
 
 
-method testReferenceFieldSetterUnique(rf: Ref) returns (ret_0: Ref)
+method testReferenceFieldSetterUnique(rf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceFields())
   requires acc(_c_ReferenceFields_unique(rf), write)
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon: Ref
   inhale acc(shared(rf), wildcard)
   anon_0 := con(intToRef(5), intToRef(6))
   anon := con(intToRef(7), intToRef(8))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /field_setters_unique_shared.kt: info: Generated Viper text for testReferenceFieldSetterShared:
@@ -59,23 +59,23 @@ field bf_shared: Ref
 
 field bf_unique: Ref
 
-method con(par_shared: Ref, par_unique: Ref) returns (ret: Ref)
+method con(par_shared: Ref, par_unique: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_shared), intType())
   requires isSubtype(typeOf(par_unique), intType())
-  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
-  ensures acc(_c_PrimitiveFields_shared(ret), wildcard)
-  ensures acc(_c_PrimitiveFields_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_PrimitiveFields())
+  ensures acc(_c_PrimitiveFields_shared(v_ret), wildcard)
+  ensures acc(_c_PrimitiveFields_unique(v_ret), write)
 
 
-method testReferenceFieldSetterShared(rf: Ref) returns (ret_0: Ref)
+method testReferenceFieldSetterShared(rf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon: Ref
   inhale acc(shared(rf), wildcard)
   anon_0 := con(intToRef(9), intToRef(10))
   anon := con(intToRef(11), intToRef(12))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/field_setters_unique_shared.fir.diag.txt
@@ -1,30 +1,30 @@
 /field_setters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldSetterUnique:
+field bf_shared: Ref
+
 field bf_unique: Ref
 
-field shared: Ref
-
-method testPrimitiveFieldSetterUnique(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  requires acc(_c_PrimitiveFields_unique(pf), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method testPrimitiveFieldSetterUnique(pf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveFields())
+  requires acc(PrimitiveFields_unique(pf), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(_c_PrimitiveFields_shared(pf), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(PrimitiveFields_shared(pf), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_setters_unique_shared.kt: info: Generated Viper text for testPrimitiveFieldSetterShared:
+field bf_shared: Ref
+
 field bf_unique: Ref
 
-field shared: Ref
-
-method testPrimitiveFieldSetterShared(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testPrimitiveFieldSetterShared(pf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(_c_PrimitiveFields_shared(pf), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(PrimitiveFields_shared(pf), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_setters_unique_shared.kt: info: Generated Viper text for testReferenceFieldSetterUnique:
@@ -35,23 +35,23 @@ field bf_unique: Ref
 method con(par_shared: Ref, par_unique: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_shared), intType())
   requires isSubtype(typeOf(par_unique), intType())
-  ensures isSubtype(typeOf(v_ret), c_PrimitiveFields())
-  ensures acc(_c_PrimitiveFields_shared(v_ret), wildcard)
-  ensures acc(_c_PrimitiveFields_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), PrimitiveFields())
+  ensures acc(PrimitiveFields_shared(v_ret), wildcard)
+  ensures acc(PrimitiveFields_unique(v_ret), write)
 
 
-method testReferenceFieldSetterUnique(rf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceFields())
-  requires acc(_c_ReferenceFields_unique(rf), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferenceFieldSetterUnique(rf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceFields())
+  requires acc(ReferenceFields_unique(rf), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var anon: Ref
-  inhale acc(shared(rf), wildcard)
+  var anon_1: Ref
+  inhale acc(ReferenceFields_shared(rf), wildcard)
   anon_0 := con(intToRef(5), intToRef(6))
-  anon := con(intToRef(7), intToRef(8))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon_1 := con(intToRef(7), intToRef(8))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /field_setters_unique_shared.kt: info: Generated Viper text for testReferenceFieldSetterShared:
@@ -62,20 +62,20 @@ field bf_unique: Ref
 method con(par_shared: Ref, par_unique: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_shared), intType())
   requires isSubtype(typeOf(par_unique), intType())
-  ensures isSubtype(typeOf(v_ret), c_PrimitiveFields())
-  ensures acc(_c_PrimitiveFields_shared(v_ret), wildcard)
-  ensures acc(_c_PrimitiveFields_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), PrimitiveFields())
+  ensures acc(PrimitiveFields_shared(v_ret), wildcard)
+  ensures acc(PrimitiveFields_unique(v_ret), write)
 
 
-method testReferenceFieldSetterShared(rf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferenceFieldSetterShared(rf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var anon: Ref
-  inhale acc(shared(rf), wildcard)
+  var anon_1: Ref
+  inhale acc(ReferenceFields_shared(rf), wildcard)
   anon_0 := con(intToRef(9), intToRef(10))
-  anon := con(intToRef(11), intToRef(12))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon_1 := con(intToRef(11), intToRef(12))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
@@ -6,7 +6,7 @@ field x: Ref
 field y: Ref
 
 method getY(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   inhale acc(shared(this), wildcard)
@@ -26,16 +26,16 @@ field y: Ref
 field z: Ref
 
 method sum(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_Bar())
+  requires isSubtype(typeOf(this), c_Bar())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var anon_0: Ref
   var anon: Ref
-  inhale acc(c_Bar_shared(this), wildcard)
-  unfold acc(c_Bar_shared(this), wildcard)
+  inhale acc(_c_Bar_shared(this), wildcard)
+  unfold acc(_c_Bar_shared(this), wildcard)
   unfold acc(shared(this), wildcard)
   anon_0 := this.x
-  unfold acc(c_Bar_shared(this), wildcard)
+  unfold acc(_c_Bar_shared(this), wildcard)
   anon := this.z
   ret_0 := plusInts(anon_0, anon)
   goto lbl_ret_0
@@ -52,17 +52,17 @@ field y: Ref
 field z: Ref
 
 method callSuperMethod(bar: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(bar), _c_Bar())
+  requires isSubtype(typeOf(bar), c_Bar())
   ensures isSubtype(typeOf(ret_0), intType())
 {
-  inhale acc(c_Bar_shared(bar), wildcard)
+  inhale acc(_c_Bar_shared(bar), wildcard)
   ret_0 := getY(bar)
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 method getY(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret), intType())
 
 
@@ -76,10 +76,10 @@ field y: Ref
 field z: Ref
 
 method accessSuperField(bar: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(bar), _c_Bar())
+  requires isSubtype(typeOf(bar), c_Bar())
   ensures isSubtype(typeOf(ret_0), boolType())
 {
-  inhale acc(c_Bar_shared(bar), wildcard)
+  inhale acc(_c_Bar_shared(bar), wildcard)
   ret_0 := havoc_Boolean()
   goto lbl_ret_0
   label lbl_ret_0
@@ -95,11 +95,11 @@ field y: Ref
 field z: Ref
 
 method accessNewField(bar: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(bar), _c_Bar())
+  requires isSubtype(typeOf(bar), c_Bar())
   ensures isSubtype(typeOf(ret_0), intType())
 {
-  inhale acc(c_Bar_shared(bar), wildcard)
-  unfold acc(c_Bar_shared(bar), wildcard)
+  inhale acc(_c_Bar_shared(bar), wildcard)
+  unfold acc(_c_Bar_shared(bar), wildcard)
   ret_0 := bar.z
   goto lbl_ret_0
   label lbl_ret_0
@@ -115,17 +115,17 @@ field y: Ref
 field z: Ref
 
 method callNewMethod(bar: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(bar), _c_Bar())
+  requires isSubtype(typeOf(bar), c_Bar())
   ensures isSubtype(typeOf(ret_0), intType())
 {
-  inhale acc(c_Bar_shared(bar), wildcard)
+  inhale acc(_c_Bar_shared(bar), wildcard)
   ret_0 := sum(bar)
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 method sum(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Bar())
+  requires isSubtype(typeOf(this), c_Bar())
   ensures isSubtype(typeOf(ret), intType())
 
 
@@ -139,10 +139,10 @@ field y: Ref
 field z: Ref
 
 method setSuperField(bar: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(bar), _c_Bar())
+  requires isSubtype(typeOf(bar), c_Bar())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  inhale acc(c_Bar_shared(bar), wildcard)
+  inhale acc(_c_Bar_shared(bar), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -157,12 +157,12 @@ field y: Ref
 field z: Ref
 
 method accessSuperSuperField(baz: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(baz), _c_Baz())
+  requires isSubtype(typeOf(baz), c_Baz())
   ensures isSubtype(typeOf(ret_0), intType())
 {
-  inhale acc(c_Baz_shared(baz), wildcard)
-  unfold acc(c_Baz_shared(baz), wildcard)
-  unfold acc(c_Bar_shared(baz), wildcard)
+  inhale acc(_c_Baz_shared(baz), wildcard)
+  unfold acc(_c_Baz_shared(baz), wildcard)
+  unfold acc(_c_Bar_shared(baz), wildcard)
   unfold acc(shared(baz), wildcard)
   ret_0 := baz.x
   goto lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
@@ -5,15 +5,15 @@ field x: Ref
 
 field y: Ref
 
-method getY(this: Ref) returns (ret_0: Ref)
+method getY(this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   inhale acc(shared(this), wildcard)
   unfold acc(shared(this), wildcard)
-  ret_0 := this.y
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := this.y
+  goto ret_0
+  label ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for sum:
@@ -25,9 +25,9 @@ field y: Ref
 
 field z: Ref
 
-method sum(this: Ref) returns (ret_0: Ref)
+method sum(this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Bar())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -37,9 +37,9 @@ method sum(this: Ref) returns (ret_0: Ref)
   anon_0 := this.x
   unfold acc(_c_Bar_shared(this), wildcard)
   anon := this.z
-  ret_0 := plusInts(anon_0, anon)
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := plusInts(anon_0, anon)
+  goto ret_0
+  label ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for callSuperMethod:
@@ -51,19 +51,19 @@ field y: Ref
 
 field z: Ref
 
-method callSuperMethod(bar: Ref) returns (ret_0: Ref)
+method callSuperMethod(bar: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   inhale acc(_c_Bar_shared(bar), wildcard)
-  ret_0 := getY(bar)
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := getY(bar)
+  goto ret_0
+  label ret_0
 }
 
-method getY(this: Ref) returns (ret: Ref)
+method getY(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
 /inheritance.kt: info: Generated Viper text for accessSuperField:
@@ -75,14 +75,14 @@ field y: Ref
 
 field z: Ref
 
-method accessSuperField(bar: Ref) returns (ret_0: Ref)
+method accessSuperField(bar: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   inhale acc(_c_Bar_shared(bar), wildcard)
-  ret_0 := havoc_Boolean()
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := havoc_Boolean()
+  goto ret_0
+  label ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for accessNewField:
@@ -94,15 +94,15 @@ field y: Ref
 
 field z: Ref
 
-method accessNewField(bar: Ref) returns (ret_0: Ref)
+method accessNewField(bar: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   inhale acc(_c_Bar_shared(bar), wildcard)
   unfold acc(_c_Bar_shared(bar), wildcard)
-  ret_0 := bar.z
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := bar.z
+  goto ret_0
+  label ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for callNewMethod:
@@ -114,19 +114,19 @@ field y: Ref
 
 field z: Ref
 
-method callNewMethod(bar: Ref) returns (ret_0: Ref)
+method callNewMethod(bar: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   inhale acc(_c_Bar_shared(bar), wildcard)
-  ret_0 := sum(bar)
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := sum(bar)
+  goto ret_0
+  label ret_0
 }
 
-method sum(this: Ref) returns (ret: Ref)
+method sum(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Bar())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
 /inheritance.kt: info: Generated Viper text for setSuperField:
@@ -138,13 +138,13 @@ field y: Ref
 
 field z: Ref
 
-method setSuperField(bar: Ref) returns (ret_0: Ref)
+method setSuperField(bar: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(_c_Bar_shared(bar), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /inheritance.kt: info: Generated Viper text for accessSuperSuperField:
@@ -156,15 +156,15 @@ field y: Ref
 
 field z: Ref
 
-method accessSuperSuperField(baz: Ref) returns (ret_0: Ref)
+method accessSuperSuperField(baz: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(baz), c_Baz())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   inhale acc(_c_Baz_shared(baz), wildcard)
   unfold acc(_c_Baz_shared(baz), wildcard)
   unfold acc(_c_Bar_shared(baz), wildcard)
   unfold acc(shared(baz), wildcard)
-  ret_0 := baz.x
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := baz.x
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance.fir.diag.txt
@@ -5,15 +5,15 @@ field x: Ref
 
 field y: Ref
 
-method getY(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), intType())
+method getY(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Foo())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   inhale acc(shared(this), wildcard)
   unfold acc(shared(this), wildcard)
-  ret := this.y
-  goto ret_0
-  label ret_0
+  v_ret_0 := this.y
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for sum:
@@ -25,21 +25,21 @@ field y: Ref
 
 field z: Ref
 
-method sum(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Bar())
-  ensures isSubtype(typeOf(ret), intType())
+method sum(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Bar())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon_0: Ref
-  var anon: Ref
-  inhale acc(_c_Bar_shared(this), wildcard)
-  unfold acc(_c_Bar_shared(this), wildcard)
-  unfold acc(shared(this), wildcard)
+  var anon_1: Ref
+  inhale acc(Bar_shared(this), wildcard)
+  unfold acc(Bar_shared(this), wildcard)
+  unfold acc(Foo_shared(this), wildcard)
   anon_0 := this.x
-  unfold acc(_c_Bar_shared(this), wildcard)
-  anon := this.z
-  ret := plusInts(anon_0, anon)
-  goto ret_0
-  label ret_0
+  unfold acc(Bar_shared(this), wildcard)
+  anon_1 := this.z
+  v_ret_0 := plusInts(anon_0, anon_1)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for callSuperMethod:
@@ -51,18 +51,18 @@ field y: Ref
 
 field z: Ref
 
-method callSuperMethod(bar: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret), intType())
+method callSuperMethod(bar: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(bar), Bar())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  inhale acc(_c_Bar_shared(bar), wildcard)
-  ret := getY(bar)
-  goto ret_0
-  label ret_0
+  inhale acc(Bar_shared(bar), wildcard)
+  v_ret_0 := getY(bar)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method getY(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
+  requires isSubtype(typeOf(this), Foo())
   ensures isSubtype(typeOf(v_ret), intType())
 
 
@@ -75,14 +75,14 @@ field y: Ref
 
 field z: Ref
 
-method accessSuperField(bar: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret), boolType())
+method accessSuperField(bar: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(bar), Bar())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  inhale acc(_c_Bar_shared(bar), wildcard)
-  ret := havoc_Boolean()
-  goto ret_0
-  label ret_0
+  inhale acc(Bar_shared(bar), wildcard)
+  v_ret_0 := havoc_Boolean()
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for accessNewField:
@@ -94,15 +94,15 @@ field y: Ref
 
 field z: Ref
 
-method accessNewField(bar: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret), intType())
+method accessNewField(bar: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(bar), Bar())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  inhale acc(_c_Bar_shared(bar), wildcard)
-  unfold acc(_c_Bar_shared(bar), wildcard)
-  ret := bar.z
-  goto ret_0
-  label ret_0
+  inhale acc(Bar_shared(bar), wildcard)
+  unfold acc(Bar_shared(bar), wildcard)
+  v_ret_0 := bar.z
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /inheritance.kt: info: Generated Viper text for callNewMethod:
@@ -114,18 +114,18 @@ field y: Ref
 
 field z: Ref
 
-method callNewMethod(bar: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret), intType())
+method callNewMethod(bar: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(bar), Bar())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  inhale acc(_c_Bar_shared(bar), wildcard)
-  ret := sum(bar)
-  goto ret_0
-  label ret_0
+  inhale acc(Bar_shared(bar), wildcard)
+  v_ret_0 := sum(bar)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method sum(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Bar())
+  requires isSubtype(typeOf(this), Bar())
   ensures isSubtype(typeOf(v_ret), intType())
 
 
@@ -138,13 +138,13 @@ field y: Ref
 
 field z: Ref
 
-method setSuperField(bar: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret), unitType())
+method setSuperField(bar: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(bar), Bar())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(_c_Bar_shared(bar), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(Bar_shared(bar), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /inheritance.kt: info: Generated Viper text for accessSuperSuperField:
@@ -156,15 +156,15 @@ field y: Ref
 
 field z: Ref
 
-method accessSuperSuperField(baz: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(baz), c_Baz())
-  ensures isSubtype(typeOf(ret), intType())
+method accessSuperSuperField(baz: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(baz), Baz())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  inhale acc(_c_Baz_shared(baz), wildcard)
-  unfold acc(_c_Baz_shared(baz), wildcard)
-  unfold acc(_c_Bar_shared(baz), wildcard)
-  unfold acc(shared(baz), wildcard)
-  ret := baz.x
-  goto ret_0
-  label ret_0
+  inhale acc(Baz_shared(baz), wildcard)
+  unfold acc(Baz_shared(baz), wildcard)
+  unfold acc(Bar_shared(baz), wildcard)
+  unfold acc(Foo_shared(baz), wildcard)
+  v_ret_0 := baz.x
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
@@ -1,17 +1,17 @@
 /inheritance_fields.kt: info: Generated Viper text for createB:
-field bf_fieldNotOverride: Ref
+field fieldNotOverride: Ref
 
-method con(fieldOverride: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(fieldOverride), _c_FieldB())
-  ensures isSubtype(typeOf(ret), _c_B())
-  ensures acc(c_B_shared(ret), wildcard)
-  ensures acc(c_B_unique(ret), write)
+method con() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_FieldB())
+  ensures acc(shared(ret), wildcard)
+  ensures acc(_c_FieldB_unique(ret), write)
 
 
-method con__c_FieldB() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_FieldB())
-  ensures acc(c_FieldB_shared(ret), wildcard)
-  ensures acc(c_FieldB_unique(ret), write)
+method con_c_B(fieldOverride: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(fieldOverride), c_FieldB())
+  ensures isSubtype(typeOf(ret), c_B())
+  ensures acc(_c_B_shared(ret), wildcard)
+  ensures acc(_c_B_unique(ret), write)
 
 
 method createB() returns (ret_0: Ref)
@@ -21,16 +21,16 @@ method createB() returns (ret_0: Ref)
   var b: Ref
   var l0_fieldOverride: Ref
   var anon: Ref
-  var fieldNotOverride: Ref
-  fieldB := con__c_FieldB()
-  b := con(fieldB)
+  var l0_fieldNotOverride: Ref
+  fieldB := con()
+  b := con_c_B(fieldB)
   anon := g_fieldOverride(b)
   l0_fieldOverride := anon
-  inhale isSubtype(typeOf(l0_fieldOverride), _c_FieldB())
-  inhale acc(c_FieldB_shared(l0_fieldOverride), wildcard)
-  unfold acc(c_B_shared(b), wildcard)
-  unfold acc(c_A_shared(b), wildcard)
-  fieldNotOverride := b.bf_fieldNotOverride
+  inhale isSubtype(typeOf(l0_fieldOverride), c_FieldB())
+  inhale acc(shared(l0_fieldOverride), wildcard)
+  unfold acc(_c_B_shared(b), wildcard)
+  unfold acc(_c_A_shared(b), wildcard)
+  l0_fieldNotOverride := b.fieldNotOverride
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -43,23 +43,23 @@ field bf_x: Ref
 
 method con(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), _c_SecondBackingFieldClass())
+  ensures isSubtype(typeOf(ret), c_SecondBackingFieldClass())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_SecondBackingFieldClass_unique(ret), write)
+  ensures acc(_c_SecondBackingFieldClass_unique(ret), write)
   ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_x)) ==
     intFromRef(x)
 
 
-method con__c_FirstBackingFieldClass() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_FirstBackingFieldClass())
-  ensures acc(c_FirstBackingFieldClass_shared(ret), wildcard)
-  ensures acc(c_FirstBackingFieldClass_unique(ret), write)
+method con_c_FirstBackingFieldClass() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_FirstBackingFieldClass())
+  ensures acc(_c_FirstBackingFieldClass_shared(ret), wildcard)
+  ensures acc(_c_FirstBackingFieldClass_unique(ret), write)
 
 
-method con__c_NoBackingFieldClass() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_NoBackingFieldClass())
-  ensures acc(c_NoBackingFieldClass_shared(ret), wildcard)
-  ensures acc(c_NoBackingFieldClass_unique(ret), write)
+method con_c_NoBackingFieldClass() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_NoBackingFieldClass())
+  ensures acc(_c_NoBackingFieldClass_shared(ret), wildcard)
+  ensures acc(_c_NoBackingFieldClass_unique(ret), write)
 
 
 method createBFsAndNoBF() returns (ret_0: Ref)
@@ -73,11 +73,11 @@ method createBFsAndNoBF() returns (ret_0: Ref)
   var anon: Ref
   var sbf: Ref
   var sbfx: Ref
-  fbf := con__c_FirstBackingFieldClass()
+  fbf := con_c_FirstBackingFieldClass()
   anon_0 := g_x(fbf)
   fbfx := anon_0
   inhale isSubtype(typeOf(fbfx), intType())
-  nbf := con__c_NoBackingFieldClass()
+  nbf := con_c_NoBackingFieldClass()
   anon := g_x(nbf)
   nbfx := anon
   inhale isSubtype(typeOf(nbfx), intType())
@@ -96,9 +96,9 @@ field bf_a: Ref
 
 method con(a: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(ret), _c_Y())
-  ensures acc(c_Y_shared(ret), wildcard)
-  ensures acc(c_Y_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_Y())
+  ensures acc(shared(ret), wildcard)
+  ensures acc(_c_Y_unique(ret), write)
 
 
 method createY() returns (ret_0: Ref)
@@ -107,8 +107,8 @@ method createY() returns (ret_0: Ref)
   var y: Ref
   var ya: Ref
   y := con(intToRef(10))
-  unfold acc(c_Y_shared(y), wildcard)
   unfold acc(shared(y), wildcard)
+  unfold acc(_c_X_shared(y), wildcard)
   ya := y.bf_a
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
@@ -1,69 +1,70 @@
 /inheritance_fields.kt: info: Generated Viper text for createB:
-field fieldNotOverride: Ref
+field bf_fieldNotOverride: Ref
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_FieldB())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_FieldB_unique(ret), write)
-
-
-method con_c_B(fieldOverride: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(fieldOverride), c_FieldB())
-  ensures isSubtype(typeOf(ret), c_B())
-  ensures acc(_c_B_shared(ret), wildcard)
-  ensures acc(_c_B_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_FieldB())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_FieldB_unique(v_ret), write)
 
 
-method createB() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method con_c_B(par_fieldOverride: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_fieldOverride), c_FieldB())
+  ensures isSubtype(typeOf(v_ret), c_B())
+  ensures acc(_c_B_shared(v_ret), wildcard)
+  ensures acc(_c_B_unique(v_ret), write)
+
+
+method createB() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var fieldB: Ref
   var b: Ref
-  var l0_fieldOverride: Ref
+  var fieldOverride: Ref
   var anon: Ref
-  var l0_fieldNotOverride: Ref
+  var fieldNotOverride: Ref
   fieldB := con()
   b := con_c_B(fieldB)
   anon := g_fieldOverride(b)
-  l0_fieldOverride := anon
-  inhale isSubtype(typeOf(l0_fieldOverride), c_FieldB())
-  inhale acc(shared(l0_fieldOverride), wildcard)
+  fieldOverride := anon
+  inhale isSubtype(typeOf(fieldOverride), c_FieldB())
+  inhale acc(shared(fieldOverride), wildcard)
   unfold acc(_c_B_shared(b), wildcard)
   unfold acc(_c_A_shared(b), wildcard)
-  l0_fieldNotOverride := b.fieldNotOverride
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  fieldNotOverride := b.bf_fieldNotOverride
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method g_fieldOverride(this: Ref) returns (ret: Ref)
+method g_fieldOverride(this: Ref) returns (v_ret: Ref)
 
 
 /inheritance_fields.kt: info: Generated Viper text for createBFsAndNoBF:
 field bf_x: Ref
 
-method con(x: Ref) returns (ret: Ref)
+method con(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), c_SecondBackingFieldClass())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_SecondBackingFieldClass_unique(ret), write)
-  ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_x)) ==
+  ensures isSubtype(typeOf(v_ret), c_SecondBackingFieldClass())
+  ensures acc(_c_SecondBackingFieldClass_shared(v_ret), wildcard)
+  ensures acc(_c_SecondBackingFieldClass_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(_c_SecondBackingFieldClass_shared(v_ret), wildcard) in
+      v_ret.bf_x)) ==
     intFromRef(x)
 
 
-method con_c_FirstBackingFieldClass() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_FirstBackingFieldClass())
-  ensures acc(_c_FirstBackingFieldClass_shared(ret), wildcard)
-  ensures acc(_c_FirstBackingFieldClass_unique(ret), write)
+method con_c_FirstBackingFieldClass() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_FirstBackingFieldClass())
+  ensures acc(_c_FirstBackingFieldClass_shared(v_ret), wildcard)
+  ensures acc(_c_FirstBackingFieldClass_unique(v_ret), write)
 
 
-method con_c_NoBackingFieldClass() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_NoBackingFieldClass())
-  ensures acc(_c_NoBackingFieldClass_shared(ret), wildcard)
-  ensures acc(_c_NoBackingFieldClass_unique(ret), write)
+method con_c_NoBackingFieldClass() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_NoBackingFieldClass())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_NoBackingFieldClass_unique(v_ret), write)
 
 
-method createBFsAndNoBF() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method createBFsAndNoBF() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var fbf: Ref
   var fbfx: Ref
@@ -82,27 +83,27 @@ method createBFsAndNoBF() returns (ret_0: Ref)
   nbfx := anon
   inhale isSubtype(typeOf(nbfx), intType())
   sbf := con(intToRef(10))
-  unfold acc(shared(sbf), wildcard)
+  unfold acc(_c_SecondBackingFieldClass_shared(sbf), wildcard)
   sbfx := sbf.bf_x
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method g_x(this: Ref) returns (ret: Ref)
+method g_x(this: Ref) returns (v_ret: Ref)
 
 
 /inheritance_fields.kt: info: Generated Viper text for createY:
 field bf_a: Ref
 
-method con(a: Ref) returns (ret: Ref)
+method con(a: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(ret), c_Y())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_Y_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_Y())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_Y_unique(v_ret), write)
 
 
-method createY() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method createY() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var y: Ref
   var ya: Ref
@@ -110,6 +111,6 @@ method createY() returns (ret_0: Ref)
   unfold acc(shared(y), wildcard)
   unfold acc(_c_X_shared(y), wildcard)
   ya := y.bf_a
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/inheritance_fields.fir.diag.txt
@@ -1,38 +1,38 @@
 /inheritance_fields.kt: info: Generated Viper text for createB:
 field bf_fieldNotOverride: Ref
 
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_FieldB())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_FieldB_unique(v_ret), write)
+method con_B(par_fieldOverride: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_fieldOverride), FieldB())
+  ensures isSubtype(typeOf(v_ret), B())
+  ensures acc(B_shared(v_ret), wildcard)
+  ensures acc(B_unique(v_ret), write)
 
 
-method con_c_B(par_fieldOverride: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(par_fieldOverride), c_FieldB())
-  ensures isSubtype(typeOf(v_ret), c_B())
-  ensures acc(_c_B_shared(v_ret), wildcard)
-  ensures acc(_c_B_unique(v_ret), write)
+method con_FieldB() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), FieldB())
+  ensures acc(FieldB_shared(v_ret), wildcard)
+  ensures acc(FieldB_unique(v_ret), write)
 
 
-method createB() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method createB() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var fieldB: Ref
   var b: Ref
-  var fieldOverride: Ref
+  var l0_fieldOverride: Ref
   var anon: Ref
-  var fieldNotOverride: Ref
-  fieldB := con()
-  b := con_c_B(fieldB)
+  var l0_fieldNotOverride: Ref
+  fieldB := con_FieldB()
+  b := con_B(fieldB)
   anon := g_fieldOverride(b)
-  fieldOverride := anon
-  inhale isSubtype(typeOf(fieldOverride), c_FieldB())
-  inhale acc(shared(fieldOverride), wildcard)
-  unfold acc(_c_B_shared(b), wildcard)
-  unfold acc(_c_A_shared(b), wildcard)
-  fieldNotOverride := b.bf_fieldNotOverride
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  l0_fieldOverride := anon
+  inhale isSubtype(typeOf(l0_fieldOverride), FieldB())
+  inhale acc(FieldB_shared(l0_fieldOverride), wildcard)
+  unfold acc(B_shared(b), wildcard)
+  unfold acc(A_shared(b), wildcard)
+  l0_fieldNotOverride := b.bf_fieldNotOverride
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method g_fieldOverride(this: Ref) returns (v_ret: Ref)
@@ -41,52 +41,52 @@ method g_fieldOverride(this: Ref) returns (v_ret: Ref)
 /inheritance_fields.kt: info: Generated Viper text for createBFsAndNoBF:
 field bf_x: Ref
 
-method con(x: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(v_ret), c_SecondBackingFieldClass())
-  ensures acc(_c_SecondBackingFieldClass_shared(v_ret), wildcard)
-  ensures acc(_c_SecondBackingFieldClass_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(_c_SecondBackingFieldClass_shared(v_ret), wildcard) in
+method con_FirstBackingFieldClass() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), FirstBackingFieldClass())
+  ensures acc(FirstBackingFieldClass_shared(v_ret), wildcard)
+  ensures acc(FirstBackingFieldClass_unique(v_ret), write)
+
+
+method con_NoBackingFieldClass() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), NoBackingFieldClass())
+  ensures acc(NoBackingFieldClass_shared(v_ret), wildcard)
+  ensures acc(NoBackingFieldClass_unique(v_ret), write)
+
+
+method con_SecondBackingFieldClass(par_x: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret), SecondBackingFieldClass())
+  ensures acc(SecondBackingFieldClass_shared(v_ret), wildcard)
+  ensures acc(SecondBackingFieldClass_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(SecondBackingFieldClass_shared(v_ret), wildcard) in
       v_ret.bf_x)) ==
-    intFromRef(x)
+    intFromRef(par_x)
 
 
-method con_c_FirstBackingFieldClass() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_FirstBackingFieldClass())
-  ensures acc(_c_FirstBackingFieldClass_shared(v_ret), wildcard)
-  ensures acc(_c_FirstBackingFieldClass_unique(v_ret), write)
-
-
-method con_c_NoBackingFieldClass() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_NoBackingFieldClass())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_NoBackingFieldClass_unique(v_ret), write)
-
-
-method createBFsAndNoBF() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method createBFsAndNoBF() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var fbf: Ref
   var fbfx: Ref
   var anon_0: Ref
   var nbf: Ref
   var nbfx: Ref
-  var anon: Ref
+  var anon_1: Ref
   var sbf: Ref
   var sbfx: Ref
-  fbf := con_c_FirstBackingFieldClass()
+  fbf := con_FirstBackingFieldClass()
   anon_0 := g_x(fbf)
   fbfx := anon_0
   inhale isSubtype(typeOf(fbfx), intType())
-  nbf := con_c_NoBackingFieldClass()
-  anon := g_x(nbf)
-  nbfx := anon
+  nbf := con_NoBackingFieldClass()
+  anon_1 := g_x(nbf)
+  nbfx := anon_1
   inhale isSubtype(typeOf(nbfx), intType())
-  sbf := con(intToRef(10))
-  unfold acc(_c_SecondBackingFieldClass_shared(sbf), wildcard)
+  sbf := con_SecondBackingFieldClass(intToRef(10))
+  unfold acc(SecondBackingFieldClass_shared(sbf), wildcard)
   sbfx := sbf.bf_x
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method g_x(this: Ref) returns (v_ret: Ref)
@@ -95,22 +95,22 @@ method g_x(this: Ref) returns (v_ret: Ref)
 /inheritance_fields.kt: info: Generated Viper text for createY:
 field bf_a: Ref
 
-method con(a: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(v_ret), c_Y())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_Y_unique(v_ret), write)
+method con(par_a: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  ensures isSubtype(typeOf(v_ret), Y())
+  ensures acc(Y_shared(v_ret), wildcard)
+  ensures acc(Y_unique(v_ret), write)
 
 
-method createY() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method createY() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
   var ya: Ref
   y := con(intToRef(10))
-  unfold acc(shared(y), wildcard)
-  unfold acc(_c_X_shared(y), wildcard)
+  unfold acc(Y_shared(y), wildcard)
+  unfold acc(X_shared(y), wildcard)
   ya := y.bf_a
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
@@ -1,10 +1,10 @@
 /interface.kt: info: Generated Viper text for testProperties:
-method g_varProp(this: Ref) returns (v_ret: Ref)
+method g_varProp(this: Ref) returns (ret: Ref)
 
 
-method testProperties(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+method testProperties(foo: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(foo), c_Foo())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var x: Ref
@@ -21,14 +21,14 @@ method testProperties(foo: Ref) returns (ret: Ref)
   anon_3 := anon
   inhale isSubtype(typeOf(anon_3), intType())
   x := plusInts(anon_1, anon_3)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method valProp(this: Ref) returns (v_ret: Ref)
+method valProp(this: Ref) returns (ret: Ref)
 
 
-method varProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
+method varProp(this: Ref, anon_0: Ref) returns (ret: Ref)
 
 
 /interface.kt: info: Generated Viper text for createImpl:
@@ -36,10 +36,10 @@ field bf_number: Ref
 
 method con(number: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(number), intType())
-  ensures isSubtype(typeOf(ret), _c_Impl())
-  ensures acc(c_Impl_shared(ret), wildcard)
-  ensures acc(c_Impl_unique(ret), write)
-  ensures intFromRef((unfolding acc(c_Impl_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_Impl())
+  ensures acc(_c_Impl_shared(ret), wildcard)
+  ensures acc(_c_Impl_unique(ret), write)
+  ensures intFromRef((unfolding acc(_c_Impl_shared(ret), wildcard) in
       ret.bf_number)) ==
     intFromRef(number)
 
@@ -50,7 +50,7 @@ method createImpl() returns (ret_0: Ref)
   var impl: Ref
   var implField: Ref
   impl := con(intToRef(-1))
-  unfold acc(c_Impl_shared(impl), wildcard)
+  unfold acc(_c_Impl_shared(impl), wildcard)
   implField := impl.bf_number
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
@@ -1,10 +1,10 @@
 /interface.kt: info: Generated Viper text for testProperties:
-method g_varProp(this: Ref) returns (ret: Ref)
+method g_varProp(this: Ref) returns (v_ret: Ref)
 
 
-method testProperties(foo: Ref) returns (ret_0: Ref)
+method testProperties(foo: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var x: Ref
@@ -21,39 +21,39 @@ method testProperties(foo: Ref) returns (ret_0: Ref)
   anon_3 := anon
   inhale isSubtype(typeOf(anon_3), intType())
   x := plusInts(anon_1, anon_3)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method valProp(this: Ref) returns (ret: Ref)
+method valProp(this: Ref) returns (v_ret: Ref)
 
 
-method varProp(this: Ref, anon_0: Ref) returns (ret: Ref)
+method varProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
 
 
 /interface.kt: info: Generated Viper text for createImpl:
 field bf_number: Ref
 
-method con(number: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(number), intType())
-  ensures isSubtype(typeOf(ret), c_Impl())
-  ensures acc(_c_Impl_shared(ret), wildcard)
-  ensures acc(_c_Impl_unique(ret), write)
-  ensures intFromRef((unfolding acc(_c_Impl_shared(ret), wildcard) in
-      ret.bf_number)) ==
-    intFromRef(number)
+method con(par_number: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_number), intType())
+  ensures isSubtype(typeOf(v_ret), c_Impl())
+  ensures acc(_c_Impl_shared(v_ret), wildcard)
+  ensures acc(_c_Impl_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(_c_Impl_shared(v_ret), wildcard) in
+      v_ret.bf_number)) ==
+    intFromRef(par_number)
 
 
-method createImpl() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method createImpl() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var impl: Ref
   var implField: Ref
   impl := con(intToRef(-1))
   unfold acc(_c_Impl_shared(impl), wildcard)
   implField := impl.bf_number
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method g_number(this: Ref) returns (ret: Ref)
+method number(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/interface.fir.diag.txt
@@ -2,33 +2,33 @@
 method g_varProp(this: Ref) returns (v_ret: Ref)
 
 
-method testProperties(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+method s_varProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
+
+
+method testProperties(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var x: Ref
   var anon_1: Ref
   var anon_2: Ref
   var anon_3: Ref
-  var anon: Ref
+  var anon_4: Ref
   inhale acc(shared(foo), wildcard)
-  anon_0 := varProp(foo, intToRef(0))
+  anon_0 := s_varProp(foo, intToRef(0))
   anon_2 := g_varProp(foo)
   anon_1 := anon_2
   inhale isSubtype(typeOf(anon_1), intType())
-  anon := valProp(foo)
-  anon_3 := anon
+  anon_4 := valProp(foo)
+  anon_3 := anon_4
   inhale isSubtype(typeOf(anon_3), intType())
   x := plusInts(anon_1, anon_3)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method valProp(this: Ref) returns (v_ret: Ref)
-
-
-method varProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
 
 
 /interface.kt: info: Generated Viper text for createImpl:
@@ -36,24 +36,24 @@ field bf_number: Ref
 
 method con(par_number: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_number), intType())
-  ensures isSubtype(typeOf(v_ret), c_Impl())
-  ensures acc(_c_Impl_shared(v_ret), wildcard)
-  ensures acc(_c_Impl_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(_c_Impl_shared(v_ret), wildcard) in
+  ensures isSubtype(typeOf(v_ret), Impl())
+  ensures acc(Impl_shared(v_ret), wildcard)
+  ensures acc(Impl_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(Impl_shared(v_ret), wildcard) in
       v_ret.bf_number)) ==
     intFromRef(par_number)
 
 
-method createImpl() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method createImpl() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var impl: Ref
   var implField: Ref
   impl := con(intToRef(-1))
-  unfold acc(_c_Impl_shared(impl), wildcard)
+  unfold acc(Impl_shared(impl), wildcard)
   implField := impl.bf_number
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
-method number(this: Ref) returns (v_ret: Ref)
+method g_number(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
@@ -1,21 +1,21 @@
 /manual_permissions.kt: info: Generated Viper text for testManualPermissionFieldGetter:
-field a: Ref
+field bf_a: Ref
 
-field b: Ref
+field bf_b: Ref
 
-method testManualPermissionFieldGetter(mpf: Ref) returns (ret_0: Ref)
+method testManualPermissionFieldGetter(mpf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(mpf), c_ManualPermissionFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  var l0_a: Ref
-  var l0_b: Ref
+  var a: Ref
+  var b: Ref
   inhale acc(shared(mpf), wildcard)
   unfold acc(shared(mpf), wildcard)
-  l0_a := mpf.a
-  l0_b := mpf.b
-  inhale isSubtype(typeOf(l0_b), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  a := mpf.bf_a
+  b := mpf.bf_b
+  inhale isSubtype(typeOf(b), intType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /manual_permissions.kt: info: Generated Viper text for testManualPermissionFieldSetter:
@@ -23,12 +23,12 @@ field a: Ref
 
 field b: Ref
 
-method testManualPermissionFieldSetter(mpf: Ref) returns (ret_0: Ref)
+method testManualPermissionFieldSetter(mpf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(mpf), c_ManualPermissionFields())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(mpf), wildcard)
   mpf.b := intToRef(123)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
@@ -1,19 +1,19 @@
 /manual_permissions.kt: info: Generated Viper text for testManualPermissionFieldGetter:
-field bf_a: Ref
+field a: Ref
 
-field bf_b: Ref
+field b: Ref
 
 method testManualPermissionFieldGetter(mpf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(mpf), _c_ManualPermissionFields())
+  requires isSubtype(typeOf(mpf), c_ManualPermissionFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var a: Ref
-  var b: Ref
+  var l0_a: Ref
+  var l0_b: Ref
   inhale acc(shared(mpf), wildcard)
   unfold acc(shared(mpf), wildcard)
-  a := mpf.bf_a
-  b := mpf.bf_b
-  inhale isSubtype(typeOf(b), intType())
+  l0_a := mpf.a
+  l0_b := mpf.b
+  inhale isSubtype(typeOf(l0_b), intType())
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -24,7 +24,7 @@ field a: Ref
 field b: Ref
 
 method testManualPermissionFieldSetter(mpf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(mpf), _c_ManualPermissionFields())
+  requires isSubtype(typeOf(mpf), c_ManualPermissionFields())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   inhale acc(shared(mpf), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/manual_permissions.fir.diag.txt
@@ -3,19 +3,19 @@ field bf_a: Ref
 
 field bf_b: Ref
 
-method testManualPermissionFieldGetter(mpf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(mpf), c_ManualPermissionFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testManualPermissionFieldGetter(mpf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(mpf), ManualPermissionFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var a: Ref
-  var b: Ref
+  var l0_a: Ref
+  var l0_b: Ref
   inhale acc(shared(mpf), wildcard)
   unfold acc(shared(mpf), wildcard)
-  a := mpf.bf_a
-  b := mpf.bf_b
-  inhale isSubtype(typeOf(b), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  l0_a := mpf.bf_a
+  l0_b := mpf.bf_b
+  inhale isSubtype(typeOf(l0_b), intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /manual_permissions.kt: info: Generated Viper text for testManualPermissionFieldSetter:
@@ -23,12 +23,12 @@ field a: Ref
 
 field b: Ref
 
-method testManualPermissionFieldSetter(mpf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(mpf), c_ManualPermissionFields())
-  ensures isSubtype(typeOf(ret), unitType())
+method testManualPermissionFieldSetter(mpf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(mpf), ManualPermissionFields())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale acc(shared(mpf), wildcard)
   mpf.b := intToRef(123)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
@@ -2,7 +2,7 @@
 field x: Ref
 
 method memberFun(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   inhale acc(shared(this), wildcard)
@@ -16,7 +16,7 @@ method memberFun(this: Ref) returns (ret_0: Ref)
 field x: Ref
 
 method callMemberFun(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
@@ -27,7 +27,7 @@ method callMemberFun(this: Ref) returns (ret_0: Ref)
 }
 
 method memberFun(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret), intType())
 
 
@@ -35,13 +35,13 @@ method memberFun(this: Ref) returns (ret: Ref)
 field x: Ref
 
 method memberFun(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret), intType())
 
 
 method siblingCall(this: Ref, other: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
-  requires isSubtype(typeOf(other), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
+  requires isSubtype(typeOf(other), c_Foo())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
@@ -56,12 +56,12 @@ method siblingCall(this: Ref, other: Ref) returns (ret_0: Ref)
 field x: Ref
 
 method memberFun(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret), intType())
 
 
 method outerMemberFunCall(f: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(f), _c_Foo())
+  requires isSubtype(typeOf(f), c_Foo())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
@@ -1,72 +1,72 @@
 /member_functions.kt: info: Generated Viper text for memberFun:
 field x: Ref
 
-method memberFun(this: Ref) returns (ret_0: Ref)
+method memberFun(this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   inhale acc(shared(this), wildcard)
   unfold acc(shared(this), wildcard)
-  ret_0 := this.x
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := this.x
+  goto ret_0
+  label ret_0
 }
 
 /member_functions.kt: info: Generated Viper text for callMemberFun:
 field x: Ref
 
-method callMemberFun(this: Ref) returns (ret_0: Ref)
+method callMemberFun(this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   inhale acc(shared(this), wildcard)
   anon := memberFun(this)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method memberFun(this: Ref) returns (ret: Ref)
+method memberFun(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
 /member_functions.kt: info: Generated Viper text for siblingCall:
 field x: Ref
 
-method memberFun(this: Ref) returns (ret: Ref)
+method memberFun(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method siblingCall(this: Ref, other: Ref) returns (ret_0: Ref)
+method siblingCall(this: Ref, other: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
   requires isSubtype(typeOf(other), c_Foo())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   inhale acc(shared(this), wildcard)
   inhale acc(shared(other), wildcard)
   anon := memberFun(other)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /member_functions.kt: info: Generated Viper text for outerMemberFunCall:
 field x: Ref
 
-method memberFun(this: Ref) returns (ret: Ref)
+method memberFun(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method outerMemberFunCall(f: Ref) returns (ret_0: Ref)
+method outerMemberFunCall(f: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(f), c_Foo())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   inhale acc(shared(f), wildcard)
   anon := memberFun(f)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/member_functions.fir.diag.txt
@@ -1,33 +1,33 @@
 /member_functions.kt: info: Generated Viper text for memberFun:
 field x: Ref
 
-method memberFun(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), intType())
+method memberFun(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Foo())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   inhale acc(shared(this), wildcard)
   unfold acc(shared(this), wildcard)
-  ret := this.x
-  goto ret_0
-  label ret_0
+  v_ret_0 := this.x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /member_functions.kt: info: Generated Viper text for callMemberFun:
 field x: Ref
 
-method callMemberFun(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+method callMemberFun(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Foo())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   inhale acc(shared(this), wildcard)
   anon := memberFun(this)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method memberFun(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
+  requires isSubtype(typeOf(this), Foo())
   ensures isSubtype(typeOf(v_ret), intType())
 
 
@@ -35,38 +35,38 @@ method memberFun(this: Ref) returns (v_ret: Ref)
 field x: Ref
 
 method memberFun(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
+  requires isSubtype(typeOf(this), Foo())
   ensures isSubtype(typeOf(v_ret), intType())
 
 
-method siblingCall(this: Ref, other: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
-  requires isSubtype(typeOf(other), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+method siblingCall(this: Ref, other: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Foo())
+  requires isSubtype(typeOf(other), Foo())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   inhale acc(shared(this), wildcard)
   inhale acc(shared(other), wildcard)
   anon := memberFun(other)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /member_functions.kt: info: Generated Viper text for outerMemberFunCall:
 field x: Ref
 
 method memberFun(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
+  requires isSubtype(typeOf(this), Foo())
   ensures isSubtype(typeOf(v_ret), intType())
 
 
-method outerMemberFunCall(f: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(f), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+method outerMemberFunCall(f: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(f), Foo())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   inhale acc(shared(f), wildcard)
   anon := memberFun(f)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
@@ -1,8 +1,8 @@
 /multiple_interfaces.kt: info: Generated Viper text for testDiamond:
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_D())
-  ensures acc(c_D_shared(ret), wildcard)
-  ensures acc(c_D_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_D())
+  ensures acc(shared(ret), wildcard)
+  ensures acc(_c_D_unique(ret), write)
 
 
 method g_field(this: Ref) returns (ret: Ref)
@@ -23,15 +23,15 @@ method testDiamond() returns (ret_0: Ref)
 
 /multiple_interfaces.kt: info: Generated Viper text for testVarVal:
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_I())
-  ensures acc(c_I_shared(ret), wildcard)
-  ensures acc(c_I_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_I())
+  ensures acc(shared(ret), wildcard)
+  ensures acc(_c_I_unique(ret), write)
 
 
-method con__c_G() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_G())
-  ensures acc(c_G_shared(ret), wildcard)
-  ensures acc(c_G_unique(ret), write)
+method con_c_G() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_G())
+  ensures acc(_c_G_shared(ret), wildcard)
+  ensures acc(_c_G_unique(ret), write)
 
 
 method g_field(this: Ref) returns (ret: Ref)
@@ -51,7 +51,7 @@ method testVarVal() returns (ret_0: Ref)
   var anon_3: Ref
   var anon_4: Ref
   var anon: Ref
-  g := con__c_G()
+  g := con_c_G()
   anon_1 := g_field(g)
   anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
@@ -1,47 +1,47 @@
 /multiple_interfaces.kt: info: Generated Viper text for testDiamond:
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_D())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_D_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_D())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_D_unique(v_ret), write)
 
 
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method testDiamond() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method testDiamond() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), intType())
 {
   var anon_0: Ref
   var anon: Ref
   anon := con()
   anon_0 := g_field(anon)
-  ret_0 := anon_0
-  inhale isSubtype(typeOf(ret_0), intType())
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := anon_0
+  inhale isSubtype(typeOf(ret), intType())
+  goto ret_0
+  label ret_0
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for testVarVal:
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_I())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_I_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_I())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_I_unique(v_ret), write)
 
 
-method con_c_G() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_G())
-  ensures acc(_c_G_shared(ret), wildcard)
-  ensures acc(_c_G_unique(ret), write)
+method con_c_G() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_G())
+  ensures acc(_c_G_shared(v_ret), wildcard)
+  ensures acc(_c_G_unique(v_ret), write)
 
 
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method s_field(this: Ref, anon_0: Ref) returns (ret: Ref)
+method s_field(this: Ref, anon_0: Ref) returns (v_ret: Ref)
 
 
-method testVarVal() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method testVarVal() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var g: Ref
   var anon_0: Ref
@@ -61,6 +61,6 @@ method testVarVal() returns (ret_0: Ref)
   anon_3 := anon_4
   inhale isSubtype(typeOf(anon_3), intType())
   anon := s_field(i, intToRef(1))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/multiple_interfaces.fir.diag.txt
@@ -1,37 +1,37 @@
 /multiple_interfaces.kt: info: Generated Viper text for testDiamond:
 method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_D())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_D_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), D())
+  ensures acc(D_shared(v_ret), wildcard)
+  ensures acc(D_unique(v_ret), write)
 
 
 method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method testDiamond() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method testDiamond() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon_0: Ref
-  var anon: Ref
-  anon := con()
-  anon_0 := g_field(anon)
-  ret := anon_0
-  inhale isSubtype(typeOf(ret), intType())
-  goto ret_0
-  label ret_0
+  var anon_1: Ref
+  anon_1 := con()
+  anon_0 := g_field(anon_1)
+  v_ret_0 := anon_0
+  inhale isSubtype(typeOf(v_ret_0), intType())
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for testVarVal:
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_I())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_I_unique(v_ret), write)
+method con_G() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), G())
+  ensures acc(G_shared(v_ret), wildcard)
+  ensures acc(G_unique(v_ret), write)
 
 
-method con_c_G() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_G())
-  ensures acc(_c_G_shared(v_ret), wildcard)
-  ensures acc(_c_G_unique(v_ret), write)
+method con_I() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), I())
+  ensures acc(I_shared(v_ret), wildcard)
+  ensures acc(I_unique(v_ret), write)
 
 
 method g_field(this: Ref) returns (v_ret: Ref)
@@ -40,8 +40,8 @@ method g_field(this: Ref) returns (v_ret: Ref)
 method s_field(this: Ref, anon_0: Ref) returns (v_ret: Ref)
 
 
-method testVarVal() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method testVarVal() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var g: Ref
   var anon_0: Ref
@@ -50,17 +50,17 @@ method testVarVal() returns (ret: Ref)
   var i: Ref
   var anon_3: Ref
   var anon_4: Ref
-  var anon: Ref
-  g := con_c_G()
+  var anon_5: Ref
+  g := con_G()
   anon_1 := g_field(g)
   anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())
   anon_2 := s_field(g, intToRef(1))
-  i := con()
+  i := con_I()
   anon_4 := g_field(i)
   anon_3 := anon_4
   inhale isSubtype(typeOf(anon_3), intType())
-  anon := s_field(i, intToRef(1))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon_5 := s_field(i, intToRef(1))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
@@ -15,10 +15,6 @@ predicate _c_Baz_unique(this: Ref) {
   true
 }
 
-predicate _c_PrimitiveFields_shared(this: Ref) {
-  acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
-}
-
 predicate _c_PrimitiveFields_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType()) &&
   acc(this.b, write) &&
@@ -39,29 +35,31 @@ predicate _c_Recursive_unique(this: Ref) {
   isSubtype(typeOf(this.next), nullable(c_Recursive()))
 }
 
+predicate _c_ReferenceField_shared(this: Ref) {
+  acc(this.pf, wildcard) && acc(shared(this.pf), wildcard) &&
+  isSubtype(typeOf(this.pf), c_PrimitiveFields()) &&
+  acc(_c_Baz_shared(this), wildcard)
+}
+
 predicate _c_ReferenceField_unique(this: Ref) {
-  acc(this.pf, wildcard) &&
-  acc(_c_PrimitiveFields_shared(this.pf), wildcard) &&
+  acc(this.pf, wildcard) && acc(shared(this.pf), wildcard) &&
   isSubtype(typeOf(this.pf), c_PrimitiveFields()) &&
   acc(_c_Baz_unique(this), write)
 }
 
 predicate shared(this: Ref) {
-  acc(this.pf, wildcard) &&
-  acc(_c_PrimitiveFields_shared(this.pf), wildcard) &&
-  isSubtype(typeOf(this.pf), c_PrimitiveFields()) &&
-  acc(_c_Baz_shared(this), wildcard)
+  acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-method useClasses(rf: Ref, rec: Ref) returns (ret_0: Ref)
+method useClasses(rf: Ref, rec: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceField())
   requires isSubtype(typeOf(rec), c_Recursive())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared(rf), wildcard)
+  inhale acc(_c_ReferenceField_shared(rf), wildcard)
   inhale acc(_c_Recursive_shared(rec), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /predicates.kt: info: Generated Viper text for threeLayersHierarchy:
@@ -95,13 +93,13 @@ predicate shared(this: Ref) {
   acc(_c_B_shared(this), wildcard)
 }
 
-method threeLayersHierarchy(c: Ref) returns (ret_0: Ref)
+method threeLayersHierarchy(c: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(c), c_C())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(c), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /predicates.kt: info: Generated Viper text for listHierarchy:
@@ -121,10 +119,6 @@ predicate collections_c_Iterable_shared(this: Ref) {
 
 predicate collections_c_Iterable_unique(this: Ref) {
   true
-}
-
-predicate collections_c_List_shared(this: Ref) {
-  acc(collections_c_Collection_shared(this), wildcard)
 }
 
 predicate collections_c_List_unique(this: Ref) {
@@ -149,25 +143,29 @@ predicate collections_c_MutableIterable_unique(this: Ref) {
   acc(collections_c_Iterable_unique(this), write)
 }
 
+predicate collections_c_MutableList_shared(this: Ref) {
+  acc(shared(this), wildcard) &&
+  acc(collections_c_MutableCollection_shared(this), wildcard)
+}
+
 predicate collections_c_MutableList_unique(this: Ref) {
   acc(collections_c_List_unique(this), write) &&
   acc(collections_c_MutableCollection_unique(this), write)
 }
 
 predicate shared(this: Ref) {
-  acc(collections_c_List_shared(this), wildcard) &&
-  acc(collections_c_MutableCollection_shared(this), wildcard)
+  acc(collections_c_Collection_shared(this), wildcard)
 }
 
-method listHierarchy(xs: Ref) returns (ret_0: Ref)
+method listHierarchy(xs: Ref) returns (ret: Ref)
   requires acc(xs.size, write)
   requires intFromRef(xs.size) >= 0
   requires isSubtype(typeOf(xs), c_MutableList())
   ensures acc(xs.size, write)
   ensures intFromRef(xs.size) >= 0
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared(xs), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale acc(collections_c_MutableList_shared(xs), wildcard)
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
@@ -7,57 +7,59 @@ field next: Ref
 
 field pf: Ref
 
-predicate c_Baz_shared(this: Ref) {
+predicate _c_Baz_shared(this: Ref) {
   true
 }
 
-predicate c_Baz_unique(this: Ref) {
+predicate _c_Baz_unique(this: Ref) {
   true
 }
 
-predicate c_PrimitiveFields_shared(this: Ref) {
+predicate _c_PrimitiveFields_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_PrimitiveFields_unique(this: Ref) {
+predicate _c_PrimitiveFields_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType()) &&
   acc(this.b, write) &&
   isSubtype(typeOf(this.b), intType())
 }
 
-predicate c_Recursive_unique(this: Ref) {
+predicate _c_Recursive_shared(this: Ref) {
   acc(this.next, wildcard) &&
-  (this.next != nullValue() ==> acc(shared(this.next), wildcard)) &&
-  isSubtype(typeOf(this.next), nullable(_c_Recursive()))
+  (this.next != nullValue() ==>
+  acc(_c_Recursive_shared(this.next), wildcard)) &&
+  isSubtype(typeOf(this.next), nullable(c_Recursive()))
 }
 
-predicate c_ReferenceField_shared(this: Ref) {
-  acc(this.pf, wildcard) &&
-  acc(c_PrimitiveFields_shared(this.pf), wildcard) &&
-  isSubtype(typeOf(this.pf), _c_PrimitiveFields()) &&
-  acc(c_Baz_shared(this), wildcard)
+predicate _c_Recursive_unique(this: Ref) {
+  acc(this.next, wildcard) &&
+  (this.next != nullValue() ==>
+  acc(_c_Recursive_shared(this.next), wildcard)) &&
+  isSubtype(typeOf(this.next), nullable(c_Recursive()))
 }
 
-predicate c_ReferenceField_unique(this: Ref) {
+predicate _c_ReferenceField_unique(this: Ref) {
   acc(this.pf, wildcard) &&
-  acc(c_PrimitiveFields_shared(this.pf), wildcard) &&
-  isSubtype(typeOf(this.pf), _c_PrimitiveFields()) &&
-  acc(c_Baz_unique(this), write)
+  acc(_c_PrimitiveFields_shared(this.pf), wildcard) &&
+  isSubtype(typeOf(this.pf), c_PrimitiveFields()) &&
+  acc(_c_Baz_unique(this), write)
 }
 
 predicate shared(this: Ref) {
-  acc(this.next, wildcard) &&
-  (this.next != nullValue() ==> acc(shared(this.next), wildcard)) &&
-  isSubtype(typeOf(this.next), nullable(_c_Recursive()))
+  acc(this.pf, wildcard) &&
+  acc(_c_PrimitiveFields_shared(this.pf), wildcard) &&
+  isSubtype(typeOf(this.pf), c_PrimitiveFields()) &&
+  acc(_c_Baz_shared(this), wildcard)
 }
 
 method useClasses(rf: Ref, rec: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceField())
-  requires isSubtype(typeOf(rec), _c_Recursive())
+  requires isSubtype(typeOf(rf), c_ReferenceField())
+  requires isSubtype(typeOf(rec), c_Recursive())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  inhale acc(c_ReferenceField_shared(rf), wildcard)
-  inhale acc(shared(rec), wildcard)
+  inhale acc(shared(rf), wildcard)
+  inhale acc(_c_Recursive_shared(rec), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -67,37 +69,37 @@ field x: Ref
 
 field y: Ref
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_shared(this: Ref) {
+  acc(this.x, wildcard) && isSubtype(typeOf(this.x), intType())
+}
+
+predicate _c_A_unique(this: Ref) {
   acc(this.x, wildcard) && isSubtype(typeOf(this.x), intType()) &&
   acc(this.y, write) &&
   isSubtype(typeOf(this.y), intType())
 }
 
-predicate c_B_shared(this: Ref) {
-  acc(shared(this), wildcard)
+predicate _c_B_shared(this: Ref) {
+  acc(_c_A_shared(this), wildcard)
 }
 
-predicate c_B_unique(this: Ref) {
-  acc(c_A_unique(this), write)
+predicate _c_B_unique(this: Ref) {
+  acc(_c_A_unique(this), write)
 }
 
-predicate c_C_shared(this: Ref) {
-  acc(c_B_shared(this), wildcard)
-}
-
-predicate c_C_unique(this: Ref) {
-  acc(c_B_unique(this), write)
+predicate _c_C_unique(this: Ref) {
+  acc(_c_B_unique(this), write)
 }
 
 predicate shared(this: Ref) {
-  acc(this.x, wildcard) && isSubtype(typeOf(this.x), intType())
+  acc(_c_B_shared(this), wildcard)
 }
 
 method threeLayersHierarchy(c: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(c), _c_C())
+  requires isSubtype(typeOf(c), c_C())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  inhale acc(c_C_shared(c), wildcard)
+  inhale acc(shared(c), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -105,66 +107,67 @@ method threeLayersHierarchy(c: Ref) returns (ret_0: Ref)
 /predicates.kt: info: Generated Viper text for listHierarchy:
 field size: Ref
 
-predicate c_Collection_shared(this: Ref) {
-  acc(c_Iterable_shared(this), wildcard)
+predicate collections_c_Collection_shared(this: Ref) {
+  acc(collections_c_Iterable_shared(this), wildcard)
 }
 
-predicate c_Collection_unique(this: Ref) {
-  acc(c_Iterable_unique(this), write)
+predicate collections_c_Collection_unique(this: Ref) {
+  acc(collections_c_Iterable_unique(this), write)
 }
 
-predicate c_Iterable_shared(this: Ref) {
+predicate collections_c_Iterable_shared(this: Ref) {
   true
 }
 
-predicate c_Iterable_unique(this: Ref) {
+predicate collections_c_Iterable_unique(this: Ref) {
   true
 }
 
-predicate c_List_shared(this: Ref) {
-  acc(c_Collection_shared(this), wildcard)
+predicate collections_c_List_shared(this: Ref) {
+  acc(collections_c_Collection_shared(this), wildcard)
 }
 
-predicate c_List_unique(this: Ref) {
-  acc(c_Collection_unique(this), write)
+predicate collections_c_List_unique(this: Ref) {
+  acc(collections_c_Collection_unique(this), write)
 }
 
-predicate c_MutableCollection_shared(this: Ref) {
-  acc(c_Collection_shared(this), wildcard) && acc(shared(this), wildcard)
+predicate collections_c_MutableCollection_shared(this: Ref) {
+  acc(collections_c_Collection_shared(this), wildcard) &&
+  acc(collections_c_MutableIterable_shared(this), wildcard)
 }
 
-predicate c_MutableCollection_unique(this: Ref) {
-  acc(c_Collection_unique(this), write) &&
-  acc(c_MutableIterable_unique(this), write)
+predicate collections_c_MutableCollection_unique(this: Ref) {
+  acc(collections_c_Collection_unique(this), write) &&
+  acc(collections_c_MutableIterable_unique(this), write)
 }
 
-predicate c_MutableIterable_unique(this: Ref) {
-  acc(c_Iterable_unique(this), write)
+predicate collections_c_MutableIterable_shared(this: Ref) {
+  acc(collections_c_Iterable_shared(this), wildcard)
 }
 
-predicate c_MutableList_shared(this: Ref) {
-  acc(c_List_shared(this), wildcard) &&
-  acc(c_MutableCollection_shared(this), wildcard)
+predicate collections_c_MutableIterable_unique(this: Ref) {
+  acc(collections_c_Iterable_unique(this), write)
 }
 
-predicate c_MutableList_unique(this: Ref) {
-  acc(c_List_unique(this), write) &&
-  acc(c_MutableCollection_unique(this), write)
+predicate collections_c_MutableList_unique(this: Ref) {
+  acc(collections_c_List_unique(this), write) &&
+  acc(collections_c_MutableCollection_unique(this), write)
 }
 
 predicate shared(this: Ref) {
-  acc(c_Iterable_shared(this), wildcard)
+  acc(collections_c_List_shared(this), wildcard) &&
+  acc(collections_c_MutableCollection_shared(this), wildcard)
 }
 
 method listHierarchy(xs: Ref) returns (ret_0: Ref)
   requires acc(xs.size, write)
   requires intFromRef(xs.size) >= 0
-  requires isSubtype(typeOf(xs), collections_c_MutableList())
+  requires isSubtype(typeOf(xs), c_MutableList())
   ensures acc(xs.size, write)
   ensures intFromRef(xs.size) >= 0
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  inhale acc(c_MutableList_shared(xs), wildcard)
+  inhale acc(shared(xs), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates.fir.diag.txt
@@ -7,59 +7,57 @@ field next: Ref
 
 field pf: Ref
 
-predicate _c_Baz_shared(this: Ref) {
+predicate Baz_shared(this: Ref) {
   true
 }
 
-predicate _c_Baz_unique(this: Ref) {
+predicate Baz_unique(this: Ref) {
   true
 }
 
-predicate _c_PrimitiveFields_unique(this: Ref) {
+predicate PrimitiveFields_shared(this: Ref) {
+  acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
+}
+
+predicate PrimitiveFields_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType()) &&
   acc(this.b, write) &&
   isSubtype(typeOf(this.b), intType())
 }
 
-predicate _c_Recursive_shared(this: Ref) {
+predicate Recursive_shared(this: Ref) {
   acc(this.next, wildcard) &&
-  (this.next != nullValue() ==>
-  acc(_c_Recursive_shared(this.next), wildcard)) &&
-  isSubtype(typeOf(this.next), nullable(c_Recursive()))
+  (this.next != nullValue() ==> acc(Recursive_shared(this.next), wildcard)) &&
+  isSubtype(typeOf(this.next), nullable(Recursive()))
 }
 
-predicate _c_Recursive_unique(this: Ref) {
+predicate Recursive_unique(this: Ref) {
   acc(this.next, wildcard) &&
-  (this.next != nullValue() ==>
-  acc(_c_Recursive_shared(this.next), wildcard)) &&
-  isSubtype(typeOf(this.next), nullable(c_Recursive()))
+  (this.next != nullValue() ==> acc(Recursive_shared(this.next), wildcard)) &&
+  isSubtype(typeOf(this.next), nullable(Recursive()))
 }
 
-predicate _c_ReferenceField_shared(this: Ref) {
-  acc(this.pf, wildcard) && acc(shared(this.pf), wildcard) &&
-  isSubtype(typeOf(this.pf), c_PrimitiveFields()) &&
-  acc(_c_Baz_shared(this), wildcard)
+predicate ReferenceField_shared(this: Ref) {
+  acc(this.pf, wildcard) && acc(PrimitiveFields_shared(this.pf), wildcard) &&
+  isSubtype(typeOf(this.pf), PrimitiveFields()) &&
+  acc(Baz_shared(this), wildcard)
 }
 
-predicate _c_ReferenceField_unique(this: Ref) {
-  acc(this.pf, wildcard) && acc(shared(this.pf), wildcard) &&
-  isSubtype(typeOf(this.pf), c_PrimitiveFields()) &&
-  acc(_c_Baz_unique(this), write)
+predicate ReferenceField_unique(this: Ref) {
+  acc(this.pf, wildcard) && acc(PrimitiveFields_shared(this.pf), wildcard) &&
+  isSubtype(typeOf(this.pf), PrimitiveFields()) &&
+  acc(Baz_unique(this), write)
 }
 
-predicate shared(this: Ref) {
-  acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
-}
-
-method useClasses(rf: Ref, rec: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceField())
-  requires isSubtype(typeOf(rec), c_Recursive())
-  ensures isSubtype(typeOf(ret), unitType())
+method useClasses(rf: Ref, rec: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceField())
+  requires isSubtype(typeOf(rec), Recursive())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(_c_ReferenceField_shared(rf), wildcard)
-  inhale acc(_c_Recursive_shared(rec), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(ReferenceField_shared(rf), wildcard)
+  inhale acc(Recursive_shared(rec), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /predicates.kt: info: Generated Viper text for threeLayersHierarchy:
@@ -67,105 +65,105 @@ field x: Ref
 
 field y: Ref
 
-predicate _c_A_shared(this: Ref) {
+predicate A_shared(this: Ref) {
   acc(this.x, wildcard) && isSubtype(typeOf(this.x), intType())
 }
 
-predicate _c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.x, wildcard) && isSubtype(typeOf(this.x), intType()) &&
   acc(this.y, write) &&
   isSubtype(typeOf(this.y), intType())
 }
 
-predicate _c_B_shared(this: Ref) {
-  acc(_c_A_shared(this), wildcard)
+predicate B_shared(this: Ref) {
+  acc(A_shared(this), wildcard)
 }
 
-predicate _c_B_unique(this: Ref) {
-  acc(_c_A_unique(this), write)
+predicate B_unique(this: Ref) {
+  acc(A_unique(this), write)
 }
 
-predicate _c_C_unique(this: Ref) {
-  acc(_c_B_unique(this), write)
+predicate C_shared(this: Ref) {
+  acc(B_shared(this), wildcard)
 }
 
-predicate shared(this: Ref) {
-  acc(_c_B_shared(this), wildcard)
+predicate C_unique(this: Ref) {
+  acc(B_unique(this), write)
 }
 
-method threeLayersHierarchy(c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(c), c_C())
-  ensures isSubtype(typeOf(ret), unitType())
+method threeLayersHierarchy(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(c), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(C_shared(c), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /predicates.kt: info: Generated Viper text for listHierarchy:
 field size: Ref
 
-predicate collections_c_Collection_shared(this: Ref) {
-  acc(collections_c_Iterable_shared(this), wildcard)
+predicate Collection_shared(this: Ref) {
+  acc(Iterable_shared(this), wildcard)
 }
 
-predicate collections_c_Collection_unique(this: Ref) {
-  acc(collections_c_Iterable_unique(this), write)
+predicate Collection_unique(this: Ref) {
+  acc(Iterable_unique(this), write)
 }
 
-predicate collections_c_Iterable_shared(this: Ref) {
+predicate Iterable_shared(this: Ref) {
   true
 }
 
-predicate collections_c_Iterable_unique(this: Ref) {
+predicate Iterable_unique(this: Ref) {
   true
 }
 
-predicate collections_c_List_unique(this: Ref) {
-  acc(collections_c_Collection_unique(this), write)
+predicate List_shared(this: Ref) {
+  acc(Collection_shared(this), wildcard)
 }
 
-predicate collections_c_MutableCollection_shared(this: Ref) {
-  acc(collections_c_Collection_shared(this), wildcard) &&
-  acc(collections_c_MutableIterable_shared(this), wildcard)
+predicate List_unique(this: Ref) {
+  acc(Collection_unique(this), write)
 }
 
-predicate collections_c_MutableCollection_unique(this: Ref) {
-  acc(collections_c_Collection_unique(this), write) &&
-  acc(collections_c_MutableIterable_unique(this), write)
+predicate MutableCollection_shared(this: Ref) {
+  acc(Collection_shared(this), wildcard) &&
+  acc(MutableIterable_shared(this), wildcard)
 }
 
-predicate collections_c_MutableIterable_shared(this: Ref) {
-  acc(collections_c_Iterable_shared(this), wildcard)
+predicate MutableCollection_unique(this: Ref) {
+  acc(Collection_unique(this), write) &&
+  acc(MutableIterable_unique(this), write)
 }
 
-predicate collections_c_MutableIterable_unique(this: Ref) {
-  acc(collections_c_Iterable_unique(this), write)
+predicate MutableIterable_shared(this: Ref) {
+  acc(Iterable_shared(this), wildcard)
 }
 
-predicate collections_c_MutableList_shared(this: Ref) {
-  acc(shared(this), wildcard) &&
-  acc(collections_c_MutableCollection_shared(this), wildcard)
+predicate MutableIterable_unique(this: Ref) {
+  acc(Iterable_unique(this), write)
 }
 
-predicate collections_c_MutableList_unique(this: Ref) {
-  acc(collections_c_List_unique(this), write) &&
-  acc(collections_c_MutableCollection_unique(this), write)
+predicate MutableList_shared(this: Ref) {
+  acc(List_shared(this), wildcard) &&
+  acc(MutableCollection_shared(this), wildcard)
 }
 
-predicate shared(this: Ref) {
-  acc(collections_c_Collection_shared(this), wildcard)
+predicate MutableList_unique(this: Ref) {
+  acc(List_unique(this), write) &&
+  acc(MutableCollection_unique(this), write)
 }
 
-method listHierarchy(xs: Ref) returns (ret: Ref)
+method listHierarchy(xs: Ref) returns (v_ret_0: Ref)
   requires acc(xs.size, write)
   requires intFromRef(xs.size) >= 0
-  requires isSubtype(typeOf(xs), c_MutableList())
+  requires isSubtype(typeOf(xs), MutableList())
   ensures acc(xs.size, write)
   ensures intFromRef(xs.size) >= 0
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(collections_c_MutableList_shared(xs), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(MutableList_shared(xs), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
@@ -7,64 +7,64 @@ field x: Ref
 
 field y: Ref
 
-predicate c_A_shared(this: Ref) {
+predicate _c_A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_B_unique(this: Ref) {
+predicate _c_B_shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_unique(this), write)
+  acc(_c_A_shared(this), wildcard)
 }
 
-predicate c_C_shared(this: Ref) {
-  acc(this.x, wildcard) && acc(c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), _c_A()) &&
-  acc(c_D_shared(this), wildcard) &&
-  acc(shared(this), wildcard)
+predicate _c_B_unique(this: Ref) {
+  acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
+  acc(_c_A_unique(this), write)
 }
 
-predicate c_C_unique(this: Ref) {
-  acc(this.x, wildcard) && acc(c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), _c_A()) &&
+predicate _c_C_shared(this: Ref) {
+  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), c_A()) &&
+  acc(shared(this), wildcard) &&
+  acc(_c_B_shared(this), wildcard)
+}
+
+predicate _c_C_unique(this: Ref) {
+  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), c_A()) &&
   acc(this.y, write) &&
-  acc(c_A_shared(this.y), wildcard) &&
-  isSubtype(typeOf(this.y), _c_A()) &&
-  acc(c_D_unique(this), write) &&
-  acc(c_B_unique(this), write)
+  acc(_c_A_shared(this.y), wildcard) &&
+  isSubtype(typeOf(this.y), c_A()) &&
+  acc(_c_D_unique(this), write) &&
+  acc(_c_B_unique(this), write)
 }
 
-predicate c_D_shared(this: Ref) {
-  true
-}
-
-predicate c_D_unique(this: Ref) {
+predicate _c_D_unique(this: Ref) {
   true
 }
 
 predicate shared(this: Ref) {
-  acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_shared(this), wildcard)
+  true
 }
 
-method accessSuperTypeProperty(c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(c), _c_C())
-  ensures isSubtype(typeOf(ret), unitType())
+method accessSuperTypeProperty(c: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(c), c_C())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var temp: Ref
-  inhale acc(c_C_shared(c), wildcard)
-  unfold acc(c_C_shared(c), wildcard)
-  unfold acc(shared(c), wildcard)
-  unfold acc(c_A_shared(c), wildcard)
+  inhale acc(_c_C_shared(c), wildcard)
+  unfold acc(_c_C_shared(c), wildcard)
+  unfold acc(_c_B_shared(c), wildcard)
+  unfold acc(_c_A_shared(c), wildcard)
   temp := c.a
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method d(this: Ref) returns (v_ret: Ref)
+method d(this: Ref) returns (ret: Ref)
 
 
 /predicates_access.kt: info: Generated Viper text for accessNested:
@@ -76,71 +76,71 @@ field x: Ref
 
 field y: Ref
 
-predicate c_A_shared(this: Ref) {
+predicate _c_A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_B_unique(this: Ref) {
+predicate _c_B_shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_unique(this), write)
+  acc(_c_A_shared(this), wildcard)
 }
 
-predicate c_C_shared(this: Ref) {
-  acc(this.x, wildcard) && acc(c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), _c_A()) &&
-  acc(c_D_shared(this), wildcard) &&
-  acc(shared(this), wildcard)
+predicate _c_B_unique(this: Ref) {
+  acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
+  acc(_c_A_unique(this), write)
 }
 
-predicate c_C_unique(this: Ref) {
-  acc(this.x, wildcard) && acc(c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), _c_A()) &&
+predicate _c_C_shared(this: Ref) {
+  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), c_A()) &&
+  acc(shared(this), wildcard) &&
+  acc(_c_B_shared(this), wildcard)
+}
+
+predicate _c_C_unique(this: Ref) {
+  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), c_A()) &&
   acc(this.y, write) &&
-  acc(c_A_shared(this.y), wildcard) &&
-  isSubtype(typeOf(this.y), _c_A()) &&
-  acc(c_D_unique(this), write) &&
-  acc(c_B_unique(this), write)
+  acc(_c_A_shared(this.y), wildcard) &&
+  isSubtype(typeOf(this.y), c_A()) &&
+  acc(_c_D_unique(this), write) &&
+  acc(_c_B_unique(this), write)
 }
 
-predicate c_D_shared(this: Ref) {
-  true
-}
-
-predicate c_D_unique(this: Ref) {
+predicate _c_D_unique(this: Ref) {
   true
 }
 
 predicate shared(this: Ref) {
-  acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_shared(this), wildcard)
+  true
 }
 
-method accessNested(c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(c), _c_C())
-  ensures isSubtype(typeOf(ret), unitType())
+method accessNested(c: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(c), c_C())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var temp: Ref
   var anon: Ref
-  inhale acc(c_C_shared(c), wildcard)
-  unfold acc(c_C_shared(c), wildcard)
+  inhale acc(_c_C_shared(c), wildcard)
+  unfold acc(_c_C_shared(c), wildcard)
   anon := c.x
-  unfold acc(c_A_shared(anon), wildcard)
+  unfold acc(_c_A_shared(anon), wildcard)
   temp := anon.a
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method d(this: Ref) returns (v_ret: Ref)
+method d(this: Ref) returns (ret: Ref)
 
 
 /predicates_access.kt: info: Generated Viper text for accessNullable:
 field a: Ref
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
@@ -149,7 +149,7 @@ predicate shared(this: Ref) {
 }
 
 method accessNullable(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), nullable(_c_A()))
+  requires isSubtype(typeOf(x), nullable(c_A()))
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var n: Ref
@@ -167,31 +167,31 @@ field a: Ref
 
 field b: Ref
 
-predicate c_A_shared(this: Ref) {
+predicate _c_A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_B_unique(this: Ref) {
+predicate _c_B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_unique(this), write)
+  acc(_c_A_unique(this), write)
 }
 
 predicate shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_shared(this), wildcard)
+  acc(_c_A_shared(this), wildcard)
 }
 
 method accessCast(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), _c_A())
+  requires isSubtype(typeOf(x), c_A())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var n: Ref
-  inhale acc(c_A_shared(x), wildcard)
-  inhale isSubtype(typeOf(x), _c_B())
+  inhale acc(_c_A_shared(x), wildcard)
+  inhale isSubtype(typeOf(x), c_B())
   inhale acc(shared(x), wildcard)
   unfold acc(shared(x), wildcard)
   n := x.b
@@ -204,37 +204,37 @@ field a: Ref
 
 field b: Ref
 
-predicate c_A_shared(this: Ref) {
+predicate _c_A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_B_unique(this: Ref) {
+predicate _c_B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_unique(this), write)
+  acc(_c_A_unique(this), write)
 }
 
 predicate shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_shared(this), wildcard)
+  acc(_c_A_shared(this), wildcard)
 }
 
 method accessSafeCast(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), _c_A())
+  requires isSubtype(typeOf(x), c_A())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var n: Ref
   var y: Ref
-  inhale acc(c_A_shared(x), wildcard)
+  inhale acc(_c_A_shared(x), wildcard)
   n := intToRef(0)
-  if (isSubtype(typeOf(x), _c_B())) {
+  if (isSubtype(typeOf(x), c_B())) {
     y := x
   } else {
     y := nullValue()}
-  inhale isSubtype(typeOf(y), nullable(_c_B()))
+  inhale isSubtype(typeOf(y), nullable(c_B()))
   inhale y != nullValue() ==> acc(shared(y), wildcard)
   if (!(y == nullValue())) {
     unfold acc(shared(y), wildcard)
@@ -249,32 +249,32 @@ field a: Ref
 
 field b: Ref
 
-predicate c_A_shared(this: Ref) {
+predicate _c_A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate c_B_unique(this: Ref) {
+predicate _c_B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_unique(this), write)
+  acc(_c_A_unique(this), write)
 }
 
 predicate shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(c_A_shared(this), wildcard)
+  acc(_c_A_shared(this), wildcard)
 }
 
 method accessSmartCast(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), _c_A())
+  requires isSubtype(typeOf(x), c_A())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var n: Ref
-  inhale acc(c_A_shared(x), wildcard)
+  inhale acc(_c_A_shared(x), wildcard)
   n := intToRef(0)
-  if (isSubtype(typeOf(x), _c_B())) {
+  if (isSubtype(typeOf(x), c_B())) {
     inhale acc(shared(x), wildcard)
     unfold acc(shared(x), wildcard)
     n := x.b

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
@@ -50,9 +50,9 @@ predicate shared(this: Ref) {
   true
 }
 
-method accessSuperTypeProperty(c: Ref) returns (ret_0: Ref)
+method accessSuperTypeProperty(c: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(c), c_C())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var temp: Ref
   inhale acc(_c_C_shared(c), wildcard)
@@ -60,11 +60,11 @@ method accessSuperTypeProperty(c: Ref) returns (ret_0: Ref)
   unfold acc(_c_B_shared(c), wildcard)
   unfold acc(_c_A_shared(c), wildcard)
   temp := c.a
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method d(this: Ref) returns (ret: Ref)
+method d(this: Ref) returns (v_ret: Ref)
 
 
 /predicates_access.kt: info: Generated Viper text for accessNested:
@@ -119,9 +119,9 @@ predicate shared(this: Ref) {
   true
 }
 
-method accessNested(c: Ref) returns (ret_0: Ref)
+method accessNested(c: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(c), c_C())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var temp: Ref
   var anon: Ref
@@ -130,11 +130,11 @@ method accessNested(c: Ref) returns (ret_0: Ref)
   anon := c.x
   unfold acc(_c_A_shared(anon), wildcard)
   temp := anon.a
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method d(this: Ref) returns (ret: Ref)
+method d(this: Ref) returns (v_ret: Ref)
 
 
 /predicates_access.kt: info: Generated Viper text for accessNullable:
@@ -148,9 +148,9 @@ predicate shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-method accessNullable(x: Ref) returns (ret_0: Ref)
+method accessNullable(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), nullable(c_A()))
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var n: Ref
   inhale x != nullValue() ==> acc(shared(x), wildcard)
@@ -158,8 +158,8 @@ method accessNullable(x: Ref) returns (ret_0: Ref)
     unfold acc(shared(x), wildcard)
     n := x.a
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /predicates_access.kt: info: Generated Viper text for accessCast:
@@ -185,9 +185,9 @@ predicate shared(this: Ref) {
   acc(_c_A_shared(this), wildcard)
 }
 
-method accessCast(x: Ref) returns (ret_0: Ref)
+method accessCast(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), c_A())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var n: Ref
   inhale acc(_c_A_shared(x), wildcard)
@@ -195,8 +195,8 @@ method accessCast(x: Ref) returns (ret_0: Ref)
   inhale acc(shared(x), wildcard)
   unfold acc(shared(x), wildcard)
   n := x.b
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /predicates_access.kt: info: Generated Viper text for accessSafeCast:
@@ -222,9 +222,9 @@ predicate shared(this: Ref) {
   acc(_c_A_shared(this), wildcard)
 }
 
-method accessSafeCast(x: Ref) returns (ret_0: Ref)
+method accessSafeCast(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), c_A())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var n: Ref
   var y: Ref
@@ -240,8 +240,8 @@ method accessSafeCast(x: Ref) returns (ret_0: Ref)
     unfold acc(shared(y), wildcard)
     n := y.b
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /predicates_access.kt: info: Generated Viper text for accessSmartCast:
@@ -267,9 +267,9 @@ predicate shared(this: Ref) {
   acc(_c_A_shared(this), wildcard)
 }
 
-method accessSmartCast(x: Ref) returns (ret_0: Ref)
+method accessSmartCast(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), c_A())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var n: Ref
   inhale acc(_c_A_shared(x), wildcard)
@@ -279,6 +279,6 @@ method accessSmartCast(x: Ref) returns (ret_0: Ref)
     unfold acc(shared(x), wildcard)
     n := x.b
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/predicates_access.fir.diag.txt
@@ -7,61 +7,61 @@ field x: Ref
 
 field y: Ref
 
-predicate _c_A_shared(this: Ref) {
+predicate A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_B_shared(this: Ref) {
+predicate B_shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_shared(this), wildcard)
+  acc(A_shared(this), wildcard)
 }
 
-predicate _c_B_unique(this: Ref) {
+predicate B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_unique(this), write)
+  acc(A_unique(this), write)
 }
 
-predicate _c_C_shared(this: Ref) {
-  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), c_A()) &&
-  acc(shared(this), wildcard) &&
-  acc(_c_B_shared(this), wildcard)
+predicate C_shared(this: Ref) {
+  acc(this.x, wildcard) && acc(A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), A()) &&
+  acc(D_shared(this), wildcard) &&
+  acc(B_shared(this), wildcard)
 }
 
-predicate _c_C_unique(this: Ref) {
-  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), c_A()) &&
+predicate C_unique(this: Ref) {
+  acc(this.x, wildcard) && acc(A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), A()) &&
   acc(this.y, write) &&
-  acc(_c_A_shared(this.y), wildcard) &&
-  isSubtype(typeOf(this.y), c_A()) &&
-  acc(_c_D_unique(this), write) &&
-  acc(_c_B_unique(this), write)
+  acc(A_shared(this.y), wildcard) &&
+  isSubtype(typeOf(this.y), A()) &&
+  acc(D_unique(this), write) &&
+  acc(B_unique(this), write)
 }
 
-predicate _c_D_unique(this: Ref) {
+predicate D_shared(this: Ref) {
   true
 }
 
-predicate shared(this: Ref) {
+predicate D_unique(this: Ref) {
   true
 }
 
-method accessSuperTypeProperty(c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(c), c_C())
-  ensures isSubtype(typeOf(ret), unitType())
+method accessSuperTypeProperty(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var temp: Ref
-  inhale acc(_c_C_shared(c), wildcard)
-  unfold acc(_c_C_shared(c), wildcard)
-  unfold acc(_c_B_shared(c), wildcard)
-  unfold acc(_c_A_shared(c), wildcard)
+  inhale acc(C_shared(c), wildcard)
+  unfold acc(C_shared(c), wildcard)
+  unfold acc(B_shared(c), wildcard)
+  unfold acc(A_shared(c), wildcard)
   temp := c.a
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method d(this: Ref) returns (v_ret: Ref)
@@ -76,62 +76,62 @@ field x: Ref
 
 field y: Ref
 
-predicate _c_A_shared(this: Ref) {
+predicate A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_B_shared(this: Ref) {
+predicate B_shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_shared(this), wildcard)
+  acc(A_shared(this), wildcard)
 }
 
-predicate _c_B_unique(this: Ref) {
+predicate B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_unique(this), write)
+  acc(A_unique(this), write)
 }
 
-predicate _c_C_shared(this: Ref) {
-  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), c_A()) &&
-  acc(shared(this), wildcard) &&
-  acc(_c_B_shared(this), wildcard)
+predicate C_shared(this: Ref) {
+  acc(this.x, wildcard) && acc(A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), A()) &&
+  acc(D_shared(this), wildcard) &&
+  acc(B_shared(this), wildcard)
 }
 
-predicate _c_C_unique(this: Ref) {
-  acc(this.x, wildcard) && acc(_c_A_shared(this.x), wildcard) &&
-  isSubtype(typeOf(this.x), c_A()) &&
+predicate C_unique(this: Ref) {
+  acc(this.x, wildcard) && acc(A_shared(this.x), wildcard) &&
+  isSubtype(typeOf(this.x), A()) &&
   acc(this.y, write) &&
-  acc(_c_A_shared(this.y), wildcard) &&
-  isSubtype(typeOf(this.y), c_A()) &&
-  acc(_c_D_unique(this), write) &&
-  acc(_c_B_unique(this), write)
+  acc(A_shared(this.y), wildcard) &&
+  isSubtype(typeOf(this.y), A()) &&
+  acc(D_unique(this), write) &&
+  acc(B_unique(this), write)
 }
 
-predicate _c_D_unique(this: Ref) {
+predicate D_shared(this: Ref) {
   true
 }
 
-predicate shared(this: Ref) {
+predicate D_unique(this: Ref) {
   true
 }
 
-method accessNested(c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(c), c_C())
-  ensures isSubtype(typeOf(ret), unitType())
+method accessNested(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var temp: Ref
   var anon: Ref
-  inhale acc(_c_C_shared(c), wildcard)
-  unfold acc(_c_C_shared(c), wildcard)
+  inhale acc(C_shared(c), wildcard)
+  unfold acc(C_shared(c), wildcard)
   anon := c.x
-  unfold acc(_c_A_shared(anon), wildcard)
+  unfold acc(A_shared(anon), wildcard)
   temp := anon.a
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method d(this: Ref) returns (v_ret: Ref)
@@ -140,7 +140,7 @@ method d(this: Ref) returns (v_ret: Ref)
 /predicates_access.kt: info: Generated Viper text for accessNullable:
 field a: Ref
 
-predicate _c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
@@ -148,9 +148,9 @@ predicate shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-method accessNullable(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), nullable(c_A()))
-  ensures isSubtype(typeOf(ret), unitType())
+method accessNullable(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), nullable(A()))
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var n: Ref
   inhale x != nullValue() ==> acc(shared(x), wildcard)
@@ -158,8 +158,8 @@ method accessNullable(x: Ref) returns (ret: Ref)
     unfold acc(shared(x), wildcard)
     n := x.a
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /predicates_access.kt: info: Generated Viper text for accessCast:
@@ -167,36 +167,36 @@ field a: Ref
 
 field b: Ref
 
-predicate _c_A_shared(this: Ref) {
+predicate A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_B_unique(this: Ref) {
+predicate B_shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_unique(this), write)
+  acc(A_shared(this), wildcard)
 }
 
-predicate shared(this: Ref) {
+predicate B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_shared(this), wildcard)
+  acc(A_unique(this), write)
 }
 
-method accessCast(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), c_A())
-  ensures isSubtype(typeOf(ret), unitType())
+method accessCast(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), A())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var n: Ref
-  inhale acc(_c_A_shared(x), wildcard)
-  inhale isSubtype(typeOf(x), c_B())
-  inhale acc(shared(x), wildcard)
-  unfold acc(shared(x), wildcard)
+  inhale acc(A_shared(x), wildcard)
+  inhale isSubtype(typeOf(x), B())
+  inhale acc(B_shared(x), wildcard)
+  unfold acc(B_shared(x), wildcard)
   n := x.b
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /predicates_access.kt: info: Generated Viper text for accessSafeCast:
@@ -204,44 +204,44 @@ field a: Ref
 
 field b: Ref
 
-predicate _c_A_shared(this: Ref) {
+predicate A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_B_unique(this: Ref) {
+predicate B_shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_unique(this), write)
+  acc(A_shared(this), wildcard)
 }
 
-predicate shared(this: Ref) {
+predicate B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_shared(this), wildcard)
+  acc(A_unique(this), write)
 }
 
-method accessSafeCast(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), c_A())
-  ensures isSubtype(typeOf(ret), unitType())
+method accessSafeCast(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), A())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var n: Ref
   var y: Ref
-  inhale acc(_c_A_shared(x), wildcard)
+  inhale acc(A_shared(x), wildcard)
   n := intToRef(0)
-  if (isSubtype(typeOf(x), c_B())) {
+  if (isSubtype(typeOf(x), B())) {
     y := x
   } else {
     y := nullValue()}
-  inhale isSubtype(typeOf(y), nullable(c_B()))
-  inhale y != nullValue() ==> acc(shared(y), wildcard)
+  inhale isSubtype(typeOf(y), nullable(B()))
+  inhale y != nullValue() ==> acc(B_shared(y), wildcard)
   if (!(y == nullValue())) {
-    unfold acc(shared(y), wildcard)
+    unfold acc(B_shared(y), wildcard)
     n := y.b
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /predicates_access.kt: info: Generated Viper text for accessSmartCast:
@@ -249,36 +249,36 @@ field a: Ref
 
 field b: Ref
 
-predicate _c_A_shared(this: Ref) {
+predicate A_shared(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.a, wildcard) && isSubtype(typeOf(this.a), intType())
 }
 
-predicate _c_B_unique(this: Ref) {
+predicate B_shared(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_unique(this), write)
+  acc(A_shared(this), wildcard)
 }
 
-predicate shared(this: Ref) {
+predicate B_unique(this: Ref) {
   acc(this.b, wildcard) && isSubtype(typeOf(this.b), intType()) &&
-  acc(_c_A_shared(this), wildcard)
+  acc(A_unique(this), write)
 }
 
-method accessSmartCast(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), c_A())
-  ensures isSubtype(typeOf(ret), unitType())
+method accessSmartCast(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), A())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var n: Ref
-  inhale acc(_c_A_shared(x), wildcard)
+  inhale acc(A_shared(x), wildcard)
   n := intToRef(0)
-  if (isSubtype(typeOf(x), c_B())) {
-    inhale acc(shared(x), wildcard)
-    unfold acc(shared(x), wildcard)
+  if (isSubtype(typeOf(x), B())) {
+    inhale acc(B_shared(x), wildcard)
+    unfold acc(B_shared(x), wildcard)
     n := x.b
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
@@ -6,9 +6,9 @@ field bf_b: Ref
 method con(a: Ref, b: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), intType())
   requires isSubtype(typeOf(b), intType())
-  ensures isSubtype(typeOf(ret), _c_PrimitiveFields())
+  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_PrimitiveFields_unique(ret), write)
+  ensures acc(_c_PrimitiveFields_unique(ret), write)
   ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_a)) ==
     intFromRef(a) &&
     intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_b)) ==
@@ -16,7 +16,7 @@ method con(a: Ref, b: Ref) returns (ret: Ref)
 
 
 method createPrimitiveFields() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), _c_PrimitiveFields())
+  ensures isSubtype(typeOf(ret_0), c_PrimitiveFields())
   ensures acc(shared(ret_0), wildcard)
 {
   ret_0 := con(intToRef(10), intToRef(20))
@@ -28,15 +28,15 @@ method createPrimitiveFields() returns (ret_0: Ref)
 field bf_a: Ref
 
 method con(a: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(a), nullable(_c_Recursive()))
-  ensures isSubtype(typeOf(ret), _c_Recursive())
+  requires isSubtype(typeOf(a), nullable(c_Recursive()))
+  ensures isSubtype(typeOf(ret), c_Recursive())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_Recursive_unique(ret), write)
+  ensures acc(_c_Recursive_unique(ret), write)
   ensures (unfolding acc(shared(ret), wildcard) in ret.bf_a) == a
 
 
 method createRecursive() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), _c_Recursive())
+  ensures isSubtype(typeOf(ret_0), c_Recursive())
   ensures acc(shared(ret_0), wildcard)
 {
   ret_0 := con(nullValue())
@@ -51,15 +51,15 @@ field bf_c: Ref
 
 method con(c: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(c), intType())
-  ensures isSubtype(typeOf(ret), _c_FieldInBody())
+  ensures isSubtype(typeOf(ret), c_FieldInBody())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_FieldInBody_unique(ret), write)
+  ensures acc(_c_FieldInBody_unique(ret), write)
   ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_c)) ==
     intFromRef(c)
 
 
 method createFieldInBody() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), _c_FieldInBody())
+  ensures isSubtype(typeOf(ret_0), c_FieldInBody())
   ensures acc(shared(ret_0), wildcard)
 {
   ret_0 := con(intToRef(10))

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
@@ -3,45 +3,45 @@ field bf_a: Ref
 
 field bf_b: Ref
 
-method con(a: Ref, b: Ref) returns (ret: Ref)
+method con(a: Ref, b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(a), intType())
   requires isSubtype(typeOf(b), intType())
-  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_PrimitiveFields_unique(ret), write)
-  ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_a)) ==
+  ensures isSubtype(typeOf(v_ret), c_PrimitiveFields())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_PrimitiveFields_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a)) ==
     intFromRef(a) &&
-    intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_b)) ==
+    intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_b)) ==
     intFromRef(b)
 
 
-method createPrimitiveFields() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), c_PrimitiveFields())
-  ensures acc(shared(ret_0), wildcard)
+method createPrimitiveFields() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
+  ensures acc(shared(ret), wildcard)
 {
-  ret_0 := con(intToRef(10), intToRef(20))
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := con(intToRef(10), intToRef(20))
+  goto ret_0
+  label ret_0
 }
 
 /primary_constructors.kt: info: Generated Viper text for createRecursive:
 field bf_a: Ref
 
-method con(a: Ref) returns (ret: Ref)
+method con(a: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(a), nullable(c_Recursive()))
+  ensures isSubtype(typeOf(v_ret), c_Recursive())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_Recursive_unique(v_ret), write)
+  ensures (unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a) == a
+
+
+method createRecursive() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), c_Recursive())
   ensures acc(shared(ret), wildcard)
-  ensures acc(_c_Recursive_unique(ret), write)
-  ensures (unfolding acc(shared(ret), wildcard) in ret.bf_a) == a
-
-
-method createRecursive() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), c_Recursive())
-  ensures acc(shared(ret_0), wildcard)
 {
-  ret_0 := con(nullValue())
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := con(nullValue())
+  goto ret_0
+  label ret_0
 }
 
 /primary_constructors.kt: info: Generated Viper text for createFieldInBody:
@@ -49,20 +49,20 @@ field a: Ref
 
 field bf_c: Ref
 
-method con(c: Ref) returns (ret: Ref)
+method con(c: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(c), intType())
-  ensures isSubtype(typeOf(ret), c_FieldInBody())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_FieldInBody_unique(ret), write)
-  ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_c)) ==
+  ensures isSubtype(typeOf(v_ret), c_FieldInBody())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_FieldInBody_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_c)) ==
     intFromRef(c)
 
 
-method createFieldInBody() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), c_FieldInBody())
-  ensures acc(shared(ret_0), wildcard)
+method createFieldInBody() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_FieldInBody())
+  ensures acc(shared(ret), wildcard)
 {
-  ret_0 := con(intToRef(10))
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := con(intToRef(10))
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/primary_constructors.fir.diag.txt
@@ -3,45 +3,45 @@ field bf_a: Ref
 
 field bf_b: Ref
 
-method con(a: Ref, b: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(a), intType())
-  requires isSubtype(typeOf(b), intType())
-  ensures isSubtype(typeOf(v_ret), c_PrimitiveFields())
+method con(par_a: Ref, par_b: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_b), intType())
+  ensures isSubtype(typeOf(v_ret), PrimitiveFields())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_PrimitiveFields_unique(v_ret), write)
+  ensures acc(PrimitiveFields_unique(v_ret), write)
   ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a)) ==
-    intFromRef(a) &&
+    intFromRef(par_a) &&
     intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_b)) ==
-    intFromRef(b)
+    intFromRef(par_b)
 
 
-method createPrimitiveFields() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_PrimitiveFields())
-  ensures acc(shared(ret), wildcard)
+method createPrimitiveFields() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), PrimitiveFields())
+  ensures acc(shared(v_ret_0), wildcard)
 {
-  ret := con(intToRef(10), intToRef(20))
-  goto ret_0
-  label ret_0
+  v_ret_0 := con(intToRef(10), intToRef(20))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /primary_constructors.kt: info: Generated Viper text for createRecursive:
 field bf_a: Ref
 
-method con(a: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(a), nullable(c_Recursive()))
-  ensures isSubtype(typeOf(v_ret), c_Recursive())
+method con(par_a: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_a), nullable(Recursive()))
+  ensures isSubtype(typeOf(v_ret), Recursive())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_Recursive_unique(v_ret), write)
-  ensures (unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a) == a
+  ensures acc(Recursive_unique(v_ret), write)
+  ensures (unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a) == par_a
 
 
-method createRecursive() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Recursive())
-  ensures acc(shared(ret), wildcard)
+method createRecursive() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), Recursive())
+  ensures acc(shared(v_ret_0), wildcard)
 {
-  ret := con(nullValue())
-  goto ret_0
-  label ret_0
+  v_ret_0 := con(nullValue())
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /primary_constructors.kt: info: Generated Viper text for createFieldInBody:
@@ -49,20 +49,20 @@ field a: Ref
 
 field bf_c: Ref
 
-method con(c: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(c), intType())
-  ensures isSubtype(typeOf(v_ret), c_FieldInBody())
+method con(par_c: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_c), intType())
+  ensures isSubtype(typeOf(v_ret), FieldInBody())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_FieldInBody_unique(v_ret), write)
+  ensures acc(FieldInBody_unique(v_ret), write)
   ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_c)) ==
-    intFromRef(c)
+    intFromRef(par_c)
 
 
-method createFieldInBody() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_FieldInBody())
-  ensures acc(shared(ret), wildcard)
+method createFieldInBody() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), FieldInBody())
+  ensures acc(shared(v_ret_0), wildcard)
 {
-  ret := con(intToRef(10))
-  goto ret_0
-  label ret_0
+  v_ret_0 := con(intToRef(10))
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
@@ -1,70 +1,70 @@
 /property_getters.kt: info: Generated Viper text for testPrimitivePropertyGetter:
-method nProp(this: Ref) returns (v_ret: Ref)
+method nProp(this: Ref) returns (ret: Ref)
 
 
-method testPrimitivePropertyGetter(pp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pp), _c_PrimitiveProperty())
-  ensures isSubtype(typeOf(ret), intType())
+method testPrimitivePropertyGetter(pp: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(pp), c_PrimitiveProperty())
+  ensures isSubtype(typeOf(ret_0), intType())
 {
   var anon: Ref
   inhale acc(shared(pp), wildcard)
   anon := nProp(pp)
-  ret := anon
-  inhale isSubtype(typeOf(ret), intType())
-  goto ret_0
-  label ret_0
+  ret_0 := anon
+  inhale isSubtype(typeOf(ret_0), intType())
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /property_getters.kt: info: Generated Viper text for testReferencePropertyGetter:
-method nProp(this: Ref) returns (v_ret: Ref)
+method nProp(this: Ref) returns (ret: Ref)
 
 
-method rProp(this: Ref) returns (v_ret: Ref)
+method rProp(this: Ref) returns (ret: Ref)
 
 
-method testReferencePropertyGetter(rp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rp), _c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferencePropertyGetter(rp: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(rp), c_ReferenceProperty())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var pp: Ref
   var anon_0: Ref
   var ppn: Ref
   var anon: Ref
-  inhale acc(c_ReferenceProperty_shared(rp), wildcard)
+  inhale acc(shared(rp), wildcard)
   anon_0 := rProp(rp)
   pp := anon_0
-  inhale isSubtype(typeOf(pp), _c_PrimitiveProperty())
-  inhale acc(shared(pp), wildcard)
+  inhale isSubtype(typeOf(pp), c_PrimitiveProperty())
+  inhale acc(_c_PrimitiveProperty_shared(pp), wildcard)
   anon := nProp(pp)
   ppn := anon
   inhale isSubtype(typeOf(ppn), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /property_getters.kt: info: Generated Viper text for testCascadingPropertyGetter:
-method nProp(this: Ref) returns (v_ret: Ref)
+method nProp(this: Ref) returns (ret: Ref)
 
 
-method rProp(this: Ref) returns (v_ret: Ref)
+method rProp(this: Ref) returns (ret: Ref)
 
 
-method testCascadingPropertyGetter(rp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rp), _c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method testCascadingPropertyGetter(rp: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(rp), c_ReferenceProperty())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var ppn: Ref
   var anon_0: Ref
   var anon_1: Ref
   var anon: Ref
-  inhale acc(c_ReferenceProperty_shared(rp), wildcard)
+  inhale acc(shared(rp), wildcard)
   anon := rProp(rp)
   anon_1 := anon
-  inhale isSubtype(typeOf(anon_1), _c_PrimitiveProperty())
-  inhale acc(shared(anon_1), wildcard)
+  inhale isSubtype(typeOf(anon_1), c_PrimitiveProperty())
+  inhale acc(_c_PrimitiveProperty_shared(anon_1), wildcard)
   anon_0 := nProp(anon_1)
   ppn := anon_0
   inhale isSubtype(typeOf(ppn), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
@@ -1,30 +1,30 @@
 /property_getters.kt: info: Generated Viper text for testPrimitivePropertyGetter:
-method nProp(this: Ref) returns (ret: Ref)
+method nProp(this: Ref) returns (v_ret: Ref)
 
 
-method testPrimitivePropertyGetter(pp: Ref) returns (ret_0: Ref)
+method testPrimitivePropertyGetter(pp: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pp), c_PrimitiveProperty())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   var anon: Ref
   inhale acc(shared(pp), wildcard)
   anon := nProp(pp)
-  ret_0 := anon
-  inhale isSubtype(typeOf(ret_0), intType())
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := anon
+  inhale isSubtype(typeOf(ret), intType())
+  goto ret_0
+  label ret_0
 }
 
 /property_getters.kt: info: Generated Viper text for testReferencePropertyGetter:
-method nProp(this: Ref) returns (ret: Ref)
+method nProp(this: Ref) returns (v_ret: Ref)
 
 
-method rProp(this: Ref) returns (ret: Ref)
+method rProp(this: Ref) returns (v_ret: Ref)
 
 
-method testReferencePropertyGetter(rp: Ref) returns (ret_0: Ref)
+method testReferencePropertyGetter(rp: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rp), c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var pp: Ref
   var anon_0: Ref
@@ -38,20 +38,20 @@ method testReferencePropertyGetter(rp: Ref) returns (ret_0: Ref)
   anon := nProp(pp)
   ppn := anon
   inhale isSubtype(typeOf(ppn), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /property_getters.kt: info: Generated Viper text for testCascadingPropertyGetter:
-method nProp(this: Ref) returns (ret: Ref)
+method nProp(this: Ref) returns (v_ret: Ref)
 
 
-method rProp(this: Ref) returns (ret: Ref)
+method rProp(this: Ref) returns (v_ret: Ref)
 
 
-method testCascadingPropertyGetter(rp: Ref) returns (ret_0: Ref)
+method testCascadingPropertyGetter(rp: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rp), c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var ppn: Ref
   var anon_0: Ref
@@ -65,6 +65,6 @@ method testCascadingPropertyGetter(rp: Ref) returns (ret_0: Ref)
   anon_0 := nProp(anon_1)
   ppn := anon_0
   inhale isSubtype(typeOf(ppn), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/property_getters.fir.diag.txt
@@ -2,17 +2,17 @@
 method nProp(this: Ref) returns (v_ret: Ref)
 
 
-method testPrimitivePropertyGetter(pp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pp), c_PrimitiveProperty())
-  ensures isSubtype(typeOf(ret), intType())
+method testPrimitivePropertyGetter(pp: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pp), PrimitiveProperty())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
   inhale acc(shared(pp), wildcard)
   anon := nProp(pp)
-  ret := anon
-  inhale isSubtype(typeOf(ret), intType())
-  goto ret_0
-  label ret_0
+  v_ret_0 := anon
+  inhale isSubtype(typeOf(v_ret_0), intType())
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /property_getters.kt: info: Generated Viper text for testReferencePropertyGetter:
@@ -22,24 +22,24 @@ method nProp(this: Ref) returns (v_ret: Ref)
 method rProp(this: Ref) returns (v_ret: Ref)
 
 
-method testReferencePropertyGetter(rp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rp), c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferencePropertyGetter(rp: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rp), ReferenceProperty())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var pp: Ref
   var anon_0: Ref
   var ppn: Ref
-  var anon: Ref
-  inhale acc(shared(rp), wildcard)
+  var anon_1: Ref
+  inhale acc(ReferenceProperty_shared(rp), wildcard)
   anon_0 := rProp(rp)
   pp := anon_0
-  inhale isSubtype(typeOf(pp), c_PrimitiveProperty())
-  inhale acc(_c_PrimitiveProperty_shared(pp), wildcard)
-  anon := nProp(pp)
-  ppn := anon
+  inhale isSubtype(typeOf(pp), PrimitiveProperty())
+  inhale acc(PrimitiveProperty_shared(pp), wildcard)
+  anon_1 := nProp(pp)
+  ppn := anon_1
   inhale isSubtype(typeOf(ppn), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /property_getters.kt: info: Generated Viper text for testCascadingPropertyGetter:
@@ -49,22 +49,22 @@ method nProp(this: Ref) returns (v_ret: Ref)
 method rProp(this: Ref) returns (v_ret: Ref)
 
 
-method testCascadingPropertyGetter(rp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rp), c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method testCascadingPropertyGetter(rp: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rp), ReferenceProperty())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var ppn: Ref
   var anon_0: Ref
   var anon_1: Ref
-  var anon: Ref
-  inhale acc(shared(rp), wildcard)
-  anon := rProp(rp)
-  anon_1 := anon
-  inhale isSubtype(typeOf(anon_1), c_PrimitiveProperty())
-  inhale acc(_c_PrimitiveProperty_shared(anon_1), wildcard)
+  var anon_2: Ref
+  inhale acc(ReferenceProperty_shared(rp), wildcard)
+  anon_2 := rProp(rp)
+  anon_1 := anon_2
+  inhale isSubtype(typeOf(anon_1), PrimitiveProperty())
+  inhale acc(PrimitiveProperty_shared(anon_1), wildcard)
   anon_0 := nProp(anon_1)
   ppn := anon_0
   inhale isSubtype(typeOf(ppn), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -5,7 +5,7 @@ field value: Ref
 
 function getValue(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let v_anon_0_0 ==
@@ -20,7 +20,7 @@ field value: Ref
 
 function getSafeNextValue(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let v_anon_2_0 ==
@@ -44,7 +44,7 @@ field value: Ref
 
 function getSafeNextNextValue(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let v_anon_3_0 ==
@@ -75,7 +75,7 @@ field value: Ref
 
 function sumFirstTwoNodes(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let l0_nextNode_0 ==
@@ -113,7 +113,7 @@ field value: Ref
 
 function isLastNode(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), boolType())
 {
   (let v_anon_0_0 ==
@@ -128,7 +128,7 @@ field value: Ref
 
 function length(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let l0_nextNode_0 ==
@@ -152,7 +152,7 @@ field value: Ref
 
 function sumAllNodes(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let l0_nextNode_0 ==
@@ -183,7 +183,7 @@ field value: Ref
 
 function containsValue(node: Ref, target: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   requires isSubtype(typeOf(target), intType())
   ensures isSubtype(typeOf(result), boolType())
 {
@@ -212,7 +212,7 @@ field value: Ref
 
 function aliasAndReassign(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let l0_alias1_0 ==
@@ -241,8 +241,8 @@ field value: Ref
 
 function id(node: Ref): Ref
   requires node != nullValue() ==> acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), nullable(_c_Node()))
-  ensures isSubtype(typeOf(result), nullable(_c_Node()))
+  requires isSubtype(typeOf(node), nullable(c_Node()))
+  ensures isSubtype(typeOf(result), nullable(c_Node()))
 {
   node
 }
@@ -254,15 +254,15 @@ field value: Ref
 
 function id(node: Ref): Ref
   requires node != nullValue() ==> acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), nullable(_c_Node()))
-  ensures isSubtype(typeOf(result), nullable(_c_Node()))
+  requires isSubtype(typeOf(node), nullable(c_Node()))
+  ensures isSubtype(typeOf(result), nullable(c_Node()))
 {
   node
 }
 
 function useIdentityFunction(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let l0_sameNode_0 ==
@@ -286,7 +286,7 @@ field value: Ref
 
 function getNextValueUsingId(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   ensures isSubtype(typeOf(result), intType())
 {
   (let v_anon_0_0 ==
@@ -308,8 +308,8 @@ function getNextValueUsingId(node: Ref): Ref
 
 function id(node: Ref): Ref
   requires node != nullValue() ==> acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), nullable(_c_Node()))
-  ensures isSubtype(typeOf(result), nullable(_c_Node()))
+  requires isSubtype(typeOf(node), nullable(c_Node()))
+  ensures isSubtype(typeOf(result), nullable(c_Node()))
 {
   node
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -5,12 +5,12 @@ field value: Ref
 
 function getValue(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let v_anon_0_0 ==
+  (let anon_0_0 ==
     ((unfolding acc(shared(node), wildcard) in node.value)) in
-    v_anon_0_0)
+    anon_0_0)
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for getSafeNextValue:
@@ -20,21 +20,21 @@ field value: Ref
 
 function getSafeNextValue(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let v_anon_2_0 ==
+  (let anon_2_0 ==
     ((unfolding acc(shared(node), wildcard) in node.next)) in
-    (let v_anon_3_0 ==
-      ((v_anon_2_0 != nullValue() ?
+    (let anon_3_0 ==
+      ((anon_2_0 != nullValue() ?
         (unfolding acc(shared(node), wildcard) in
-          (unfolding acc(shared(v_anon_2_0), wildcard) in v_anon_2_0.value)) :
+          (unfolding acc(shared(anon_2_0), wildcard) in anon_2_0.value)) :
         null)) in
-      (let v_anon_1_0 ==
-        ((v_anon_2_0 != nullValue() ? v_anon_3_0 : nullValue())) in
-        (let v_anon_0_0 ==
-          ((v_anon_1_0 != nullValue() ? v_anon_1_0 : intToRef(-1))) in
-          v_anon_0_0))))
+      (let anon_1_0 ==
+        ((anon_2_0 != nullValue() ? anon_3_0 : nullValue())) in
+        (let anon_0_0 ==
+          ((anon_1_0 != nullValue() ? anon_1_0 : intToRef(-1))) in
+          anon_0_0))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for getSafeNextNextValue:
@@ -44,28 +44,27 @@ field value: Ref
 
 function getSafeNextNextValue(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let v_anon_3_0 ==
+  (let anon_3_0 ==
     ((unfolding acc(shared(node), wildcard) in node.next)) in
-    (let v_anon_4_0 ==
-      ((v_anon_3_0 != nullValue() ?
+    (let anon_4_0 ==
+      ((anon_3_0 != nullValue() ?
         (unfolding acc(shared(node), wildcard) in
-          (unfolding acc(shared(v_anon_3_0), wildcard) in v_anon_3_0.next)) :
+          (unfolding acc(shared(anon_3_0), wildcard) in anon_3_0.next)) :
         null)) in
-      (let v_anon_2_0 ==
-        ((v_anon_3_0 != nullValue() ? v_anon_4_0 : nullValue())) in
-        (let v_anon_5_0 ==
-          ((v_anon_2_0 != nullValue() ?
-            (unfolding acc(shared(v_anon_2_0), wildcard) in
-              v_anon_2_0.value) :
+      (let anon_2_0 ==
+        ((anon_3_0 != nullValue() ? anon_4_0 : nullValue())) in
+        (let anon_5_0 ==
+          ((anon_2_0 != nullValue() ?
+            (unfolding acc(shared(anon_2_0), wildcard) in anon_2_0.value) :
             null)) in
-          (let v_anon_1_0 ==
-            ((v_anon_2_0 != nullValue() ? v_anon_5_0 : nullValue())) in
-            (let v_anon_0_0 ==
-              ((v_anon_1_0 != nullValue() ? v_anon_1_0 : intToRef(0))) in
-              v_anon_0_0))))))
+          (let anon_1_0 ==
+            ((anon_2_0 != nullValue() ? anon_5_0 : nullValue())) in
+            (let anon_0_0 ==
+              ((anon_1_0 != nullValue() ? anon_1_0 : intToRef(0))) in
+              anon_0_0))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for sumFirstTwoNodes:
@@ -75,35 +74,35 @@ field value: Ref
 
 function sumFirstTwoNodes(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_nextNode_0 ==
+  (let nextNode_0 ==
     ((unfolding acc(shared(node), wildcard) in node.next)) in
-    (let v_anon_2_0 ==
-      ((!(l0_nextNode_0 == nullValue()) ?
+    (let anon_2_0 ==
+      ((!(nextNode_0 == nullValue()) ?
         (unfolding acc(shared(node), wildcard) in node.value) :
         null)) in
-      (let v_anon_3_0 ==
-        ((!(l0_nextNode_0 == nullValue()) ?
+      (let anon_3_0 ==
+        ((!(nextNode_0 == nullValue()) ?
           (unfolding acc(shared(node), wildcard) in
-            (unfolding acc(shared(l0_nextNode_0), wildcard) in
-              l0_nextNode_0.value)) :
+            (unfolding acc(shared(nextNode_0), wildcard) in
+              nextNode_0.value)) :
           null)) in
-        (let v_anon_1_0 ==
-          ((!(l0_nextNode_0 == nullValue()) ?
+        (let anon_1_0 ==
+          ((!(nextNode_0 == nullValue()) ?
             (unfolding acc(shared(node), wildcard) in
-              (unfolding acc(shared(l0_nextNode_0), wildcard) in
+              (unfolding acc(shared(nextNode_0), wildcard) in
                 (unfolding acc(shared(node), wildcard) in
-                  plusInts(v_anon_2_0, v_anon_3_0)))) :
+                  plusInts(anon_2_0, anon_3_0)))) :
             null)) in
-          (let v_anon_4_0 ==
-            ((!!(l0_nextNode_0 == nullValue()) ?
+          (let anon_4_0 ==
+            ((!!(nextNode_0 == nullValue()) ?
               (unfolding acc(shared(node), wildcard) in node.value) :
               null)) in
-            (let v_anon_0_0 ==
-              ((!(l0_nextNode_0 == nullValue()) ? v_anon_1_0 : v_anon_4_0)) in
-              v_anon_0_0))))))
+            (let anon_0_0 ==
+              ((!(nextNode_0 == nullValue()) ? anon_1_0 : anon_4_0)) in
+              anon_0_0))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for isLastNode:
@@ -113,12 +112,12 @@ field value: Ref
 
 function isLastNode(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), boolType())
 {
-  (let v_anon_0_0 ==
+  (let anon_0_0 ==
     ((unfolding acc(shared(node), wildcard) in node.next)) in
-    boolToRef(v_anon_0_0 == nullValue()))
+    boolToRef(anon_0_0 == nullValue()))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for length:
@@ -128,21 +127,21 @@ field value: Ref
 
 function length(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_nextNode_0 ==
+  (let nextNode_0 ==
     ((unfolding acc(shared(node), wildcard) in node.next)) in
-    (let v_anon_1_0 ==
-      ((l0_nextNode_0 == nullValue() ? intToRef(1) : null)) in
-      (let v_anon_2_0 ==
-        ((!(l0_nextNode_0 == nullValue()) ?
+    (let anon_1_0 ==
+      ((nextNode_0 == nullValue() ? intToRef(1) : null)) in
+      (let anon_2_0 ==
+        ((!(nextNode_0 == nullValue()) ?
           (unfolding acc(shared(node), wildcard) in
-            plusInts(intToRef(1), length(l0_nextNode_0))) :
+            plusInts(intToRef(1), length(nextNode_0))) :
           null)) in
-        (let v_anon_0_0 ==
-          ((l0_nextNode_0 == nullValue() ? v_anon_1_0 : v_anon_2_0)) in
-          v_anon_0_0))))
+        (let anon_0_0 ==
+          ((nextNode_0 == nullValue() ? anon_1_0 : anon_2_0)) in
+          anon_0_0))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for sumAllNodes:
@@ -152,28 +151,28 @@ field value: Ref
 
 function sumAllNodes(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_nextNode_0 ==
+  (let nextNode_0 ==
     ((unfolding acc(shared(node), wildcard) in node.next)) in
-    (let v_anon_1_0 ==
-      ((l0_nextNode_0 == nullValue() ?
+    (let anon_1_0 ==
+      ((nextNode_0 == nullValue() ?
         (unfolding acc(shared(node), wildcard) in node.value) :
         null)) in
-      (let v_anon_3_0 ==
-        ((!(l0_nextNode_0 == nullValue()) ?
+      (let anon_3_0 ==
+        ((!(nextNode_0 == nullValue()) ?
           (unfolding acc(shared(node), wildcard) in node.value) :
           null)) in
-        (let v_anon_2_0 ==
-          ((!(l0_nextNode_0 == nullValue()) ?
+        (let anon_2_0 ==
+          ((!(nextNode_0 == nullValue()) ?
             (unfolding acc(shared(node), wildcard) in
               (unfolding acc(shared(node), wildcard) in
-                plusInts(v_anon_3_0, sumAllNodes(l0_nextNode_0)))) :
+                plusInts(anon_3_0, sumAllNodes(nextNode_0)))) :
             null)) in
-          (let v_anon_0_0 ==
-            ((l0_nextNode_0 == nullValue() ? v_anon_1_0 : v_anon_2_0)) in
-            v_anon_0_0)))))
+          (let anon_0_0 ==
+            ((nextNode_0 == nullValue() ? anon_1_0 : anon_2_0)) in
+            anon_0_0)))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for containsValue:
@@ -183,26 +182,26 @@ field value: Ref
 
 function containsValue(node: Ref, target: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   requires isSubtype(typeOf(target), intType())
   ensures isSubtype(typeOf(result), boolType())
 {
-  (let v_anon_0_0 ==
+  (let anon_0_0 ==
     ((unfolding acc(shared(node), wildcard) in node.value)) in
-    (let l0_nextNode_0 ==
+    (let nextNode_0 ==
       ((unfolding acc(shared(node), wildcard) in node.next)) in
-      (let v_anon_2_0 ==
-        ((!(l0_nextNode_0 == nullValue()) ?
+      (let anon_2_0 ==
+        ((!(nextNode_0 == nullValue()) ?
           (unfolding acc(shared(node), wildcard) in
-            containsValue(l0_nextNode_0, target)) :
+            containsValue(nextNode_0, target)) :
           null)) in
-        (let v_anon_3_0 ==
-          ((!!(l0_nextNode_0 == nullValue()) ? boolToRef(false) : null)) in
-          (let v_anon_1_0 ==
-            ((!(l0_nextNode_0 == nullValue()) ? v_anon_2_0 : v_anon_3_0)) in
-            (intFromRef(v_anon_0_0) == intFromRef(target) ?
+        (let anon_3_0 ==
+          ((!!(nextNode_0 == nullValue()) ? boolToRef(false) : null)) in
+          (let anon_1_0 ==
+            ((!(nextNode_0 == nullValue()) ? anon_2_0 : anon_3_0)) in
+            (intFromRef(anon_0_0) == intFromRef(target) ?
               boolToRef(true) :
-              v_anon_1_0))))))
+              anon_1_0))))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for aliasAndReassign:
@@ -212,26 +211,25 @@ field value: Ref
 
 function aliasAndReassign(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_alias1_0 ==
+  (let alias1_0 ==
     (node) in
-    (let l0_alias2_0 ==
-      ((unfolding acc(shared(l0_alias1_0), wildcard) in l0_alias1_0.next)) in
-      (let l0_fallbackValue_0 ==
+    (let alias2_0 ==
+      ((unfolding acc(shared(alias1_0), wildcard) in alias1_0.next)) in
+      (let fallbackValue_0 ==
         (intToRef(-1)) in
-        (let l0_fallbackValue_1 ==
-          ((!(l0_alias2_0 == nullValue()) ?
-            (unfolding acc(shared(l0_alias1_0), wildcard) in
-              (unfolding acc(shared(l0_alias2_0), wildcard) in
-                l0_alias2_0.value)) :
+        (let fallbackValue_1 ==
+          ((!(alias2_0 == nullValue()) ?
+            (unfolding acc(shared(alias1_0), wildcard) in
+              (unfolding acc(shared(alias2_0), wildcard) in alias2_0.value)) :
             null)) in
-          (let l0_fallbackValue_2 ==
-            ((!(l0_alias2_0 == nullValue()) ?
-              l0_fallbackValue_1 :
-              l0_fallbackValue_0)) in
-            l0_fallbackValue_2)))))
+          (let fallbackValue_2 ==
+            ((!(alias2_0 == nullValue()) ?
+              fallbackValue_1 :
+              fallbackValue_0)) in
+            fallbackValue_2)))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for id:
@@ -241,8 +239,8 @@ field value: Ref
 
 function id(node: Ref): Ref
   requires node != nullValue() ==> acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), nullable(c_Node()))
-  ensures isSubtype(typeOf(result), nullable(c_Node()))
+  requires isSubtype(typeOf(node), nullable(Node()))
+  ensures isSubtype(typeOf(result), nullable(Node()))
 {
   node
 }
@@ -254,29 +252,28 @@ field value: Ref
 
 function id(node: Ref): Ref
   requires node != nullValue() ==> acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), nullable(c_Node()))
-  ensures isSubtype(typeOf(result), nullable(c_Node()))
+  requires isSubtype(typeOf(node), nullable(Node()))
+  ensures isSubtype(typeOf(result), nullable(Node()))
 {
   node
 }
 
 function useIdentityFunction(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_sameNode_0 ==
+  (let sameNode_0 ==
     (id(node)) in
-    (let v_anon_2_0 ==
-      ((l0_sameNode_0 != nullValue() ?
-        (unfolding acc(shared(l0_sameNode_0), wildcard) in
-          l0_sameNode_0.value) :
+    (let anon_2_0 ==
+      ((sameNode_0 != nullValue() ?
+        (unfolding acc(shared(sameNode_0), wildcard) in sameNode_0.value) :
         null)) in
-      (let v_anon_1_0 ==
-        ((l0_sameNode_0 != nullValue() ? v_anon_2_0 : nullValue())) in
-        (let v_anon_0_0 ==
-          ((v_anon_1_0 != nullValue() ? v_anon_1_0 : intToRef(0))) in
-          v_anon_0_0))))
+      (let anon_1_0 ==
+        ((sameNode_0 != nullValue() ? anon_2_0 : nullValue())) in
+        (let anon_0_0 ==
+          ((anon_1_0 != nullValue() ? anon_1_0 : intToRef(0))) in
+          anon_0_0))))
 }
 
 /pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for getNextValueUsingId:
@@ -286,30 +283,30 @@ field value: Ref
 
 function getNextValueUsingId(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let v_anon_0_0 ==
+  (let anon_0_0 ==
     ((unfolding acc(shared(node), wildcard) in node.next)) in
-    (let l0_nextNode_0 ==
-      ((unfolding acc(shared(node), wildcard) in id(v_anon_0_0))) in
-      (let v_anon_2_0 ==
-        ((l0_nextNode_0 == nullValue() ? intToRef(0) : null)) in
-        (let v_anon_3_0 ==
-          ((!(l0_nextNode_0 == nullValue()) ?
+    (let nextNode_0 ==
+      ((unfolding acc(shared(node), wildcard) in id(anon_0_0))) in
+      (let anon_2_0 ==
+        ((nextNode_0 == nullValue() ? intToRef(0) : null)) in
+        (let anon_3_0 ==
+          ((!(nextNode_0 == nullValue()) ?
             (unfolding acc(shared(node), wildcard) in
-              (unfolding acc(shared(l0_nextNode_0), wildcard) in
-                l0_nextNode_0.value)) :
+              (unfolding acc(shared(nextNode_0), wildcard) in
+                nextNode_0.value)) :
             null)) in
-          (let v_anon_1_0 ==
-            ((l0_nextNode_0 == nullValue() ? v_anon_2_0 : v_anon_3_0)) in
-            v_anon_1_0)))))
+          (let anon_1_0 ==
+            ((nextNode_0 == nullValue() ? anon_2_0 : anon_3_0)) in
+            anon_1_0)))))
 }
 
 function id(node: Ref): Ref
   requires node != nullValue() ==> acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), nullable(c_Node()))
-  ensures isSubtype(typeOf(result), nullable(c_Node()))
+  requires isSubtype(typeOf(node), nullable(Node()))
+  ensures isSubtype(typeOf(result), nullable(Node()))
 {
   node
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
@@ -3,16 +3,16 @@ field a: Ref
 
 method con(n: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(n), intType())
-  ensures isSubtype(typeOf(ret), _c_NoPrimaryConstructor())
+  ensures isSubtype(typeOf(ret), c_NoPrimaryConstructor())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_NoPrimaryConstructor_unique(ret), write)
+  ensures acc(_c_NoPrimaryConstructor_unique(ret), write)
 
 
-method con__c_NoPrimaryConstructor(b: Ref) returns (ret: Ref)
+method con_c_NoPrimaryConstructor(b: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), _c_NoPrimaryConstructor())
+  ensures isSubtype(typeOf(ret), c_NoPrimaryConstructor())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_NoPrimaryConstructor_unique(ret), write)
+  ensures acc(_c_NoPrimaryConstructor_unique(ret), write)
 
 
 method onlySecondConstructors() returns (ret_0: Ref)
@@ -20,7 +20,7 @@ method onlySecondConstructors() returns (ret_0: Ref)
 {
   var npc1: Ref
   var npc2: Ref
-  npc1 := con__c_NoPrimaryConstructor(boolToRef(true))
+  npc1 := con_c_NoPrimaryConstructor(boolToRef(true))
   npc2 := con(intToRef(42))
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
@@ -31,18 +31,18 @@ field bf_a: Ref
 
 method con(a: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(ret), _c_BothConstructors())
+  ensures isSubtype(typeOf(ret), c_BothConstructors())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_BothConstructors_unique(ret), write)
+  ensures acc(_c_BothConstructors_unique(ret), write)
   ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_a)) ==
     intFromRef(a)
 
 
-method con__c_BothConstructors(b: Ref) returns (ret: Ref)
+method con_c_BothConstructors(b: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), _c_BothConstructors())
+  ensures isSubtype(typeOf(ret), c_BothConstructors())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_BothConstructors_unique(ret), write)
+  ensures acc(_c_BothConstructors_unique(ret), write)
 
 
 method primaryAndSecondConstructor() returns (ret_0: Ref)
@@ -50,7 +50,7 @@ method primaryAndSecondConstructor() returns (ret_0: Ref)
 {
   var bc1: Ref
   var bc2: Ref
-  bc1 := con__c_BothConstructors(boolToRef(false))
+  bc1 := con_c_BothConstructors(boolToRef(false))
   bc2 := con(intToRef(42))
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
@@ -1,57 +1,57 @@
 /secondary_constructors.kt: info: Generated Viper text for onlySecondConstructors:
 field a: Ref
 
-method con(n: Ref) returns (ret: Ref)
+method con(n: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(n), intType())
-  ensures isSubtype(typeOf(ret), c_NoPrimaryConstructor())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_NoPrimaryConstructor_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_NoPrimaryConstructor())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_NoPrimaryConstructor_unique(v_ret), write)
 
 
-method con_c_NoPrimaryConstructor(b: Ref) returns (ret: Ref)
+method con_c_NoPrimaryConstructor(b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), c_NoPrimaryConstructor())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_NoPrimaryConstructor_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_NoPrimaryConstructor())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_NoPrimaryConstructor_unique(v_ret), write)
 
 
-method onlySecondConstructors() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method onlySecondConstructors() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var npc1: Ref
   var npc2: Ref
   npc1 := con_c_NoPrimaryConstructor(boolToRef(true))
   npc2 := con(intToRef(42))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /secondary_constructors.kt: info: Generated Viper text for primaryAndSecondConstructor:
 field bf_a: Ref
 
-method con(a: Ref) returns (ret: Ref)
+method con(a: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(ret), c_BothConstructors())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_BothConstructors_unique(ret), write)
-  ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_a)) ==
+  ensures isSubtype(typeOf(v_ret), c_BothConstructors())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_BothConstructors_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a)) ==
     intFromRef(a)
 
 
-method con_c_BothConstructors(b: Ref) returns (ret: Ref)
+method con_c_BothConstructors(b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), c_BothConstructors())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_BothConstructors_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_BothConstructors())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_BothConstructors_unique(v_ret), write)
 
 
-method primaryAndSecondConstructor() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method primaryAndSecondConstructor() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var bc1: Ref
   var bc2: Ref
   bc1 := con_c_BothConstructors(boolToRef(false))
   bc2 := con(intToRef(42))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/secondary_constructors.fir.diag.txt
@@ -1,57 +1,57 @@
 /secondary_constructors.kt: info: Generated Viper text for onlySecondConstructors:
 field a: Ref
 
-method con(n: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(n), intType())
-  ensures isSubtype(typeOf(v_ret), c_NoPrimaryConstructor())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_NoPrimaryConstructor_unique(v_ret), write)
-
-
-method con_c_NoPrimaryConstructor(b: Ref) returns (v_ret: Ref)
+method con_c_NoPrimaryConstructor_args_Boolean(b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(b), boolType())
   ensures isSubtype(typeOf(v_ret), c_NoPrimaryConstructor())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_NoPrimaryConstructor_unique(v_ret), write)
+  ensures acc(c_NoPrimaryConstructor_unique(v_ret), write)
 
 
-method onlySecondConstructors() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method con_c_NoPrimaryConstructor_args_Int(n: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(n), intType())
+  ensures isSubtype(typeOf(v_ret), c_NoPrimaryConstructor())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(c_NoPrimaryConstructor_unique(v_ret), write)
+
+
+method onlySecondConstructors() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var npc1: Ref
   var npc2: Ref
-  npc1 := con_c_NoPrimaryConstructor(boolToRef(true))
-  npc2 := con(intToRef(42))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  npc1 := con_c_NoPrimaryConstructor_args_Boolean(boolToRef(true))
+  npc2 := con_c_NoPrimaryConstructor_args_Int(intToRef(42))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /secondary_constructors.kt: info: Generated Viper text for primaryAndSecondConstructor:
 field bf_a: Ref
 
-method con(a: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(v_ret), c_BothConstructors())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_BothConstructors_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a)) ==
-    intFromRef(a)
-
-
-method con_c_BothConstructors(b: Ref) returns (v_ret: Ref)
+method con_c_BothConstructors_args_Boolean(b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(b), boolType())
   ensures isSubtype(typeOf(v_ret), c_BothConstructors())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_BothConstructors_unique(v_ret), write)
+  ensures acc(c_BothConstructors_unique(v_ret), write)
 
 
-method primaryAndSecondConstructor() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method con_c_BothConstructors_args_Int(par_a: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  ensures isSubtype(typeOf(v_ret), c_BothConstructors())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(c_BothConstructors_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_a)) ==
+    intFromRef(par_a)
+
+
+method primaryAndSecondConstructor() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var bc1: Ref
   var bc2: Ref
-  bc1 := con_c_BothConstructors(boolToRef(false))
-  bc2 := con(intToRef(42))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  bc1 := con_c_BothConstructors_args_Boolean(boolToRef(false))
+  bc2 := con_c_BothConstructors_args_Int(intToRef(42))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
@@ -2,7 +2,7 @@
 field a: Ref
 
 method testPrimitiveFieldSetter(pf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveField())
+  requires isSubtype(typeOf(pf), c_PrimitiveField())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   inhale acc(shared(pf), wildcard)
@@ -17,68 +17,68 @@ field pf: Ref
 
 method con(a: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(ret), _c_PrimitiveField())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(c_PrimitiveField_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_PrimitiveField())
+  ensures acc(_c_PrimitiveField_shared(ret), wildcard)
+  ensures acc(_c_PrimitiveField_unique(ret), write)
 
 
 method testReferenceFieldSetter(rf: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rf), _c_ReferenceField())
+  requires isSubtype(typeOf(rf), c_ReferenceField())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
-  inhale acc(c_ReferenceField_shared(rf), wildcard)
+  inhale acc(shared(rf), wildcard)
   anon := con(intToRef(0))
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testPrimitivePropertySetter:
-method aProp(this: Ref, anon: Ref) returns (v_ret: Ref)
+method aProp(this: Ref, anon: Ref) returns (ret: Ref)
 
 
-method g_aProp(this: Ref) returns (v_ret: Ref)
+method g_aProp(this: Ref) returns (ret: Ref)
 
 
-method testPrimitivePropertySetter(pp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pp), _c_PrimitiveProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method testPrimitivePropertySetter(pp: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(pp), c_PrimitiveProperty())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
   inhale acc(shared(pp), wildcard)
   anon := aProp(pp, intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testReferencePropertySetter:
-method aProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
+method aProp(this: Ref, anon_0: Ref) returns (ret: Ref)
 
 
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), _c_PrimitiveProperty())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(c_PrimitiveProperty_unique(v_ret), write)
+method con() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_PrimitiveProperty())
+  ensures acc(_c_PrimitiveProperty_shared(ret), wildcard)
+  ensures acc(_c_PrimitiveProperty_unique(ret), write)
 
 
-method g_aProp(this: Ref) returns (v_ret: Ref)
+method g_aProp(this: Ref) returns (ret: Ref)
 
 
-method g_ppProp(this: Ref) returns (v_ret: Ref)
+method g_ppProp(this: Ref) returns (ret: Ref)
 
 
-method ppProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
+method ppProp(this: Ref, anon_0: Ref) returns (ret: Ref)
 
 
-method testReferencePropertySetter(rp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rp), _c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferencePropertySetter(rp: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(rp), c_ReferenceProperty())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon: Ref
-  inhale acc(c_ReferenceProperty_shared(rp), wildcard)
+  inhale acc(shared(rp), wildcard)
   anon := con()
   anon_0 := ppProp(rp, anon)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
@@ -1,13 +1,13 @@
 /setters.kt: info: Generated Viper text for testPrimitiveFieldSetter:
 field a: Ref
 
-method testPrimitiveFieldSetter(pf: Ref) returns (ret_0: Ref)
+method testPrimitiveFieldSetter(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveField())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(pf), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testReferenceFieldSetter:
@@ -15,70 +15,70 @@ field bf_a: Ref
 
 field pf: Ref
 
-method con(a: Ref) returns (ret: Ref)
+method con(a: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(ret), c_PrimitiveField())
-  ensures acc(_c_PrimitiveField_shared(ret), wildcard)
-  ensures acc(_c_PrimitiveField_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_PrimitiveField())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_PrimitiveField_unique(v_ret), write)
 
 
-method testReferenceFieldSetter(rf: Ref) returns (ret_0: Ref)
+method testReferenceFieldSetter(rf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rf), c_ReferenceField())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
-  inhale acc(shared(rf), wildcard)
+  inhale acc(_c_ReferenceField_shared(rf), wildcard)
   anon := con(intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testPrimitivePropertySetter:
-method aProp(this: Ref, anon: Ref) returns (ret: Ref)
+method aProp(this: Ref, anon: Ref) returns (v_ret: Ref)
 
 
-method g_aProp(this: Ref) returns (ret: Ref)
+method g_aProp(this: Ref) returns (v_ret: Ref)
 
 
-method testPrimitivePropertySetter(pp: Ref) returns (ret_0: Ref)
+method testPrimitivePropertySetter(pp: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pp), c_PrimitiveProperty())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   inhale acc(shared(pp), wildcard)
   anon := aProp(pp, intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testReferencePropertySetter:
-method aProp(this: Ref, anon_0: Ref) returns (ret: Ref)
+method aProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
 
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_PrimitiveProperty())
-  ensures acc(_c_PrimitiveProperty_shared(ret), wildcard)
-  ensures acc(_c_PrimitiveProperty_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_PrimitiveProperty())
+  ensures acc(_c_PrimitiveProperty_shared(v_ret), wildcard)
+  ensures acc(_c_PrimitiveProperty_unique(v_ret), write)
 
 
-method g_aProp(this: Ref) returns (ret: Ref)
+method g_aProp(this: Ref) returns (v_ret: Ref)
 
 
-method g_ppProp(this: Ref) returns (ret: Ref)
+method g_ppProp(this: Ref) returns (v_ret: Ref)
 
 
-method ppProp(this: Ref, anon_0: Ref) returns (ret: Ref)
+method ppProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
 
 
-method testReferencePropertySetter(rp: Ref) returns (ret_0: Ref)
+method testReferencePropertySetter(rp: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rp), c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon: Ref
   inhale acc(shared(rp), wildcard)
   anon := con()
   anon_0 := ppProp(rp, anon)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/setters.fir.diag.txt
@@ -1,13 +1,13 @@
 /setters.kt: info: Generated Viper text for testPrimitiveFieldSetter:
 field a: Ref
 
-method testPrimitiveFieldSetter(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveField())
-  ensures isSubtype(typeOf(ret), unitType())
+method testPrimitiveFieldSetter(pf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveField())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale acc(shared(pf), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testReferenceFieldSetter:
@@ -15,50 +15,47 @@ field bf_a: Ref
 
 field pf: Ref
 
-method con(a: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(a), intType())
-  ensures isSubtype(typeOf(v_ret), c_PrimitiveField())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_PrimitiveField_unique(v_ret), write)
+method con(par_a: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  ensures isSubtype(typeOf(v_ret), PrimitiveField())
+  ensures acc(PrimitiveField_shared(v_ret), wildcard)
+  ensures acc(PrimitiveField_unique(v_ret), write)
 
 
-method testReferenceFieldSetter(rf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rf), c_ReferenceField())
-  ensures isSubtype(typeOf(ret), unitType())
+method testReferenceFieldSetter(rf: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rf), ReferenceField())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
-  inhale acc(_c_ReferenceField_shared(rf), wildcard)
+  inhale acc(ReferenceField_shared(rf), wildcard)
   anon := con(intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testPrimitivePropertySetter:
-method aProp(this: Ref, anon: Ref) returns (v_ret: Ref)
-
-
 method g_aProp(this: Ref) returns (v_ret: Ref)
 
 
-method testPrimitivePropertySetter(pp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pp), c_PrimitiveProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method s_aProp(this: Ref, anon: Ref) returns (v_ret: Ref)
+
+
+method testPrimitivePropertySetter(pp: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pp), PrimitiveProperty())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   inhale acc(shared(pp), wildcard)
-  anon := aProp(pp, intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon := s_aProp(pp, intToRef(0))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /setters.kt: info: Generated Viper text for testReferencePropertySetter:
-method aProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
-
-
 method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_PrimitiveProperty())
-  ensures acc(_c_PrimitiveProperty_shared(v_ret), wildcard)
-  ensures acc(_c_PrimitiveProperty_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), PrimitiveProperty())
+  ensures acc(PrimitiveProperty_shared(v_ret), wildcard)
+  ensures acc(PrimitiveProperty_unique(v_ret), write)
 
 
 method g_aProp(this: Ref) returns (v_ret: Ref)
@@ -67,18 +64,21 @@ method g_aProp(this: Ref) returns (v_ret: Ref)
 method g_ppProp(this: Ref) returns (v_ret: Ref)
 
 
-method ppProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
+method s_aProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
 
 
-method testReferencePropertySetter(rp: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rp), c_ReferenceProperty())
-  ensures isSubtype(typeOf(ret), unitType())
+method s_ppProp(this: Ref, anon_0: Ref) returns (v_ret: Ref)
+
+
+method testReferencePropertySetter(rp: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rp), ReferenceProperty())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var anon: Ref
-  inhale acc(shared(rp), wildcard)
-  anon := con()
-  anon_0 := ppProp(rp, anon)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  var anon_1: Ref
+  inhale acc(ReferenceProperty_shared(rp), wildcard)
+  anon_1 := con()
+  anon_0 := s_ppProp(rp, anon_1)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
@@ -34,15 +34,15 @@ method assignmentSubtyping() returns (ret: Ref)
 }
 
 /subtyping.kt: info: Generated Viper text for functionParameterSubtyping:
-method functionParameterSubtyping() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method functionParameterSubtyping() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   anon := nullableParameter(boolToRef(false))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method nullableParameter(b: Ref) returns (ret: Ref)
+method nullableParameter(b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(b), nullable(boolType()))
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/subtyping.fir.diag.txt
@@ -1,46 +1,46 @@
 /subtyping.kt: info: Generated Viper text for smartCast:
-method smartCast(x: Ref) returns (ret: Ref)
+method smartCast(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (x == nullValue()) {
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
   } else {
-    ret := x
-    goto ret_0
+    v_ret_0 := x
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /subtyping.kt: info: Generated Viper text for returnSubtyping:
-method returnSubtyping() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method returnSubtyping() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
-  ret := intToRef(0)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(0)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /subtyping.kt: info: Generated Viper text for assignmentSubtyping:
-method assignmentSubtyping() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method assignmentSubtyping() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   x := boolToRef(false)
   x := boolToRef(true)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /subtyping.kt: info: Generated Viper text for functionParameterSubtyping:
-method functionParameterSubtyping() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method functionParameterSubtyping() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   anon := nullableParameter(boolToRef(false))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method nullableParameter(b: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
@@ -7,38 +7,38 @@ field y: Ref
 
 field z: Ref
 
-predicate c_Foo_shared(this: Ref) {
+predicate _c_Foo_shared(this: Ref) {
   acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
   acc(this.y, wildcard) &&
-  acc(c_T_shared(this.y), wildcard) &&
-  isSubtype(typeOf(this.y), _c_T()) &&
-  acc(shared(this), wildcard)
+  acc(shared(this.y), wildcard) &&
+  isSubtype(typeOf(this.y), c_T()) &&
+  acc(_c_S_shared(this), wildcard)
 }
 
-predicate c_Foo_unique(this: Ref) {
+predicate _c_Foo_unique(this: Ref) {
   acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
   acc(this.x, write) &&
   isSubtype(typeOf(this.x), intType()) &&
   acc(this.y, wildcard) &&
-  acc(c_T_shared(this.y), wildcard) &&
-  acc(c_T_unique(this.y), write) &&
-  isSubtype(typeOf(this.y), _c_T()) &&
+  acc(shared(this.y), wildcard) &&
+  acc(_c_T_unique(this.y), write) &&
+  isSubtype(typeOf(this.y), c_T()) &&
   acc(this.z, write) &&
-  acc(c_T_shared(this.z), wildcard) &&
-  acc(c_T_unique(this.z), write) &&
-  isSubtype(typeOf(this.z), _c_T()) &&
-  acc(c_S_unique(this), write)
+  acc(shared(this.z), wildcard) &&
+  acc(_c_T_unique(this.z), write) &&
+  isSubtype(typeOf(this.z), c_T()) &&
+  acc(_c_S_unique(this), write)
 }
 
-predicate c_S_unique(this: Ref) {
+predicate _c_S_shared(this: Ref) {
   true
 }
 
-predicate c_T_shared(this: Ref) {
+predicate _c_S_unique(this: Ref) {
   true
 }
 
-predicate c_T_unique(this: Ref) {
+predicate _c_T_unique(this: Ref) {
   true
 }
 
@@ -47,17 +47,17 @@ predicate shared(this: Ref) {
 }
 
 method unique_foo_arg(foo: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
-  requires acc(c_Foo_unique(foo), write)
+  requires isSubtype(typeOf(foo), c_Foo())
+  requires acc(_c_Foo_unique(foo), write)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  inhale acc(c_Foo_shared(foo), wildcard)
+  inhale acc(_c_Foo_shared(foo), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for nullable_unique_arg:
-predicate c_T_unique(this: Ref) {
+predicate _c_T_unique(this: Ref) {
   true
 }
 
@@ -66,8 +66,8 @@ predicate shared(this: Ref) {
 }
 
 method nullable_unique_arg(par_t: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(par_t), nullable(_c_T()))
-  requires par_t != nullValue() ==> acc(c_T_unique(par_t), write)
+  requires isSubtype(typeOf(par_t), nullable(c_T()))
+  requires par_t != nullValue() ==> acc(_c_T_unique(par_t), write)
   ensures isSubtype(typeOf(ret), unitType())
 {
   inhale par_t != nullValue() ==> acc(shared(par_t), wildcard)
@@ -76,7 +76,7 @@ method nullable_unique_arg(par_t: Ref) returns (ret: Ref)
 }
 
 /unique_predicates.kt: info: Generated Viper text for borrowed_unique_arg:
-predicate c_T_unique(this: Ref) {
+predicate _c_T_unique(this: Ref) {
   true
 }
 
@@ -85,9 +85,9 @@ predicate shared(this: Ref) {
 }
 
 method borrowed_unique_arg(par_t: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(par_t), _c_T())
-  requires acc(c_T_unique(par_t), write)
-  ensures acc(c_T_unique(par_t), write)
+  requires isSubtype(typeOf(par_t), c_T())
+  requires acc(_c_T_unique(par_t), write)
+  ensures acc(_c_T_unique(par_t), write)
   ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(par_t), wildcard)
@@ -95,47 +95,83 @@ method borrowed_unique_arg(par_t: Ref) returns (ret: Ref)
   inhale isSubtype(typeOf(ret), unitType())
 }
 
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /unique_predicates.kt: info: Generated Viper text for unique_receiver:
-predicate c_T_unique(v_this: Ref) {
+predicate _c_T_unique(this: Ref) {
   true
 }
 
-predicate shared(v_this: Ref) {
+predicate shared(this: Ref) {
   true
 }
 
-method unique_receiver(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_T())
-  requires acc(c_T_unique(this), write)
+method unique_receiver([v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), c_T())
+  requires acc(_c_T_unique([v$this]), write)
   ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared(this), wildcard)
+  inhale acc(shared([v$this]), wildcard)
   label ret_0
   inhale isSubtype(typeOf(ret), unitType())
 }
 
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/unique_predicates.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /unique_predicates.kt: info: Generated Viper text for borrowed_unique_receiver:
-predicate c_T_unique(v_this: Ref) {
+predicate _c_T_unique(this: Ref) {
   true
 }
 
-predicate shared(v_this: Ref) {
+predicate shared(this: Ref) {
   true
 }
 
-method borrowed_unique_receiver(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_T())
-  requires acc(c_T_unique(this), write)
-  ensures acc(c_T_unique(this), write)
+method borrowed_unique_receiver([v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), c_T())
+  requires acc(_c_T_unique([v$this]), write)
+  ensures acc(_c_T_unique([v$this]), write)
   ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared(this), wildcard)
+  inhale acc(shared([v$this]), wildcard)
   label ret_0
   inhale isSubtype(typeOf(ret), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for unique_result:
-predicate c_T_unique(this: Ref) {
+predicate _c_T_unique(this: Ref) {
   true
 }
 
@@ -144,15 +180,15 @@ predicate shared(this: Ref) {
 }
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_T())
+  ensures isSubtype(typeOf(ret), c_T())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_T_unique(ret), write)
+  ensures acc(_c_T_unique(ret), write)
 
 
 method unique_result() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), _c_T())
+  ensures isSubtype(typeOf(ret_0), c_T())
   ensures acc(shared(ret_0), wildcard)
-  ensures acc(c_T_unique(ret_0), write)
+  ensures acc(_c_T_unique(ret_0), write)
 {
   ret_0 := con()
   goto lbl_ret_0
@@ -160,7 +196,7 @@ method unique_result() returns (ret_0: Ref)
 }
 
 /unique_predicates.kt: info: Generated Viper text for unique_nullable_result:
-predicate c_T_unique(this: Ref) {
+predicate _c_T_unique(this: Ref) {
   true
 }
 
@@ -169,9 +205,9 @@ predicate shared(this: Ref) {
 }
 
 method unique_nullable_result() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(_c_T()))
+  ensures isSubtype(typeOf(ret), nullable(c_T()))
   ensures ret != nullValue() ==> acc(shared(ret), wildcard)
-  ensures ret != nullValue() ==> acc(c_T_unique(ret), write)
+  ensures ret != nullValue() ==> acc(_c_T_unique(ret), write)
 {
   ret := nullValue()
   goto ret_0

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
@@ -7,24 +7,16 @@ field y: Ref
 
 field z: Ref
 
-predicate _c_Foo_shared(this: Ref) {
-  acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
-  acc(this.y, wildcard) &&
-  acc(shared(this.y), wildcard) &&
-  isSubtype(typeOf(this.y), c_T()) &&
-  acc(_c_S_shared(this), wildcard)
-}
-
 predicate _c_Foo_unique(this: Ref) {
   acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
   acc(this.x, write) &&
   isSubtype(typeOf(this.x), intType()) &&
   acc(this.y, wildcard) &&
-  acc(shared(this.y), wildcard) &&
+  acc(_c_T_shared(this.y), wildcard) &&
   acc(_c_T_unique(this.y), write) &&
   isSubtype(typeOf(this.y), c_T()) &&
   acc(this.z, write) &&
-  acc(shared(this.z), wildcard) &&
+  acc(_c_T_shared(this.z), wildcard) &&
   acc(_c_T_unique(this.z), write) &&
   isSubtype(typeOf(this.z), c_T()) &&
   acc(_c_S_unique(this), write)
@@ -38,22 +30,30 @@ predicate _c_S_unique(this: Ref) {
   true
 }
 
+predicate _c_T_shared(this: Ref) {
+  true
+}
+
 predicate _c_T_unique(this: Ref) {
   true
 }
 
 predicate shared(this: Ref) {
-  true
+  acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
+  acc(this.y, wildcard) &&
+  acc(_c_T_shared(this.y), wildcard) &&
+  isSubtype(typeOf(this.y), c_T()) &&
+  acc(_c_S_shared(this), wildcard)
 }
 
-method unique_foo_arg(foo: Ref) returns (ret_0: Ref)
+method unique_foo_arg(foo: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(foo), c_Foo())
   requires acc(_c_Foo_unique(foo), write)
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(_c_Foo_shared(foo), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale acc(shared(foo), wildcard)
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for nullable_unique_arg:
@@ -95,22 +95,6 @@ method borrowed_unique_arg(par_t: Ref) returns (ret: Ref)
   inhale isSubtype(typeOf(ret), unitType())
 }
 
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /unique_predicates.kt: info: Generated Viper text for unique_receiver:
 predicate _c_T_unique(this: Ref) {
   true
@@ -120,35 +104,15 @@ predicate shared(this: Ref) {
   true
 }
 
-method unique_receiver([v$this]: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), c_T())
-  requires acc(_c_T_unique([v$this]), write)
+method unique_receiver(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), c_T())
+  requires acc(_c_T_unique(v_this), write)
   ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared([v$this]), wildcard)
+  inhale acc(shared(v_this), wildcard)
   label ret_0
   inhale isSubtype(typeOf(ret), unitType())
 }
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/unique_predicates.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /unique_predicates.kt: info: Generated Viper text for borrowed_unique_receiver:
 predicate _c_T_unique(this: Ref) {
@@ -159,13 +123,13 @@ predicate shared(this: Ref) {
   true
 }
 
-method borrowed_unique_receiver([v$this]: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), c_T())
-  requires acc(_c_T_unique([v$this]), write)
-  ensures acc(_c_T_unique([v$this]), write)
+method borrowed_unique_receiver(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), c_T())
+  requires acc(_c_T_unique(v_this), write)
+  ensures acc(_c_T_unique(v_this), write)
   ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared([v$this]), wildcard)
+  inhale acc(shared(v_this), wildcard)
   label ret_0
   inhale isSubtype(typeOf(ret), unitType())
 }
@@ -179,20 +143,20 @@ predicate shared(this: Ref) {
   true
 }
 
-method con() returns (ret: Ref)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_T())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_T_unique(v_ret), write)
+
+
+method unique_result() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), c_T())
   ensures acc(shared(ret), wildcard)
   ensures acc(_c_T_unique(ret), write)
-
-
-method unique_result() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), c_T())
-  ensures acc(shared(ret_0), wildcard)
-  ensures acc(_c_T_unique(ret_0), write)
 {
-  ret_0 := con()
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := con()
+  goto ret_0
+  label ret_0
 }
 
 /unique_predicates.kt: info: Generated Viper text for unique_nullable_result:

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
@@ -7,57 +7,57 @@ field y: Ref
 
 field z: Ref
 
-predicate _c_Foo_unique(this: Ref) {
+predicate Foo_shared(this: Ref) {
+  acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
+  acc(this.y, wildcard) &&
+  acc(T_shared(this.y), wildcard) &&
+  isSubtype(typeOf(this.y), T()) &&
+  acc(S_shared(this), wildcard)
+}
+
+predicate Foo_unique(this: Ref) {
   acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
   acc(this.x, write) &&
   isSubtype(typeOf(this.x), intType()) &&
   acc(this.y, wildcard) &&
-  acc(_c_T_shared(this.y), wildcard) &&
-  acc(_c_T_unique(this.y), write) &&
-  isSubtype(typeOf(this.y), c_T()) &&
+  acc(T_shared(this.y), wildcard) &&
+  acc(T_unique(this.y), write) &&
+  isSubtype(typeOf(this.y), T()) &&
   acc(this.z, write) &&
-  acc(_c_T_shared(this.z), wildcard) &&
-  acc(_c_T_unique(this.z), write) &&
-  isSubtype(typeOf(this.z), c_T()) &&
-  acc(_c_S_unique(this), write)
+  acc(T_shared(this.z), wildcard) &&
+  acc(T_unique(this.z), write) &&
+  isSubtype(typeOf(this.z), T()) &&
+  acc(S_unique(this), write)
 }
 
-predicate _c_S_shared(this: Ref) {
+predicate S_shared(this: Ref) {
   true
 }
 
-predicate _c_S_unique(this: Ref) {
+predicate S_unique(this: Ref) {
   true
 }
 
-predicate _c_T_shared(this: Ref) {
+predicate T_shared(this: Ref) {
   true
 }
 
-predicate _c_T_unique(this: Ref) {
+predicate T_unique(this: Ref) {
   true
 }
 
-predicate shared(this: Ref) {
-  acc(this.w, wildcard) && isSubtype(typeOf(this.w), intType()) &&
-  acc(this.y, wildcard) &&
-  acc(_c_T_shared(this.y), wildcard) &&
-  isSubtype(typeOf(this.y), c_T()) &&
-  acc(_c_S_shared(this), wildcard)
-}
-
-method unique_foo_arg(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  requires acc(_c_Foo_unique(foo), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method unique_foo_arg(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  requires acc(Foo_unique(foo), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(foo), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(Foo_shared(foo), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for nullable_unique_arg:
-predicate _c_T_unique(this: Ref) {
+predicate T_unique(this: Ref) {
   true
 }
 
@@ -65,18 +65,18 @@ predicate shared(this: Ref) {
   true
 }
 
-method nullable_unique_arg(par_t: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(par_t), nullable(c_T()))
-  requires par_t != nullValue() ==> acc(_c_T_unique(par_t), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method nullable_unique_arg(par_t: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_t), nullable(T()))
+  requires par_t != nullValue() ==> acc(T_unique(par_t), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale par_t != nullValue() ==> acc(shared(par_t), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for borrowed_unique_arg:
-predicate _c_T_unique(this: Ref) {
+predicate T_unique(this: Ref) {
   true
 }
 
@@ -84,58 +84,59 @@ predicate shared(this: Ref) {
   true
 }
 
-method borrowed_unique_arg(par_t: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(par_t), c_T())
-  requires acc(_c_T_unique(par_t), write)
-  ensures acc(_c_T_unique(par_t), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method borrowed_unique_arg(par_t: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_t), T())
+  requires acc(T_unique(par_t), write)
+  ensures acc(T_unique(par_t), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale acc(shared(par_t), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for unique_receiver:
-predicate _c_T_unique(this: Ref) {
+predicate T_unique(v_this: Ref) {
   true
 }
 
-predicate shared(this: Ref) {
+predicate shared(v_this: Ref) {
   true
 }
 
-method unique_receiver(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), c_T())
-  requires acc(_c_T_unique(v_this), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method unique_receiver(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), T())
+  requires acc(T_unique(v_this_dispatch), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(v_this), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(shared(v_this_dispatch), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for borrowed_unique_receiver:
-predicate _c_T_unique(this: Ref) {
+predicate T_unique(v_this: Ref) {
   true
 }
 
-predicate shared(this: Ref) {
+predicate shared(v_this: Ref) {
   true
 }
 
-method borrowed_unique_receiver(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), c_T())
-  requires acc(_c_T_unique(v_this), write)
-  ensures acc(_c_T_unique(v_this), write)
-  ensures isSubtype(typeOf(ret), unitType())
+method borrowed_unique_receiver(v_this_dispatch: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), T())
+  requires acc(T_unique(v_this_dispatch), write)
+  ensures acc(T_unique(v_this_dispatch), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(v_this), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(shared(v_this_dispatch), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /unique_predicates.kt: info: Generated Viper text for unique_result:
-predicate _c_T_unique(this: Ref) {
+predicate T_unique(this: Ref) {
   true
 }
 
@@ -144,23 +145,23 @@ predicate shared(this: Ref) {
 }
 
 method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_T())
+  ensures isSubtype(typeOf(v_ret), T())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_T_unique(v_ret), write)
+  ensures acc(T_unique(v_ret), write)
 
 
-method unique_result() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_T())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_T_unique(ret), write)
+method unique_result() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), T())
+  ensures acc(shared(v_ret_0), wildcard)
+  ensures acc(T_unique(v_ret_0), write)
 {
-  ret := con()
-  goto ret_0
-  label ret_0
+  v_ret_0 := con()
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /unique_predicates.kt: info: Generated Viper text for unique_nullable_result:
-predicate _c_T_unique(this: Ref) {
+predicate T_unique(this: Ref) {
   true
 }
 
@@ -168,12 +169,12 @@ predicate shared(this: Ref) {
   true
 }
 
-method unique_nullable_result() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(c_T()))
-  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
-  ensures ret != nullValue() ==> acc(_c_T_unique(ret), write)
+method unique_nullable_result() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), nullable(T()))
+  ensures v_ret_0 != nullValue() ==> acc(shared(v_ret_0), wildcard)
+  ensures v_ret_0 != nullValue() ==> acc(T_unique(v_ret_0), write)
 {
-  ret := nullValue()
-  goto ret_0
-  label ret_0
+  v_ret_0 := nullValue()
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/classes/unique_predicates.fir.diag.txt
@@ -104,12 +104,12 @@ predicate shared(v_this: Ref) {
   true
 }
 
-method unique_receiver(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), T())
-  requires acc(T_unique(v_this_dispatch), write)
+method unique_receiver(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), T())
+  requires acc(T_unique(v_this_extension), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(v_this_dispatch), wildcard)
+  inhale acc(shared(v_this_extension), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -123,14 +123,14 @@ predicate shared(v_this: Ref) {
   true
 }
 
-method borrowed_unique_receiver(v_this_dispatch: Ref)
+method borrowed_unique_receiver(v_this_extension: Ref)
   returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), T())
-  requires acc(T_unique(v_this_dispatch), write)
-  ensures acc(T_unique(v_this_dispatch), write)
+  requires isSubtype(typeOf(v_this_extension), T())
+  requires acc(T_unique(v_this_extension), write)
+  ensures acc(T_unique(v_this_extension), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(v_this_dispatch), wildcard)
+  inhale acc(shared(v_this_extension), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
@@ -1,17 +1,17 @@
 /exp_side_effects.kt: info: Generated Viper text for test:
 field x: Ref
 
-method getFoo() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Foo())
-  ensures acc(shared(ret), wildcard)
+method getFoo() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Foo())
+  ensures acc(shared(v_ret), wildcard)
 
 
-method sideEffect() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method sideEffect() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method test() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method test() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -25,6 +25,6 @@ method test() returns (ret_0: Ref)
   anon_2 := havoc()
   anon := sideEffect()
   y := plusInts(anon_2, anon)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
@@ -2,7 +2,7 @@
 field x: Ref
 
 method getFoo() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Foo())
+  ensures isSubtype(typeOf(ret), c_Foo())
   ensures acc(shared(ret), wildcard)
 
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/exp_side_effects.fir.diag.txt
@@ -2,7 +2,7 @@
 field x: Ref
 
 method getFoo() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Foo())
+  ensures isSubtype(typeOf(v_ret), Foo())
   ensures acc(shared(v_ret), wildcard)
 
 
@@ -10,21 +10,21 @@ method sideEffect() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), intType())
 
 
-method test() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method test() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
   var y: Ref
   var anon_2: Ref
   var anon_3: Ref
-  var anon: Ref
+  var anon_4: Ref
   anon_0 := getFoo()
   anon_1 := sideEffect()
   anon_3 := getFoo()
   anon_2 := havoc()
-  anon := sideEffect()
-  y := plusInts(anon_2, anon)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon_4 := sideEffect()
+  y := plusInts(anon_2, anon_4)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
@@ -1,28 +1,28 @@
 /function_call.kt: info: Generated Viper text for functionCall:
-method f(x: Ref) returns (ret: Ref)
+method f(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method functionCall() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method functionCall() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon: Ref
   anon_0 := f(intToRef(0))
   anon := f(intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /function_call.kt: info: Generated Viper text for functionCallNested:
-method f(x: Ref) returns (ret: Ref)
+method f(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method functionCallNested() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method functionCallNested() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -30,8 +30,8 @@ method functionCallNested() returns (ret_0: Ref)
   anon := f(intToRef(0))
   anon_1 := f(anon)
   anon_0 := f(anon_1)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /function_call.kt: info: Generated Viper text for callItself:

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/function_call.fir.diag.txt
@@ -4,15 +4,15 @@ method f(x: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), intType())
 
 
-method functionCall() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method functionCall() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var anon: Ref
+  var anon_1: Ref
   anon_0 := f(intToRef(0))
-  anon := f(intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon_1 := f(intToRef(0))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_call.kt: info: Generated Viper text for functionCallNested:
@@ -21,25 +21,25 @@ method f(x: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), intType())
 
 
-method functionCallNested() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method functionCallNested() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
-  var anon: Ref
-  anon := f(intToRef(0))
-  anon_1 := f(anon)
+  var anon_2: Ref
+  anon_2 := f(intToRef(0))
+  anon_1 := f(anon_2)
   anon_0 := f(anon_1)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_call.kt: info: Generated Viper text for callItself:
-method callItself() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method callItself() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   anon := callItself()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
@@ -28,28 +28,28 @@ method ifOnParameter(b: Ref) returns (ret: Ref)
 }
 
 /if.kt: info: Generated Viper text for ifAsExpression:
-method ifAsExpression() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
+method ifAsExpression() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var l0_b: Ref
   l0_b := boolToRef(false)
   if (boolFromRef(l0_b)) {
     var anon_0: Ref
     anon_0 := simpleIf()
-    ret_0 := boolToRef(false)
+    ret := boolToRef(false)
   } else {
     var anon: Ref
     anon := ifOnParameter(l0_b)
-    ret_0 := boolToRef(true)
+    ret := boolToRef(true)
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method ifOnParameter(b: Ref) returns (ret: Ref)
+method ifOnParameter(b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method simpleIf() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method simpleIf() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), intType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/if.fir.diag.txt
@@ -1,53 +1,53 @@
 /if.kt: info: Generated Viper text for simpleIf:
-method simpleIf() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method simpleIf() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (true) {
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
   } else {
-    ret := intToRef(1)
-    goto ret_0
+    v_ret_0 := intToRef(1)
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /if.kt: info: Generated Viper text for ifOnParameter:
-method ifOnParameter(b: Ref) returns (ret: Ref)
+method ifOnParameter(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (boolFromRef(b)) {
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
   } else {
-    ret := intToRef(1)
-    goto ret_0
+    v_ret_0 := intToRef(1)
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /if.kt: info: Generated Viper text for ifAsExpression:
-method ifAsExpression() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
+method ifAsExpression() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var l0_b: Ref
   l0_b := boolToRef(false)
   if (boolFromRef(l0_b)) {
     var anon_0: Ref
     anon_0 := simpleIf()
-    ret := boolToRef(false)
+    v_ret_0 := boolToRef(false)
   } else {
-    var anon: Ref
-    anon := ifOnParameter(l0_b)
-    ret := boolToRef(true)
+    var anon_1: Ref
+    anon_1 := ifOnParameter(l0_b)
+    v_ret_0 := boolToRef(true)
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method ifOnParameter(b: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(b), boolType())
+method ifOnParameter(par_b: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_b), boolType())
   ensures isSubtype(typeOf(v_ret), intType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
@@ -22,8 +22,8 @@ method whileLoop(b: Ref) returns (ret: Ref)
 }
 
 /loop.kt: info: Generated Viper text for whileFunctionCondition:
-method whileFunctionCondition() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method whileFunctionCondition() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   label cont
@@ -32,10 +32,10 @@ method whileFunctionCondition() returns (ret_0: Ref)
     goto cont
   }
   label break
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method whileLoop(b: Ref) returns (ret: Ref)
+method whileLoop(b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop.fir.diag.txt
@@ -1,7 +1,7 @@
 /loop.kt: info: Generated Viper text for whileLoop:
-method whileLoop(b: Ref) returns (ret: Ref)
+method whileLoop(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var anon: Ref
   label cont
@@ -16,14 +16,14 @@ method whileLoop(b: Ref) returns (ret: Ref)
   }
   label break
   assert isSubtype(typeOf(b), boolType())
-  ret := boolToRef(false)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(false)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /loop.kt: info: Generated Viper text for whileFunctionCondition:
-method whileFunctionCondition() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method whileFunctionCondition() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   label cont
@@ -32,8 +32,8 @@ method whileFunctionCondition() returns (ret: Ref)
     goto cont
   }
   label break
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method whileLoop(b: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
@@ -1,7 +1,7 @@
 /loop_invariants.kt: info: Generated Viper text for dynamicLambdaInvariant:
-method dynamicLambdaInvariant(f: Ref) returns (ret_0: Ref)
+method dynamicLambdaInvariant(f: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(f), functionType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   label cont
@@ -14,18 +14,18 @@ method dynamicLambdaInvariant(f: Ref) returns (ret_0: Ref)
   }
   label break
   assert isSubtype(typeOf(f), functionType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method returnsBoolean() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
+method returnsBoolean() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), boolType())
 
 
 /loop_invariants.kt: info: Generated Viper text for functionAssignment:
-method functionAssignment(f: Ref) returns (ret_0: Ref)
+method functionAssignment(f: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(f), functionType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var g: Ref
   var anon_0: Ref
@@ -42,21 +42,21 @@ method functionAssignment(f: Ref) returns (ret_0: Ref)
   label break
   assert isSubtype(typeOf(g), functionType())
   assert isSubtype(typeOf(f), functionType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method returnsBoolean() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
+method returnsBoolean() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), boolType())
 
 
 /loop_invariants.kt: info: Generated Viper text for conditionalFunctionAssignment:
 method conditionalFunctionAssignment(b: Ref, f: Ref, h: Ref)
-  returns (ret_0: Ref)
+  returns (ret: Ref)
   requires isSubtype(typeOf(b), boolType())
   requires isSubtype(typeOf(f), functionType())
   requires isSubtype(typeOf(h), functionType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var g: Ref
   var anon_0: Ref
@@ -80,9 +80,9 @@ method conditionalFunctionAssignment(b: Ref, f: Ref, h: Ref)
   assert isSubtype(typeOf(b), boolType())
   assert isSubtype(typeOf(f), functionType())
   assert isSubtype(typeOf(h), functionType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method returnsBoolean() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
+method returnsBoolean() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), boolType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/loop_invariants.fir.diag.txt
@@ -1,21 +1,21 @@
 /loop_invariants.kt: info: Generated Viper text for dynamicLambdaInvariant:
-method dynamicLambdaInvariant(f: Ref) returns (ret: Ref)
+method dynamicLambdaInvariant(f: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(f), functionType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   label cont
     invariant isSubtype(typeOf(f), functionType())
   anon_0 := returnsBoolean()
   if (boolFromRef(anon_0)) {
-    var anon: Ref
-    inhale isSubtype(typeOf(anon), intType())
+    var anon_1: Ref
+    inhale isSubtype(typeOf(anon_1), intType())
     goto cont
   }
   label break
   assert isSubtype(typeOf(f), functionType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method returnsBoolean() returns (v_ret: Ref)
@@ -23,9 +23,9 @@ method returnsBoolean() returns (v_ret: Ref)
 
 
 /loop_invariants.kt: info: Generated Viper text for functionAssignment:
-method functionAssignment(f: Ref) returns (ret: Ref)
+method functionAssignment(f: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(f), functionType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var g: Ref
   var anon_0: Ref
@@ -35,15 +35,15 @@ method functionAssignment(f: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(f), functionType())
   anon_0 := returnsBoolean()
   if (boolFromRef(anon_0)) {
-    var anon: Ref
-    inhale isSubtype(typeOf(anon), intType())
+    var anon_1: Ref
+    inhale isSubtype(typeOf(anon_1), intType())
     goto cont
   }
   label break
   assert isSubtype(typeOf(g), functionType())
   assert isSubtype(typeOf(f), functionType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method returnsBoolean() returns (v_ret: Ref)
@@ -52,11 +52,11 @@ method returnsBoolean() returns (v_ret: Ref)
 
 /loop_invariants.kt: info: Generated Viper text for conditionalFunctionAssignment:
 method conditionalFunctionAssignment(b: Ref, f: Ref, h: Ref)
-  returns (ret: Ref)
+  returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
   requires isSubtype(typeOf(f), functionType())
   requires isSubtype(typeOf(h), functionType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var g: Ref
   var anon_0: Ref
@@ -71,8 +71,8 @@ method conditionalFunctionAssignment(b: Ref, f: Ref, h: Ref)
     invariant isSubtype(typeOf(h), functionType())
   anon_0 := returnsBoolean()
   if (boolFromRef(anon_0)) {
-    var anon: Ref
-    inhale isSubtype(typeOf(anon), intType())
+    var anon_1: Ref
+    inhale isSubtype(typeOf(anon_1), intType())
     goto cont
   }
   label break
@@ -80,8 +80,8 @@ method conditionalFunctionAssignment(b: Ref, f: Ref, h: Ref)
   assert isSubtype(typeOf(b), boolType())
   assert isSubtype(typeOf(f), functionType())
   assert isSubtype(typeOf(h), functionType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method returnsBoolean() returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/non-local-returns.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/non-local-returns.fir.diag.txt
@@ -1,111 +1,111 @@
 /non-local-returns.kt: info: Generated Viper text for simpleReturn:
-method simpleReturn() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method simpleReturn() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   anon := intToRef(0)
-  ret_0 := intToRef(1)
+  v_ret_0 := intToRef(1)
   goto lbl_ret_0
-  ret := anon
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  v_ret_2 := anon
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /non-local-returns.kt: info: Generated Viper text for returnAtInline:
-method returnAtInline() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method returnAtInline() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   anon := intToRef(0)
-  ret := intToRef(1)
-  goto ret_2
-  ret := anon
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  v_ret_2 := intToRef(1)
+  goto lbl_ret_2
+  v_ret_2 := anon
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /non-local-returns.kt: info: Generated Viper text for doubleInvoke:
-method doubleInvoke() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method doubleInvoke() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret_2: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon_0: Ref
-  var ret_3: Ref
-  var ret: Ref
-  var anon: Ref
+  var v_ret_3: Ref
+  var v_ret_4: Ref
+  var anon_1: Ref
   anon_0 := intToRef(0)
-  anon := intToRef(0)
-  ret := intToRef(1)
-  goto ret_4
-  ret := anon
-  goto ret_4
-  label ret_4
-  ret_3 := ret
+  anon_1 := intToRef(0)
+  v_ret_4 := intToRef(1)
+  goto lbl_ret_4
+  v_ret_4 := anon_1
+  goto lbl_ret_4
+  label lbl_ret_4
+  v_ret_3 := v_ret_4
   goto lbl_ret_3
   label lbl_ret_3
-  ret_2 := intToRef(2)
+  v_ret_2 := intToRef(2)
   goto lbl_ret_2
-  ret_2 := anon_0
+  v_ret_2 := anon_0
   goto lbl_ret_2
   label lbl_ret_2
-  ret_1 := ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /non-local-returns.kt: info: Generated Viper text for nested:
-method nested() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method nested() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret_2: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon_0: Ref
-  var ret_3: Ref
-  var ret: Ref
-  var anon: Ref
+  var v_ret_3: Ref
+  var v_ret_4: Ref
+  var anon_1: Ref
   anon_0 := intToRef(0)
-  anon := intToRef(1)
-  ret := intToRef(2)
-  goto ret_4
-  ret_2 := intToRef(3)
+  anon_1 := intToRef(1)
+  v_ret_4 := intToRef(2)
+  goto lbl_ret_4
+  v_ret_2 := intToRef(3)
   goto lbl_ret_2
-  ret_0 := intToRef(4)
+  v_ret_0 := intToRef(4)
   goto lbl_ret_0
-  ret := anon
-  goto ret_4
-  label ret_4
-  ret_3 := ret
+  v_ret_4 := anon_1
+  goto lbl_ret_4
+  label lbl_ret_4
+  v_ret_3 := v_ret_4
   goto lbl_ret_3
   label lbl_ret_3
-  ret_2 := intToRef(5)
+  v_ret_2 := intToRef(5)
   goto lbl_ret_2
-  ret_2 := anon_0
+  v_ret_2 := anon_0
   goto lbl_ret_2
   label lbl_ret_2
-  ret_1 := ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/recursion.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/recursion.fir.diag.txt
@@ -1,9 +1,9 @@
 /recursion.kt: info: Generated Viper text for recursive:
-method recursive() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method recursive() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  ret := recursive()
-  goto ret_0
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  v_ret_0 := recursive()
+  goto lbl_ret_0
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/return_break_continue.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/return_break_continue.fir.diag.txt
@@ -1,36 +1,36 @@
 /return_break_continue.kt: info: Generated Viper text for testReturn:
-method testReturn() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method testReturn() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  ret := intToRef(0)
-  goto ret_0
-  ret := intToRef(1)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(0)
+  goto lbl_ret_0
+  v_ret_0 := intToRef(1)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /return_break_continue.kt: info: Generated Viper text for returnFromLoop:
-method returnFromLoop() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method returnFromLoop() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
   label cont
   anon := boolToRef(true)
   if (boolFromRef(anon)) {
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
     goto cont
   }
   label break
-  ret := intToRef(1)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(1)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /return_break_continue.kt: info: Generated Viper text for whileBreak:
-method whileBreak(b: Ref) returns (ret: Ref)
+method whileBreak(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var i: Ref
   var anon: Ref
@@ -47,14 +47,14 @@ method whileBreak(b: Ref) returns (ret: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(b), boolType())
-  ret := i
-  goto ret_0
-  label ret_0
+  v_ret_0 := i
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /return_break_continue.kt: info: Generated Viper text for whileContinue:
-method whileContinue() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method whileContinue() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var b: Ref
   var anon: Ref
@@ -69,14 +69,14 @@ method whileContinue() returns (ret: Ref)
   }
   label break
   assert isSubtype(typeOf(b), boolType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /return_break_continue.kt: info: Generated Viper text for whileNested:
-method whileNested(b: Ref) returns (ret: Ref)
+method whileNested(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   label cont_0
@@ -84,7 +84,7 @@ method whileNested(b: Ref) returns (ret: Ref)
   anon_0 := b
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
-    var anon: Ref
+    var anon_2: Ref
     label cont_1
       invariant isSubtype(typeOf(b), boolType())
     anon_1 := b
@@ -95,92 +95,28 @@ method whileNested(b: Ref) returns (ret: Ref)
     label break_1
     assert isSubtype(typeOf(b), boolType())
     goto cont_0
-    label cont
+    label cont_2
       invariant isSubtype(typeOf(b), boolType())
-    anon := b
-    if (boolFromRef(anon)) {
-      goto cont
-      goto cont
+    anon_2 := b
+    if (boolFromRef(anon_2)) {
+      goto cont_2
+      goto cont_2
     }
-    label break
+    label break_2
     assert isSubtype(typeOf(b), boolType())
     goto break_0
     goto cont_0
   }
   label break_0
   assert isSubtype(typeOf(b), boolType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /return_break_continue.kt: info: Generated Viper text for labelledBreak:
-method labelledBreak(b: Ref) returns (ret: Ref)
+method labelledBreak(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
-{
-  var anon_0: Ref
-  label cont_0
-    invariant isSubtype(typeOf(b), boolType())
-  anon_0 := b
-  if (boolFromRef(anon_0)) {
-    var anon: Ref
-    label cont
-      invariant isSubtype(typeOf(b), boolType())
-    anon := b
-    if (boolFromRef(anon)) {
-      goto break_0
-      goto break
-      goto break
-      goto cont
-    }
-    label break
-    assert isSubtype(typeOf(b), boolType())
-    goto break_0
-    goto break_0
-    goto cont_0
-  }
-  label break_0
-  assert isSubtype(typeOf(b), boolType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
-}
-
-/return_break_continue.kt: info: Generated Viper text for labelledContinue:
-method labelledContinue(b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
-{
-  var anon_0: Ref
-  label cont_0
-    invariant isSubtype(typeOf(b), boolType())
-  anon_0 := b
-  if (boolFromRef(anon_0)) {
-    var anon: Ref
-    label cont
-      invariant isSubtype(typeOf(b), boolType())
-    anon := b
-    if (boolFromRef(anon)) {
-      goto cont_0
-      goto cont
-      goto cont
-      goto cont
-    }
-    label break
-    assert isSubtype(typeOf(b), boolType())
-    goto cont_0
-    goto cont_0
-    goto cont_0
-  }
-  label break_0
-  assert isSubtype(typeOf(b), boolType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
-}
-
-/return_break_continue.kt: info: Generated Viper text for labelledWhileShadowing:
-method labelledWhileShadowing(b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   label cont_0
@@ -188,7 +124,71 @@ method labelledWhileShadowing(b: Ref) returns (ret: Ref)
   anon_0 := b
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
-    var anon: Ref
+    label cont_1
+      invariant isSubtype(typeOf(b), boolType())
+    anon_1 := b
+    if (boolFromRef(anon_1)) {
+      goto break_0
+      goto break_1
+      goto break_1
+      goto cont_1
+    }
+    label break_1
+    assert isSubtype(typeOf(b), boolType())
+    goto break_0
+    goto break_0
+    goto cont_0
+  }
+  label break_0
+  assert isSubtype(typeOf(b), boolType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/return_break_continue.kt: info: Generated Viper text for labelledContinue:
+method labelledContinue(b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(b), boolType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  label cont_0
+    invariant isSubtype(typeOf(b), boolType())
+  anon_0 := b
+  if (boolFromRef(anon_0)) {
+    var anon_1: Ref
+    label cont_1
+      invariant isSubtype(typeOf(b), boolType())
+    anon_1 := b
+    if (boolFromRef(anon_1)) {
+      goto cont_0
+      goto cont_1
+      goto cont_1
+      goto cont_1
+    }
+    label break_1
+    assert isSubtype(typeOf(b), boolType())
+    goto cont_0
+    goto cont_0
+    goto cont_0
+  }
+  label break_0
+  assert isSubtype(typeOf(b), boolType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/return_break_continue.kt: info: Generated Viper text for labelledWhileShadowing:
+method labelledWhileShadowing(b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(b), boolType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  label cont_0
+    invariant isSubtype(typeOf(b), boolType())
+  anon_0 := b
+  if (boolFromRef(anon_0)) {
+    var anon_1: Ref
+    var anon_2: Ref
     label cont_1
       invariant isSubtype(typeOf(b), boolType())
     anon_1 := b
@@ -199,15 +199,15 @@ method labelledWhileShadowing(b: Ref) returns (ret: Ref)
     }
     label break_1
     assert isSubtype(typeOf(b), boolType())
-    label cont
+    label cont_2
       invariant isSubtype(typeOf(b), boolType())
-    anon := b
-    if (boolFromRef(anon)) {
-      goto break
-      goto cont
-      goto cont
+    anon_2 := b
+    if (boolFromRef(anon_2)) {
+      goto break_2
+      goto cont_2
+      goto cont_2
     }
-    label break
+    label break_2
     assert isSubtype(typeOf(b), boolType())
     goto break_0
     goto cont_0
@@ -215,6 +215,6 @@ method labelledWhileShadowing(b: Ref) returns (ret: Ref)
   }
   label break_0
   assert isSubtype(typeOf(b), boolType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
@@ -1,17 +1,17 @@
 /try_catch.kt: info: Generated Viper text for tryCatch:
-method call(x: Ref) returns (ret: Ref)
+method call(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method cause(this: Ref) returns (v_ret: Ref)
+
+
+method message(this: Ref) returns (v_ret: Ref)
+
+
+method tryCatch() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), unitType())
-
-
-method cause(this: Ref) returns (ret: Ref)
-
-
-method message(this: Ref) returns (ret: Ref)
-
-
-method tryCatch() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -32,24 +32,24 @@ method tryCatch() returns (ret_0: Ref)
   anon := call(intToRef(2))
   goto tryExit
   label tryExit
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for nestedTryCatch:
-method call(x: Ref) returns (ret: Ref)
+method call(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method cause(this: Ref) returns (v_ret: Ref)
+
+
+method message(this: Ref) returns (v_ret: Ref)
+
+
+method nestedTryCatch() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), unitType())
-
-
-method cause(this: Ref) returns (ret: Ref)
-
-
-method message(this: Ref) returns (ret: Ref)
-
-
-method nestedTryCatch() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -83,27 +83,27 @@ method nestedTryCatch() returns (ret_0: Ref)
   label catch_0
   goto tryExit_0
   label tryExit_0
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for tryCatchWithInline:
-method call(x: Ref) returns (ret: Ref)
+method call(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method cause(this: Ref) returns (ret: Ref)
+method cause(this: Ref) returns (v_ret: Ref)
 
 
-method message(this: Ref) returns (ret: Ref)
+method message(this: Ref) returns (v_ret: Ref)
 
 
 method tryCatchWithInline() returns (ret_0: Ref)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
-  var ret_1: Ref
+  var ret: Ref
   var anon_1: Ref
   var anon_2: Ref
   var anon_3: Ref
@@ -114,8 +114,8 @@ method tryCatchWithInline() returns (ret_0: Ref)
   }
   anon_1 := call(intToRef(0))
   anon_2 := call(intToRef(1))
-  label lbl_ret_1
-  inhale isSubtype(typeOf(ret_1), unitType())
+  label ret_1
+  inhale isSubtype(typeOf(ret), unitType())
   if (boolFromRef(anon_3)) {
     goto catch
   }
@@ -129,14 +129,14 @@ method tryCatchWithInline() returns (ret_0: Ref)
 }
 
 /try_catch.kt: info: Generated Viper text for tryCatchShadowing:
-method cause(this: Ref) returns (ret: Ref)
+method cause(this: Ref) returns (v_ret: Ref)
 
 
-method message(this: Ref) returns (ret: Ref)
+method message(this: Ref) returns (v_ret: Ref)
 
 
-method tryCatchShadowing() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method tryCatchShadowing() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l0_x: Ref
   var anon_0: Ref
@@ -157,24 +157,24 @@ method tryCatchShadowing() returns (ret_0: Ref)
   x := intToRef(2)
   goto tryExit
   label tryExit
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for multipleCatches:
-method call(x: Ref) returns (ret: Ref)
+method call(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method cause(this: Ref) returns (v_ret: Ref)
+
+
+method message(this: Ref) returns (v_ret: Ref)
+
+
+method multipleCatches() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), unitType())
-
-
-method cause(this: Ref) returns (ret: Ref)
-
-
-method message(this: Ref) returns (ret: Ref)
-
-
-method multipleCatches() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -208,29 +208,29 @@ method multipleCatches() returns (ret_0: Ref)
   anon := call(intToRef(3))
   goto tryExit
   label tryExit
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for useException:
-method call(x: Ref) returns (ret: Ref)
+method call(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method cause(this: Ref) returns (ret: Ref)
+method cause(this: Ref) returns (v_ret: Ref)
 
 
-method ignore(e: Ref) returns (ret: Ref)
+method ignore(e: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(e), c_Exception())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method message(this: Ref) returns (v_ret: Ref)
+
+
+method useException() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), unitType())
-
-
-method message(this: Ref) returns (ret: Ref)
-
-
-method useException() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -249,6 +249,6 @@ method useException() returns (ret_0: Ref)
   anon := ignore(l2_e)
   goto tryExit
   label tryExit
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
@@ -61,28 +61,28 @@ method nestedTryCatch() returns (ret_0: Ref)
   var anon: Ref
   var e: Ref
   if (boolFromRef(anon_0)) {
-    goto catch
+    goto catch_0
   }
   anon_1 := call(intToRef(0))
   if (boolFromRef(anon_2)) {
-    goto catch_1
+    goto catch
   }
   anon_3 := call(intToRef(1))
   if (boolFromRef(anon_4)) {
-    goto catch_1
-  }
-  goto tryExit_1
-  label catch_1
-  anon_5 := call(intToRef(2))
-  goto tryExit_1
-  label tryExit_1
-  if (boolFromRef(anon)) {
     goto catch
   }
   goto tryExit
   label catch
+  anon_5 := call(intToRef(2))
   goto tryExit
   label tryExit
+  if (boolFromRef(anon)) {
+    goto catch_0
+  }
+  goto tryExit_0
+  label catch_0
+  goto tryExit_0
+  label tryExit_0
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -222,7 +222,7 @@ method cause(this: Ref) returns (ret: Ref)
 
 
 method ignore(e: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(e), lang_c_Exception())
+  requires isSubtype(typeOf(e), c_Exception())
   ensures isSubtype(typeOf(ret), unitType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/try_catch.fir.diag.txt
@@ -10,15 +10,15 @@ method cause(this: Ref) returns (v_ret: Ref)
 method message(this: Ref) returns (v_ret: Ref)
 
 
-method tryCatch() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method tryCatch() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
   var anon_2: Ref
   var anon_3: Ref
   var e: Ref
-  var anon: Ref
+  var anon_4: Ref
   if (boolFromRef(anon_0)) {
     goto catch
   }
@@ -29,11 +29,11 @@ method tryCatch() returns (ret: Ref)
   }
   goto tryExit
   label catch
-  anon := call(intToRef(2))
+  anon_4 := call(intToRef(2))
   goto tryExit
   label tryExit
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for nestedTryCatch:
@@ -48,8 +48,8 @@ method cause(this: Ref) returns (v_ret: Ref)
 method message(this: Ref) returns (v_ret: Ref)
 
 
-method nestedTryCatch() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method nestedTryCatch() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -58,33 +58,33 @@ method nestedTryCatch() returns (ret: Ref)
   var anon_4: Ref
   var l3_e: Ref
   var anon_5: Ref
-  var anon: Ref
-  var e: Ref
+  var anon_6: Ref
+  var l4_e: Ref
   if (boolFromRef(anon_0)) {
     goto catch_0
   }
   anon_1 := call(intToRef(0))
   if (boolFromRef(anon_2)) {
-    goto catch
+    goto catch_1
   }
   anon_3 := call(intToRef(1))
   if (boolFromRef(anon_4)) {
-    goto catch
+    goto catch_1
   }
-  goto tryExit
-  label catch
+  goto tryExit_1
+  label catch_1
   anon_5 := call(intToRef(2))
-  goto tryExit
-  label tryExit
-  if (boolFromRef(anon)) {
+  goto tryExit_1
+  label tryExit_1
+  if (boolFromRef(anon_6)) {
     goto catch_0
   }
   goto tryExit_0
   label catch_0
   goto tryExit_0
   label tryExit_0
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for tryCatchWithInline:
@@ -99,33 +99,33 @@ method cause(this: Ref) returns (v_ret: Ref)
 method message(this: Ref) returns (v_ret: Ref)
 
 
-method tryCatchWithInline() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method tryCatchWithInline() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var ret: Ref
+  var v_ret_1: Ref
   var anon_1: Ref
   var anon_2: Ref
   var anon_3: Ref
   var e: Ref
-  var anon: Ref
+  var anon_4: Ref
   if (boolFromRef(anon_0)) {
     goto catch
   }
   anon_1 := call(intToRef(0))
   anon_2 := call(intToRef(1))
-  label ret_1
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_1
+  inhale isSubtype(typeOf(v_ret_1), unitType())
   if (boolFromRef(anon_3)) {
     goto catch
   }
   goto tryExit
   label catch
-  anon := call(intToRef(2))
+  anon_4 := call(intToRef(2))
   goto tryExit
   label tryExit
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for tryCatchShadowing:
@@ -135,30 +135,30 @@ method cause(this: Ref) returns (v_ret: Ref)
 method message(this: Ref) returns (v_ret: Ref)
 
 
-method tryCatchShadowing() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method tryCatchShadowing() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_x: Ref
   var anon_0: Ref
   var l1_x: Ref
-  var anon: Ref
+  var anon_1: Ref
   var e: Ref
-  var x: Ref
+  var l2_x: Ref
   l0_x := intToRef(0)
   if (boolFromRef(anon_0)) {
     goto catch
   }
   l1_x := intToRef(1)
-  if (boolFromRef(anon)) {
+  if (boolFromRef(anon_1)) {
     goto catch
   }
   goto tryExit
   label catch
-  x := intToRef(2)
+  l2_x := intToRef(2)
   goto tryExit
   label tryExit
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for multipleCatches:
@@ -173,8 +173,8 @@ method cause(this: Ref) returns (v_ret: Ref)
 method message(this: Ref) returns (v_ret: Ref)
 
 
-method multipleCatches() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method multipleCatches() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -184,13 +184,13 @@ method multipleCatches() returns (ret: Ref)
   var anon_5: Ref
   var l2_e: Ref
   var anon_6: Ref
-  var e: Ref
-  var anon: Ref
+  var l3_e: Ref
+  var anon_7: Ref
   if (boolFromRef(anon_0)) {
     goto catch_0
   }
   if (boolFromRef(anon_1)) {
-    goto catch
+    goto catch_1
   }
   anon_2 := call(intToRef(0))
   anon_3 := call(intToRef(1))
@@ -198,18 +198,18 @@ method multipleCatches() returns (ret: Ref)
     goto catch_0
   }
   if (boolFromRef(anon_5)) {
-    goto catch
+    goto catch_1
   }
   goto tryExit
   label catch_0
   anon_6 := call(intToRef(2))
   goto tryExit
-  label catch
-  anon := call(intToRef(3))
+  label catch_1
+  anon_7 := call(intToRef(3))
   goto tryExit
   label tryExit
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /try_catch.kt: info: Generated Viper text for useException:
@@ -221,22 +221,22 @@ method call(x: Ref) returns (v_ret: Ref)
 method cause(this: Ref) returns (v_ret: Ref)
 
 
-method ignore(e: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(e), c_Exception())
+method ignore(par_e: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_e), Exception())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
 method message(this: Ref) returns (v_ret: Ref)
 
 
-method useException() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method useException() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
   var anon_2: Ref
   var l2_e: Ref
-  var anon: Ref
+  var anon_3: Ref
   if (boolFromRef(anon_0)) {
     goto catch
   }
@@ -246,9 +246,9 @@ method useException() returns (ret: Ref)
   }
   goto tryExit
   label catch
-  anon := ignore(l2_e)
+  anon_3 := ignore(l2_e)
   goto tryExit
   label tryExit
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
@@ -145,13 +145,13 @@ method unusedResult() returns (ret: Ref)
 
 /when.kt: info: Generated Viper text for whenIs:
 method whenIs(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), _c_Foo())
+  requires isSubtype(typeOf(x), c_Foo())
   ensures isSubtype(typeOf(ret), boolType())
 {
   var anon: Ref
-  inhale acc(c_Foo_shared(x), wildcard)
+  inhale acc(shared(x), wildcard)
   anon := x
-  if (isSubtype(typeOf(anon), _c_Bar())) {
+  if (isSubtype(typeOf(anon), c_Bar())) {
     ret := boolToRef(true)
   } else {
     ret := boolToRef(false)}

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
@@ -94,33 +94,33 @@ method whenWithSubjectVar(x: Ref) returns (ret: Ref)
 }
 
 /when.kt: info: Generated Viper text for whenWithSubjectCall:
-method whenWithSubjectCall(x: Ref) returns (ret_0: Ref)
+method whenWithSubjectCall(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   var anon_0: Ref
   anon_0 := whenWithSubjectVar(x)
   if (intFromRef(anon_0) == 1) {
-    ret_0 := intToRef(2)
+    ret := intToRef(2)
   } elseif (intFromRef(anon_0) == 2) {
-    ret_0 := intToRef(3)
+    ret := intToRef(3)
   } else {
     var anon: Ref
     anon := whenWithSubjectVar(intToRef(0))
     if (intFromRef(anon) == 3) {
-      ret_0 := intToRef(4)
+      ret := intToRef(4)
     } elseif (intFromRef(anon) == 4) {
-      ret_0 := intToRef(5)
+      ret := intToRef(5)
     } else {
-      ret_0 := intToRef(42)}
+      ret := intToRef(42)}
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method whenWithSubjectVar(x: Ref) returns (ret: Ref)
+method whenWithSubjectVar(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
 /when.kt: info: Generated Viper text for emptyWhen:

--- a/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/control_flow/when.fir.diag.txt
@@ -1,66 +1,66 @@
 /when.kt: info: Generated Viper text for returnWhen:
-method returnWhen(a: Ref, b: Ref, c: Ref) returns (ret: Ref)
+method returnWhen(a: Ref, b: Ref, c: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), boolType())
   requires isSubtype(typeOf(b), boolType())
   requires isSubtype(typeOf(c), boolType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (boolFromRef(a)) {
-    ret := intToRef(0)
+    v_ret_0 := intToRef(0)
   } elseif (boolFromRef(b)) {
-    ret := intToRef(1)
+    v_ret_0 := intToRef(1)
   } elseif (boolFromRef(c)) {
-    ret := intToRef(2)
+    v_ret_0 := intToRef(2)
   } else {
-    ret := intToRef(3)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := intToRef(3)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for whenReturn:
-method whenReturn(a: Ref, b: Ref, c: Ref) returns (ret: Ref)
+method whenReturn(a: Ref, b: Ref, c: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), boolType())
   requires isSubtype(typeOf(b), boolType())
   requires isSubtype(typeOf(c), boolType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (boolFromRef(a)) {
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
   } elseif (boolFromRef(b)) {
-    ret := intToRef(1)
-    goto ret_0
+    v_ret_0 := intToRef(1)
+    goto lbl_ret_0
   } elseif (boolFromRef(c)) {
-    ret := intToRef(2)
-    goto ret_0
+    v_ret_0 := intToRef(2)
+    goto lbl_ret_0
   } else {
-    ret := intToRef(3)
-    goto ret_0
+    v_ret_0 := intToRef(3)
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for singleBranchWhen:
-method singleBranchWhen(a: Ref) returns (ret: Ref)
+method singleBranchWhen(a: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), boolType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var x: Ref
   x := intToRef(1)
   if (boolFromRef(a)) {
     x := intToRef(2)
   }
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for noElseWhen:
-method noElseWhen(a: Ref, b: Ref, c: Ref) returns (ret: Ref)
+method noElseWhen(a: Ref, b: Ref, c: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), boolType())
   requires isSubtype(typeOf(b), boolType())
   requires isSubtype(typeOf(c), boolType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var y: Ref
   y := intToRef(0)
@@ -71,51 +71,51 @@ method noElseWhen(a: Ref, b: Ref, c: Ref) returns (ret: Ref)
   } elseif (boolFromRef(c)) {
     y := intToRef(3)
   }
-  ret := y
-  goto ret_0
-  label ret_0
+  v_ret_0 := y
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for whenWithSubjectVar:
-method whenWithSubjectVar(x: Ref) returns (ret: Ref)
+method whenWithSubjectVar(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
   anon := x
   if (intFromRef(anon) == 1) {
-    ret := intToRef(2)
+    v_ret_0 := intToRef(2)
   } elseif (intFromRef(anon) == 2) {
-    ret := intToRef(3)
+    v_ret_0 := intToRef(3)
   } else {
-    ret := intToRef(42)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := intToRef(42)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for whenWithSubjectCall:
-method whenWithSubjectCall(x: Ref) returns (ret: Ref)
+method whenWithSubjectCall(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon_0: Ref
   anon_0 := whenWithSubjectVar(x)
   if (intFromRef(anon_0) == 1) {
-    ret := intToRef(2)
+    v_ret_0 := intToRef(2)
   } elseif (intFromRef(anon_0) == 2) {
-    ret := intToRef(3)
+    v_ret_0 := intToRef(3)
   } else {
-    var anon: Ref
-    anon := whenWithSubjectVar(intToRef(0))
-    if (intFromRef(anon) == 3) {
-      ret := intToRef(4)
-    } elseif (intFromRef(anon) == 4) {
-      ret := intToRef(5)
+    var anon_1: Ref
+    anon_1 := whenWithSubjectVar(intToRef(0))
+    if (intFromRef(anon_1) == 3) {
+      v_ret_0 := intToRef(4)
+    } elseif (intFromRef(anon_1) == 4) {
+      v_ret_0 := intToRef(5)
     } else {
-      ret := intToRef(42)}
+      v_ret_0 := intToRef(42)}
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method whenWithSubjectVar(x: Ref) returns (v_ret: Ref)
@@ -124,58 +124,58 @@ method whenWithSubjectVar(x: Ref) returns (v_ret: Ref)
 
 
 /when.kt: info: Generated Viper text for emptyWhen:
-method emptyWhen() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method emptyWhen() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  ret := intToRef(1)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(1)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for unusedResult:
-method unusedResult() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method unusedResult() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var x: Ref
   x := intToRef(0)
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for whenIs:
-method whenIs(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), c_Foo())
-  ensures isSubtype(typeOf(ret), boolType())
+method whenIs(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), Foo())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var anon: Ref
-  inhale acc(shared(x), wildcard)
+  inhale acc(Foo_shared(x), wildcard)
   anon := x
-  if (isSubtype(typeOf(anon), c_Bar())) {
-    ret := boolToRef(true)
+  if (isSubtype(typeOf(anon), Bar())) {
+    v_ret_0 := boolToRef(true)
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for whenSubjectVal:
-method whenSubjectVal() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method whenSubjectVal() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var x: Ref
   x := intToRef(0)
   if (intFromRef(x) == 1) {
-    ret := intToRef(1)
+    v_ret_0 := intToRef(1)
   } else {
-    ret := x}
-  goto ret_0
-  label ret_0
+    v_ret_0 := x}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /when.kt: info: Generated Viper text for whenSubjectValNested:
-method whenSubjectValNested() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method whenSubjectValNested() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   x := intToRef(1)
@@ -199,18 +199,18 @@ method whenSubjectValNested() returns (ret: Ref)
     if (intFromRef(x) == intFromRef(anon)) {
     }
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /when.kt: info: Generated Viper text for whenSubjectVarShadowing:
-method whenSubjectVarShadowing() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method whenSubjectVarShadowing() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_x: Ref
-  var x: Ref
+  var l1_x: Ref
   l0_x := intToRef(0)
-  x := intToRef(1)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  l1_x := intToRef(1)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/do_not_verify.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/do_not_verify.fir.diag.txt
@@ -1,9 +1,9 @@
 /do_not_verify.kt: info: Generated Viper text for bad_returns:
-method bad_returns() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true
+method bad_returns() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  ret := boolToRef(false)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(false)
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
@@ -25,35 +25,35 @@ method intValProp(this: Ref) returns (ret: Ref)
 
 
 /extension_properties.kt: info: Generated Viper text for extensionSetterProperty:
-method es_intVarProp(this: Ref, anon: Ref) returns (ret: Ref)
+method eg_intVarProp(this: Ref) returns (ret: Ref)
 
 
 method extensionSetterProperty() returns (ret_0: Ref)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
-  anon := es_intVarProp(intToRef(42), intToRef(0))
+  anon := intVarProp(intToRef(42), intToRef(0))
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method intVarProp(this: Ref) returns (ret: Ref)
+method intVarProp(this: Ref, anon: Ref) returns (ret: Ref)
 
 
 /extension_properties.kt: info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
-field bf_x: Ref
+field x: Ref
 
 method extensionGetterPropertyUserDefinedClass(pf: Ref)
   returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveField())
+  requires isSubtype(typeOf(pf), c_PrimitiveField())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var x: Ref
+  var l0_x: Ref
   var anon: Ref
   inhale acc(shared(pf), wildcard)
   anon := pfValProp(pf)
-  x := anon
-  inhale isSubtype(typeOf(x), intType())
+  l0_x := anon
+  inhale isSubtype(typeOf(l0_x), intType())
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -64,19 +64,19 @@ method pfValProp(this: Ref) returns (ret: Ref)
 /extension_properties.kt: info: Generated Viper text for extensionSetterPropertyUserDefinedClass:
 field x: Ref
 
-method es_pfVarProp(this: Ref, anon: Ref) returns (ret: Ref)
+method eg_pfVarProp(this: Ref) returns (ret: Ref)
 
 
 method extensionSetterPropertyUserDefinedClass(pf: Ref)
   returns (ret_0: Ref)
-  requires isSubtype(typeOf(pf), _c_PrimitiveField())
+  requires isSubtype(typeOf(pf), c_PrimitiveField())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
   inhale acc(shared(pf), wildcard)
-  anon := es_pfVarProp(pf, intToRef(42))
+  anon := pfVarProp(pf, intToRef(42))
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method pfVarProp(this: Ref) returns (ret: Ref)
+method pfVarProp(this: Ref, anon: Ref) returns (ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
@@ -1,6 +1,6 @@
 /extension_properties.kt: info: Generated Viper text for extensionGetterProperty:
-method extensionGetterProperty() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method extensionGetterProperty() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var a: Ref
   var anon_0: Ref
@@ -17,66 +17,64 @@ method extensionGetterProperty() returns (ret_0: Ref)
   anon_1 := intValProp(anon_2)
   b := anon_1
   inhale isSubtype(typeOf(b), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method intValProp(this: Ref) returns (ret: Ref)
+method intValProp(this: Ref) returns (v_ret: Ref)
 
 
 /extension_properties.kt: info: Generated Viper text for extensionSetterProperty:
-method eg_intVarProp(this: Ref) returns (ret: Ref)
+method eg_intVarProp(this: Ref) returns (v_ret: Ref)
 
 
-method extensionSetterProperty() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method extensionSetterProperty() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   anon := intVarProp(intToRef(42), intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method intVarProp(this: Ref, anon: Ref) returns (ret: Ref)
+method intVarProp(this: Ref, anon: Ref) returns (v_ret: Ref)
 
 
 /extension_properties.kt: info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
-field x: Ref
+field bf_x: Ref
 
-method extensionGetterPropertyUserDefinedClass(pf: Ref)
-  returns (ret_0: Ref)
+method extensionGetterPropertyUserDefinedClass(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveField())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  var l0_x: Ref
+  var x: Ref
   var anon: Ref
   inhale acc(shared(pf), wildcard)
   anon := pfValProp(pf)
-  l0_x := anon
-  inhale isSubtype(typeOf(l0_x), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  x := anon
+  inhale isSubtype(typeOf(x), intType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method pfValProp(this: Ref) returns (ret: Ref)
+method pfValProp(this: Ref) returns (v_ret: Ref)
 
 
 /extension_properties.kt: info: Generated Viper text for extensionSetterPropertyUserDefinedClass:
 field x: Ref
 
-method eg_pfVarProp(this: Ref) returns (ret: Ref)
+method eg_pfVarProp(this: Ref) returns (v_ret: Ref)
 
 
-method extensionSetterPropertyUserDefinedClass(pf: Ref)
-  returns (ret_0: Ref)
+method extensionSetterPropertyUserDefinedClass(pf: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(pf), c_PrimitiveField())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   inhale acc(shared(pf), wildcard)
   anon := pfVarProp(pf, intToRef(42))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method pfVarProp(this: Ref, anon: Ref) returns (ret: Ref)
+method pfVarProp(this: Ref, anon: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/extension_properties.fir.diag.txt
@@ -1,24 +1,24 @@
 /extension_properties.kt: info: Generated Viper text for extensionGetterProperty:
-method extensionGetterProperty() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method extensionGetterProperty() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var a: Ref
   var anon_0: Ref
   var b: Ref
   var anon_1: Ref
   var anon_2: Ref
-  var anon: Ref
+  var anon_3: Ref
   anon_0 := intValProp(intToRef(0))
   a := anon_0
   inhale isSubtype(typeOf(a), intType())
-  anon := intValProp(intToRef(1))
-  anon_2 := anon
+  anon_3 := intValProp(intToRef(1))
+  anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), intType())
   anon_1 := intValProp(anon_2)
   b := anon_1
   inhale isSubtype(typeOf(b), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method intValProp(this: Ref) returns (v_ret: Ref)
@@ -28,33 +28,34 @@ method intValProp(this: Ref) returns (v_ret: Ref)
 method eg_intVarProp(this: Ref) returns (v_ret: Ref)
 
 
-method extensionSetterProperty() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method es_intVarProp(this: Ref, anon: Ref) returns (v_ret: Ref)
+
+
+method extensionSetterProperty() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
-  anon := intVarProp(intToRef(42), intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon := es_intVarProp(intToRef(42), intToRef(0))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
-
-method intVarProp(this: Ref, anon: Ref) returns (v_ret: Ref)
-
 
 /extension_properties.kt: info: Generated Viper text for extensionGetterPropertyUserDefinedClass:
 field bf_x: Ref
 
-method extensionGetterPropertyUserDefinedClass(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveField())
-  ensures isSubtype(typeOf(ret), unitType())
+method extensionGetterPropertyUserDefinedClass(pf: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveField())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var x: Ref
+  var l0_x: Ref
   var anon: Ref
   inhale acc(shared(pf), wildcard)
   anon := pfValProp(pf)
-  x := anon
-  inhale isSubtype(typeOf(x), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  l0_x := anon
+  inhale isSubtype(typeOf(l0_x), intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method pfValProp(this: Ref) returns (v_ret: Ref)
@@ -66,15 +67,17 @@ field x: Ref
 method eg_pfVarProp(this: Ref) returns (v_ret: Ref)
 
 
-method extensionSetterPropertyUserDefinedClass(pf: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(pf), c_PrimitiveField())
-  ensures isSubtype(typeOf(ret), unitType())
+method es_pfVarProp(this: Ref, anon: Ref) returns (v_ret: Ref)
+
+
+method extensionSetterPropertyUserDefinedClass(pf: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(pf), PrimitiveField())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   inhale acc(shared(pf), wildcard)
-  anon := pfVarProp(pf, intToRef(42))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon := es_pfVarProp(pf, intToRef(42))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
-
-method pfVarProp(this: Ref, anon: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
@@ -24,7 +24,7 @@ domain rt  {
 
   unique function stringType(): rt
 
-  unique function _c_Foo(): rt
+  unique function c_Foo(): rt
 
   function nullValue(): Ref
 
@@ -123,7 +123,7 @@ domain rt  {
   }
 
   axiom {
-    isSubtype(_c_Foo(), anyType())
+    isSubtype(c_Foo(), anyType())
   }
 
   axiom supertypeOfNothing {
@@ -376,7 +376,7 @@ function timesInts(arg_1: Ref, arg: Ref): Ref
   ensures intFromRef(result) == intFromRef(arg_1) * intFromRef(arg)
 
 
-predicate c_Foo_unique(this: Ref) {
+predicate _c_Foo_unique(this: Ref) {
   acc(this.bf_x, wildcard) && isSubtype(typeOf(this.bf_x), intType())
 }
 
@@ -386,9 +386,9 @@ predicate shared(this: Ref) {
 
 method con(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), _c_Foo())
+  ensures isSubtype(typeOf(ret), c_Foo())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_Foo_unique(ret), write)
+  ensures acc(_c_Foo_unique(ret), write)
   ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_x)) ==
     intFromRef(x)
 

--- a/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
@@ -1,9 +1,5 @@
 /full_viper_dump.kt: info: Generated ExpEmbedding for f:
-Function(
-    name = f,
-    { Declare(Var(foo), [c$[pkg$]$[c$Foo]], MethodCall(callee = con, Int(0))) },
-    return = lbl_ret_0,
-)
+Function(name = f, { Declare(Var(foo), [c$[pkg$]$[c$Foo]], MethodCall(callee = con, Int(0))) }, return = ret_0)
 
 /full_viper_dump.kt: info: Generated Viper text for f:
 domain rt  {
@@ -384,23 +380,23 @@ predicate shared(this: Ref) {
   acc(this.bf_x, wildcard) && isSubtype(typeOf(this.bf_x), intType())
 }
 
-method con(x: Ref) returns (ret: Ref)
+method con(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), c_Foo())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_Foo_unique(ret), write)
-  ensures intFromRef((unfolding acc(shared(ret), wildcard) in ret.bf_x)) ==
+  ensures isSubtype(typeOf(v_ret), c_Foo())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_Foo_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_x)) ==
     intFromRef(x)
 
 
-method f() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method f() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var foo: Ref
   foo := con(intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method havoc() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method havoc() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), intType())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/full_viper_dump.fir.diag.txt
@@ -1,5 +1,5 @@
 /full_viper_dump.kt: info: Generated ExpEmbedding for f:
-Function(name = f, { Declare(Var(foo), [c$[pkg$]$[c$Foo]], MethodCall(callee = con, Int(0))) }, return = ret_0)
+Function(name = f, { Declare(Var(foo), [pkg$[c$Foo]], MethodCall(callee = con, Int(0))) }, return = lbl_ret_0)
 
 /full_viper_dump.kt: info: Generated Viper text for f:
 domain rt  {
@@ -20,7 +20,7 @@ domain rt  {
 
   unique function stringType(): rt
 
-  unique function c_Foo(): rt
+  unique function Foo(): rt
 
   function nullValue(): Ref
 
@@ -119,7 +119,7 @@ domain rt  {
   }
 
   axiom {
-    isSubtype(c_Foo(), anyType())
+    isSubtype(Foo(), anyType())
   }
 
   axiom supertypeOfNothing {
@@ -242,82 +242,83 @@ domain rt  {
 
 field bf_x: Ref
 
-function addCharInt(arg_1: Ref, arg: Ref): Ref
+function addCharInt(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), charType())
-  ensures charFromRef(result) == charFromRef(arg_1) + intFromRef(arg)
+  ensures charFromRef(result) == charFromRef(arg_1) + intFromRef(arg_2)
 
 
-function addStringChar(arg_1: Ref, arg: Ref): Ref
+function addStringChar(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), stringType())
   ensures stringFromRef(result) ==
-    stringFromRef(arg_1) ++ Seq(charFromRef(arg))
+    stringFromRef(arg_1) ++ Seq(charFromRef(arg_2))
 
 
-function addStrings(arg_1: Ref, arg: Ref): Ref
+function addStrings(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), stringType())
   ensures stringFromRef(result) ==
-    stringFromRef(arg_1) ++ stringFromRef(arg)
+    stringFromRef(arg_1) ++ stringFromRef(arg_2)
 
 
-function andBools(arg_1: Ref, arg: Ref): Ref
+function andBools(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == (boolFromRef(arg_1) && boolFromRef(arg))
+  ensures boolFromRef(result) == (boolFromRef(arg_1) && boolFromRef(arg_2))
 
 
-function divInts(arg_1: Ref, arg: Ref): Ref
-  requires intFromRef(arg) != 0
+function divInts(arg_1: Ref, arg_2: Ref): Ref
+  requires intFromRef(arg_2) != 0
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) \ intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) \ intFromRef(arg_2)
 
 
-function geChars(arg_1: Ref, arg: Ref): Ref
+function geChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) >= charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) >= charFromRef(arg_2)
 
 
-function geInts(arg_1: Ref, arg: Ref): Ref
+function geInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) >= intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) >= intFromRef(arg_2)
 
 
-function gtChars(arg_1: Ref, arg: Ref): Ref
+function gtChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) > charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) > charFromRef(arg_2)
 
 
-function gtInts(arg_1: Ref, arg: Ref): Ref
+function gtInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) > intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) > intFromRef(arg_2)
 
 
-function impliesBools(arg_1: Ref, arg: Ref): Ref
+function impliesBools(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == (boolFromRef(arg_1) ==> boolFromRef(arg))
+  ensures boolFromRef(result) ==
+    (boolFromRef(arg_1) ==> boolFromRef(arg_2))
 
 
-function leChars(arg_1: Ref, arg: Ref): Ref
+function leChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) <= charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) <= charFromRef(arg_2)
 
 
-function leInts(arg_1: Ref, arg: Ref): Ref
+function leInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) <= intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) <= intFromRef(arg_2)
 
 
-function ltChars(arg_1: Ref, arg: Ref): Ref
+function ltChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) < charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) < charFromRef(arg_2)
 
 
-function ltInts(arg_1: Ref, arg: Ref): Ref
+function ltInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) < intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) < intFromRef(arg_2)
 
 
-function minusInts(arg_1: Ref, arg: Ref): Ref
+function minusInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) - intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) - intFromRef(arg_2)
 
 
 function negInt(arg_1: Ref): Ref
@@ -330,26 +331,27 @@ function notBool(arg_1: Ref): Ref
   ensures boolFromRef(result) == !boolFromRef(arg_1)
 
 
-function orBools(arg_1: Ref, arg: Ref): Ref
+function orBools(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == (boolFromRef(arg_1) || boolFromRef(arg))
+  ensures boolFromRef(result) == (boolFromRef(arg_1) || boolFromRef(arg_2))
 
 
-function plusInts(arg_1: Ref, arg: Ref): Ref
+function plusInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) + intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) + intFromRef(arg_2)
 
 
-function remInts(arg_1: Ref, arg: Ref): Ref
-  requires intFromRef(arg) != 0
+function remInts(arg_1: Ref, arg_2: Ref): Ref
+  requires intFromRef(arg_2) != 0
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) % intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) % intFromRef(arg_2)
 
 
-function stringGet(arg_1: Ref, arg: Ref): Ref
-  requires intFromRef(arg) >= 0 && intFromRef(arg) < |stringFromRef(arg_1)|
+function stringGet(arg_1: Ref, arg_2: Ref): Ref
+  requires intFromRef(arg_2) >= 0 &&
+    intFromRef(arg_2) < |stringFromRef(arg_1)|
   ensures isSubtype(typeOf(result), charType())
-  ensures charFromRef(result) == stringFromRef(arg_1)[intFromRef(arg)]
+  ensures charFromRef(result) == stringFromRef(arg_1)[intFromRef(arg_2)]
 
 
 function stringLength(arg_1: Ref): Ref
@@ -357,22 +359,22 @@ function stringLength(arg_1: Ref): Ref
   ensures intFromRef(result) == |stringFromRef(arg_1)|
 
 
-function subCharInt(arg_1: Ref, arg: Ref): Ref
+function subCharInt(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), charType())
-  ensures charFromRef(result) == charFromRef(arg_1) - intFromRef(arg)
+  ensures charFromRef(result) == charFromRef(arg_1) - intFromRef(arg_2)
 
 
-function subChars(arg_1: Ref, arg: Ref): Ref
+function subChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == charFromRef(arg_1) - charFromRef(arg)
+  ensures intFromRef(result) == charFromRef(arg_1) - charFromRef(arg_2)
 
 
-function timesInts(arg_1: Ref, arg: Ref): Ref
+function timesInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) * intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) * intFromRef(arg_2)
 
 
-predicate _c_Foo_unique(this: Ref) {
+predicate Foo_unique(this: Ref) {
   acc(this.bf_x, wildcard) && isSubtype(typeOf(this.bf_x), intType())
 }
 
@@ -380,22 +382,22 @@ predicate shared(this: Ref) {
   acc(this.bf_x, wildcard) && isSubtype(typeOf(this.bf_x), intType())
 }
 
-method con(x: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(v_ret), c_Foo())
+method con(par_x: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret), Foo())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_Foo_unique(v_ret), write)
+  ensures acc(Foo_unique(v_ret), write)
   ensures intFromRef((unfolding acc(shared(v_ret), wildcard) in v_ret.bf_x)) ==
-    intFromRef(x)
+    intFromRef(par_x)
 
 
-method f() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method f() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var foo: Ref
   foo := con(intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method havoc() returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_object.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_object.fir.diag.txt
@@ -1,37 +1,37 @@
 /function_object.kt: info: Generated Viper text for unitFunction:
-method unitFunction(f: Ref) returns (ret: Ref)
+method unitFunction(f: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(f), functionType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_object.kt: info: Generated Viper text for functionObjectCall:
-method functionObjectCall(g: Ref) returns (ret: Ref)
+method functionObjectCall(g: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(g), functionType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
   inhale isSubtype(typeOf(anon), intType())
-  ret := anon
-  goto ret_0
-  label ret_0
+  v_ret_0 := anon
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /function_object.kt: info: Generated Viper text for functionObjectNestedCall:
-method functionObjectNestedCall(f: Ref, g: Ref) returns (ret: Ref)
+method functionObjectNestedCall(f: Ref, g: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(f), functionType())
   requires isSubtype(typeOf(g), functionType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon_0: Ref
   var anon_1: Ref
-  var anon: Ref
-  inhale isSubtype(typeOf(anon), intType())
+  var anon_2: Ref
+  inhale isSubtype(typeOf(anon_2), intType())
   inhale isSubtype(typeOf(anon_1), intType())
   inhale isSubtype(typeOf(anon_0), intType())
-  ret := anon_0
-  goto ret_0
-  label ret_0
+  v_ret_0 := anon_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
@@ -1,10 +1,10 @@
 /function_overloading.kt: info: Generated Viper text for baz:
 method baz(this: Ref, f: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Bar())
-  requires isSubtype(typeOf(f), _c_Foo())
+  requires isSubtype(typeOf(this), c_Bar())
+  requires isSubtype(typeOf(f), c_Foo())
   ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(c_Bar_shared(this), wildcard)
+  inhale acc(_c_Bar_shared(this), wildcard)
   inhale acc(shared(f), wildcard)
   label ret_0
   inhale isSubtype(typeOf(ret), unitType())
@@ -12,8 +12,8 @@ method baz(this: Ref, f: Ref) returns (ret: Ref)
 
 /function_overloading.kt: info: Generated Viper text for baz:
 method baz(this: Ref, b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Bar())
-  requires isSubtype(typeOf(b), _c_Bar())
+  requires isSubtype(typeOf(this), c_Bar())
+  requires isSubtype(typeOf(b), c_Bar())
   ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(this), wildcard)
@@ -24,7 +24,7 @@ method baz(this: Ref, b: Ref) returns (ret: Ref)
 
 /function_overloading.kt: info: Generated Viper text for fakePrint:
 method fakePrint(b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(b), _c_Bar())
+  requires isSubtype(typeOf(b), c_Bar())
   ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(b), wildcard)
@@ -34,7 +34,7 @@ method fakePrint(b: Ref) returns (ret: Ref)
 
 /function_overloading.kt: info: Generated Viper text for fakePrint:
 method fakePrint(f: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(f), _c_Foo())
+  requires isSubtype(typeOf(f), c_Foo())
   ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(f), wildcard)
@@ -80,34 +80,34 @@ method differInNullability(i: Ref) returns (ret: Ref)
 
 /function_overloading.kt: info: Generated Viper text for testGlobalScopeOverloading:
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Bar())
+  ensures isSubtype(typeOf(ret), c_Foo())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_Bar_unique(ret), write)
+  ensures acc(_c_Foo_unique(ret), write)
 
 
-method con__c_Foo() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Foo())
-  ensures acc(c_Foo_shared(ret), wildcard)
-  ensures acc(c_Foo_unique(ret), write)
+method con_c_Bar() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_Bar())
+  ensures acc(_c_Bar_shared(ret), wildcard)
+  ensures acc(_c_Bar_unique(ret), write)
 
 
-method f_fakePrint(f: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(f), _c_Foo())
+method f_fakePrint(b: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(b), c_Bar())
   ensures isSubtype(typeOf(ret), unitType())
 
 
-method f_fakePrint_Unit(truth: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(truth), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
-
-
-method f_fakePrint_args_Int_ret_Unit(value: Ref) returns (ret: Ref)
+method f_fakePrint_Unit(value: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(value), intType())
   ensures isSubtype(typeOf(ret), unitType())
 
 
-method fakePrint(b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(b), _c_Bar())
+method f_fakePrint_args_Boolean_ret_Unit(truth: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(truth), boolType())
+  ensures isSubtype(typeOf(ret), unitType())
+
+
+method fakePrint(f: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(f), c_Foo())
   ensures isSubtype(typeOf(ret), unitType())
 
 
@@ -120,38 +120,38 @@ method testGlobalScopeOverloading() returns (ret_0: Ref)
   var anon_3: Ref
   var anon_4: Ref
   var anon: Ref
-  anon_0 := f_fakePrint_args_Int_ret_Unit(intToRef(42))
-  anon_1 := f_fakePrint_Unit(boolToRef(true))
-  anon_3 := con__c_Foo()
-  anon_2 := f_fakePrint(anon_3)
-  anon := con()
-  anon_4 := fakePrint(anon)
+  anon_0 := f_fakePrint_Unit(intToRef(42))
+  anon_1 := f_fakePrint_args_Boolean_ret_Unit(boolToRef(true))
+  anon_3 := con()
+  anon_2 := fakePrint(anon_3)
+  anon := con_c_Bar()
+  anon_4 := f_fakePrint(anon)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for testClassFunctionOverloading:
-method baz(this: Ref, b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Bar())
-  requires isSubtype(typeOf(b), _c_Bar())
+method baz(this: Ref, f: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(this), c_Bar())
+  requires isSubtype(typeOf(f), c_Foo())
   ensures isSubtype(typeOf(ret), unitType())
 
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Foo())
+  ensures isSubtype(typeOf(ret), c_Foo())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_Foo_unique(ret), write)
+  ensures acc(_c_Foo_unique(ret), write)
 
 
-method con__c_Bar() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Bar())
-  ensures acc(c_Bar_shared(ret), wildcard)
-  ensures acc(c_Bar_unique(ret), write)
+method con_c_Bar() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_Bar())
+  ensures acc(_c_Bar_shared(ret), wildcard)
+  ensures acc(_c_Bar_unique(ret), write)
 
 
-method f_baz(this: Ref, f: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Bar())
-  requires isSubtype(typeOf(f), _c_Foo())
+method f_baz(this: Ref, b: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(this), c_Bar())
+  requires isSubtype(typeOf(b), c_Bar())
   ensures isSubtype(typeOf(ret), unitType())
 
 
@@ -163,11 +163,11 @@ method testClassFunctionOverloading() returns (ret_0: Ref)
   var anon_1: Ref
   var anon_2: Ref
   var anon: Ref
-  l0_b := con__c_Bar()
+  l0_b := con_c_Bar()
   anon_1 := con()
-  anon_0 := f_baz(l0_b, anon_1)
-  anon := con__c_Bar()
-  anon_2 := baz(l0_b, anon)
+  anon_0 := baz(l0_b, anon_1)
+  anon := con_c_Bar()
+  anon_2 := f_baz(l0_b, anon)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
@@ -79,40 +79,40 @@ method differInNullability(i: Ref) returns (ret: Ref)
 }
 
 /function_overloading.kt: info: Generated Viper text for testGlobalScopeOverloading:
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Foo())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_Foo_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Foo())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_Foo_unique(v_ret), write)
 
 
-method con_c_Bar() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Bar())
-  ensures acc(_c_Bar_shared(ret), wildcard)
-  ensures acc(_c_Bar_unique(ret), write)
+method con_c_Bar() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Bar())
+  ensures acc(_c_Bar_shared(v_ret), wildcard)
+  ensures acc(_c_Bar_unique(v_ret), write)
 
 
-method f_fakePrint(b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(b), c_Bar())
-  ensures isSubtype(typeOf(ret), unitType())
-
-
-method f_fakePrint_Unit(value: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(value), intType())
-  ensures isSubtype(typeOf(ret), unitType())
-
-
-method f_fakePrint_args_Boolean_ret_Unit(truth: Ref) returns (ret: Ref)
+method f_fakePrint(truth: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(truth), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method fakePrint(f: Ref) returns (ret: Ref)
+method f_fakePrint_Unit(f: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(f), c_Foo())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method f_fakePrint_args_c_Bar_ret_Unit(b: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(b), c_Bar())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method fakePrint(value: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(value), intType())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method testGlobalScopeOverloading() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), unitType())
-
-
-method testGlobalScopeOverloading() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -120,43 +120,43 @@ method testGlobalScopeOverloading() returns (ret_0: Ref)
   var anon_3: Ref
   var anon_4: Ref
   var anon: Ref
-  anon_0 := f_fakePrint_Unit(intToRef(42))
-  anon_1 := f_fakePrint_args_Boolean_ret_Unit(boolToRef(true))
+  anon_0 := fakePrint(intToRef(42))
+  anon_1 := f_fakePrint(boolToRef(true))
   anon_3 := con()
-  anon_2 := fakePrint(anon_3)
+  anon_2 := f_fakePrint_Unit(anon_3)
   anon := con_c_Bar()
-  anon_4 := f_fakePrint(anon)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  anon_4 := f_fakePrint_args_c_Bar_ret_Unit(anon)
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for testClassFunctionOverloading:
-method baz(this: Ref, f: Ref) returns (ret: Ref)
+method baz(this: Ref, f: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Bar())
   requires isSubtype(typeOf(f), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Foo())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_Foo_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Foo())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_Foo_unique(v_ret), write)
 
 
-method con_c_Bar() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Bar())
-  ensures acc(_c_Bar_shared(ret), wildcard)
-  ensures acc(_c_Bar_unique(ret), write)
+method con_c_Bar() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Bar())
+  ensures acc(_c_Bar_shared(v_ret), wildcard)
+  ensures acc(_c_Bar_unique(v_ret), write)
 
 
-method f_baz(this: Ref, b: Ref) returns (ret: Ref)
+method f_baz(this: Ref, b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Bar())
   requires isSubtype(typeOf(b), c_Bar())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method testClassFunctionOverloading() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), unitType())
-
-
-method testClassFunctionOverloading() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var l0_b: Ref
   var anon_0: Ref
@@ -168,6 +168,6 @@ method testClassFunctionOverloading() returns (ret_0: Ref)
   anon_0 := baz(l0_b, anon_1)
   anon := con_c_Bar()
   anon_2 := f_baz(l0_b, anon)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/function_overloading.fir.diag.txt
@@ -1,173 +1,175 @@
 /function_overloading.kt: info: Generated Viper text for baz:
-method baz(this: Ref, f: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Bar())
-  requires isSubtype(typeOf(f), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+method baz(this: Ref, f: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Bar())
+  requires isSubtype(typeOf(f), Foo())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(_c_Bar_shared(this), wildcard)
-  inhale acc(shared(f), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(Bar_shared(this), wildcard)
+  inhale acc(Foo_shared(f), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for baz:
-method baz(this: Ref, b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Bar())
-  requires isSubtype(typeOf(b), c_Bar())
-  ensures isSubtype(typeOf(ret), unitType())
+method baz(this: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Bar())
+  requires isSubtype(typeOf(b), Bar())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale acc(shared(this), wildcard)
   inhale acc(shared(b), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for fakePrint:
-method fakePrint(b: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(b), c_Bar())
-  ensures isSubtype(typeOf(ret), unitType())
+method fakePrint(b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(b), Bar())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale acc(shared(b), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for fakePrint:
-method fakePrint(f: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(f), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+method fakePrint(f: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(f), Foo())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale acc(shared(f), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for fakePrint:
-method fakePrint(value: Ref) returns (ret: Ref)
+method fakePrint(value: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(value), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for fakePrint:
-method fakePrint(truth: Ref) returns (ret: Ref)
+method fakePrint(truth: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(truth), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for differInNullability:
-method differInNullability(i: Ref) returns (ret: Ref)
+method differInNullability(i: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(i), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for differInNullability:
-method differInNullability(i: Ref) returns (ret: Ref)
+method differInNullability(i: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(i), nullable(intType()))
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for testGlobalScopeOverloading:
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Foo())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_Foo_unique(v_ret), write)
+method con_Bar() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Bar())
+  ensures acc(Bar_shared(v_ret), wildcard)
+  ensures acc(Bar_unique(v_ret), write)
 
 
-method con_c_Bar() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Bar())
-  ensures acc(_c_Bar_shared(v_ret), wildcard)
-  ensures acc(_c_Bar_unique(v_ret), write)
+method con_Foo() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Foo())
+  ensures acc(Foo_shared(v_ret), wildcard)
+  ensures acc(Foo_unique(v_ret), write)
 
 
-method f_fakePrint(truth: Ref) returns (v_ret: Ref)
+method f_fakePrint_args_Bar_ret_Unit(b: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(b), Bar())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method f_fakePrint_args_Boolean_ret_Unit(truth: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(truth), boolType())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method f_fakePrint_Unit(f: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(f), c_Foo())
+method f_fakePrint_args_Foo_ret_Unit(f: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(f), Foo())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method f_fakePrint_args_c_Bar_ret_Unit(b: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(b), c_Bar())
-  ensures isSubtype(typeOf(v_ret), unitType())
-
-
-method fakePrint(value: Ref) returns (v_ret: Ref)
+method f_fakePrint_args_Int_ret_Unit(value: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(value), intType())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method testGlobalScopeOverloading() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method testGlobalScopeOverloading() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
   var anon_2: Ref
   var anon_3: Ref
   var anon_4: Ref
-  var anon: Ref
-  anon_0 := fakePrint(intToRef(42))
-  anon_1 := f_fakePrint(boolToRef(true))
-  anon_3 := con()
-  anon_2 := f_fakePrint_Unit(anon_3)
-  anon := con_c_Bar()
-  anon_4 := f_fakePrint_args_c_Bar_ret_Unit(anon)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  var anon_5: Ref
+  anon_0 := f_fakePrint_args_Int_ret_Unit(intToRef(42))
+  anon_1 := f_fakePrint_args_Boolean_ret_Unit(boolToRef(true))
+  anon_3 := con_Foo()
+  anon_2 := f_fakePrint_args_Foo_ret_Unit(anon_3)
+  anon_5 := con_Bar()
+  anon_4 := f_fakePrint_args_Bar_ret_Unit(anon_5)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /function_overloading.kt: info: Generated Viper text for testClassFunctionOverloading:
-method baz(this: Ref, f: Ref) returns (v_ret: Ref)
+method c_Bar_f_baz_args_c_Bar_Foo_ret_Unit(this: Ref, f: Ref)
+  returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Bar())
-  requires isSubtype(typeOf(f), c_Foo())
+  requires isSubtype(typeOf(f), Foo())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Foo())
-  ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_Foo_unique(v_ret), write)
+method c_Bar_f_baz_args_c_Bar_c_Bar_ret_Unit(this: Ref, par_b: Ref)
+  returns (v_ret: Ref)
+  requires isSubtype(typeOf(this), c_Bar())
+  requires isSubtype(typeOf(par_b), c_Bar())
+  ensures isSubtype(typeOf(v_ret), unitType())
+
+
+method con_Foo() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Foo())
+  ensures acc(Foo_shared(v_ret), wildcard)
+  ensures acc(Foo_unique(v_ret), write)
 
 
 method con_c_Bar() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), c_Bar())
-  ensures acc(_c_Bar_shared(v_ret), wildcard)
-  ensures acc(_c_Bar_unique(v_ret), write)
+  ensures acc(c_Bar_shared(v_ret), wildcard)
+  ensures acc(c_Bar_unique(v_ret), write)
 
 
-method f_baz(this: Ref, b: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Bar())
-  requires isSubtype(typeOf(b), c_Bar())
-  ensures isSubtype(typeOf(v_ret), unitType())
-
-
-method testClassFunctionOverloading() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method testClassFunctionOverloading() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_b: Ref
   var anon_0: Ref
   var anon_1: Ref
   var anon_2: Ref
-  var anon: Ref
+  var anon_3: Ref
   l0_b := con_c_Bar()
-  anon_1 := con()
-  anon_0 := baz(l0_b, anon_1)
-  anon := con_c_Bar()
-  anon_2 := f_baz(l0_b, anon)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  anon_1 := con_Foo()
+  anon_0 := c_Bar_f_baz_args_c_Bar_Foo_ret_Unit(l0_b, anon_1)
+  anon_3 := con_c_Bar()
+  anon_2 := c_Bar_f_baz_args_c_Bar_c_Bar_ret_Unit(l0_b, anon_3)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
@@ -19,7 +19,7 @@ domain rt  {
 
   unique function c_A(): rt
 
-  unique function c_B(): rt
+  unique function c_pkg__c_B(): rt
 
   function nullValue(): Ref
 
@@ -122,7 +122,7 @@ domain rt  {
   }
 
   axiom {
-    isSubtype(c_B(), anyType())
+    isSubtype(c_pkg__c_B(), anyType())
   }
 
   axiom supertypeOfNothing {
@@ -405,11 +405,11 @@ function timesInts(arg_1: Ref, arg: Ref): Ref
   ensures intFromRef(result) == intFromRef(arg_1) * intFromRef(arg)
 
 
-predicate _c_A_shared(this: Ref) {
+predicate pkg__c_A_shared(this: Ref) {
   true
 }
 
-predicate _c_A_unique(this: Ref) {
+predicate pkg__c_A_unique(this: Ref) {
   acc(this.unit, write) && isSubtype(typeOf(this.unit), unitType()) &&
   acc(this.nothing, write) &&
   isSubtype(typeOf(this.nothing), nothingType()) &&
@@ -425,7 +425,7 @@ predicate _c_A_unique(this: Ref) {
   isSubtype(typeOf(this.string), stringType()) &&
   acc(this.classType, write) &&
   acc(shared(this.classType), wildcard) &&
-  isSubtype(typeOf(this.classType), c_B()) &&
+  isSubtype(typeOf(this.classType), c_pkg__c_B()) &&
   acc(this.unitNull, write) &&
   isSubtype(typeOf(this.unitNull), nullable(unitType())) &&
   acc(this.nothingNull, write) &&
@@ -443,10 +443,10 @@ predicate _c_A_unique(this: Ref) {
   acc(this.classTypeNull, write) &&
   (this.classTypeNull != nullValue() ==>
   acc(shared(this.classTypeNull), wildcard)) &&
-  isSubtype(typeOf(this.classTypeNull), nullable(c_B()))
+  isSubtype(typeOf(this.classTypeNull), nullable(c_pkg__c_B()))
 }
 
-predicate _c_B_unique(this: Ref) {
+predicate pkg__c_B_unique(this: Ref) {
   true
 }
 
@@ -454,9 +454,9 @@ predicate shared(this: Ref) {
   true
 }
 
-method f_havoc(a: Ref) returns (ret_0: Ref)
+method f_havoc(a: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), c_A())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var localUnit: Ref
   var localNothing: Ref
@@ -474,88 +474,88 @@ method f_havoc(a: Ref) returns (ret_0: Ref)
   var localCharNull: Ref
   var localStringNull: Ref
   var localClassTypeNull: Ref
-  inhale acc(_c_A_shared(a), wildcard)
+  inhale acc(pkg__c_A_shared(a), wildcard)
   localUnit := havoc_Unit()
   localNothing := havoc_Nothing()
   localAny := havoc_Any()
   localInt := havoc_Int()
   localBoolean := havoc_Boolean()
   localChar := havoc_Char()
-  localString := havoc_String()
-  localClassType := havoc()
+  localString := havoc()
+  localClassType := havoc_c_pkg__c_B()
   localUnitNull := havoc_NUnit()
   localNothingNull := havoc_NNothing()
   localAnyNull := havoc_NAny()
   localIntNull := havoc_NInt()
   localBooleanNull := havoc_NBoolean()
   localCharNull := havoc_NChar()
-  localStringNull := havoc_NString()
-  localClassTypeNull := havoc_c_B()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  localStringNull := havoc_String()
+  localClassTypeNull := havoc_Nc_pkg__c_B()
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method havoc() returns (ret: Ref)
-  ensures acc(shared(ret), wildcard)
-  ensures isSubtype(typeOf(ret), c_B())
+method havoc() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method havoc_Any() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), anyType())
+method havoc_Any() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), anyType())
 
 
-method havoc_Boolean() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
+method havoc_Boolean() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), boolType())
 
 
-method havoc_Char() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), charType())
+method havoc_Char() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), charType())
 
 
-method havoc_Int() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method havoc_Int() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method havoc_NAny() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+method havoc_NAny() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
-method havoc_NBoolean() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(boolType()))
+method havoc_NBoolean() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(boolType()))
 
 
-method havoc_NChar() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(charType()))
+method havoc_NChar() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(charType()))
 
 
-method havoc_NInt() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method havoc_NInt() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(intType()))
 
 
-method havoc_NNothing() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(nothingType()))
+method havoc_NNothing() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(nothingType()))
 
 
-method havoc_NString() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(stringType()))
+method havoc_NUnit() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(unitType()))
 
 
-method havoc_NUnit() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(unitType()))
+method havoc_Nc_pkg__c_B() returns (v_ret: Ref)
+  ensures v_ret != nullValue() ==> acc(shared(v_ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), nullable(c_pkg__c_B()))
 
 
-method havoc_Nothing() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nothingType())
+method havoc_Nothing() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nothingType())
 
 
-method havoc_String() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), stringType())
+method havoc_String() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(stringType()))
 
 
-method havoc_Unit() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method havoc_Unit() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method havoc_c_B() returns (ret: Ref)
-  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
-  ensures isSubtype(typeOf(ret), nullable(c_B()))
+method havoc_c_pkg__c_B() returns (v_ret: Ref)
+  ensures acc(shared(v_ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), c_pkg__c_B())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
@@ -17,9 +17,9 @@ domain rt  {
 
   unique function stringType(): rt
 
-  unique function _c_A(): rt
+  unique function c_A(): rt
 
-  unique function _c_B(): rt
+  unique function c_B(): rt
 
   function nullValue(): Ref
 
@@ -118,11 +118,11 @@ domain rt  {
   }
 
   axiom {
-    isSubtype(_c_A(), anyType())
+    isSubtype(c_A(), anyType())
   }
 
   axiom {
-    isSubtype(_c_B(), anyType())
+    isSubtype(c_B(), anyType())
   }
 
   axiom supertypeOfNothing {
@@ -405,11 +405,11 @@ function timesInts(arg_1: Ref, arg: Ref): Ref
   ensures intFromRef(result) == intFromRef(arg_1) * intFromRef(arg)
 
 
-predicate c_A_shared(this: Ref) {
+predicate _c_A_shared(this: Ref) {
   true
 }
 
-predicate c_A_unique(this: Ref) {
+predicate _c_A_unique(this: Ref) {
   acc(this.unit, write) && isSubtype(typeOf(this.unit), unitType()) &&
   acc(this.nothing, write) &&
   isSubtype(typeOf(this.nothing), nothingType()) &&
@@ -425,7 +425,7 @@ predicate c_A_unique(this: Ref) {
   isSubtype(typeOf(this.string), stringType()) &&
   acc(this.classType, write) &&
   acc(shared(this.classType), wildcard) &&
-  isSubtype(typeOf(this.classType), _c_B()) &&
+  isSubtype(typeOf(this.classType), c_B()) &&
   acc(this.unitNull, write) &&
   isSubtype(typeOf(this.unitNull), nullable(unitType())) &&
   acc(this.nothingNull, write) &&
@@ -443,10 +443,10 @@ predicate c_A_unique(this: Ref) {
   acc(this.classTypeNull, write) &&
   (this.classTypeNull != nullValue() ==>
   acc(shared(this.classTypeNull), wildcard)) &&
-  isSubtype(typeOf(this.classTypeNull), nullable(_c_B()))
+  isSubtype(typeOf(this.classTypeNull), nullable(c_B()))
 }
 
-predicate c_B_unique(this: Ref) {
+predicate _c_B_unique(this: Ref) {
   true
 }
 
@@ -455,7 +455,7 @@ predicate shared(this: Ref) {
 }
 
 method f_havoc(a: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(a), _c_A())
+  requires isSubtype(typeOf(a), c_A())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var localUnit: Ref
@@ -474,7 +474,7 @@ method f_havoc(a: Ref) returns (ret_0: Ref)
   var localCharNull: Ref
   var localStringNull: Ref
   var localClassTypeNull: Ref
-  inhale acc(c_A_shared(a), wildcard)
+  inhale acc(_c_A_shared(a), wildcard)
   localUnit := havoc_Unit()
   localNothing := havoc_Nothing()
   localAny := havoc_Any()
@@ -482,7 +482,7 @@ method f_havoc(a: Ref) returns (ret_0: Ref)
   localBoolean := havoc_Boolean()
   localChar := havoc_Char()
   localString := havoc_String()
-  localClassType := havoc__c_B()
+  localClassType := havoc()
   localUnitNull := havoc_NUnit()
   localNothingNull := havoc_NNothing()
   localAnyNull := havoc_NAny()
@@ -490,14 +490,14 @@ method f_havoc(a: Ref) returns (ret_0: Ref)
   localBooleanNull := havoc_NBoolean()
   localCharNull := havoc_NChar()
   localStringNull := havoc_NString()
-  localClassTypeNull := havoc()
+  localClassTypeNull := havoc_c_B()
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 method havoc() returns (ret: Ref)
-  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
-  ensures isSubtype(typeOf(ret), nullable(_c_B()))
+  ensures acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(ret), c_B())
 
 
 method havoc_Any() returns (ret: Ref)
@@ -556,6 +556,6 @@ method havoc_Unit() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), unitType())
 
 
-method havoc__c_B() returns (ret: Ref)
-  ensures acc(shared(ret), wildcard)
-  ensures isSubtype(typeOf(ret), _c_B())
+method havoc_c_B() returns (ret: Ref)
+  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(ret), nullable(c_B()))

--- a/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/havoc.fir.diag.txt
@@ -17,9 +17,9 @@ domain rt  {
 
   unique function stringType(): rt
 
-  unique function c_A(): rt
+  unique function A(): rt
 
-  unique function c_pkg__c_B(): rt
+  unique function B(): rt
 
   function nullValue(): Ref
 
@@ -118,11 +118,11 @@ domain rt  {
   }
 
   axiom {
-    isSubtype(c_A(), anyType())
+    isSubtype(A(), anyType())
   }
 
   axiom {
-    isSubtype(c_pkg__c_B(), anyType())
+    isSubtype(B(), anyType())
   }
 
   axiom supertypeOfNothing {
@@ -275,82 +275,83 @@ field unit: Ref
 
 field unitNull: Ref
 
-function addCharInt(arg_1: Ref, arg: Ref): Ref
+function addCharInt(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), charType())
-  ensures charFromRef(result) == charFromRef(arg_1) + intFromRef(arg)
+  ensures charFromRef(result) == charFromRef(arg_1) + intFromRef(arg_2)
 
 
-function addStringChar(arg_1: Ref, arg: Ref): Ref
+function addStringChar(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), stringType())
   ensures stringFromRef(result) ==
-    stringFromRef(arg_1) ++ Seq(charFromRef(arg))
+    stringFromRef(arg_1) ++ Seq(charFromRef(arg_2))
 
 
-function addStrings(arg_1: Ref, arg: Ref): Ref
+function addStrings(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), stringType())
   ensures stringFromRef(result) ==
-    stringFromRef(arg_1) ++ stringFromRef(arg)
+    stringFromRef(arg_1) ++ stringFromRef(arg_2)
 
 
-function andBools(arg_1: Ref, arg: Ref): Ref
+function andBools(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == (boolFromRef(arg_1) && boolFromRef(arg))
+  ensures boolFromRef(result) == (boolFromRef(arg_1) && boolFromRef(arg_2))
 
 
-function divInts(arg_1: Ref, arg: Ref): Ref
-  requires intFromRef(arg) != 0
+function divInts(arg_1: Ref, arg_2: Ref): Ref
+  requires intFromRef(arg_2) != 0
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) \ intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) \ intFromRef(arg_2)
 
 
-function geChars(arg_1: Ref, arg: Ref): Ref
+function geChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) >= charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) >= charFromRef(arg_2)
 
 
-function geInts(arg_1: Ref, arg: Ref): Ref
+function geInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) >= intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) >= intFromRef(arg_2)
 
 
-function gtChars(arg_1: Ref, arg: Ref): Ref
+function gtChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) > charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) > charFromRef(arg_2)
 
 
-function gtInts(arg_1: Ref, arg: Ref): Ref
+function gtInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) > intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) > intFromRef(arg_2)
 
 
-function impliesBools(arg_1: Ref, arg: Ref): Ref
+function impliesBools(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == (boolFromRef(arg_1) ==> boolFromRef(arg))
+  ensures boolFromRef(result) ==
+    (boolFromRef(arg_1) ==> boolFromRef(arg_2))
 
 
-function leChars(arg_1: Ref, arg: Ref): Ref
+function leChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) <= charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) <= charFromRef(arg_2)
 
 
-function leInts(arg_1: Ref, arg: Ref): Ref
+function leInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) <= intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) <= intFromRef(arg_2)
 
 
-function ltChars(arg_1: Ref, arg: Ref): Ref
+function ltChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == charFromRef(arg_1) < charFromRef(arg)
+  ensures boolFromRef(result) == charFromRef(arg_1) < charFromRef(arg_2)
 
 
-function ltInts(arg_1: Ref, arg: Ref): Ref
+function ltInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == intFromRef(arg_1) < intFromRef(arg)
+  ensures boolFromRef(result) == intFromRef(arg_1) < intFromRef(arg_2)
 
 
-function minusInts(arg_1: Ref, arg: Ref): Ref
+function minusInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) - intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) - intFromRef(arg_2)
 
 
 function negInt(arg_1: Ref): Ref
@@ -363,26 +364,27 @@ function notBool(arg_1: Ref): Ref
   ensures boolFromRef(result) == !boolFromRef(arg_1)
 
 
-function orBools(arg_1: Ref, arg: Ref): Ref
+function orBools(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
-  ensures boolFromRef(result) == (boolFromRef(arg_1) || boolFromRef(arg))
+  ensures boolFromRef(result) == (boolFromRef(arg_1) || boolFromRef(arg_2))
 
 
-function plusInts(arg_1: Ref, arg: Ref): Ref
+function plusInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) + intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) + intFromRef(arg_2)
 
 
-function remInts(arg_1: Ref, arg: Ref): Ref
-  requires intFromRef(arg) != 0
+function remInts(arg_1: Ref, arg_2: Ref): Ref
+  requires intFromRef(arg_2) != 0
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) % intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) % intFromRef(arg_2)
 
 
-function stringGet(arg_1: Ref, arg: Ref): Ref
-  requires intFromRef(arg) >= 0 && intFromRef(arg) < |stringFromRef(arg_1)|
+function stringGet(arg_1: Ref, arg_2: Ref): Ref
+  requires intFromRef(arg_2) >= 0 &&
+    intFromRef(arg_2) < |stringFromRef(arg_1)|
   ensures isSubtype(typeOf(result), charType())
-  ensures charFromRef(result) == stringFromRef(arg_1)[intFromRef(arg)]
+  ensures charFromRef(result) == stringFromRef(arg_1)[intFromRef(arg_2)]
 
 
 function stringLength(arg_1: Ref): Ref
@@ -390,26 +392,26 @@ function stringLength(arg_1: Ref): Ref
   ensures intFromRef(result) == |stringFromRef(arg_1)|
 
 
-function subCharInt(arg_1: Ref, arg: Ref): Ref
+function subCharInt(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), charType())
-  ensures charFromRef(result) == charFromRef(arg_1) - intFromRef(arg)
+  ensures charFromRef(result) == charFromRef(arg_1) - intFromRef(arg_2)
 
 
-function subChars(arg_1: Ref, arg: Ref): Ref
+function subChars(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == charFromRef(arg_1) - charFromRef(arg)
+  ensures intFromRef(result) == charFromRef(arg_1) - charFromRef(arg_2)
 
 
-function timesInts(arg_1: Ref, arg: Ref): Ref
+function timesInts(arg_1: Ref, arg_2: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
-  ensures intFromRef(result) == intFromRef(arg_1) * intFromRef(arg)
+  ensures intFromRef(result) == intFromRef(arg_1) * intFromRef(arg_2)
 
 
-predicate pkg__c_A_shared(this: Ref) {
+predicate A_shared(this: Ref) {
   true
 }
 
-predicate pkg__c_A_unique(this: Ref) {
+predicate A_unique(this: Ref) {
   acc(this.unit, write) && isSubtype(typeOf(this.unit), unitType()) &&
   acc(this.nothing, write) &&
   isSubtype(typeOf(this.nothing), nothingType()) &&
@@ -424,8 +426,8 @@ predicate pkg__c_A_unique(this: Ref) {
   acc(this.string, write) &&
   isSubtype(typeOf(this.string), stringType()) &&
   acc(this.classType, write) &&
-  acc(shared(this.classType), wildcard) &&
-  isSubtype(typeOf(this.classType), c_pkg__c_B()) &&
+  acc(B_shared(this.classType), wildcard) &&
+  isSubtype(typeOf(this.classType), B()) &&
   acc(this.unitNull, write) &&
   isSubtype(typeOf(this.unitNull), nullable(unitType())) &&
   acc(this.nothingNull, write) &&
@@ -442,21 +444,21 @@ predicate pkg__c_A_unique(this: Ref) {
   isSubtype(typeOf(this.stringNull), nullable(stringType())) &&
   acc(this.classTypeNull, write) &&
   (this.classTypeNull != nullValue() ==>
-  acc(shared(this.classTypeNull), wildcard)) &&
-  isSubtype(typeOf(this.classTypeNull), nullable(c_pkg__c_B()))
+  acc(B_shared(this.classTypeNull), wildcard)) &&
+  isSubtype(typeOf(this.classTypeNull), nullable(B()))
 }
 
-predicate pkg__c_B_unique(this: Ref) {
+predicate B_shared(this: Ref) {
   true
 }
 
-predicate shared(this: Ref) {
+predicate B_unique(this: Ref) {
   true
 }
 
-method f_havoc(a: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(a), c_A())
-  ensures isSubtype(typeOf(ret), unitType())
+method f_havoc(a: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), A())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var localUnit: Ref
   var localNothing: Ref
@@ -474,33 +476,34 @@ method f_havoc(a: Ref) returns (ret: Ref)
   var localCharNull: Ref
   var localStringNull: Ref
   var localClassTypeNull: Ref
-  inhale acc(pkg__c_A_shared(a), wildcard)
+  inhale acc(A_shared(a), wildcard)
   localUnit := havoc_Unit()
   localNothing := havoc_Nothing()
   localAny := havoc_Any()
   localInt := havoc_Int()
   localBoolean := havoc_Boolean()
   localChar := havoc_Char()
-  localString := havoc()
-  localClassType := havoc_c_pkg__c_B()
+  localString := havoc_String()
+  localClassType := havoc_B()
   localUnitNull := havoc_NUnit()
   localNothingNull := havoc_NNothing()
   localAnyNull := havoc_NAny()
   localIntNull := havoc_NInt()
   localBooleanNull := havoc_NBoolean()
   localCharNull := havoc_NChar()
-  localStringNull := havoc_String()
-  localClassTypeNull := havoc_Nc_pkg__c_B()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  localStringNull := havoc_NString()
+  localClassTypeNull := havoc_NB()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
-
-method havoc() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), stringType())
-
 
 method havoc_Any() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), anyType())
+
+
+method havoc_B() returns (v_ret: Ref)
+  ensures acc(B_shared(v_ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), B())
 
 
 method havoc_Boolean() returns (v_ret: Ref)
@@ -519,6 +522,11 @@ method havoc_NAny() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
+method havoc_NB() returns (v_ret: Ref)
+  ensures v_ret != nullValue() ==> acc(B_shared(v_ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), nullable(B()))
+
+
 method havoc_NBoolean() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), nullable(boolType()))
 
@@ -535,13 +543,12 @@ method havoc_NNothing() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), nullable(nothingType()))
 
 
+method havoc_NString() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), nullable(stringType()))
+
+
 method havoc_NUnit() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), nullable(unitType()))
-
-
-method havoc_Nc_pkg__c_B() returns (v_ret: Ref)
-  ensures v_ret != nullValue() ==> acc(shared(v_ret), wildcard)
-  ensures isSubtype(typeOf(v_ret), nullable(c_pkg__c_B()))
 
 
 method havoc_Nothing() returns (v_ret: Ref)
@@ -549,13 +556,8 @@ method havoc_Nothing() returns (v_ret: Ref)
 
 
 method havoc_String() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), nullable(stringType()))
+  ensures isSubtype(typeOf(v_ret), stringType())
 
 
 method havoc_Unit() returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), unitType())
-
-
-method havoc_c_pkg__c_B() returns (v_ret: Ref)
-  ensures acc(shared(v_ret), wildcard)
-  ensures isSubtype(typeOf(v_ret), c_pkg__c_B())

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
@@ -42,19 +42,19 @@ method captureVar() returns (ret_0: Ref)
 }
 
 /captured.kt: info: Generated Viper text for captureAndShadow:
-method captureAndShadow(par_x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(par_x), intType())
+method captureAndShadow(x: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var ret_1: Ref
   var ret: Ref
   var anon: Ref
   var y: Ref
-  var x: Ref
+  var l2_x: Ref
   anon := intToRef(0)
-  y := par_x
-  x := intToRef(1)
-  ret := plusInts(plusInts(anon, x), y)
+  y := x
+  l2_x := intToRef(1)
+  ret := plusInts(plusInts(anon, l2_x), y)
   goto ret_2
   label ret_2
   ret_1 := ret
@@ -66,22 +66,22 @@ method captureAndShadow(par_x: Ref) returns (ret_0: Ref)
 }
 
 /captured.kt: info: Generated Viper text for captureVarClash:
-method captureVarClash(par_x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(par_x), intType())
+method captureVarClash(x: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var ret_1: Ref
-  var x: Ref
-  var anon_1: Ref
-  var ret: Ref
+  var l1_x: Ref
   var anon: Ref
-  x := intToRef(1)
-  anon := intToRef(0)
-  ret := timesInts(anon, par_x)
+  var ret: Ref
+  var anon_0: Ref
+  l1_x := intToRef(1)
+  anon_0 := intToRef(0)
+  ret := timesInts(anon_0, x)
   goto ret_2
   label ret_2
-  anon_1 := ret
-  ret_1 := plusInts(anon_1, x)
+  anon := ret
+  ret_1 := plusInts(anon, l1_x)
   goto lbl_ret_1
   label lbl_ret_1
   ret_0 := ret_1
@@ -90,26 +90,26 @@ method captureVarClash(par_x: Ref) returns (ret_0: Ref)
 }
 
 /captured.kt: info: Generated Viper text for captureAndShadowClash:
-method captureAndShadowClash(par_x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(par_x), intType())
+method captureAndShadowClash(x: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var ret_1: Ref
   var l1_x: Ref
-  var anon_1: Ref
-  var ret: Ref
   var anon: Ref
+  var ret: Ref
+  var anon_0: Ref
   var y: Ref
-  var x: Ref
+  var l2_x: Ref
   l1_x := intToRef(1)
-  anon := intToRef(0)
-  y := par_x
-  x := intToRef(2)
-  ret := plusInts(plusInts(x, y), anon)
+  anon_0 := intToRef(0)
+  y := x
+  l2_x := intToRef(2)
+  ret := plusInts(plusInts(l2_x, y), anon_0)
   goto ret_2
   label ret_2
-  anon_1 := ret
-  ret_1 := plusInts(anon_1, l1_x)
+  anon := ret
+  ret_1 := plusInts(anon, l1_x)
   goto lbl_ret_1
   label lbl_ret_1
   ret_0 := ret_1
@@ -118,8 +118,8 @@ method captureAndShadowClash(par_x: Ref) returns (ret_0: Ref)
 }
 
 /captured.kt: info: Generated Viper text for nestedLambdaShadowing:
-method nestedLambdaShadowing(par_x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(par_x), intType())
+method nestedLambdaShadowing(x: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var ret_1: Ref
@@ -129,27 +129,27 @@ method nestedLambdaShadowing(par_x: Ref) returns (ret_0: Ref)
   var anon_0: Ref
   var ret_3: Ref
   var l3_x: Ref
-  var anon_3: Ref
-  var ret: Ref
   var anon: Ref
+  var ret: Ref
+  var anon_1: Ref
   var l4_x: Ref
   var y: Ref
-  var x: Ref
+  var l2_x: Ref
   l1_x := intToRef(1)
   anon_0 := intToRef(0)
   l3_x := intToRef(1)
-  anon := intToRef(0)
+  anon_1 := intToRef(0)
   l4_x := intToRef(3)
-  ret := plusInts(l4_x, anon)
+  ret := plusInts(l4_x, anon_1)
   goto ret_4
   label ret_4
-  anon_3 := ret
-  ret_3 := plusInts(anon_3, l3_x)
+  anon := ret
+  ret_3 := plusInts(anon, l3_x)
   goto lbl_ret_3
   label lbl_ret_3
-  y := par_x
-  x := intToRef(4)
-  ret_2 := plusInts(plusInts(x, y), anon_0)
+  y := x
+  l2_x := intToRef(4)
+  ret_2 := plusInts(plusInts(l2_x, y), anon_0)
   goto lbl_ret_2
   label lbl_ret_2
   anon_2 := ret_2
@@ -162,8 +162,8 @@ method nestedLambdaShadowing(par_x: Ref) returns (ret_0: Ref)
 }
 
 /captured.kt: info: Generated Viper text for callDoubleInvoke:
-method callDoubleInvoke(par_x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(par_x), intType())
+method callDoubleInvoke(x: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var ret_1: Ref
@@ -172,15 +172,15 @@ method callDoubleInvoke(par_x: Ref) returns (ret_0: Ref)
   var l2_x: Ref
   var ret: Ref
   var anon: Ref
-  var x: Ref
+  var l3_x: Ref
   anon_0 := intToRef(0)
   l2_x := anon_0
   ret_2 := l2_x
   goto lbl_ret_2
   label lbl_ret_2
   anon := intToRef(1)
-  x := anon
-  ret := x
+  l3_x := anon
+  ret := l3_x
   goto ret_3
   label ret_3
   ret_1 := ret

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/captured.fir.diag.txt
@@ -1,136 +1,136 @@
 /captured.kt: info: Generated Viper text for captureArg:
-method captureArg(g: Ref) returns (ret_0: Ref)
+method captureArg(g: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(g), functionType())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon_0: Ref
-  var anon: Ref
+  var anon_1: Ref
   anon_0 := intToRef(0)
-  inhale isSubtype(typeOf(anon), intType())
-  ret := anon
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  inhale isSubtype(typeOf(anon_1), intType())
+  v_ret_2 := anon_1
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /captured.kt: info: Generated Viper text for captureVar:
-method captureVar() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method captureVar() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var x: Ref
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   x := intToRef(1)
   anon := intToRef(0)
-  ret := plusInts(anon, x)
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  v_ret_2 := plusInts(anon, x)
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /captured.kt: info: Generated Viper text for captureAndShadow:
-method captureAndShadow(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), intType())
+method captureAndShadow(par_x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   var y: Ref
   var l2_x: Ref
   anon := intToRef(0)
-  y := x
+  y := par_x
   l2_x := intToRef(1)
-  ret := plusInts(plusInts(anon, l2_x), y)
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  v_ret_2 := plusInts(plusInts(anon, l2_x), y)
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /captured.kt: info: Generated Viper text for captureVarClash:
-method captureVarClash(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), intType())
+method captureVarClash(par_x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var l1_x: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_1: Ref
+  var v_ret_2: Ref
   var anon_0: Ref
   l1_x := intToRef(1)
   anon_0 := intToRef(0)
-  ret := timesInts(anon_0, x)
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := plusInts(anon, l1_x)
+  v_ret_2 := timesInts(anon_0, par_x)
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon_1 := v_ret_2
+  v_ret_1 := plusInts(anon_1, l1_x)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /captured.kt: info: Generated Viper text for captureAndShadowClash:
-method captureAndShadowClash(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), intType())
+method captureAndShadowClash(par_x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var l1_x: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_1: Ref
+  var v_ret_2: Ref
   var anon_0: Ref
   var y: Ref
   var l2_x: Ref
   l1_x := intToRef(1)
   anon_0 := intToRef(0)
-  y := x
+  y := par_x
   l2_x := intToRef(2)
-  ret := plusInts(plusInts(l2_x, y), anon_0)
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := plusInts(anon, l1_x)
+  v_ret_2 := plusInts(plusInts(l2_x, y), anon_0)
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon_1 := v_ret_2
+  v_ret_1 := plusInts(anon_1, l1_x)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /captured.kt: info: Generated Viper text for nestedLambdaShadowing:
-method nestedLambdaShadowing(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), intType())
+method nestedLambdaShadowing(par_x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var l1_x: Ref
   var anon_2: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var anon_0: Ref
-  var ret_3: Ref
+  var v_ret_3: Ref
   var l3_x: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_3: Ref
+  var v_ret_4: Ref
   var anon_1: Ref
   var l4_x: Ref
   var y: Ref
@@ -140,53 +140,53 @@ method nestedLambdaShadowing(x: Ref) returns (ret_0: Ref)
   l3_x := intToRef(1)
   anon_1 := intToRef(0)
   l4_x := intToRef(3)
-  ret := plusInts(l4_x, anon_1)
-  goto ret_4
-  label ret_4
-  anon := ret
-  ret_3 := plusInts(anon, l3_x)
+  v_ret_4 := plusInts(l4_x, anon_1)
+  goto lbl_ret_4
+  label lbl_ret_4
+  anon_3 := v_ret_4
+  v_ret_3 := plusInts(anon_3, l3_x)
   goto lbl_ret_3
   label lbl_ret_3
-  y := x
+  y := par_x
   l2_x := intToRef(4)
-  ret_2 := plusInts(plusInts(l2_x, y), anon_0)
+  v_ret_2 := plusInts(plusInts(l2_x, y), anon_0)
   goto lbl_ret_2
   label lbl_ret_2
-  anon_2 := ret_2
-  ret_1 := plusInts(anon_2, l1_x)
+  anon_2 := v_ret_2
+  v_ret_1 := plusInts(anon_2, l1_x)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /captured.kt: info: Generated Viper text for callDoubleInvoke:
-method callDoubleInvoke(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), intType())
+method callDoubleInvoke(par_x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret_2: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon_0: Ref
   var l2_x: Ref
-  var ret: Ref
-  var anon: Ref
+  var v_ret_3: Ref
+  var anon_1: Ref
   var l3_x: Ref
   anon_0 := intToRef(0)
   l2_x := anon_0
-  ret_2 := l2_x
+  v_ret_2 := l2_x
   goto lbl_ret_2
   label lbl_ret_2
-  anon := intToRef(1)
-  l3_x := anon
-  ret := l3_x
-  goto ret_3
-  label ret_3
-  ret_1 := ret
+  anon_1 := intToRef(1)
+  l3_x := anon_1
+  v_ret_3 := l3_x
+  goto lbl_ret_3
+  label lbl_ret_3
+  v_ret_1 := v_ret_3
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
@@ -31,9 +31,9 @@ method useBranching() returns (ret_0: Ref)
   var anon_2: Ref
   var ret_1: Ref
   var anon_0: Ref
-  var anon_3: Ref
-  var ret: Ref
   var anon: Ref
+  var ret: Ref
+  var anon_1: Ref
   anon_0 := boolToRef(false)
   if (boolFromRef(anon_0)) {
     ret_1 := intToRef(1)
@@ -44,8 +44,8 @@ method useBranching() returns (ret_0: Ref)
   }
   label lbl_ret_1
   anon_2 := ret_1
-  anon := boolToRef(true)
-  if (boolFromRef(anon)) {
+  anon_1 := boolToRef(true)
+  if (boolFromRef(anon_1)) {
     ret := intToRef(1)
     goto ret_2
   } else {
@@ -53,8 +53,8 @@ method useBranching() returns (ret_0: Ref)
     goto ret_2
   }
   label ret_2
-  anon_3 := ret
-  ret_0 := plusInts(anon_2, anon_3)
+  anon := ret
+  ret_0 := plusInts(anon_2, anon)
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/inline.fir.diag.txt
@@ -1,60 +1,60 @@
 /inline.kt: info: Generated Viper text for quadruple:
-method quadruple(x: Ref) returns (ret_0: Ref)
+method quadruple(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon_0: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var l1_y: Ref
-  var anon: Ref
-  var ret: Ref
-  var y: Ref
+  var anon_1: Ref
+  var v_ret_2: Ref
+  var l2_y: Ref
   l1_y := plusInts(x, x)
-  ret_1 := l1_y
+  v_ret_1 := l1_y
   goto lbl_ret_1
   label lbl_ret_1
-  anon_0 := ret_1
-  y := plusInts(x, x)
-  ret := y
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_0 := plusInts(anon_0, anon)
+  anon_0 := v_ret_1
+  l2_y := plusInts(x, x)
+  v_ret_2 := l2_y
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon_1 := v_ret_2
+  v_ret_0 := plusInts(anon_0, anon_1)
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /inline.kt: info: Generated Viper text for useBranching:
-method useBranching() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method useBranching() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon_2: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_3: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   anon_0 := boolToRef(false)
   if (boolFromRef(anon_0)) {
-    ret_1 := intToRef(1)
+    v_ret_1 := intToRef(1)
     goto lbl_ret_1
   } else {
-    ret_1 := intToRef(0)
+    v_ret_1 := intToRef(0)
     goto lbl_ret_1
   }
   label lbl_ret_1
-  anon_2 := ret_1
+  anon_2 := v_ret_1
   anon_1 := boolToRef(true)
   if (boolFromRef(anon_1)) {
-    ret := intToRef(1)
-    goto ret_2
+    v_ret_2 := intToRef(1)
+    goto lbl_ret_2
   } else {
-    ret := intToRef(0)
-    goto ret_2
+    v_ret_2 := intToRef(0)
+    goto lbl_ret_2
   }
-  label ret_2
-  anon := ret
-  ret_0 := plusInts(anon_2, anon)
+  label lbl_ret_2
+  anon_3 := v_ret_2
+  v_ret_0 := plusInts(anon_2, anon_3)
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/inlining/lambdas.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/inlining/lambdas.fir.diag.txt
@@ -1,150 +1,150 @@
 /lambdas.kt: info: Generated Viper text for explicitArg:
-method explicitArg() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method explicitArg() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   anon := intToRef(0)
-  ret := plusInts(anon, anon)
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  v_ret_2 := plusInts(anon, anon)
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /lambdas.kt: info: Generated Viper text for implicitArg:
-method implicitArg() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method implicitArg() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   anon := intToRef(0)
-  ret := timesInts(anon, intToRef(2))
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  v_ret_2 := timesInts(anon, intToRef(2))
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /lambdas.kt: info: Generated Viper text for lambdaIf:
-method lambdaIf() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method lambdaIf() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   anon := intToRef(0)
   if (intFromRef(anon) == 0) {
-    ret := plusInts(anon, intToRef(1))
+    v_ret_2 := plusInts(anon, intToRef(1))
   } else {
-    ret := plusInts(anon, intToRef(2))}
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+    v_ret_2 := plusInts(anon, intToRef(2))}
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /lambdas.kt: info: Generated Viper text for returnValueNotUsed:
-method returnValueNotUsed() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method returnValueNotUsed() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
   anon := intToRef(0)
-  ret := anon
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  v_ret_2 := anon
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /lambdas.kt: info: Generated Viper text for shadowing:
-method shadowing() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method shadowing() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var x: Ref
   var l0_y: Ref
-  var ret_1: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
   var anon: Ref
-  var y: Ref
+  var l2_y: Ref
   x := intToRef(1)
   l0_y := intToRef(1)
   anon := intToRef(0)
-  y := intToRef(0)
-  ret := plusInts(anon, y)
-  goto ret_2
-  label ret_2
-  ret_1 := ret
+  l2_y := intToRef(0)
+  v_ret_2 := plusInts(anon, l2_y)
+  goto lbl_ret_2
+  label lbl_ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /lambdas.kt: info: Generated Viper text for nested:
-method nested() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method nested() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var l0_x: Ref
-  var ret_1: Ref
-  var x: Ref
-  var ret_2: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var l1_x: Ref
+  var v_ret_2: Ref
+  var v_ret_3: Ref
   var anon: Ref
   l0_x := intToRef(2)
-  x := intToRef(2)
+  l1_x := intToRef(2)
   anon := intToRef(0)
-  ret := plusInts(anon, intToRef(1))
-  goto ret_3
-  label ret_3
-  ret_2 := ret
+  v_ret_3 := plusInts(anon, intToRef(1))
+  goto lbl_ret_3
+  label lbl_ret_3
+  v_ret_2 := v_ret_3
   goto lbl_ret_2
   label lbl_ret_2
-  ret_1 := ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /lambdas.kt: info: Generated Viper text for lambdaPassthrough:
-method lambdaPassthrough() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method lambdaPassthrough() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var ret_1: Ref
-  var ret_2: Ref
-  var ret: Ref
+  var v_ret_1: Ref
+  var v_ret_2: Ref
+  var v_ret_3: Ref
   var anon: Ref
   anon := intToRef(0)
-  ret := plusInts(anon, intToRef(1))
-  goto ret_3
-  label ret_3
-  ret_2 := ret
+  v_ret_3 := plusInts(anon, intToRef(1))
+  goto lbl_ret_3
+  label lbl_ret_3
+  v_ret_2 := v_ret_3
   goto lbl_ret_2
   label lbl_ret_2
   label lbl_ret_1
-  inhale isSubtype(typeOf(ret_1), unitType())
+  inhale isSubtype(typeOf(v_ret_1), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/arithmetic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/arithmetic.fir.diag.txt
@@ -1,65 +1,65 @@
 /arithmetic.kt: info: Generated Viper text for addition:
-method addition(x: Ref) returns (ret: Ref)
+method addition(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
   y := plusInts(x, x)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /arithmetic.kt: info: Generated Viper text for subtraction:
-method subtraction(x: Ref) returns (ret: Ref)
+method subtraction(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
   y := minusInts(x, x)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /arithmetic.kt: info: Generated Viper text for multiplication:
-method multiplication(x: Ref) returns (ret: Ref)
+method multiplication(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
   y := timesInts(x, x)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /arithmetic.kt: info: Generated Viper text for division:
-method division(x: Ref) returns (ret: Ref)
+method division(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
   y := divInts(x, x)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /arithmetic.kt: info: Generated Viper text for remainder:
-method remainder(x: Ref) returns (ret: Ref)
+method remainder(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
   y := remInts(x, x)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /arithmetic.kt: info: Generated Viper text for unary_minus:
-method unary_minus(x: Ref) returns (ret: Ref)
+method unary_minus(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
   y := negInt(x)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
@@ -1,12 +1,12 @@
 /as_operator.kt: info: Generated Viper text for testAs:
 method testAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
-  ensures isSubtype(typeOf(ret), _c_Bar())
-  ensures acc(shared(ret), wildcard)
+  requires isSubtype(typeOf(foo), c_Foo())
+  ensures isSubtype(typeOf(ret), c_Bar())
+  ensures acc(_c_Bar_shared(ret), wildcard)
 {
-  inhale acc(c_Foo_shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), _c_Bar())
   inhale acc(shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), c_Bar())
+  inhale acc(_c_Bar_shared(foo), wildcard)
   ret := foo
   goto ret_0
   label ret_0
@@ -14,13 +14,13 @@ method testAs(foo: Ref) returns (ret: Ref)
 
 /as_operator.kt: info: Generated Viper text for testNullableAs:
 method testNullableAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), nullable(_c_Foo()))
-  ensures isSubtype(typeOf(ret), nullable(_c_Bar()))
-  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
+  requires isSubtype(typeOf(foo), nullable(c_Foo()))
+  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
+  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
 {
-  inhale foo != nullValue() ==> acc(c_Foo_shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), nullable(_c_Bar()))
   inhale foo != nullValue() ==> acc(shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), nullable(c_Bar()))
+  inhale foo != nullValue() ==> acc(_c_Bar_shared(foo), wildcard)
   ret := foo
   goto ret_0
   label ret_0
@@ -28,34 +28,34 @@ method testNullableAs(foo: Ref) returns (ret: Ref)
 
 /as_operator.kt: info: Generated Viper text for testSafeAs:
 method testSafeAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
-  ensures isSubtype(typeOf(ret), nullable(_c_Bar()))
-  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
+  requires isSubtype(typeOf(foo), c_Foo())
+  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
+  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
 {
-  inhale acc(c_Foo_shared(foo), wildcard)
-  if (isSubtype(typeOf(foo), _c_Bar())) {
+  inhale acc(shared(foo), wildcard)
+  if (isSubtype(typeOf(foo), c_Bar())) {
     ret := foo
   } else {
     ret := nullValue()}
-  inhale isSubtype(typeOf(ret), nullable(_c_Bar()))
-  inhale ret != nullValue() ==> acc(shared(ret), wildcard)
+  inhale isSubtype(typeOf(ret), nullable(c_Bar()))
+  inhale ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
   goto ret_0
   label ret_0
 }
 
 /as_operator.kt: info: Generated Viper text for testNullableSafeAs:
 method testNullableSafeAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), nullable(_c_Foo()))
-  ensures isSubtype(typeOf(ret), nullable(_c_Bar()))
-  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
+  requires isSubtype(typeOf(foo), nullable(c_Foo()))
+  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
+  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
 {
-  inhale foo != nullValue() ==> acc(c_Foo_shared(foo), wildcard)
-  if (isSubtype(typeOf(foo), _c_Bar())) {
+  inhale foo != nullValue() ==> acc(shared(foo), wildcard)
+  if (isSubtype(typeOf(foo), c_Bar())) {
     ret := foo
   } else {
     ret := nullValue()}
-  inhale isSubtype(typeOf(ret), nullable(_c_Bar()))
-  inhale ret != nullValue() ==> acc(shared(ret), wildcard)
+  inhale isSubtype(typeOf(ret), nullable(c_Bar()))
+  inhale ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
   goto ret_0
   label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/as_operator.fir.diag.txt
@@ -1,61 +1,61 @@
 /as_operator.kt: info: Generated Viper text for testAs:
-method testAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), c_Bar())
-  ensures acc(_c_Bar_shared(ret), wildcard)
+method testAs(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), Bar())
+  ensures acc(Bar_shared(v_ret_0), wildcard)
 {
-  inhale acc(shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), c_Bar())
-  inhale acc(_c_Bar_shared(foo), wildcard)
-  ret := foo
-  goto ret_0
-  label ret_0
+  inhale acc(Foo_shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), Bar())
+  inhale acc(Bar_shared(foo), wildcard)
+  v_ret_0 := foo
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /as_operator.kt: info: Generated Viper text for testNullableAs:
-method testNullableAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), nullable(c_Foo()))
-  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
-  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
+method testNullableAs(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), nullable(Foo()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(Bar()))
+  ensures v_ret_0 != nullValue() ==> acc(Bar_shared(v_ret_0), wildcard)
 {
-  inhale foo != nullValue() ==> acc(shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), nullable(c_Bar()))
-  inhale foo != nullValue() ==> acc(_c_Bar_shared(foo), wildcard)
-  ret := foo
-  goto ret_0
-  label ret_0
+  inhale foo != nullValue() ==> acc(Foo_shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), nullable(Bar()))
+  inhale foo != nullValue() ==> acc(Bar_shared(foo), wildcard)
+  v_ret_0 := foo
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /as_operator.kt: info: Generated Viper text for testSafeAs:
-method testSafeAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
-  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
+method testSafeAs(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), nullable(Bar()))
+  ensures v_ret_0 != nullValue() ==> acc(Bar_shared(v_ret_0), wildcard)
 {
-  inhale acc(shared(foo), wildcard)
-  if (isSubtype(typeOf(foo), c_Bar())) {
-    ret := foo
+  inhale acc(Foo_shared(foo), wildcard)
+  if (isSubtype(typeOf(foo), Bar())) {
+    v_ret_0 := foo
   } else {
-    ret := nullValue()}
-  inhale isSubtype(typeOf(ret), nullable(c_Bar()))
-  inhale ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  inhale isSubtype(typeOf(v_ret_0), nullable(Bar()))
+  inhale v_ret_0 != nullValue() ==> acc(Bar_shared(v_ret_0), wildcard)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /as_operator.kt: info: Generated Viper text for testNullableSafeAs:
-method testNullableSafeAs(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), nullable(c_Foo()))
-  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
-  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
+method testNullableSafeAs(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), nullable(Foo()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(Bar()))
+  ensures v_ret_0 != nullValue() ==> acc(Bar_shared(v_ret_0), wildcard)
 {
-  inhale foo != nullValue() ==> acc(shared(foo), wildcard)
-  if (isSubtype(typeOf(foo), c_Bar())) {
-    ret := foo
+  inhale foo != nullValue() ==> acc(Foo_shared(foo), wildcard)
+  if (isSubtype(typeOf(foo), Bar())) {
+    v_ret_0 := foo
   } else {
-    ret := nullValue()}
-  inhale isSubtype(typeOf(ret), nullable(c_Bar()))
-  inhale ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  inhale isSubtype(typeOf(v_ret_0), nullable(Bar()))
+  inhale v_ret_0 != nullValue() ==> acc(Bar_shared(v_ret_0), wildcard)
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
@@ -23,24 +23,24 @@ method conjunction(x: Ref, y: Ref) returns (ret: Ref)
 }
 
 /boolean_logic.kt: info: Generated Viper text for conjunctionSideEffects:
-method conjunctionSideEffects(x: Ref, y: Ref) returns (ret_0: Ref)
+method conjunctionSideEffects(x: Ref, y: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), boolType())
   requires isSubtype(typeOf(y), boolType())
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var anon: Ref
   anon := negation(x)
   if (boolFromRef(anon)) {
-    ret_0 := negation(y)
+    ret := negation(y)
   } else {
-    ret_0 := boolToRef(false)}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := boolToRef(false)}
+  goto ret_0
+  label ret_0
 }
 
-method negation(x: Ref) returns (ret: Ref)
+method negation(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
 
 
 /boolean_logic.kt: info: Generated Viper text for disjunction:

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/boolean_logic.fir.diag.txt
@@ -1,41 +1,41 @@
 /boolean_logic.kt: info: Generated Viper text for negation:
-method negation(x: Ref) returns (ret: Ref)
+method negation(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := notBool(x)
-  goto ret_0
-  label ret_0
+  v_ret_0 := notBool(x)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /boolean_logic.kt: info: Generated Viper text for conjunction:
-method conjunction(x: Ref, y: Ref) returns (ret: Ref)
+method conjunction(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), boolType())
   requires isSubtype(typeOf(y), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   if (boolFromRef(x)) {
-    ret := y
+    v_ret_0 := y
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /boolean_logic.kt: info: Generated Viper text for conjunctionSideEffects:
-method conjunctionSideEffects(x: Ref, y: Ref) returns (ret: Ref)
+method conjunctionSideEffects(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), boolType())
   requires isSubtype(typeOf(y), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var anon: Ref
   anon := negation(x)
   if (boolFromRef(anon)) {
-    ret := negation(y)
+    v_ret_0 := negation(y)
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method negation(x: Ref) returns (v_ret: Ref)
@@ -44,15 +44,15 @@ method negation(x: Ref) returns (v_ret: Ref)
 
 
 /boolean_logic.kt: info: Generated Viper text for disjunction:
-method disjunction(x: Ref, y: Ref) returns (ret: Ref)
+method disjunction(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), boolType())
   requires isSubtype(typeOf(y), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   if (boolFromRef(x)) {
-    ret := boolToRef(true)
+    v_ret_0 := boolToRef(true)
   } else {
-    ret := y}
-  goto ret_0
-  label ret_0
+    v_ret_0 := y}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/comparison.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/comparison.fir.diag.txt
@@ -1,43 +1,43 @@
 /comparison.kt: info: Generated Viper text for less:
-method less(x: Ref, y: Ref) returns (ret: Ref)
+method less(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := ltInts(x, y)
-  goto ret_0
-  label ret_0
+  v_ret_0 := ltInts(x, y)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /comparison.kt: info: Generated Viper text for lessEqual:
-method lessEqual(x: Ref, y: Ref) returns (ret: Ref)
+method lessEqual(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := leInts(x, y)
-  goto ret_0
-  label ret_0
+  v_ret_0 := leInts(x, y)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /comparison.kt: info: Generated Viper text for greater:
-method greater(x: Ref, y: Ref) returns (ret: Ref)
+method greater(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := gtInts(x, y)
-  goto ret_0
-  label ret_0
+  v_ret_0 := gtInts(x, y)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /comparison.kt: info: Generated Viper text for greaterEqual:
-method greaterEqual(x: Ref, y: Ref) returns (ret: Ref)
+method greaterEqual(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := geInts(x, y)
-  goto ret_0
-  label ret_0
+  v_ret_0 := geInts(x, y)
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
@@ -12,28 +12,28 @@ method elvisOperator(x: Ref) returns (ret: Ref)
 }
 
 /elvis.kt: info: Generated Viper text for elvisOperatorComplex:
-method elvisOperator(x: Ref) returns (ret: Ref)
+method elvisOperator(x: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(x), nullable(intType()))
+  ensures isSubtype(typeOf(v_ret), intType())
+
+
+method elvisOperatorComplex(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
   ensures isSubtype(typeOf(ret), intType())
-
-
-method elvisOperatorComplex(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret_0), intType())
 {
   var anon: Ref
   anon := id(x)
   if (anon != nullValue()) {
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := elvisOperator(intToRef(2))}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := elvisOperator(intToRef(2))}
+  goto ret_0
+  label ret_0
 }
 
-method id(x: Ref) returns (ret: Ref)
+method id(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures isSubtype(typeOf(v_ret), nullable(intType()))
 
 
 /elvis.kt: info: Generated Viper text for elvisOperatorReturn:

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/elvis.fir.diag.txt
@@ -1,14 +1,14 @@
 /elvis.kt: info: Generated Viper text for elvisOperator:
-method elvisOperator(x: Ref) returns (ret: Ref)
+method elvisOperator(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (x != nullValue()) {
-    ret := x
+    v_ret_0 := x
   } else {
-    ret := intToRef(3)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := intToRef(3)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /elvis.kt: info: Generated Viper text for elvisOperatorComplex:
@@ -17,18 +17,18 @@ method elvisOperator(x: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), intType())
 
 
-method elvisOperatorComplex(x: Ref) returns (ret: Ref)
+method elvisOperatorComplex(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
   anon := id(x)
   if (anon != nullValue()) {
-    ret := anon
+    v_ret_0 := anon
   } else {
-    ret := elvisOperator(intToRef(2))}
-  goto ret_0
-  label ret_0
+    v_ret_0 := elvisOperator(intToRef(2))}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method id(x: Ref) returns (v_ret: Ref)
@@ -37,20 +37,20 @@ method id(x: Ref) returns (v_ret: Ref)
 
 
 /elvis.kt: info: Generated Viper text for elvisOperatorReturn:
-method elvisOperatorReturn(x: Ref) returns (ret: Ref)
+method elvisOperatorReturn(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var y: Ref
   if (x != nullValue()) {
     y := x
   } else {
     var anon: Ref
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
     y := anon
   }
-  ret := y
-  goto ret_0
-  label ret_0
+  v_ret_0 := y
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/increment.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/increment.fir.diag.txt
@@ -1,6 +1,6 @@
 /increment.kt: info: Generated Viper text for test_simple:
-method test_simple() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method test_simple() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   x := intToRef(10)
@@ -10,28 +10,28 @@ method test_simple() returns (ret: Ref)
   x := plusInts(x, intToRef(1))
   x := timesInts(x, intToRef(2))
   x := divInts(x, intToRef(4))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /increment.kt: info: Generated Viper text for test_postincvrement:
-method test_postincvrement() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method test_postincvrement() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   var first: Ref
   var anon_0: Ref
   var second: Ref
-  var anon: Ref
+  var anon_1: Ref
   var unary: Ref
   x := intToRef(10)
   anon_0 := x
   x := plusInts(anon_0, intToRef(1))
   first := anon_0
-  anon := x
-  x := minusInts(anon, intToRef(1))
-  second := anon
+  anon_1 := x
+  x := minusInts(anon_1, intToRef(1))
+  second := anon_1
   unary := x
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/is_operator.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/is_operator.fir.diag.txt
@@ -1,34 +1,34 @@
 /is_operator.kt: info: Generated Viper text for isNonNullable:
-method isNonNullable(x: Ref) returns (ret: Ref)
+method isNonNullable(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := boolToRef(isSubtype(typeOf(x), intType()))
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(isSubtype(typeOf(x), intType()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /is_operator.kt: info: Generated Viper text for notIsNullable:
-method notIsNullable(x: Ref) returns (ret: Ref)
+method notIsNullable(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := notBool(boolToRef(isSubtype(typeOf(x), nothingType())))
-  goto ret_0
-  label ret_0
+  v_ret_0 := notBool(boolToRef(isSubtype(typeOf(x), nothingType())))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /is_operator.kt: info: Generated Viper text for smartCast:
-method smartCast(x: Ref) returns (ret: Ref)
+method smartCast(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (isSubtype(typeOf(x), intType())) {
-    ret := x
-    goto ret_0
+    v_ret_0 := x
+    goto lbl_ret_0
   } else {
-    ret := intToRef(-1)
-    goto ret_0
+    v_ret_0 := intToRef(-1)
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
@@ -1,99 +1,99 @@
 /safe_call.kt: info: Generated Viper text for testSafeCall:
 field x: Ref
 
-method f(this: Ref) returns (ret: Ref)
+method f(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method testSafeCall(foo: Ref) returns (ret_0: Ref)
+method testSafeCall(foo: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(foo), nullable(c_Foo()))
-  ensures isSubtype(typeOf(ret_0), nullable(unitType()))
+  ensures isSubtype(typeOf(ret), nullable(unitType()))
 {
   inhale foo != nullValue() ==> acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     anon := f(foo)
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for testSafeCallNonNullable:
 field x: Ref
 
-method f(this: Ref) returns (ret: Ref)
+method f(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Foo())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method testSafeCallNonNullable(foo: Ref) returns (ret_0: Ref)
+method testSafeCallNonNullable(foo: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret_0), nullable(unitType()))
+  ensures isSubtype(typeOf(ret), nullable(unitType()))
 {
   inhale acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     anon := f(foo)
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for testSafeCallProperty:
 field x: Ref
 
-method testSafeCallProperty(foo: Ref) returns (ret_0: Ref)
+method testSafeCallProperty(foo: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(foo), nullable(c_Foo()))
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures isSubtype(typeOf(ret), nullable(intType()))
 {
   inhale foo != nullValue() ==> acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     unfold acc(shared(foo), wildcard)
     anon := foo.x
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for testSafeCallPropertyNonNullable:
 field x: Ref
 
-method testSafeCallPropertyNonNullable(foo: Ref) returns (ret_0: Ref)
+method testSafeCallPropertyNonNullable(foo: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures isSubtype(typeOf(ret), nullable(intType()))
 {
   inhale acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     unfold acc(shared(foo), wildcard)
     anon := foo.x
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for safeCallChain:
 field bf_v: Ref
 
-method f_nullable(this: Ref) returns (ret: Ref)
+method f_nullable(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_Rec())
-  ensures isSubtype(typeOf(ret), nullable(c_Rec()))
-  ensures ret != nullValue() ==> acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), nullable(c_Rec()))
+  ensures v_ret != nullValue() ==> acc(shared(v_ret), wildcard)
 
 
-method safeCallChain(rec: Ref) returns (ret_0: Ref)
+method safeCallChain(rec: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(rec), nullable(c_Rec()))
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures isSubtype(typeOf(ret), nullable(intType()))
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -110,9 +110,9 @@ method safeCallChain(rec: Ref) returns (ret_0: Ref)
     var anon: Ref
     unfold acc(shared(anon_0), wildcard)
     anon := anon_0.bf_v
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
@@ -2,12 +2,12 @@
 field x: Ref
 
 method f(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret), unitType())
 
 
 method testSafeCall(foo: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(foo), nullable(_c_Foo()))
+  requires isSubtype(typeOf(foo), nullable(c_Foo()))
   ensures isSubtype(typeOf(ret_0), nullable(unitType()))
 {
   inhale foo != nullValue() ==> acc(shared(foo), wildcard)
@@ -25,12 +25,12 @@ method testSafeCall(foo: Ref) returns (ret_0: Ref)
 field x: Ref
 
 method f(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Foo())
+  requires isSubtype(typeOf(this), c_Foo())
   ensures isSubtype(typeOf(ret), unitType())
 
 
 method testSafeCallNonNullable(foo: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
+  requires isSubtype(typeOf(foo), c_Foo())
   ensures isSubtype(typeOf(ret_0), nullable(unitType()))
 {
   inhale acc(shared(foo), wildcard)
@@ -48,7 +48,7 @@ method testSafeCallNonNullable(foo: Ref) returns (ret_0: Ref)
 field x: Ref
 
 method testSafeCallProperty(foo: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(foo), nullable(_c_Foo()))
+  requires isSubtype(typeOf(foo), nullable(c_Foo()))
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
 {
   inhale foo != nullValue() ==> acc(shared(foo), wildcard)
@@ -67,7 +67,7 @@ method testSafeCallProperty(foo: Ref) returns (ret_0: Ref)
 field x: Ref
 
 method testSafeCallPropertyNonNullable(foo: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
+  requires isSubtype(typeOf(foo), c_Foo())
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
 {
   inhale acc(shared(foo), wildcard)
@@ -86,13 +86,13 @@ method testSafeCallPropertyNonNullable(foo: Ref) returns (ret_0: Ref)
 field bf_v: Ref
 
 method f_nullable(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Rec())
-  ensures isSubtype(typeOf(ret), nullable(_c_Rec()))
+  requires isSubtype(typeOf(this), c_Rec())
+  ensures isSubtype(typeOf(ret), nullable(c_Rec()))
   ensures ret != nullValue() ==> acc(shared(ret), wildcard)
 
 
 method safeCallChain(rec: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(rec), nullable(_c_Rec()))
+  requires isSubtype(typeOf(rec), nullable(c_Rec()))
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
 {
   var anon_0: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/operators/safe_call.fir.diag.txt
@@ -2,98 +2,98 @@
 field x: Ref
 
 method f(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
+  requires isSubtype(typeOf(this), Foo())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method testSafeCall(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), nullable(c_Foo()))
-  ensures isSubtype(typeOf(ret), nullable(unitType()))
+method testSafeCall(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), nullable(Foo()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(unitType()))
 {
   inhale foo != nullValue() ==> acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     anon := f(foo)
-    ret := anon
+    v_ret_0 := anon
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for testSafeCallNonNullable:
 field x: Ref
 
 method f(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Foo())
+  requires isSubtype(typeOf(this), Foo())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method testSafeCallNonNullable(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), nullable(unitType()))
+method testSafeCallNonNullable(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), nullable(unitType()))
 {
   inhale acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     anon := f(foo)
-    ret := anon
+    v_ret_0 := anon
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for testSafeCallProperty:
 field x: Ref
 
-method testSafeCallProperty(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), nullable(c_Foo()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method testSafeCallProperty(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), nullable(Foo()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
   inhale foo != nullValue() ==> acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     unfold acc(shared(foo), wildcard)
     anon := foo.x
-    ret := anon
+    v_ret_0 := anon
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for testSafeCallPropertyNonNullable:
 field x: Ref
 
-method testSafeCallPropertyNonNullable(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method testSafeCallPropertyNonNullable(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
   inhale acc(shared(foo), wildcard)
   if (foo != nullValue()) {
     var anon: Ref
     unfold acc(shared(foo), wildcard)
     anon := foo.x
-    ret := anon
+    v_ret_0 := anon
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /safe_call.kt: info: Generated Viper text for safeCallChain:
 field bf_v: Ref
 
 method f_nullable(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_Rec())
-  ensures isSubtype(typeOf(v_ret), nullable(c_Rec()))
+  requires isSubtype(typeOf(this), Rec())
+  ensures isSubtype(typeOf(v_ret), rt_nullable(Rec()))
   ensures v_ret != nullValue() ==> acc(shared(v_ret), wildcard)
 
 
-method safeCallChain(rec: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(rec), nullable(c_Rec()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method safeCallChain(rec: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(rec), rt_nullable(Rec()))
+  ensures isSubtype(typeOf(v_ret_0), rt_nullable(intType()))
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -107,12 +107,12 @@ method safeCallChain(rec: Ref) returns (ret: Ref)
   } else {
     anon_0 := nullValue()}
   if (anon_0 != nullValue()) {
-    var anon: Ref
+    var anon_2: Ref
     unfold acc(shared(anon_0), wildcard)
-    anon := anon_0.bf_v
-    ret := anon
+    anon_2 := anon_0.bf_v
+    v_ret_0 := anon_2
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_assignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_assignments.fir.diag.txt
@@ -2,37 +2,37 @@
 function returnNumberVal(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_x_0 ==
+  (let x_0 ==
     (intToRef(42)) in
-    l0_x_0)
+    x_0)
 }
 
 /pure_function_with_assignments.kt: info: Generated Viper text for multipleAssignmentsOfDifferentType:
 function multipleAssignmentsOfDifferentType(): Ref
   ensures isSubtype(typeOf(result), boolType())
 {
-  (let l0_a_0 ==
+  (let a_0 ==
     (intToRef(42)) in
-    (let l0_b_0 ==
+    (let b_0 ==
       (stringToRef(Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116))) in
-      (let l0_c_0 ==
+      (let c_0 ==
         (boolToRef(true)) in
-        (let l0_d_0 ==
+        (let d_0 ==
           (charToRef(65)) in
-          l0_c_0))))
+          c_0))))
 }
 
 /pure_function_with_assignments.kt: info: Generated Viper text for multipleAssignmentsWithLiteralReturn:
 function multipleAssignmentsWithLiteralReturn(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_a_0 ==
+  (let a_0 ==
     (intToRef(42)) in
-    (let l0_b_0 ==
+    (let b_0 ==
       (stringToRef(Seq(72, 101, 108, 108, 111, 32, 83, 110, 97, 75, 116))) in
-      (let l0_c_0 ==
+      (let c_0 ==
         (boolToRef(true)) in
-        (let l0_d_0 ==
+        (let d_0 ==
           (charToRef(65)) in
           intToRef(42)))))
 }
@@ -41,13 +41,13 @@ function multipleAssignmentsWithLiteralReturn(): Ref
 function laterInitializersCanRelyOnPrevious(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_a_0 ==
+  (let a_0 ==
     (intToRef(40)) in
-    (let l0_b_0 ==
-      (plusInts(l0_a_0, intToRef(2))) in
-      (let l0_c_0 ==
-        (timesInts(l0_b_0, intToRef(2))) in
-        l0_c_0)))
+    (let b_0 ==
+      (plusInts(a_0, intToRef(2))) in
+      (let c_0 ==
+        (timesInts(b_0, intToRef(2))) in
+        c_0)))
 }
 
 /pure_function_with_assignments.kt: info: Generated Viper text for initializersCanRelyOnParameters:
@@ -56,11 +56,11 @@ function initializersCanRelyOnParameters(x: Ref, y: Ref): Ref
   requires isSubtype(typeOf(y), intType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_sum_0 ==
+  (let sum_0 ==
     (plusInts(x, y)) in
-    (let l0_diff_0 ==
+    (let diff_0 ==
       (minusInts(x, y)) in
-      (let l0_res_0 ==
-        (timesInts(l0_sum_0, l0_diff_0)) in
-        l0_res_0)))
+      (let res_0 ==
+        (timesInts(sum_0, diff_0)) in
+        res_0)))
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_branching.fir.diag.txt
@@ -74,25 +74,23 @@ function whenExpressionSimple(x: Ref): Ref
   requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_y_0 ==
+  (let y_0 ==
     (intToRef(0)) in
-    (let v_anon_0_0 ==
+    (let anon_0_0 ==
       (x) in
-      (let l0_y_1 ==
-        ((intFromRef(v_anon_0_0) == 1 ? intToRef(10) : null)) in
-        (let l0_y_2 ==
-          ((!(intFromRef(v_anon_0_0) == 2) &&
-          !(intFromRef(v_anon_0_0) == 1) ?
+      (let y_1 ==
+        ((intFromRef(anon_0_0) == 1 ? intToRef(10) : null)) in
+        (let y_2 ==
+          ((!(intFromRef(anon_0_0) == 2) && !(intFromRef(anon_0_0) == 1) ?
             intToRef(30) :
             null)) in
-          (let l0_y_3 ==
-            ((intFromRef(v_anon_0_0) == 2 ? l0_y_0 : l0_y_2)) in
-            (let l0_y_4 ==
-              ((intFromRef(v_anon_0_0) == 1 ? l0_y_1 : l0_y_3)) in
-              (intFromRef(v_anon_0_0) == 2 &&
-              !(intFromRef(v_anon_0_0) == 1) ?
+          (let y_3 ==
+            ((intFromRef(anon_0_0) == 2 ? y_0 : y_2)) in
+            (let y_4 ==
+              ((intFromRef(anon_0_0) == 1 ? y_1 : y_3)) in
+              (intFromRef(anon_0_0) == 2 && !(intFromRef(anon_0_0) == 1) ?
                 intToRef(20) :
-                plusInts(l0_y_4, intToRef(1)))))))))
+                plusInts(y_4, intToRef(1)))))))))
 }
 
 /pure_function_with_branching.kt: info: Generated Viper text for whenNoArgumentBranching:
@@ -101,7 +99,7 @@ function whenNoArgumentBranching(x: Ref, y: Ref): Ref
   requires isSubtype(typeOf(y), intType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l5_z_0 ==
+  (let z_0 ==
     ((!(intFromRef(x) < 0 || intFromRef(y) < 0) &&
     (!(intFromRef(x) > 0 && intFromRef(y) > 0) && !(intFromRef(x) == 0)) ?
       intToRef(5) :
@@ -113,7 +111,7 @@ function whenNoArgumentBranching(x: Ref, y: Ref): Ref
         ((intFromRef(x) < 0 || intFromRef(y) < 0) &&
         (!(intFromRef(x) > 0 && intFromRef(y) > 0) && !(intFromRef(x) == 0)) ?
           intToRef(-1) :
-          l5_z_0))))
+          z_0))))
 }
 
 /pure_function_with_branching.kt: info: Generated Viper text for stringEqualityBranching:
@@ -121,44 +119,44 @@ function stringEqualityBranching(input: Ref): Ref
   requires isSubtype(typeOf(input), stringType())
   ensures isSubtype(typeOf(result), boolType())
 {
-  (let l0_isValid_0 ==
+  (let isValid_0 ==
     (boolToRef(false)) in
-    (let l0_isValid_1 ==
+    (let isValid_1 ==
       ((stringFromRef(input) == Seq(117, 115, 101, 114) &&
       !(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) ?
         boolToRef(true) :
         null)) in
-      (let l0_isValid_2 ==
+      (let isValid_2 ==
         ((!(stringFromRef(input) == Seq(117, 115, 101, 114)) &&
         !(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) ?
           boolToRef(false) :
           null)) in
-        (let l0_isValid_3 ==
+        (let isValid_3 ==
           ((stringFromRef(input) == Seq(117, 115, 101, 114) ?
-            l0_isValid_1 :
-            l0_isValid_2)) in
-          (let l0_isValid_4 ==
+            isValid_1 :
+            isValid_2)) in
+          (let isValid_4 ==
             ((stringFromRef(input) == Seq(97, 100, 109, 105, 110) ?
-              l0_isValid_0 :
-              l0_isValid_3)) in
+              isValid_0 :
+              isValid_3)) in
             (stringFromRef(input) == Seq(97, 100, 109, 105, 110) ?
               boolToRef(true) :
-              l0_isValid_4))))))
+              isValid_4))))))
 }
 
 /pure_function_with_branching.kt: info: Generated Viper text for sequentialIfWithMutation:
 function sequentialIfWithMutation(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_x_0 ==
+  (let x_0 ==
     (intToRef(10)) in
-    (let l0_x_1 ==
-      ((intFromRef(l0_x_0) > 5 ? intToRef(2) : null)) in
-      (let l0_x_2 ==
-        ((!(intFromRef(l0_x_0) > 5) ? intToRef(20) : null)) in
-        (let l0_x_3 ==
-          ((intFromRef(l0_x_0) > 5 ? l0_x_1 : l0_x_2)) in
-          (intFromRef(l0_x_3) == 2 ? intToRef(100) : intToRef(0))))))
+    (let x_1 ==
+      ((intFromRef(x_0) > 5 ? intToRef(2) : null)) in
+      (let x_2 ==
+        ((!(intFromRef(x_0) > 5) ? intToRef(20) : null)) in
+        (let x_3 ==
+          ((intFromRef(x_0) > 5 ? x_1 : x_2)) in
+          (intFromRef(x_3) == 2 ? intToRef(100) : intToRef(0))))))
 }
 
 /pure_function_with_branching.kt: info: Generated Viper text for complexBooleanReturn:

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_function_with_reassignments.fir.diag.txt
@@ -2,65 +2,65 @@
 function doubleIncrement(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_x_0 ==
+  (let x_0 ==
     (intToRef(1)) in
-    (let l0_x_1 ==
-      (plusInts(l0_x_0, intToRef(1))) in
-      (let l0_x_2 ==
-        (plusInts(l0_x_1, intToRef(1))) in
-        l0_x_2)))
+    (let x_1 ==
+      (plusInts(x_0, intToRef(1))) in
+      (let x_2 ==
+        (plusInts(x_1, intToRef(1))) in
+        x_2)))
 }
 
 /pure_function_with_reassignments.kt: info: Generated Viper text for updateThenReadIntoOther:
 function updateThenReadIntoOther(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_x_0 ==
+  (let x_0 ==
     (intToRef(3)) in
-    (let l0_x_1 ==
-      (plusInts(l0_x_0, intToRef(4))) in
-      (let l0_y_0 ==
-        (plusInts(l0_x_1, intToRef(1))) in
-        l0_y_0)))
+    (let x_1 ==
+      (plusInts(x_0, intToRef(4))) in
+      (let y_0 ==
+        (plusInts(x_1, intToRef(1))) in
+        y_0)))
 }
 
 /pure_function_with_reassignments.kt: info: Generated Viper text for readOldValueBeforeUpdate:
 function readOldValueBeforeUpdate(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_x_0 ==
+  (let x_0 ==
     (intToRef(10)) in
-    (let l0_y_0 ==
-      (plusInts(l0_x_0, intToRef(1))) in
-      (let l0_x_1 ==
-        (plusInts(l0_x_0, intToRef(5))) in
-        (let l0_x_2 ==
-          (plusInts(l0_y_0, l0_x_1)) in
-          l0_x_2))))
+    (let y_0 ==
+      (plusInts(x_0, intToRef(1))) in
+      (let x_1 ==
+        (plusInts(x_0, intToRef(5))) in
+        (let x_2 ==
+          (plusInts(y_0, x_1)) in
+          x_2))))
 }
 
 /pure_function_with_reassignments.kt: info: Generated Viper text for chainThroughTemp:
 function chainThroughTemp(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_x_0 ==
+  (let x_0 ==
     (intToRef(2)) in
-    (let l0_t_0 ==
-      (plusInts(l0_x_0, intToRef(3))) in
-      (let l0_x_1 ==
-        (plusInts(l0_t_0, intToRef(4))) in
-        l0_x_1)))
+    (let t_0 ==
+      (plusInts(x_0, intToRef(3))) in
+      (let x_1 ==
+        (plusInts(t_0, intToRef(4))) in
+        x_1)))
 }
 
 /pure_function_with_reassignments.kt: info: Generated Viper text for overwriteNotSelfReferential:
 function overwriteNotSelfReferential(): Ref
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_x_0 ==
+  (let x_0 ==
     (intToRef(7)) in
-    (let l0_x_1 ==
+    (let x_1 ==
       (intToRef(100)) in
-      l0_x_1))
+      x_1))
 }
 
 /pure_function_with_reassignments.kt: info: Generated Viper text for nestedConditionalAssignment:
@@ -69,25 +69,23 @@ function nestedConditionalAssignment(a: Ref, b: Ref): Ref
   requires isSubtype(typeOf(b), boolType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let v_anon_1_0 ==
+  (let anon_1_0 ==
     ((boolFromRef(b) && boolFromRef(a) ? intToRef(4) : null)) in
-    (let v_anon_2_0 ==
+    (let anon_2_0 ==
       ((!boolFromRef(b) && boolFromRef(a) ? intToRef(3) : null)) in
-      (let v_anon_0_0 ==
-        ((boolFromRef(a) ?
-          (boolFromRef(b) ? v_anon_1_0 : v_anon_2_0) :
-          null)) in
-        (let v_anon_4_0 ==
+      (let anon_0_0 ==
+        ((boolFromRef(a) ? (boolFromRef(b) ? anon_1_0 : anon_2_0) : null)) in
+        (let anon_4_0 ==
           ((boolFromRef(b) && !boolFromRef(a) ? intToRef(2) : null)) in
-          (let v_anon_5_0 ==
+          (let anon_5_0 ==
             ((!boolFromRef(b) && !boolFromRef(a) ? intToRef(1) : null)) in
-            (let v_anon_3_0 ==
+            (let anon_3_0 ==
               ((!boolFromRef(a) ?
-                (boolFromRef(b) ? v_anon_4_0 : v_anon_5_0) :
+                (boolFromRef(b) ? anon_4_0 : anon_5_0) :
                 null)) in
-              (let l0_x_0 ==
-                ((boolFromRef(a) ? v_anon_0_0 : v_anon_3_0)) in
-                l0_x_0)))))))
+              (let x_0 ==
+                ((boolFromRef(a) ? anon_0_0 : anon_3_0)) in
+                x_0)))))))
 }
 
 /pure_function_with_reassignments.kt: info: Generated Viper text for blockConditionalAssignment:
@@ -96,21 +94,19 @@ function blockConditionalAssignment(a: Ref, b: Ref): Ref
   requires isSubtype(typeOf(b), boolType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let v_anon_1_0 ==
+  (let anon_1_0 ==
     ((boolFromRef(b) && boolFromRef(a) ? intToRef(10) : null)) in
-    (let v_anon_2_0 ==
+    (let anon_2_0 ==
       ((!boolFromRef(b) && boolFromRef(a) ? intToRef(20) : null)) in
-      (let l2_y_0 ==
-        ((boolFromRef(a) ?
-          (boolFromRef(b) ? v_anon_1_0 : v_anon_2_0) :
-          null)) in
-        (let v_anon_0_0 ==
-          ((boolFromRef(a) ? plusInts(l2_y_0, intToRef(1)) : null)) in
-          (let v_anon_3_0 ==
+      (let y_0 ==
+        ((boolFromRef(a) ? (boolFromRef(b) ? anon_1_0 : anon_2_0) : null)) in
+        (let anon_0_0 ==
+          ((boolFromRef(a) ? plusInts(y_0, intToRef(1)) : null)) in
+          (let anon_3_0 ==
             ((!boolFromRef(a) ? intToRef(30) : null)) in
-            (let l0_x_0 ==
-              ((boolFromRef(a) ? v_anon_0_0 : v_anon_3_0)) in
-              l0_x_0))))))
+            (let x_0 ==
+              ((boolFromRef(a) ? anon_0_0 : anon_3_0)) in
+              x_0))))))
 }
 
 /pure_function_with_reassignments.kt: info: Generated Viper text for whenAssignment:
@@ -119,32 +115,32 @@ function whenAssignment(a: Ref, b: Ref): Ref
   requires isSubtype(typeOf(b), boolType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let v_anon_0_0 ==
+  (let anon_0_0 ==
     (a) in
-    (let v_anon_2_0 ==
-      ((boolFromRef(b) && intFromRef(v_anon_0_0) == 1 ? intToRef(2) : null)) in
-      (let v_anon_3_0 ==
-        ((!boolFromRef(b) && intFromRef(v_anon_0_0) == 1 ?
+    (let anon_2_0 ==
+      ((boolFromRef(b) && intFromRef(anon_0_0) == 1 ? intToRef(2) : null)) in
+      (let anon_3_0 ==
+        ((!boolFromRef(b) && intFromRef(anon_0_0) == 1 ?
           intToRef(3) :
           null)) in
-        (let v_anon_1_0 ==
-          ((intFromRef(v_anon_0_0) == 1 ?
-            (boolFromRef(b) ? v_anon_2_0 : v_anon_3_0) :
+        (let anon_1_0 ==
+          ((intFromRef(anon_0_0) == 1 ?
+            (boolFromRef(b) ? anon_2_0 : anon_3_0) :
             null)) in
-          (let v_anon_5_0 ==
-            ((intFromRef(v_anon_0_0) == 2 && !(intFromRef(v_anon_0_0) == 1) ?
+          (let anon_5_0 ==
+            ((intFromRef(anon_0_0) == 2 && !(intFromRef(anon_0_0) == 1) ?
               intToRef(4) :
               null)) in
-            (let v_anon_6_0 ==
-              ((!(intFromRef(v_anon_0_0) == 2) &&
-              !(intFromRef(v_anon_0_0) == 1) ?
+            (let anon_6_0 ==
+              ((!(intFromRef(anon_0_0) == 2) &&
+              !(intFromRef(anon_0_0) == 1) ?
                 intToRef(5) :
                 null)) in
-              (let v_anon_4_0 ==
-                ((!(intFromRef(v_anon_0_0) == 1) ?
-                  (intFromRef(v_anon_0_0) == 2 ? v_anon_5_0 : v_anon_6_0) :
+              (let anon_4_0 ==
+                ((!(intFromRef(anon_0_0) == 1) ?
+                  (intFromRef(anon_0_0) == 2 ? anon_5_0 : anon_6_0) :
                   null)) in
-                (let l0_x_0 ==
-                  ((intFromRef(v_anon_0_0) == 1 ? v_anon_1_0 : v_anon_4_0)) in
-                  l0_x_0))))))))
+                (let x_0 ==
+                  ((intFromRef(anon_0_0) == 1 ? anon_1_0 : anon_4_0)) in
+                  x_0))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
@@ -56,8 +56,8 @@ field b: Ref
 
 function annotatedReferenceReturn(x: Ref): Ref
   requires acc(shared(x), wildcard)
-  requires isSubtype(typeOf(x), _c_X())
-  ensures isSubtype(typeOf(result), _c_X())
+  requires isSubtype(typeOf(x), c_X())
+  ensures isSubtype(typeOf(result), c_X())
 {
   x
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/pure_functions/pure_literal_function.fir.diag.txt
@@ -5,13 +5,13 @@ function emptyAnnotatedFunction(): Ref
   nullValue()
 }
 
-method emptyFunction() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method emptyFunction() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   x := emptyAnnotatedFunction()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /pure_literal_function.kt: info: Generated Viper text for emptyAnnotatedFunction:
@@ -56,8 +56,8 @@ field b: Ref
 
 function annotatedReferenceReturn(x: Ref): Ref
   requires acc(shared(x), wildcard)
-  requires isSubtype(typeOf(x), c_X())
-  ensures isSubtype(typeOf(result), c_X())
+  requires isSubtype(typeOf(x), X())
+  ensures isSubtype(typeOf(result), X())
 {
   x
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
@@ -13,14 +13,26 @@ method iAmAMethod() returns (ret: Ref)
 
 /wrongly_annotated.kt: error: Impure function body detected in pure function
 
+/wrongly_annotated.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/wrongly_annotated.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/wrongly_annotated.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /wrongly_annotated.kt: info: Generated Viper text for impureExtension:
 field value: Ref
 
-method impureExtension(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_Field())
+method impureExtension([v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), c_Field())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  inhale acc(shared(this), wildcard)
+  inhale acc(shared([v$this]), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
@@ -13,28 +13,16 @@ method iAmAMethod() returns (ret: Ref)
 
 /wrongly_annotated.kt: error: Impure function body detected in pure function
 
-/wrongly_annotated.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/wrongly_annotated.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/wrongly_annotated.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /wrongly_annotated.kt: info: Generated Viper text for impureExtension:
 field value: Ref
 
-method impureExtension([v$this]: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), c_Field())
-  ensures isSubtype(typeOf(ret_0), unitType())
+method impureExtension(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), c_Field())
+  ensures isSubtype(typeOf(ret), unitType())
 {
-  inhale acc(shared([v$this]), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale acc(shared(v_this), wildcard)
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /wrongly_annotated.kt: error: Impure function body detected in pure function

--- a/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
@@ -16,11 +16,11 @@ method iAmAMethod() returns (v_ret_0: Ref)
 /wrongly_annotated.kt: info: Generated Viper text for impureExtension:
 field value: Ref
 
-method impureExtension(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), Field())
+method impureExtension(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), Field())
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(v_this_dispatch), wildcard)
+  inhale acc(shared(v_this_extension), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/purity/wrongly_annotated.fir.diag.txt
@@ -1,10 +1,10 @@
 /wrongly_annotated.kt: info: Generated Viper text for iAmAMethod:
-method iAmAMethod() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method iAmAMethod() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  ret := intToRef(1)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(1)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /wrongly_annotated.kt: error: Impure function body detected in pure function
@@ -16,13 +16,13 @@ method iAmAMethod() returns (ret: Ref)
 /wrongly_annotated.kt: info: Generated Viper text for impureExtension:
 field value: Ref
 
-method impureExtension(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), c_Field())
-  ensures isSubtype(typeOf(ret), unitType())
+method impureExtension(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), Field())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  inhale acc(shared(v_this), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(shared(v_this_dispatch), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /wrongly_annotated.kt: error: Impure function body detected in pure function

--- a/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
@@ -22,27 +22,27 @@ method shadowLocal() returns (ret: Ref)
 }
 
 /shadowing.kt: info: Generated Viper text for shadowParam:
-method shadowParam(par_x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(par_x), intType())
+method shadowParam(x: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(ret), unitType())
 {
   var foo: Ref
-  var x: Ref
-  foo := par_x
-  x := intToRef(0)
+  var l0_x: Ref
   foo := x
+  l0_x := intToRef(0)
+  foo := l0_x
   label ret_0
   inhale isSubtype(typeOf(ret), unitType())
 }
 
 /shadowing.kt: info: Generated Viper text for shadowNested:
-method shadowNested(par_x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(par_x), intType())
+method shadowNested(x: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(x), intType())
   ensures isSubtype(typeOf(ret), unitType())
 {
   var foo: Ref
   var l0_x: Ref
-  foo := par_x
+  foo := x
   l0_x := intToRef(0)
   foo := l0_x
   if (true) {
@@ -55,20 +55,20 @@ method shadowNested(par_x: Ref) returns (ret: Ref)
       invariant isSubtype(typeOf(l2_x), intType())
       invariant isSubtype(typeOf(foo), intType())
       invariant isSubtype(typeOf(l0_x), intType())
-      invariant isSubtype(typeOf(par_x), intType())
+      invariant isSubtype(typeOf(x), intType())
     anon := boolToRef(true)
     if (boolFromRef(anon)) {
-      var x: Ref
+      var l3_x: Ref
       foo := l2_x
-      x := intToRef(2)
-      foo := x
+      l3_x := intToRef(2)
+      foo := l3_x
       goto cont
     }
     label break
     assert isSubtype(typeOf(l2_x), intType())
     assert isSubtype(typeOf(foo), intType())
     assert isSubtype(typeOf(l0_x), intType())
-    assert isSubtype(typeOf(par_x), intType())
+    assert isSubtype(typeOf(x), intType())
     foo := l2_x
   }
   foo := l0_x

--- a/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/shadowing.fir.diag.txt
@@ -1,6 +1,6 @@
 /shadowing.kt: info: Generated Viper text for shadowLocal:
-method shadowLocal() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method shadowLocal() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var foo: Ref
   var l0_x: Ref
@@ -11,38 +11,38 @@ method shadowLocal() returns (ret: Ref)
     l2_x := intToRef(1)
     foo := l2_x
   } else {
-    var x: Ref
+    var l3_x: Ref
     foo := l0_x
-    x := intToRef(2)
-    foo := x
+    l3_x := intToRef(2)
+    foo := l3_x
   }
   foo := l0_x
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /shadowing.kt: info: Generated Viper text for shadowParam:
-method shadowParam(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+method shadowParam(par_x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var foo: Ref
   var l0_x: Ref
-  foo := x
+  foo := par_x
   l0_x := intToRef(0)
   foo := l0_x
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /shadowing.kt: info: Generated Viper text for shadowNested:
-method shadowNested(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+method shadowNested(par_x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var foo: Ref
   var l0_x: Ref
-  foo := x
+  foo := par_x
   l0_x := intToRef(0)
   foo := l0_x
   if (true) {
@@ -55,7 +55,7 @@ method shadowNested(x: Ref) returns (ret: Ref)
       invariant isSubtype(typeOf(l2_x), intType())
       invariant isSubtype(typeOf(foo), intType())
       invariant isSubtype(typeOf(l0_x), intType())
-      invariant isSubtype(typeOf(x), intType())
+      invariant isSubtype(typeOf(par_x), intType())
     anon := boolToRef(true)
     if (boolFromRef(anon)) {
       var l3_x: Ref
@@ -68,10 +68,10 @@ method shadowNested(x: Ref) returns (ret: Ref)
     assert isSubtype(typeOf(l2_x), intType())
     assert isSubtype(typeOf(foo), intType())
     assert isSubtype(typeOf(l0_x), intType())
-    assert isSubtype(typeOf(x), intType())
+    assert isSubtype(typeOf(par_x), intType())
     foo := l2_x
   }
   foo := l0_x
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/any.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/any.fir.diag.txt
@@ -1,19 +1,19 @@
 /any.kt: info: Generated Viper text for anyArgumentReturn:
-method anyArgumentReturn(x: Ref) returns (ret: Ref)
+method anyArgumentReturn(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), anyType())
-  ensures isSubtype(typeOf(ret), anyType())
+  ensures isSubtype(typeOf(v_ret_0), anyType())
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /any.kt: info: Generated Viper text for anyCast:
-method anyCast(x: Ref) returns (ret: Ref)
+method anyCast(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), anyType())
+  ensures isSubtype(typeOf(v_ret_0), anyType())
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
@@ -2,7 +2,7 @@
 field bf_t: Ref
 
 method genericMethod(this: Ref, x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_Box())
+  requires isSubtype(typeOf(this), c_Box())
   requires isSubtype(typeOf(x), nullable(anyType()))
   ensures isSubtype(typeOf(ret_0), nullable(anyType()))
 {
@@ -17,9 +17,9 @@ field bf_t: Ref
 
 method con(par_t: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), _c_Box())
+  ensures isSubtype(typeOf(ret), c_Box())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_Box_unique(ret), write)
+  ensures acc(_c_Box_unique(ret), write)
 
 
 method createBox() returns (ret_0: Ref)
@@ -47,9 +47,9 @@ field bf_t: Ref
 
 method con(par_t: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), _c_Box())
+  ensures isSubtype(typeOf(ret), c_Box())
   ensures acc(shared(ret), wildcard)
-  ensures acc(c_Box_unique(ret), write)
+  ensures acc(_c_Box_unique(ret), write)
 
 
 method setGenericField() returns (ret_0: Ref)
@@ -93,7 +93,7 @@ method genericFun(par_t: Ref) returns (ret: Ref)
 field bf_t: Ref
 
 method genericAsIfCondition(box: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(box), _c_Box())
+  requires isSubtype(typeOf(box), c_Box())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var anon_0: Ref

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
@@ -1,29 +1,29 @@
 /generics.kt: info: Generated Viper text for genericMethod:
 field bf_t: Ref
 
-method genericMethod(this: Ref, x: Ref) returns (ret_0: Ref)
+method genericMethod(this: Ref, x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Box())
   requires isSubtype(typeOf(x), nullable(anyType()))
-  ensures isSubtype(typeOf(ret_0), nullable(anyType()))
+  ensures isSubtype(typeOf(ret), nullable(anyType()))
 {
   inhale acc(shared(this), wildcard)
-  ret_0 := x
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := x
+  goto ret_0
+  label ret_0
 }
 
 /generics.kt: info: Generated Viper text for createBox:
 field bf_t: Ref
 
-method con(par_t: Ref) returns (ret: Ref)
+method con(par_t: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), c_Box())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_Box_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_Box())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_Box_unique(v_ret), write)
 
 
-method createBox() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
+method createBox() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), intType())
 {
   var boolBox: Ref
   var b: Ref
@@ -36,29 +36,29 @@ method createBox() returns (ret_0: Ref)
   inhale isSubtype(typeOf(b), boolType())
   intBox := con(intToRef(2))
   anon := havoc()
-  ret_0 := anon
-  inhale isSubtype(typeOf(ret_0), intType())
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := anon
+  inhale isSubtype(typeOf(ret), intType())
+  goto ret_0
+  label ret_0
 }
 
 /generics.kt: info: Generated Viper text for setGenericField:
 field bf_t: Ref
 
-method con(par_t: Ref) returns (ret: Ref)
+method con(par_t: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), c_Box())
-  ensures acc(shared(ret), wildcard)
-  ensures acc(_c_Box_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_Box())
+  ensures acc(shared(v_ret), wildcard)
+  ensures acc(_c_Box_unique(v_ret), write)
 
 
-method setGenericField() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method setGenericField() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var box: Ref
   box := con(intToRef(3))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /generics.kt: info: Generated Viper text for genericFun:
@@ -72,29 +72,29 @@ method genericFun(par_t: Ref) returns (ret: Ref)
 }
 
 /generics.kt: info: Generated Viper text for callGenericFunc:
-method callGenericFunc() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method callGenericFunc() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var x: Ref
   var anon: Ref
   anon := genericFun(intToRef(3))
   x := anon
   inhale isSubtype(typeOf(x), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method genericFun(par_t: Ref) returns (ret: Ref)
+method genericFun(par_t: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
 /generics.kt: info: Generated Viper text for genericAsIfCondition:
 field bf_t: Ref
 
-method genericAsIfCondition(box: Ref) returns (ret_0: Ref)
+method genericAsIfCondition(box: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(box), c_Box())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -103,9 +103,9 @@ method genericAsIfCondition(box: Ref) returns (ret_0: Ref)
   anon_0 := anon
   inhale isSubtype(typeOf(anon_0), boolType())
   if (boolFromRef(anon_0)) {
-    ret_0 := intToRef(20)
+    ret := intToRef(20)
   } else {
-    ret_0 := intToRef(10)}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := intToRef(10)}
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/generics.fir.diag.txt
@@ -1,15 +1,15 @@
 /generics.kt: info: Generated Viper text for genericMethod:
 field bf_t: Ref
 
-method genericMethod(this: Ref, x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Box())
+method genericMethod(this: Ref, x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Box())
   requires isSubtype(typeOf(x), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(anyType()))
 {
   inhale acc(shared(this), wildcard)
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /generics.kt: info: Generated Viper text for createBox:
@@ -17,29 +17,29 @@ field bf_t: Ref
 
 method con(par_t: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), c_Box())
+  ensures isSubtype(typeOf(v_ret), Box())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_Box_unique(v_ret), write)
+  ensures acc(Box_unique(v_ret), write)
 
 
-method createBox() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method createBox() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var boolBox: Ref
   var b: Ref
   var anon_0: Ref
   var intBox: Ref
-  var anon: Ref
+  var anon_1: Ref
   boolBox := con(boolToRef(true))
   anon_0 := havoc()
   b := anon_0
   inhale isSubtype(typeOf(b), boolType())
   intBox := con(intToRef(2))
-  anon := havoc()
-  ret := anon
-  inhale isSubtype(typeOf(ret), intType())
-  goto ret_0
-  label ret_0
+  anon_1 := havoc()
+  v_ret_0 := anon_1
+  inhale isSubtype(typeOf(v_ret_0), intType())
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /generics.kt: info: Generated Viper text for setGenericField:
@@ -47,41 +47,41 @@ field bf_t: Ref
 
 method con(par_t: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), c_Box())
+  ensures isSubtype(typeOf(v_ret), Box())
   ensures acc(shared(v_ret), wildcard)
-  ensures acc(_c_Box_unique(v_ret), write)
+  ensures acc(Box_unique(v_ret), write)
 
 
-method setGenericField() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method setGenericField() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var box: Ref
   box := con(intToRef(3))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /generics.kt: info: Generated Viper text for genericFun:
-method genericFun(par_t: Ref) returns (ret: Ref)
+method genericFun(par_t: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(anyType()))
 {
-  ret := par_t
-  goto ret_0
-  label ret_0
+  v_ret_0 := par_t
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /generics.kt: info: Generated Viper text for callGenericFunc:
-method callGenericFunc() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method callGenericFunc() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var x: Ref
   var anon: Ref
   anon := genericFun(intToRef(3))
   x := anon
   inhale isSubtype(typeOf(x), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method genericFun(par_t: Ref) returns (v_ret: Ref)
@@ -92,20 +92,20 @@ method genericFun(par_t: Ref) returns (v_ret: Ref)
 /generics.kt: info: Generated Viper text for genericAsIfCondition:
 field bf_t: Ref
 
-method genericAsIfCondition(box: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(box), c_Box())
-  ensures isSubtype(typeOf(ret), intType())
+method genericAsIfCondition(box: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(box), Box())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon_0: Ref
-  var anon: Ref
+  var anon_1: Ref
   inhale acc(shared(box), wildcard)
-  anon := havoc()
-  anon_0 := anon
+  anon_1 := havoc()
+  anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), boolType())
   if (boolFromRef(anon_0)) {
-    ret := intToRef(20)
+    v_ret_0 := intToRef(20)
   } else {
-    ret := intToRef(10)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := intToRef(10)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
@@ -13,20 +13,20 @@ method useNullableTwice(x: Ref) returns (ret: Ref)
 }
 
 /nullable.kt: info: Generated Viper text for passNullableParameter:
-method passNullableParameter(x: Ref) returns (ret_0: Ref)
+method passNullableParameter(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures isSubtype(typeOf(ret), nullable(intType()))
 {
   var anon: Ref
   anon := useNullableTwice(x)
-  ret_0 := x
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := x
+  goto ret_0
+  label ret_0
 }
 
-method useNullableTwice(x: Ref) returns (ret: Ref)
+method useNullableTwice(x: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures isSubtype(typeOf(v_ret), nullable(intType()))
 
 
 /nullable.kt: info: Generated Viper text for nullableNullableComparison:

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/nullable.fir.diag.txt
@@ -1,27 +1,27 @@
 /nullable.kt: info: Generated Viper text for useNullableTwice:
-method useNullableTwice(x: Ref) returns (ret: Ref)
+method useNullableTwice(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
   var a: Ref
   var b: Ref
   a := x
   b := x
-  ret := a
-  goto ret_0
-  label ret_0
+  v_ret_0 := a
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /nullable.kt: info: Generated Viper text for passNullableParameter:
-method passNullableParameter(x: Ref) returns (ret: Ref)
+method passNullableParameter(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
   var anon: Ref
   anon := useNullableTwice(x)
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method useNullableTwice(x: Ref) returns (v_ret: Ref)
@@ -30,33 +30,33 @@ method useNullableTwice(x: Ref) returns (v_ret: Ref)
 
 
 /nullable.kt: info: Generated Viper text for nullableNullableComparison:
-method nullableNullableComparison(x: Ref, y: Ref) returns (ret: Ref)
+method nullableNullableComparison(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
   requires isSubtype(typeOf(y), nullable(intType()))
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := boolToRef(x == y)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(x == y)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /nullable.kt: info: Generated Viper text for nullableNonNullableComparison:
-method nullableNonNullableComparison(x: Ref, y: Ref) returns (ret: Ref)
+method nullableNonNullableComparison(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
   requires isSubtype(typeOf(y), nullable(intType()))
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := notBool(boolToRef(x == intToRef(3)))
-  goto ret_0
-  label ret_0
+  v_ret_0 := notBool(boolToRef(x == intToRef(3)))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /nullable.kt: info: Generated Viper text for nullComparison:
-method nullComparison(x: Ref) returns (ret: Ref)
+method nullComparison(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
-  ret := boolToRef(x == nullValue())
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(x == nullValue())
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
@@ -12,9 +12,9 @@ method smartcastReturn(n: Ref) returns (ret: Ref)
 }
 
 /smartcast.kt: info: Generated Viper text for isNullOrEmptyWrong:
-method isNullOrEmptyWrong(seq: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(seq), nullable(kotlin_c_CharSequence()))
-  ensures isSubtype(typeOf(ret), boolType())
+method isNullOrEmptyWrong(seq: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(seq), nullable(c_CharSequence()))
+  ensures isSubtype(typeOf(ret_0), boolType())
 {
   inhale seq != nullValue() ==> acc(shared(seq), wildcard)
   if (seq == nullValue()) {
@@ -28,11 +28,11 @@ method isNullOrEmptyWrong(seq: Ref) returns (ret: Ref)
       anon_0 := anon_1
     } else {
       anon_0 := nullValue()}
-    ret := boolToRef(anon_0 == intToRef(0))
+    ret_0 := boolToRef(anon_0 == intToRef(0))
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method length(this: Ref) returns (v_ret: Ref)
+method length(this: Ref) returns (ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
@@ -12,9 +12,9 @@ method smartcastReturn(n: Ref) returns (ret: Ref)
 }
 
 /smartcast.kt: info: Generated Viper text for isNullOrEmptyWrong:
-method isNullOrEmptyWrong(seq: Ref) returns (ret_0: Ref)
+method isNullOrEmptyWrong(seq: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(seq), nullable(c_CharSequence()))
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   inhale seq != nullValue() ==> acc(shared(seq), wildcard)
   if (seq == nullValue()) {
@@ -28,11 +28,11 @@ method isNullOrEmptyWrong(seq: Ref) returns (ret_0: Ref)
       anon_0 := anon_1
     } else {
       anon_0 := nullValue()}
-    ret_0 := boolToRef(anon_0 == intToRef(0))
+    ret := boolToRef(anon_0 == intToRef(0))
   } else {
-    ret_0 := boolToRef(false)}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := boolToRef(false)}
+  goto ret_0
+  label ret_0
 }
 
-method length(this: Ref) returns (ret: Ref)
+method length(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/conversion/types/smartcast.fir.diag.txt
@@ -1,38 +1,38 @@
 /smartcast.kt: info: Generated Viper text for smartcastReturn:
-method smartcastReturn(n: Ref) returns (ret: Ref)
+method smartcastReturn(n: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(n), nullable(intType()))
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   if (!(n == nullValue())) {
-    ret := n
+    v_ret_0 := n
   } else {
-    ret := intToRef(0)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := intToRef(0)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /smartcast.kt: info: Generated Viper text for isNullOrEmptyWrong:
-method isNullOrEmptyWrong(seq: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(seq), nullable(c_CharSequence()))
-  ensures isSubtype(typeOf(ret), boolType())
+method isNullOrEmptyWrong(seq: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(seq), nullable(CharSequence()))
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   inhale seq != nullValue() ==> acc(shared(seq), wildcard)
   if (seq == nullValue()) {
     var anon_0: Ref
     if (seq != nullValue()) {
       var anon_1: Ref
-      var anon: Ref
-      anon := length(seq)
-      anon_1 := anon
+      var anon_2: Ref
+      anon_2 := length(seq)
+      anon_1 := anon_2
       inhale isSubtype(typeOf(anon_1), intType())
       anon_0 := anon_1
     } else {
       anon_0 := nullValue()}
-    ret := boolToRef(anon_0 == intToRef(0))
+    v_ret_0 := boolToRef(anon_0 == intToRef(0))
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method length(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
@@ -4,7 +4,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -17,7 +17,7 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method isEmpty(this: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())
@@ -29,7 +29,7 @@ method isEmpty(this: Ref) returns (ret: Ref)
 method mid_increased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), collections_c_List())
+  requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
@@ -39,7 +39,7 @@ method mid_increased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(c_List_shared(arr), wildcard)
+  inhale acc(shared(arr), wildcard)
   l0_size := arr.size
   inhale isSubtype(typeOf(l0_size), intType())
   anon_0 := arr.size
@@ -74,7 +74,7 @@ method mid_increased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -82,10 +82,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
@@ -97,7 +97,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -110,7 +110,7 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method isEmpty(this: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())
@@ -122,7 +122,7 @@ method isEmpty(this: Ref) returns (ret: Ref)
 method mid_decreased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), collections_c_List())
+  requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
@@ -132,7 +132,7 @@ method mid_decreased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(c_List_shared(arr), wildcard)
+  inhale acc(shared(arr), wildcard)
   l0_size := arr.size
   inhale isSubtype(typeOf(l0_size), intType())
   anon_0 := arr.size
@@ -167,7 +167,7 @@ method mid_decreased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -175,10 +175,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
@@ -190,7 +190,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -203,7 +203,7 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method isEmpty(this: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())
@@ -216,7 +216,7 @@ method mid_decreased_by_one_in_rec_call(arr: Ref, target: Ref)
   returns (ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), collections_c_List())
+  requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
@@ -226,7 +226,7 @@ method mid_decreased_by_one_in_rec_call(arr: Ref, target: Ref)
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(c_List_shared(arr), wildcard)
+  inhale acc(shared(arr), wildcard)
   l0_size := arr.size
   inhale isSubtype(typeOf(l0_size), intType())
   anon_0 := arr.size
@@ -261,7 +261,7 @@ method mid_decreased_by_one_in_rec_call(arr: Ref, target: Ref)
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -269,10 +269,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
@@ -284,7 +284,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -298,7 +298,7 @@ method unsafe_binary_search(arr: Ref, target: Ref, left: Ref, right: Ref)
   returns (ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), collections_c_List())
+  requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   requires isSubtype(typeOf(left), intType())
   requires isSubtype(typeOf(right), intType())
@@ -308,7 +308,7 @@ method unsafe_binary_search(arr: Ref, target: Ref, left: Ref, right: Ref)
 {
   var mid: Ref
   var anon_0: Ref
-  inhale acc(c_List_shared(arr), wildcard)
+  inhale acc(shared(arr), wildcard)
   if (intFromRef(left) > intFromRef(right)) {
     ret_0 := boolToRef(false)
     goto lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
@@ -1,7 +1,7 @@
 /binary_search.kt: info: Generated Viper text for mid_increased_by_one:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -10,30 +10,30 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method mid_increased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
+method mid_increased_by_one(arr: Ref, target: Ref) returns (ret: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
   requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var l0_size: Ref
   var mid: Ref
@@ -47,31 +47,32 @@ method mid_increased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
   mid := plusInts(divInts(anon_0, intToRef(2)), intToRef(1))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret_0 := boolToRef(false)
+    ret := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret_0 := boolToRef(true)
+      ret := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret_0 := mid_increased_by_one(anon_4, target)
+        ret := mid_increased_by_one(anon_4, target)
       } else {
         var anon: Ref
         anon := subList(arr, intToRef(0), mid)
-        ret_0 := mid_increased_by_one(anon, target)
+        ret := mid_increased_by_one(anon, target)
       }
     }
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
+method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
+  returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -82,19 +83,19 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(ret.size) ==
+  ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
 /binary_search.kt: info: Generated Viper text for mid_decreased_by_one:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -103,30 +104,30 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method mid_decreased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
+method mid_decreased_by_one(arr: Ref, target: Ref) returns (ret: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
   requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var l0_size: Ref
   var mid: Ref
@@ -140,31 +141,32 @@ method mid_decreased_by_one(arr: Ref, target: Ref) returns (ret_0: Ref)
   mid := minusInts(divInts(anon_0, intToRef(2)), intToRef(1))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret_0 := boolToRef(false)
+    ret := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret_0 := boolToRef(true)
+      ret := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret_0 := mid_decreased_by_one(anon_4, target)
+        ret := mid_decreased_by_one(anon_4, target)
       } else {
         var anon: Ref
         anon := subList(arr, intToRef(0), mid)
-        ret_0 := mid_decreased_by_one(anon, target)
+        ret := mid_decreased_by_one(anon, target)
       }
     }
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
+method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
+  returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -175,19 +177,19 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(ret.size) ==
+  ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
 /binary_search.kt: info: Generated Viper text for mid_decreased_by_one_in_rec_call:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -196,31 +198,31 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
 method mid_decreased_by_one_in_rec_call(arr: Ref, target: Ref)
-  returns (ret_0: Ref)
+  returns (ret: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
   requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var l0_size: Ref
   var mid: Ref
@@ -234,31 +236,32 @@ method mid_decreased_by_one_in_rec_call(arr: Ref, target: Ref)
   mid := divInts(anon_0, intToRef(2))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret_0 := boolToRef(false)
+    ret := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret_0 := boolToRef(true)
+      ret := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret_0 := mid_decreased_by_one_in_rec_call(anon_4, target)
+        ret := mid_decreased_by_one_in_rec_call(anon_4, target)
       } else {
         var anon: Ref
         anon := subList(arr, intToRef(0), minusInts(mid, intToRef(1)))
-        ret_0 := mid_decreased_by_one_in_rec_call(anon, target)
+        ret := mid_decreased_by_one_in_rec_call(anon, target)
       }
     }
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
+method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
+  returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -269,19 +272,19 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(ret.size) ==
+  ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
 /binary_search.kt: info: Generated Viper text for unsafe_binary_search:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -290,12 +293,12 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
 method unsafe_binary_search(arr: Ref, target: Ref, left: Ref, right: Ref)
-  returns (ret_0: Ref)
+  returns (ret: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
   requires isSubtype(typeOf(arr), c_List())
@@ -304,28 +307,27 @@ method unsafe_binary_search(arr: Ref, target: Ref, left: Ref, right: Ref)
   requires isSubtype(typeOf(right), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var mid: Ref
   var anon_0: Ref
   inhale acc(shared(arr), wildcard)
   if (intFromRef(left) > intFromRef(right)) {
-    ret_0 := boolToRef(false)
-    goto lbl_ret_0
+    ret := boolToRef(false)
+    goto ret_0
   }
   mid := plusInts(left, divInts(minusInts(right, left), intToRef(2)))
   anon_0 := get(arr, mid)
   if (intFromRef(anon_0) == intFromRef(target)) {
-    ret_0 := boolToRef(true)
+    ret := boolToRef(true)
   } else {
     var anon: Ref
     anon := get(arr, mid)
     if (intFromRef(anon) < intFromRef(target)) {
-      ret_0 := unsafe_binary_search(arr, target, plusInts(mid, intToRef(1)),
-        right)
+      ret := unsafe_binary_search(arr, target, plusInts(mid, intToRef(1)), right)
     } else {
-      ret_0 := unsafe_binary_search(arr, target, left, minusInts(mid, intToRef(1)))}
+      ret := unsafe_binary_search(arr, target, left, minusInts(mid, intToRef(1)))}
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
@@ -1,283 +1,283 @@
 /binary_search.kt: info: Generated Viper text for mid_increased_by_one:
-field size: Ref
+field p_size: Ref
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
-  requires intFromRef(this.size) > intFromRef(index)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires intFromRef(this.p_size) > intFromRef(index)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
 
 
 method isEmpty(this: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures boolFromRef(v_ret) ==> intFromRef(this.p_size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.p_size) > 0
 
 
-method mid_increased_by_one(arr: Ref, target: Ref) returns (ret: Ref)
-  requires acc(arr.size, write)
-  requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), c_List())
+method mid_increased_by_one(arr: Ref, target: Ref) returns (v_ret_0: Ref)
+  requires acc(arr.p_size, write)
+  requires intFromRef(arr.p_size) >= 0
+  requires isSubtype(typeOf(arr), List())
   requires isSubtype(typeOf(target), intType())
-  ensures acc(arr.size, write)
-  ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures acc(arr.p_size, write)
+  ensures intFromRef(arr.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var l0_size: Ref
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(shared(arr), wildcard)
-  l0_size := arr.size
+  inhale acc(List_shared(arr), wildcard)
+  l0_size := arr.p_size
   inhale isSubtype(typeOf(l0_size), intType())
-  anon_0 := arr.size
+  anon_0 := arr.p_size
   inhale isSubtype(typeOf(anon_0), intType())
   mid := plusInts(divInts(anon_0, intToRef(2)), intToRef(1))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret := boolToRef(false)
+    v_ret_0 := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret := boolToRef(true)
+      v_ret_0 := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret := mid_increased_by_one(anon_4, target)
+        v_ret_0 := mid_increased_by_one(anon_4, target)
       } else {
-        var anon: Ref
-        anon := subList(arr, intToRef(0), mid)
-        ret := mid_increased_by_one(anon, target)
+        var anon_5: Ref
+        anon_5 := subList(arr, intToRef(0), mid)
+        v_ret_0 := mid_increased_by_one(anon_5, target)
       }
     }
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
   requires intFromRef(fromIndex) >= 0
-  requires intFromRef(toIndex) <= intFromRef(this.size)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(v_ret), c_List())
-  ensures acc(v_ret.size, write)
-  ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(v_ret.size) ==
+  requires intFromRef(toIndex) <= intFromRef(this.p_size)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret), List())
+  ensures acc(v_ret.p_size, write)
+  ensures intFromRef(v_ret.p_size) >= 0
+  ensures acc(List_shared(v_ret), wildcard)
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures intFromRef(v_ret.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
 /binary_search.kt: info: Generated Viper text for mid_decreased_by_one:
-field size: Ref
+field p_size: Ref
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
-  requires intFromRef(this.size) > intFromRef(index)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires intFromRef(this.p_size) > intFromRef(index)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
 
 
 method isEmpty(this: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures boolFromRef(v_ret) ==> intFromRef(this.p_size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.p_size) > 0
 
 
-method mid_decreased_by_one(arr: Ref, target: Ref) returns (ret: Ref)
-  requires acc(arr.size, write)
-  requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), c_List())
+method mid_decreased_by_one(arr: Ref, target: Ref) returns (v_ret_0: Ref)
+  requires acc(arr.p_size, write)
+  requires intFromRef(arr.p_size) >= 0
+  requires isSubtype(typeOf(arr), List())
   requires isSubtype(typeOf(target), intType())
-  ensures acc(arr.size, write)
-  ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures acc(arr.p_size, write)
+  ensures intFromRef(arr.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var l0_size: Ref
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(shared(arr), wildcard)
-  l0_size := arr.size
+  inhale acc(List_shared(arr), wildcard)
+  l0_size := arr.p_size
   inhale isSubtype(typeOf(l0_size), intType())
-  anon_0 := arr.size
+  anon_0 := arr.p_size
   inhale isSubtype(typeOf(anon_0), intType())
   mid := minusInts(divInts(anon_0, intToRef(2)), intToRef(1))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret := boolToRef(false)
+    v_ret_0 := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret := boolToRef(true)
+      v_ret_0 := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret := mid_decreased_by_one(anon_4, target)
+        v_ret_0 := mid_decreased_by_one(anon_4, target)
       } else {
-        var anon: Ref
-        anon := subList(arr, intToRef(0), mid)
-        ret := mid_decreased_by_one(anon, target)
+        var anon_5: Ref
+        anon_5 := subList(arr, intToRef(0), mid)
+        v_ret_0 := mid_decreased_by_one(anon_5, target)
       }
     }
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
   requires intFromRef(fromIndex) >= 0
-  requires intFromRef(toIndex) <= intFromRef(this.size)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(v_ret), c_List())
-  ensures acc(v_ret.size, write)
-  ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(v_ret.size) ==
+  requires intFromRef(toIndex) <= intFromRef(this.p_size)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret), List())
+  ensures acc(v_ret.p_size, write)
+  ensures intFromRef(v_ret.p_size) >= 0
+  ensures acc(List_shared(v_ret), wildcard)
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures intFromRef(v_ret.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
 /binary_search.kt: info: Generated Viper text for mid_decreased_by_one_in_rec_call:
-field size: Ref
+field p_size: Ref
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
-  requires intFromRef(this.size) > intFromRef(index)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires intFromRef(this.p_size) > intFromRef(index)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
 
 
 method isEmpty(this: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures boolFromRef(v_ret) ==> intFromRef(this.p_size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.p_size) > 0
 
 
 method mid_decreased_by_one_in_rec_call(arr: Ref, target: Ref)
-  returns (ret: Ref)
-  requires acc(arr.size, write)
-  requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), c_List())
+  returns (v_ret_0: Ref)
+  requires acc(arr.p_size, write)
+  requires intFromRef(arr.p_size) >= 0
+  requires isSubtype(typeOf(arr), List())
   requires isSubtype(typeOf(target), intType())
-  ensures acc(arr.size, write)
-  ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures acc(arr.p_size, write)
+  ensures intFromRef(arr.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var l0_size: Ref
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(shared(arr), wildcard)
-  l0_size := arr.size
+  inhale acc(List_shared(arr), wildcard)
+  l0_size := arr.p_size
   inhale isSubtype(typeOf(l0_size), intType())
-  anon_0 := arr.size
+  anon_0 := arr.p_size
   inhale isSubtype(typeOf(anon_0), intType())
   mid := divInts(anon_0, intToRef(2))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret := boolToRef(false)
+    v_ret_0 := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret := boolToRef(true)
+      v_ret_0 := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret := mid_decreased_by_one_in_rec_call(anon_4, target)
+        v_ret_0 := mid_decreased_by_one_in_rec_call(anon_4, target)
       } else {
-        var anon: Ref
-        anon := subList(arr, intToRef(0), minusInts(mid, intToRef(1)))
-        ret := mid_decreased_by_one_in_rec_call(anon, target)
+        var anon_5: Ref
+        anon_5 := subList(arr, intToRef(0), minusInts(mid, intToRef(1)))
+        v_ret_0 := mid_decreased_by_one_in_rec_call(anon_5, target)
       }
     }
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
   requires intFromRef(fromIndex) >= 0
-  requires intFromRef(toIndex) <= intFromRef(this.size)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(v_ret), c_List())
-  ensures acc(v_ret.size, write)
-  ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(v_ret.size) ==
+  requires intFromRef(toIndex) <= intFromRef(this.p_size)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret), List())
+  ensures acc(v_ret.p_size, write)
+  ensures intFromRef(v_ret.p_size) >= 0
+  ensures acc(List_shared(v_ret), wildcard)
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures intFromRef(v_ret.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
@@ -287,7 +287,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -298,36 +298,37 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
 
 
 method unsafe_binary_search(arr: Ref, target: Ref, left: Ref, right: Ref)
-  returns (ret: Ref)
+  returns (v_ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), c_List())
+  requires isSubtype(typeOf(arr), List())
   requires isSubtype(typeOf(target), intType())
   requires isSubtype(typeOf(left), intType())
   requires isSubtype(typeOf(right), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var mid: Ref
   var anon_0: Ref
-  inhale acc(shared(arr), wildcard)
+  inhale acc(List_shared(arr), wildcard)
   if (intFromRef(left) > intFromRef(right)) {
-    ret := boolToRef(false)
-    goto ret_0
+    v_ret_0 := boolToRef(false)
+    goto lbl_ret_0
   }
   mid := plusInts(left, divInts(minusInts(right, left), intToRef(2)))
   anon_0 := get(arr, mid)
   if (intFromRef(anon_0) == intFromRef(target)) {
-    ret := boolToRef(true)
+    v_ret_0 := boolToRef(true)
   } else {
-    var anon: Ref
-    anon := get(arr, mid)
-    if (intFromRef(anon) < intFromRef(target)) {
-      ret := unsafe_binary_search(arr, target, plusInts(mid, intToRef(1)), right)
+    var anon_1: Ref
+    anon_1 := get(arr, mid)
+    if (intFromRef(anon_1) < intFromRef(target)) {
+      v_ret_0 := unsafe_binary_search(arr, target, plusInts(mid, intToRef(1)),
+        right)
     } else {
-      ret := unsafe_binary_search(arr, target, left, minusInts(mid, intToRef(1)))}
+      v_ret_0 := unsafe_binary_search(arr, target, left, minusInts(mid, intToRef(1)))}
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -1,22 +1,30 @@
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /merge_sort_of_string.kt: info: Generated Viper text for subs:
-method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
-  requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), stringType())
-
-
-method subs(this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), stringType())
+  requires isSubtype(typeOf(other), nullable(anyType()))
+  ensures isSubtype(typeOf(ret), stringType())
+
+
+method subs([v$this]: Ref, lo: Ref, hi: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(this)|
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == intFromRef(hi) - intFromRef(lo)
-  ensures (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
-      anon_builtin_2 < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin_2] ==
-      stringFromRef(this)[anon_builtin_2 + intFromRef(lo)])
+    intFromRef(hi) <= |stringFromRef([v$this])|
+  ensures isSubtype(typeOf(ret_0), stringType())
+  ensures |stringFromRef(ret_0)| == intFromRef(hi) - intFromRef(lo)
+  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < |stringFromRef(ret_0)| ==>
+      stringFromRef(ret_0)[anon_builtin] ==
+      stringFromRef([v$this])[anon_builtin + intFromRef(lo)])
 {
   var res: Ref
   var i: Ref
@@ -30,18 +38,18 @@ method subs(this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(hi), intType())
     invariant 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(hi)
     invariant |stringFromRef(res)| == intFromRef(i) - intFromRef(lo)
-    invariant (forall anon_builtin: Int ::0 <= anon_builtin &&
-        anon_builtin < |stringFromRef(res)| ==>
-        stringFromRef(res)[anon_builtin] ==
-        stringFromRef(this)[anon_builtin + intFromRef(lo)])
+    invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+        anon_builtin_1 < |stringFromRef(res)| ==>
+        stringFromRef(res)[anon_builtin_1] ==
+        stringFromRef([v$this])[anon_builtin_1 + intFromRef(lo)])
   anon_1 := ltInts(i, hi)
   if (boolFromRef(anon_1)) {
-    var anon_2: Ref
     var anon: Ref
-    anon := i
-    i := plusInts(anon, intToRef(1))
-    anon_2 := anon
-    res := addStringChar(res, stringGet(this, anon_2))
+    var anon_0: Ref
+    anon_0 := i
+    i := plusInts(anon_0, intToRef(1))
+    anon := anon_0
+    res := addStringChar(res, stringGet([v$this], anon))
     goto cont
   }
   label break
@@ -51,17 +59,49 @@ method subs(this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(hi), intType())
   assert 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(hi)
   assert |stringFromRef(res)| == intFromRef(i) - intFromRef(lo)
-  assert (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(res)| ==>
-      stringFromRef(res)[anon_builtin] ==
-      stringFromRef(this)[anon_builtin + intFromRef(lo)])
-  ret := res
-  goto ret_0
-  label ret_0
+  assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+      anon_builtin_1 < |stringFromRef(res)| ==>
+      stringFromRef(res)[anon_builtin_1] ==
+      stringFromRef([v$this])[anon_builtin_1 + intFromRef(lo)])
+  ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /merge_sort_of_string.kt: info: Generated Viper text for mergeStrings:
-method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
+method mergeStrings(a: Ref, b: Ref) returns (ret_0: Ref)
   requires isSubtype(typeOf(a), stringType())
   requires isSubtype(typeOf(b), stringType())
   requires (forall anon_builtin_3: Int ::(1 <= anon_builtin_3 &&
@@ -71,12 +111,12 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
       (1 <= anon_builtin_3 && anon_builtin_3 < |stringFromRef(b)| ==>
       stringFromRef(b)[anon_builtin_3 - 1] <=
       stringFromRef(b)[anon_builtin_3]))
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(a)| + |stringFromRef(b)|
-  ensures (forall anon_builtin_4: Int ::1 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin_4 - 1] <=
-      stringFromRef(ret)[anon_builtin_4])
+  ensures isSubtype(typeOf(ret_0), stringType())
+  ensures |stringFromRef(ret_0)| == |stringFromRef(a)| + |stringFromRef(b)|
+  ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
+      anon_builtin < |stringFromRef(ret_0)| ==>
+      stringFromRef(ret_0)[anon_builtin - 1] <=
+      stringFromRef(ret_0)[anon_builtin])
 {
   var pa: Ref
   var pb: Ref
@@ -97,10 +137,10 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
     invariant 0 <= intFromRef(pa) && intFromRef(pa) <= |stringFromRef(a)|
     invariant 0 <= intFromRef(pb) && intFromRef(pb) <= |stringFromRef(b)|
     invariant |stringFromRef(res)| == intFromRef(pa) + intFromRef(pb)
-    invariant (forall anon_builtin: Int ::1 <= anon_builtin &&
-        anon_builtin < |stringFromRef(res)| ==>
-        stringFromRef(res)[anon_builtin - 1] <=
-        stringFromRef(res)[anon_builtin])
+    invariant (forall anon_builtin_2: Int ::1 <= anon_builtin_2 &&
+        anon_builtin_2 < |stringFromRef(res)| ==>
+        stringFromRef(res)[anon_builtin_2 - 1] <=
+        stringFromRef(res)[anon_builtin_2])
     invariant |stringFromRef(res)| == 0 ||
       intFromRef(pa) == |stringFromRef(a)| ||
       stringFromRef(res)[|stringFromRef(res)| - 1] <=
@@ -135,12 +175,12 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
       anon_8 := anon_2
       anon_5 := stringGet(a, anon_8)
     } else {
-      var anon_9: Ref
       var anon: Ref
-      anon := pb
-      pb := plusInts(anon, intToRef(1))
-      anon_9 := anon
-      anon_5 := stringGet(b, anon_9)
+      var anon_3: Ref
+      anon_3 := pb
+      pb := plusInts(anon_3, intToRef(1))
+      anon := anon_3
+      anon_5 := stringGet(b, anon)
     }
     res := addStringChar(res, anon_5)
     goto cont
@@ -155,48 +195,64 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
   assert 0 <= intFromRef(pa) && intFromRef(pa) <= |stringFromRef(a)|
   assert 0 <= intFromRef(pb) && intFromRef(pb) <= |stringFromRef(b)|
   assert |stringFromRef(res)| == intFromRef(pa) + intFromRef(pb)
-  assert (forall anon_builtin: Int ::1 <= anon_builtin &&
-      anon_builtin < |stringFromRef(res)| ==>
-      stringFromRef(res)[anon_builtin - 1] <=
-      stringFromRef(res)[anon_builtin])
+  assert (forall anon_builtin_2: Int ::1 <= anon_builtin_2 &&
+      anon_builtin_2 < |stringFromRef(res)| ==>
+      stringFromRef(res)[anon_builtin_2 - 1] <=
+      stringFromRef(res)[anon_builtin_2])
   assert |stringFromRef(res)| == 0 || intFromRef(pa) == |stringFromRef(a)| ||
     stringFromRef(res)[|stringFromRef(res)| - 1] <=
     stringFromRef(a)[intFromRef(pa)]
   assert |stringFromRef(res)| == 0 || intFromRef(pb) == |stringFromRef(b)| ||
     stringFromRef(res)[|stringFromRef(res)| - 1] <=
     stringFromRef(b)[intFromRef(pb)]
-  ret := res
-  goto ret_0
-  label ret_0
+  ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method plus(this: Ref, other: Ref) returns (v_ret: Ref)
+method plus(this: Ref, other: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
 
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
 
 /merge_sort_of_string.kt: info: Generated Viper text for mergeSorted:
-method mergeSorted(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method mergeSorted([v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef(this)|
+  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
   ensures (forall anon_builtin_4: Int ::1 <= anon_builtin_4 &&
       anon_builtin_4 < |stringFromRef(ret_0)| ==>
       stringFromRef(ret_0)[anon_builtin_4 - 1] <=
       stringFromRef(ret_0)[anon_builtin_4])
 {
-  if (|stringFromRef(this)| <= 1) {
-    ret_0 := this
+  if (|stringFromRef([v$this])| <= 1) {
+    ret_0 := [v$this]
   } else {
     var anon_0: Ref
     var anon_1: Ref
     var anon_2: Ref
-    var anon_3: Ref
-    anon_1 := subs(this, intToRef(0), divInts(stringLength(this), intToRef(2)))
+    var anon: Ref
+    anon_1 := subs([v$this], intToRef(0), divInts(stringLength([v$this]), intToRef(2)))
     anon_0 := mergeSorted(anon_1)
-    anon_3 := subs(this, divInts(stringLength(this), intToRef(2)), stringLength(this))
-    anon_2 := mergeSorted(anon_3)
+    anon := subs([v$this], divInts(stringLength([v$this]), intToRef(2)), stringLength([v$this]))
+    anon_2 := mergeSorted(anon)
     ret_0 := mergeStrings(anon_0, anon_2)
   }
   goto lbl_ret_0
@@ -215,20 +271,54 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
       stringFromRef(b)[anon_builtin_5]))
   ensures isSubtype(typeOf(ret), stringType())
   ensures |stringFromRef(ret)| == |stringFromRef(a)| + |stringFromRef(b)|
-  ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin - 1] <=
-      stringFromRef(ret)[anon_builtin])
+  ensures (forall anon_builtin_6: Int ::1 <= anon_builtin_6 &&
+      anon_builtin_6 < |stringFromRef(ret)| ==>
+      stringFromRef(ret)[anon_builtin_6 - 1] <=
+      stringFromRef(ret)[anon_builtin_6])
 
 
-method subs(this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method subs([v$this]: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(this)|
+    intFromRef(hi) <= |stringFromRef([v$this])|
   ensures isSubtype(typeOf(ret), stringType())
   ensures |stringFromRef(ret)| == intFromRef(hi) - intFromRef(lo)
-  ensures (forall anon: Int ::0 <= anon && anon < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon] ==
-      stringFromRef(this)[anon + intFromRef(lo)])
+  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < |stringFromRef(ret)| ==>
+      stringFromRef(ret)[anon_builtin] ==
+      stringFromRef([v$this])[anon_builtin + intFromRef(lo)])
+
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/merge_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -1,30 +1,22 @@
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /merge_sort_of_string.kt: info: Generated Viper text for subs:
-method plus(this: Ref, other: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), stringType())
+  ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method subs([v$this]: Ref, lo: Ref, hi: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
+method subs(v_this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef([v$this])|
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == intFromRef(hi) - intFromRef(lo)
+    intFromRef(hi) <= |stringFromRef(v_this)|
+  ensures isSubtype(typeOf(ret), stringType())
+  ensures |stringFromRef(ret)| == intFromRef(hi) - intFromRef(lo)
   ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret_0)| ==>
-      stringFromRef(ret_0)[anon_builtin] ==
-      stringFromRef([v$this])[anon_builtin + intFromRef(lo)])
+      anon_builtin < |stringFromRef(ret)| ==>
+      stringFromRef(ret)[anon_builtin] ==
+      stringFromRef(v_this)[anon_builtin + intFromRef(lo)])
 {
   var res: Ref
   var i: Ref
@@ -41,7 +33,7 @@ method subs([v$this]: Ref, lo: Ref, hi: Ref) returns (ret_0: Ref)
     invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
         anon_builtin_1 < |stringFromRef(res)| ==>
         stringFromRef(res)[anon_builtin_1] ==
-        stringFromRef([v$this])[anon_builtin_1 + intFromRef(lo)])
+        stringFromRef(v_this)[anon_builtin_1 + intFromRef(lo)])
   anon_1 := ltInts(i, hi)
   if (boolFromRef(anon_1)) {
     var anon: Ref
@@ -49,7 +41,7 @@ method subs([v$this]: Ref, lo: Ref, hi: Ref) returns (ret_0: Ref)
     anon_0 := i
     i := plusInts(anon_0, intToRef(1))
     anon := anon_0
-    res := addStringChar(res, stringGet([v$this], anon))
+    res := addStringChar(res, stringGet(v_this, anon))
     goto cont
   }
   label break
@@ -62,46 +54,14 @@ method subs([v$this]: Ref, lo: Ref, hi: Ref) returns (ret_0: Ref)
   assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
       anon_builtin_1 < |stringFromRef(res)| ==>
       stringFromRef(res)[anon_builtin_1] ==
-      stringFromRef([v$this])[anon_builtin_1 + intFromRef(lo)])
-  ret_0 := res
-  goto lbl_ret_0
-  label lbl_ret_0
+      stringFromRef(v_this)[anon_builtin_1 + intFromRef(lo)])
+  ret := res
+  goto ret_0
+  label ret_0
 }
 
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /merge_sort_of_string.kt: info: Generated Viper text for mergeStrings:
-method mergeStrings(a: Ref, b: Ref) returns (ret_0: Ref)
+method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), stringType())
   requires isSubtype(typeOf(b), stringType())
   requires (forall anon_builtin_3: Int ::(1 <= anon_builtin_3 &&
@@ -111,12 +71,12 @@ method mergeStrings(a: Ref, b: Ref) returns (ret_0: Ref)
       (1 <= anon_builtin_3 && anon_builtin_3 < |stringFromRef(b)| ==>
       stringFromRef(b)[anon_builtin_3 - 1] <=
       stringFromRef(b)[anon_builtin_3]))
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef(a)| + |stringFromRef(b)|
+  ensures isSubtype(typeOf(ret), stringType())
+  ensures |stringFromRef(ret)| == |stringFromRef(a)| + |stringFromRef(b)|
   ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret_0)| ==>
-      stringFromRef(ret_0)[anon_builtin - 1] <=
-      stringFromRef(ret_0)[anon_builtin])
+      anon_builtin < |stringFromRef(ret)| ==>
+      stringFromRef(ret)[anon_builtin - 1] <=
+      stringFromRef(ret)[anon_builtin])
 {
   var pa: Ref
   var pb: Ref
@@ -205,61 +165,45 @@ method mergeStrings(a: Ref, b: Ref) returns (ret_0: Ref)
   assert |stringFromRef(res)| == 0 || intFromRef(pb) == |stringFromRef(b)| ||
     stringFromRef(res)[|stringFromRef(res)| - 1] <=
     stringFromRef(b)[intFromRef(pb)]
-  ret_0 := res
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := res
+  goto ret_0
+  label ret_0
 }
 
-method plus(this: Ref, other: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), stringType())
+  ensures isSubtype(typeOf(v_ret), stringType())
 
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /merge_sort_of_string.kt: info: Generated Viper text for mergeSorted:
-method mergeSorted([v$this]: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
+method mergeSorted(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
+  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
   ensures (forall anon_builtin_4: Int ::1 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(ret_0)| ==>
-      stringFromRef(ret_0)[anon_builtin_4 - 1] <=
-      stringFromRef(ret_0)[anon_builtin_4])
+      anon_builtin_4 < |stringFromRef(ret)| ==>
+      stringFromRef(ret)[anon_builtin_4 - 1] <=
+      stringFromRef(ret)[anon_builtin_4])
 {
-  if (|stringFromRef([v$this])| <= 1) {
-    ret_0 := [v$this]
+  if (|stringFromRef(v_this)| <= 1) {
+    ret := v_this
   } else {
     var anon_0: Ref
     var anon_1: Ref
     var anon_2: Ref
-    var anon: Ref
-    anon_1 := subs([v$this], intToRef(0), divInts(stringLength([v$this]), intToRef(2)))
+    var anon_3: Ref
+    anon_1 := subs(v_this, intToRef(0), divInts(stringLength(v_this), intToRef(2)))
     anon_0 := mergeSorted(anon_1)
-    anon := subs([v$this], divInts(stringLength([v$this]), intToRef(2)), stringLength([v$this]))
-    anon_2 := mergeSorted(anon)
-    ret_0 := mergeStrings(anon_0, anon_2)
+    anon_3 := subs(v_this, divInts(stringLength(v_this), intToRef(2)), stringLength(v_this))
+    anon_2 := mergeSorted(anon_3)
+    ret := mergeStrings(anon_0, anon_2)
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
+method mergeStrings(a: Ref, b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(a), stringType())
   requires isSubtype(typeOf(b), stringType())
   requires (forall anon_builtin_5: Int ::(1 <= anon_builtin_5 &&
@@ -269,56 +213,22 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
       (1 <= anon_builtin_5 && anon_builtin_5 < |stringFromRef(b)| ==>
       stringFromRef(b)[anon_builtin_5 - 1] <=
       stringFromRef(b)[anon_builtin_5]))
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(a)| + |stringFromRef(b)|
-  ensures (forall anon_builtin_6: Int ::1 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin_6 - 1] <=
-      stringFromRef(ret)[anon_builtin_6])
+  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures |stringFromRef(v_ret)| == |stringFromRef(a)| + |stringFromRef(b)|
+  ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
+      anon_builtin < |stringFromRef(v_ret)| ==>
+      stringFromRef(v_ret)[anon_builtin - 1] <=
+      stringFromRef(v_ret)[anon_builtin])
 
 
-method subs([v$this]: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
+method subs(v_this: Ref, lo: Ref, hi: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef([v$this])|
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == intFromRef(hi) - intFromRef(lo)
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin] ==
-      stringFromRef([v$this])[anon_builtin + intFromRef(lo)])
-
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/merge_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
+    intFromRef(hi) <= |stringFromRef(v_this)|
+  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures |stringFromRef(v_ret)| == intFromRef(hi) - intFromRef(lo)
+  ensures (forall anon: Int ::0 <= anon && anon < |stringFromRef(v_ret)| ==>
+      stringFromRef(v_ret)[anon] ==
+      stringFromRef(v_this)[anon + intFromRef(lo)])

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -1,22 +1,22 @@
 /merge_sort_of_string.kt: info: Generated Viper text for subs:
-method plus(this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method subs(v_this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method subs(v_this_dispatch: Ref, lo: Ref, hi: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(v_this)|
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == intFromRef(hi) - intFromRef(lo)
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin] ==
-      stringFromRef(v_this)[anon_builtin + intFromRef(lo)])
+    intFromRef(hi) <= |stringFromRef(v_this_dispatch)|
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| == intFromRef(hi) - intFromRef(lo)
+  ensures (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
+      anon_builtin_2 < |stringFromRef(v_ret_0)| ==>
+      stringFromRef(v_ret_0)[anon_builtin_2] ==
+      stringFromRef(v_this_dispatch)[anon_builtin_2 + intFromRef(lo)])
 {
   var res: Ref
   var i: Ref
@@ -33,15 +33,15 @@ method subs(v_this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
     invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
         anon_builtin_1 < |stringFromRef(res)| ==>
         stringFromRef(res)[anon_builtin_1] ==
-        stringFromRef(v_this)[anon_builtin_1 + intFromRef(lo)])
+        stringFromRef(v_this_dispatch)[anon_builtin_1 + intFromRef(lo)])
   anon_1 := ltInts(i, hi)
   if (boolFromRef(anon_1)) {
-    var anon: Ref
+    var anon_2: Ref
     var anon_0: Ref
     anon_0 := i
     i := plusInts(anon_0, intToRef(1))
-    anon := anon_0
-    res := addStringChar(res, stringGet(v_this, anon))
+    anon_2 := anon_0
+    res := addStringChar(res, stringGet(v_this_dispatch, anon_2))
     goto cont
   }
   label break
@@ -54,14 +54,14 @@ method subs(v_this: Ref, lo: Ref, hi: Ref) returns (ret: Ref)
   assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
       anon_builtin_1 < |stringFromRef(res)| ==>
       stringFromRef(res)[anon_builtin_1] ==
-      stringFromRef(v_this)[anon_builtin_1 + intFromRef(lo)])
-  ret := res
-  goto ret_0
-  label ret_0
+      stringFromRef(v_this_dispatch)[anon_builtin_1 + intFromRef(lo)])
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /merge_sort_of_string.kt: info: Generated Viper text for mergeStrings:
-method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
+method mergeStrings(a: Ref, b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), stringType())
   requires isSubtype(typeOf(b), stringType())
   requires (forall anon_builtin_3: Int ::(1 <= anon_builtin_3 &&
@@ -71,12 +71,13 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
       (1 <= anon_builtin_3 && anon_builtin_3 < |stringFromRef(b)| ==>
       stringFromRef(b)[anon_builtin_3 - 1] <=
       stringFromRef(b)[anon_builtin_3]))
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(a)| + |stringFromRef(b)|
-  ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin - 1] <=
-      stringFromRef(ret)[anon_builtin])
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| ==
+    |stringFromRef(a)| + |stringFromRef(b)|
+  ensures (forall anon_builtin_4: Int ::1 <= anon_builtin_4 &&
+      anon_builtin_4 < |stringFromRef(v_ret_0)| ==>
+      stringFromRef(v_ret_0)[anon_builtin_4 - 1] <=
+      stringFromRef(v_ret_0)[anon_builtin_4])
 {
   var pa: Ref
   var pb: Ref
@@ -135,12 +136,12 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
       anon_8 := anon_2
       anon_5 := stringGet(a, anon_8)
     } else {
-      var anon: Ref
+      var anon_9: Ref
       var anon_3: Ref
       anon_3 := pb
       pb := plusInts(anon_3, intToRef(1))
-      anon := anon_3
-      anon_5 := stringGet(b, anon)
+      anon_9 := anon_3
+      anon_5 := stringGet(b, anon_9)
     }
     res := addStringChar(res, anon_5)
     goto cont
@@ -165,9 +166,9 @@ method mergeStrings(a: Ref, b: Ref) returns (ret: Ref)
   assert |stringFromRef(res)| == 0 || intFromRef(pb) == |stringFromRef(b)| ||
     stringFromRef(res)[|stringFromRef(res)| - 1] <=
     stringFromRef(b)[intFromRef(pb)]
-  ret := res
-  goto ret_0
-  label ret_0
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method plus(this: Ref, other: Ref) returns (v_ret: Ref)
@@ -177,30 +178,32 @@ method plus(this: Ref, other: Ref) returns (v_ret: Ref)
 
 
 /merge_sort_of_string.kt: info: Generated Viper text for mergeSorted:
-method mergeSorted(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
+method mergeSorted(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
   ensures (forall anon_builtin_4: Int ::1 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin_4 - 1] <=
-      stringFromRef(ret)[anon_builtin_4])
+      anon_builtin_4 < |stringFromRef(v_ret_0)| ==>
+      stringFromRef(v_ret_0)[anon_builtin_4 - 1] <=
+      stringFromRef(v_ret_0)[anon_builtin_4])
 {
-  if (|stringFromRef(v_this)| <= 1) {
-    ret := v_this
+  if (|stringFromRef(v_this_dispatch)| <= 1) {
+    v_ret_0 := v_this_dispatch
   } else {
     var anon_0: Ref
     var anon_1: Ref
     var anon_2: Ref
     var anon_3: Ref
-    anon_1 := subs(v_this, intToRef(0), divInts(stringLength(v_this), intToRef(2)))
+    anon_1 := subs(v_this_dispatch, intToRef(0), divInts(stringLength(v_this_dispatch),
+      intToRef(2)))
     anon_0 := mergeSorted(anon_1)
-    anon_3 := subs(v_this, divInts(stringLength(v_this), intToRef(2)), stringLength(v_this))
+    anon_3 := subs(v_this_dispatch, divInts(stringLength(v_this_dispatch), intToRef(2)),
+      stringLength(v_this_dispatch))
     anon_2 := mergeSorted(anon_3)
-    ret := mergeStrings(anon_0, anon_2)
+    v_ret_0 := mergeStrings(anon_0, anon_2)
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method mergeStrings(a: Ref, b: Ref) returns (v_ret: Ref)
@@ -215,20 +218,21 @@ method mergeStrings(a: Ref, b: Ref) returns (v_ret: Ref)
       stringFromRef(b)[anon_builtin_5]))
   ensures isSubtype(typeOf(v_ret), stringType())
   ensures |stringFromRef(v_ret)| == |stringFromRef(a)| + |stringFromRef(b)|
-  ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
-      anon_builtin < |stringFromRef(v_ret)| ==>
-      stringFromRef(v_ret)[anon_builtin - 1] <=
-      stringFromRef(v_ret)[anon_builtin])
+  ensures (forall anon_builtin_6: Int ::1 <= anon_builtin_6 &&
+      anon_builtin_6 < |stringFromRef(v_ret)| ==>
+      stringFromRef(v_ret)[anon_builtin_6 - 1] <=
+      stringFromRef(v_ret)[anon_builtin_6])
 
 
-method subs(v_this: Ref, lo: Ref, hi: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method subs(v_this_dispatch: Ref, lo: Ref, hi: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(v_this)|
+    intFromRef(hi) <= |stringFromRef(v_this_dispatch)|
   ensures isSubtype(typeOf(v_ret), stringType())
   ensures |stringFromRef(v_ret)| == intFromRef(hi) - intFromRef(lo)
-  ensures (forall anon: Int ::0 <= anon && anon < |stringFromRef(v_ret)| ==>
-      stringFromRef(v_ret)[anon] ==
-      stringFromRef(v_this)[anon + intFromRef(lo)])
+  ensures (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
+      anon_builtin_7 < |stringFromRef(v_ret)| ==>
+      stringFromRef(v_ret)[anon_builtin_7] ==
+      stringFromRef(v_this_dispatch)[anon_builtin_7 + intFromRef(lo)])

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -5,18 +5,18 @@ method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method subs(v_this_dispatch: Ref, lo: Ref, hi: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method subs(v_this_extension: Ref, lo: Ref, hi: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(hi) <= |stringFromRef(v_this_extension)|
   ensures isSubtype(typeOf(v_ret_0), stringType())
   ensures |stringFromRef(v_ret_0)| == intFromRef(hi) - intFromRef(lo)
   ensures (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < |stringFromRef(v_ret_0)| ==>
       stringFromRef(v_ret_0)[anon_builtin_2] ==
-      stringFromRef(v_this_dispatch)[anon_builtin_2 + intFromRef(lo)])
+      stringFromRef(v_this_extension)[anon_builtin_2 + intFromRef(lo)])
 {
   var res: Ref
   var i: Ref
@@ -33,7 +33,7 @@ method subs(v_this_dispatch: Ref, lo: Ref, hi: Ref) returns (v_ret_0: Ref)
     invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
         anon_builtin_1 < |stringFromRef(res)| ==>
         stringFromRef(res)[anon_builtin_1] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_1 + intFromRef(lo)])
+        stringFromRef(v_this_extension)[anon_builtin_1 + intFromRef(lo)])
   anon_1 := ltInts(i, hi)
   if (boolFromRef(anon_1)) {
     var anon_2: Ref
@@ -41,7 +41,7 @@ method subs(v_this_dispatch: Ref, lo: Ref, hi: Ref) returns (v_ret_0: Ref)
     anon_0 := i
     i := plusInts(anon_0, intToRef(1))
     anon_2 := anon_0
-    res := addStringChar(res, stringGet(v_this_dispatch, anon_2))
+    res := addStringChar(res, stringGet(v_this_extension, anon_2))
     goto cont
   }
   label break
@@ -54,7 +54,7 @@ method subs(v_this_dispatch: Ref, lo: Ref, hi: Ref) returns (v_ret_0: Ref)
   assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
       anon_builtin_1 < |stringFromRef(res)| ==>
       stringFromRef(res)[anon_builtin_1] ==
-      stringFromRef(v_this_dispatch)[anon_builtin_1 + intFromRef(lo)])
+      stringFromRef(v_this_extension)[anon_builtin_1 + intFromRef(lo)])
   v_ret_0 := res
   goto lbl_ret_0
   label lbl_ret_0
@@ -178,27 +178,27 @@ method plus(this: Ref, other: Ref) returns (v_ret: Ref)
 
 
 /merge_sort_of_string.kt: info: Generated Viper text for mergeSorted:
-method mergeSorted(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method mergeSorted(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_4: Int ::1 <= anon_builtin_4 &&
       anon_builtin_4 < |stringFromRef(v_ret_0)| ==>
       stringFromRef(v_ret_0)[anon_builtin_4 - 1] <=
       stringFromRef(v_ret_0)[anon_builtin_4])
 {
-  if (|stringFromRef(v_this_dispatch)| <= 1) {
-    v_ret_0 := v_this_dispatch
+  if (|stringFromRef(v_this_extension)| <= 1) {
+    v_ret_0 := v_this_extension
   } else {
     var anon_0: Ref
     var anon_1: Ref
     var anon_2: Ref
     var anon_3: Ref
-    anon_1 := subs(v_this_dispatch, intToRef(0), divInts(stringLength(v_this_dispatch),
+    anon_1 := subs(v_this_extension, intToRef(0), divInts(stringLength(v_this_extension),
       intToRef(2)))
     anon_0 := mergeSorted(anon_1)
-    anon_3 := subs(v_this_dispatch, divInts(stringLength(v_this_dispatch), intToRef(2)),
-      stringLength(v_this_dispatch))
+    anon_3 := subs(v_this_extension, divInts(stringLength(v_this_extension),
+      intToRef(2)), stringLength(v_this_extension))
     anon_2 := mergeSorted(anon_3)
     v_ret_0 := mergeStrings(anon_0, anon_2)
   }
@@ -224,15 +224,15 @@ method mergeStrings(a: Ref, b: Ref) returns (v_ret: Ref)
       stringFromRef(v_ret)[anon_builtin_6])
 
 
-method subs(v_this_dispatch: Ref, lo: Ref, hi: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method subs(v_this_extension: Ref, lo: Ref, hi: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(hi) <= |stringFromRef(v_this_extension)|
   ensures isSubtype(typeOf(v_ret), stringType())
   ensures |stringFromRef(v_ret)| == intFromRef(hi) - intFromRef(lo)
   ensures (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
       anon_builtin_7 < |stringFromRef(v_ret)| ==>
       stringFromRef(v_ret)[anon_builtin_7] ==
-      stringFromRef(v_this_dispatch)[anon_builtin_7 + intFromRef(lo)])
+      stringFromRef(v_this_extension)[anon_builtin_7 + intFromRef(lo)])

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
@@ -1,52 +1,69 @@
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /quick_sort_of_string.kt: info: Generated Viper text for minOrMaxChar:
-method minOrMaxChar(this: Ref, calcMin: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method minOrMaxChar([v$this]: Ref, calcMin: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(this)| >= 1
+  requires |stringFromRef([v$this])| >= 1
   ensures isSubtype(typeOf(ret), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(this)| ==>
-      charFromRef(ret) <= stringFromRef(this)[anon_builtin_4])
+      anon_builtin_4 < |stringFromRef([v$this])| ==>
+      charFromRef(ret) <= stringFromRef([v$this])[anon_builtin_4])
   ensures !boolFromRef(calcMin) ==>
-    (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
-      anon_builtin_5 < |stringFromRef(this)| ==>
-      charFromRef(ret) >= stringFromRef(this)[anon_builtin_5])
+    (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < |stringFromRef([v$this])| ==>
+      charFromRef(ret) >= stringFromRef([v$this])[anon_builtin])
 {
   var res: Ref
   var i: Ref
   var anon_0: Ref
-  res := stringGet(this, intToRef(0))
+  res := stringGet([v$this], intToRef(0))
   i := intToRef(1)
   label cont
     invariant isSubtype(typeOf(res), charType())
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(calcMin), boolType())
-    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+    invariant 0 <= intFromRef(i) &&
+      intFromRef(i) <= |stringFromRef([v$this])|
     invariant boolFromRef(calcMin) ==>
       (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
-        charFromRef(res) <= stringFromRef(this)[anon_builtin_2])
+        charFromRef(res) <= stringFromRef([v$this])[anon_builtin_2])
     invariant !boolFromRef(calcMin) ==>
-      (forall anon_builtin: Int ::0 <= anon_builtin &&
-        anon_builtin < intFromRef(i) ==>
-        charFromRef(res) >= stringFromRef(this)[anon_builtin])
-  anon_0 := ltInts(i, stringLength(this))
+      (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
+        anon_builtin_3 < intFromRef(i) ==>
+        charFromRef(res) >= stringFromRef([v$this])[anon_builtin_3])
+  anon_0 := ltInts(i, stringLength([v$this]))
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
     var anon: Ref
     if (boolFromRef(calcMin)) {
-      anon := ltChars(stringGet(this, i), res)
+      anon := ltChars(stringGet([v$this], i), res)
     } else {
       anon := boolToRef(false)}
     if (boolFromRef(anon)) {
       anon_1 := boolToRef(true)
     } elseif (!boolFromRef(calcMin)) {
-      anon_1 := gtChars(stringGet(this, i), res)
+      anon_1 := gtChars(stringGet([v$this], i), res)
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
-      res := stringGet(this, i)
+      res := stringGet([v$this], i)
     }
     i := plusInts(i, intToRef(1))
     goto cont
@@ -55,109 +72,277 @@ method minOrMaxChar(this: Ref, calcMin: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(res), charType())
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(calcMin), boolType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
   assert boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
-      charFromRef(res) <= stringFromRef(this)[anon_builtin_2])
+      charFromRef(res) <= stringFromRef([v$this])[anon_builtin_2])
   assert !boolFromRef(calcMin) ==>
-    (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < intFromRef(i) ==>
-      charFromRef(res) >= stringFromRef(this)[anon_builtin])
+    (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
+      anon_builtin_3 < intFromRef(i) ==>
+      charFromRef(res) >= stringFromRef([v$this])[anon_builtin_3])
   ret := res
   goto ret_0
   label ret_0
 }
 
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /quick_sort_of_string.kt: info: Generated Viper text for quickSort:
-method minOrMaxChar(this: Ref, calcMin: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method minOrMaxChar([v$this]: Ref, calcMin: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(this)| >= 1
+  requires |stringFromRef([v$this])| >= 1
   ensures isSubtype(typeOf(ret), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
-      anon_builtin_7 < |stringFromRef(this)| ==>
-      charFromRef(ret) <= stringFromRef(this)[anon_builtin_7])
+      anon_builtin_7 < |stringFromRef([v$this])| ==>
+      charFromRef(ret) <= stringFromRef([v$this])[anon_builtin_7])
   ensures !boolFromRef(calcMin) ==>
-    (forall anon_builtin_8: Int ::0 <= anon_builtin_8 &&
-      anon_builtin_8 < |stringFromRef(this)| ==>
-      charFromRef(ret) >= stringFromRef(this)[anon_builtin_8])
+    (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < |stringFromRef([v$this])| ==>
+      charFromRef(ret) >= stringFromRef([v$this])[anon_builtin])
 
 
-method quickSort(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method quickSort([v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef(this)|
+  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
   ensures (forall anon_builtin_6: Int ::1 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef(this)| ==>
+      anon_builtin_6 < |stringFromRef([v$this])| ==>
       stringFromRef(ret_0)[anon_builtin_6 - 1] <=
       stringFromRef(ret_0)[anon_builtin_6])
 {
   var l0_minVal: Ref
   var l0_maxVal: Ref
-  if (|stringFromRef(this)| <= 1) {
-    ret_0 := this
+  if (|stringFromRef([v$this])| <= 1) {
+    ret_0 := [v$this]
     goto lbl_ret_0
   }
-  l0_minVal := minOrMaxChar(this, boolToRef(true))
-  l0_maxVal := minOrMaxChar(this, boolToRef(false))
-  ret_0 := quickSortRec(this, l0_minVal, l0_maxVal)
+  l0_minVal := minOrMaxChar([v$this], boolToRef(true))
+  l0_maxVal := minOrMaxChar([v$this], boolToRef(false))
+  ret_0 := quickSortRec([v$this], l0_minVal, l0_maxVal)
   goto lbl_ret_0
   label lbl_ret_0
 }
 
-method quickSortRec(this: Ref, minVal: Ref, maxVal: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
+  returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(minVal), charType())
   requires isSubtype(typeOf(maxVal), charType())
-  requires (forall anon_builtin_9: Int ::0 <= anon_builtin_9 &&
-      anon_builtin_9 < |stringFromRef(this)| ==>
-      charFromRef(minVal) <= stringFromRef(this)[anon_builtin_9] &&
-      stringFromRef(this)[anon_builtin_9] <= charFromRef(maxVal))
+  requires (forall anon: Int ::0 <= anon &&
+      anon < |stringFromRef([v$this])| ==>
+      charFromRef(minVal) <= stringFromRef([v$this])[anon] &&
+      stringFromRef([v$this])[anon] <= charFromRef(maxVal))
   ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(this)|
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(this)| ==>
-      charFromRef(minVal) <= stringFromRef(ret)[anon_builtin] &&
-      stringFromRef(ret)[anon_builtin] <= charFromRef(maxVal))
-  ensures (forall anon: Int ::1 <= anon && anon < |stringFromRef(this)| ==>
-      stringFromRef(ret)[anon - 1] <= stringFromRef(ret)[anon])
+  ensures |stringFromRef(ret)| == |stringFromRef([v$this])|
+  ensures (forall anon_builtin_10: Int ::0 <= anon_builtin_10 &&
+      anon_builtin_10 < |stringFromRef([v$this])| ==>
+      charFromRef(minVal) <= stringFromRef(ret)[anon_builtin_10] &&
+      stringFromRef(ret)[anon_builtin_10] <= charFromRef(maxVal))
+  ensures (forall anon_builtin_11: Int ::1 <= anon_builtin_11 &&
+      anon_builtin_11 < |stringFromRef([v$this])| ==>
+      stringFromRef(ret)[anon_builtin_11 - 1] <=
+      stringFromRef(ret)[anon_builtin_11])
 
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSortRec:
-method chooseIndex(this: Ref) returns (v_ret: Ref)
+method chooseIndex([v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
+  requires |stringFromRef([v$this])| >= 1
+  ensures isSubtype(typeOf(ret), intType())
+  ensures 0 <= intFromRef(ret) &&
+    intFromRef(ret) < |stringFromRef([v$this])|
+
+
+method plus(this: Ref, other: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), stringType())
-  requires |stringFromRef(this)| >= 1
-  ensures isSubtype(typeOf(v_ret), intType())
-  ensures 0 <= intFromRef(v_ret) &&
-    intFromRef(v_ret) < |stringFromRef(this)|
-
-
-method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
 
 
-method quickSortRec(this: Ref, minVal: Ref, maxVal: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
+  returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(minVal), charType())
   requires isSubtype(typeOf(maxVal), charType())
   requires (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef(this)| ==>
-      charFromRef(minVal) <= stringFromRef(this)[anon_builtin_6] &&
-      stringFromRef(this)[anon_builtin_6] <= charFromRef(maxVal))
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(this)|
+      anon_builtin_6 < |stringFromRef([v$this])| ==>
+      charFromRef(minVal) <= stringFromRef([v$this])[anon_builtin_6] &&
+      stringFromRef([v$this])[anon_builtin_6] <= charFromRef(maxVal))
+  ensures isSubtype(typeOf(ret_0), stringType())
+  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
   ensures (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
-      anon_builtin_7 < |stringFromRef(this)| ==>
-      charFromRef(minVal) <= stringFromRef(ret)[anon_builtin_7] &&
-      stringFromRef(ret)[anon_builtin_7] <= charFromRef(maxVal))
-  ensures (forall anon_builtin_8: Int ::1 <= anon_builtin_8 &&
-      anon_builtin_8 < |stringFromRef(this)| ==>
-      stringFromRef(ret)[anon_builtin_8 - 1] <=
-      stringFromRef(ret)[anon_builtin_8])
+      anon_builtin_7 < |stringFromRef([v$this])| ==>
+      charFromRef(minVal) <= stringFromRef(ret_0)[anon_builtin_7] &&
+      stringFromRef(ret_0)[anon_builtin_7] <= charFromRef(maxVal))
+  ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
+      anon_builtin < |stringFromRef([v$this])| ==>
+      stringFromRef(ret_0)[anon_builtin - 1] <=
+      stringFromRef(ret_0)[anon_builtin])
 {
   var medVal: Ref
   var anon_1: Ref
@@ -167,13 +352,13 @@ method quickSortRec(this: Ref, minVal: Ref, maxVal: Ref) returns (ret: Ref)
   var eqString: Ref
   var anon_2: Ref
   var anon_4: Ref
-  var anon_5: Ref
-  if (|stringFromRef(this)| <= 1) {
-    ret := this
-    goto ret_0
+  var anon: Ref
+  if (|stringFromRef([v$this])| <= 1) {
+    ret_0 := [v$this]
+    goto lbl_ret_0
   }
-  anon_1 := chooseIndex(this)
-  medVal := stringGet(this, anon_1)
+  anon_1 := chooseIndex([v$this])
+  medVal := stringGet([v$this], anon_1)
   i := intToRef(0)
   lessString := stringToRef(Seq[Int]())
   greaterString := stringToRef(Seq[Int]())
@@ -186,7 +371,8 @@ method quickSortRec(this: Ref, minVal: Ref, maxVal: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(eqString), stringType())
     invariant isSubtype(typeOf(minVal), charType())
     invariant isSubtype(typeOf(maxVal), charType())
-    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+    invariant 0 <= intFromRef(i) &&
+      intFromRef(i) <= |stringFromRef([v$this])|
     invariant |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
       |stringFromRef(eqString)| ==
       intFromRef(i)
@@ -198,18 +384,18 @@ method quickSortRec(this: Ref, minVal: Ref, maxVal: Ref) returns (ret: Ref)
         anon_builtin_4 < |stringFromRef(greaterString)| ==>
         charFromRef(medVal) <= stringFromRef(greaterString)[anon_builtin_4] &&
         stringFromRef(greaterString)[anon_builtin_4] <= charFromRef(maxVal))
-    invariant (forall anon_builtin: Int ::0 <= anon_builtin &&
-        anon_builtin < |stringFromRef(eqString)| ==>
-        stringFromRef(eqString)[anon_builtin] == charFromRef(medVal))
-  anon_2 := ltInts(i, stringLength(this))
+    invariant (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
+        anon_builtin_5 < |stringFromRef(eqString)| ==>
+        stringFromRef(eqString)[anon_builtin_5] == charFromRef(medVal))
+  anon_2 := ltInts(i, stringLength([v$this]))
   if (boolFromRef(anon_2)) {
     var curChar: Ref
     var anon_3: Ref
-    var anon: Ref
-    anon := i
-    i := plusInts(anon, intToRef(1))
-    anon_3 := anon
-    curChar := stringGet(this, anon_3)
+    var anon_0: Ref
+    anon_0 := i
+    i := plusInts(anon_0, intToRef(1))
+    anon_3 := anon_0
+    curChar := stringGet([v$this], anon_3)
     if (charFromRef(curChar) < charFromRef(medVal)) {
       lessString := addStringChar(lessString, curChar)
     } elseif (charFromRef(curChar) > charFromRef(medVal)) {
@@ -226,7 +412,7 @@ method quickSortRec(this: Ref, minVal: Ref, maxVal: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(eqString), stringType())
   assert isSubtype(typeOf(minVal), charType())
   assert isSubtype(typeOf(maxVal), charType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
   assert |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
     |stringFromRef(eqString)| ==
     intFromRef(i)
@@ -238,12 +424,96 @@ method quickSortRec(this: Ref, minVal: Ref, maxVal: Ref) returns (ret: Ref)
       anon_builtin_4 < |stringFromRef(greaterString)| ==>
       charFromRef(medVal) <= stringFromRef(greaterString)[anon_builtin_4] &&
       stringFromRef(greaterString)[anon_builtin_4] <= charFromRef(maxVal))
-  assert (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(eqString)| ==>
-      stringFromRef(eqString)[anon_builtin] == charFromRef(medVal))
+  assert (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
+      anon_builtin_5 < |stringFromRef(eqString)| ==>
+      stringFromRef(eqString)[anon_builtin_5] == charFromRef(medVal))
   anon_4 := quickSortRec(lessString, minVal, medVal)
-  anon_5 := quickSortRec(greaterString, medVal, maxVal)
-  ret := addStrings(addStrings(anon_4, eqString), anon_5)
-  goto ret_0
-  label ret_0
+  anon := quickSortRec(greaterString, medVal, maxVal)
+  ret_0 := addStrings(addStrings(anon_4, eqString), anon)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/quick_sort_of_string.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
@@ -1,69 +1,52 @@
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /quick_sort_of_string.kt: info: Generated Viper text for minOrMaxChar:
-method minOrMaxChar([v$this]: Ref, calcMin: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
+method minOrMaxChar(v_this: Ref, calcMin: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef([v$this])| >= 1
+  requires |stringFromRef(v_this)| >= 1
   ensures isSubtype(typeOf(ret), charType())
   ensures boolFromRef(calcMin) ==>
-    (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef([v$this])| ==>
-      charFromRef(ret) <= stringFromRef([v$this])[anon_builtin_4])
-  ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef([v$this])| ==>
-      charFromRef(ret) >= stringFromRef([v$this])[anon_builtin])
+      anon_builtin < |stringFromRef(v_this)| ==>
+      charFromRef(ret) <= stringFromRef(v_this)[anon_builtin])
+  ensures !boolFromRef(calcMin) ==>
+    (forall anon: Int ::0 <= anon && anon < |stringFromRef(v_this)| ==>
+      charFromRef(ret) >= stringFromRef(v_this)[anon])
 {
   var res: Ref
   var i: Ref
   var anon_0: Ref
-  res := stringGet([v$this], intToRef(0))
+  res := stringGet(v_this, intToRef(0))
   i := intToRef(1)
   label cont
     invariant isSubtype(typeOf(res), charType())
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(calcMin), boolType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef([v$this])|
+      intFromRef(i) <= |stringFromRef(v_this)|
     invariant boolFromRef(calcMin) ==>
       (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
-        charFromRef(res) <= stringFromRef([v$this])[anon_builtin_2])
+        charFromRef(res) <= stringFromRef(v_this)[anon_builtin_2])
     invariant !boolFromRef(calcMin) ==>
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < intFromRef(i) ==>
-        charFromRef(res) >= stringFromRef([v$this])[anon_builtin_3])
-  anon_0 := ltInts(i, stringLength([v$this]))
+        charFromRef(res) >= stringFromRef(v_this)[anon_builtin_3])
+  anon_0 := ltInts(i, stringLength(v_this))
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
-    var anon: Ref
+    var anon_2: Ref
     if (boolFromRef(calcMin)) {
-      anon := ltChars(stringGet([v$this], i), res)
+      anon_2 := ltChars(stringGet(v_this, i), res)
     } else {
-      anon := boolToRef(false)}
-    if (boolFromRef(anon)) {
+      anon_2 := boolToRef(false)}
+    if (boolFromRef(anon_2)) {
       anon_1 := boolToRef(true)
     } elseif (!boolFromRef(calcMin)) {
-      anon_1 := gtChars(stringGet([v$this], i), res)
+      anon_1 := gtChars(stringGet(v_this, i), res)
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
-      res := stringGet([v$this], i)
+      res := stringGet(v_this, i)
     }
     i := plusInts(i, intToRef(1))
     goto cont
@@ -72,277 +55,109 @@ method minOrMaxChar([v$this]: Ref, calcMin: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(res), charType())
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(calcMin), boolType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
   assert boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
-      charFromRef(res) <= stringFromRef([v$this])[anon_builtin_2])
+      charFromRef(res) <= stringFromRef(v_this)[anon_builtin_2])
   assert !boolFromRef(calcMin) ==>
     (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
       anon_builtin_3 < intFromRef(i) ==>
-      charFromRef(res) >= stringFromRef([v$this])[anon_builtin_3])
+      charFromRef(res) >= stringFromRef(v_this)[anon_builtin_3])
   ret := res
   goto ret_0
   label ret_0
 }
 
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /quick_sort_of_string.kt: info: Generated Viper text for quickSort:
-method minOrMaxChar([v$this]: Ref, calcMin: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
+method minOrMaxChar(v_this: Ref, calcMin: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef([v$this])| >= 1
-  ensures isSubtype(typeOf(ret), charType())
+  requires |stringFromRef(v_this)| >= 1
+  ensures isSubtype(typeOf(v_ret), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
-      anon_builtin_7 < |stringFromRef([v$this])| ==>
-      charFromRef(ret) <= stringFromRef([v$this])[anon_builtin_7])
+      anon_builtin_7 < |stringFromRef(v_this)| ==>
+      charFromRef(v_ret) <= stringFromRef(v_this)[anon_builtin_7])
   ensures !boolFromRef(calcMin) ==>
-    (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef([v$this])| ==>
-      charFromRef(ret) >= stringFromRef([v$this])[anon_builtin])
+    (forall anon_builtin_8: Int ::0 <= anon_builtin_8 &&
+      anon_builtin_8 < |stringFromRef(v_this)| ==>
+      charFromRef(v_ret) >= stringFromRef(v_this)[anon_builtin_8])
 
 
-method quickSort([v$this]: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
+method quickSort(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
+  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
   ensures (forall anon_builtin_6: Int ::1 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef([v$this])| ==>
-      stringFromRef(ret_0)[anon_builtin_6 - 1] <=
-      stringFromRef(ret_0)[anon_builtin_6])
+      anon_builtin_6 < |stringFromRef(v_this)| ==>
+      stringFromRef(ret)[anon_builtin_6 - 1] <=
+      stringFromRef(ret)[anon_builtin_6])
 {
-  var l0_minVal: Ref
-  var l0_maxVal: Ref
-  if (|stringFromRef([v$this])| <= 1) {
-    ret_0 := [v$this]
-    goto lbl_ret_0
+  var minVal: Ref
+  var maxVal: Ref
+  if (|stringFromRef(v_this)| <= 1) {
+    ret := v_this
+    goto ret_0
   }
-  l0_minVal := minOrMaxChar([v$this], boolToRef(true))
-  l0_maxVal := minOrMaxChar([v$this], boolToRef(false))
-  ret_0 := quickSortRec([v$this], l0_minVal, l0_maxVal)
-  goto lbl_ret_0
-  label lbl_ret_0
+  minVal := minOrMaxChar(v_this, boolToRef(true))
+  maxVal := minOrMaxChar(v_this, boolToRef(false))
+  ret := quickSortRec(v_this, minVal, maxVal)
+  goto ret_0
+  label ret_0
 }
 
-method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
-  returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
-  requires isSubtype(typeOf(minVal), charType())
-  requires isSubtype(typeOf(maxVal), charType())
-  requires (forall anon: Int ::0 <= anon &&
-      anon < |stringFromRef([v$this])| ==>
-      charFromRef(minVal) <= stringFromRef([v$this])[anon] &&
-      stringFromRef([v$this])[anon] <= charFromRef(maxVal))
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef([v$this])|
-  ensures (forall anon_builtin_10: Int ::0 <= anon_builtin_10 &&
-      anon_builtin_10 < |stringFromRef([v$this])| ==>
-      charFromRef(minVal) <= stringFromRef(ret)[anon_builtin_10] &&
-      stringFromRef(ret)[anon_builtin_10] <= charFromRef(maxVal))
-  ensures (forall anon_builtin_11: Int ::1 <= anon_builtin_11 &&
-      anon_builtin_11 < |stringFromRef([v$this])| ==>
-      stringFromRef(ret)[anon_builtin_11 - 1] <=
-      stringFromRef(ret)[anon_builtin_11])
+method quickSortRec(v_this: Ref, par_minVal: Ref, par_maxVal: Ref)
+  returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
+  requires isSubtype(typeOf(par_minVal), charType())
+  requires isSubtype(typeOf(par_maxVal), charType())
+  requires (forall anon_builtin_9: Int ::0 <= anon_builtin_9 &&
+      anon_builtin_9 < |stringFromRef(v_this)| ==>
+      charFromRef(par_minVal) <= stringFromRef(v_this)[anon_builtin_9] &&
+      stringFromRef(v_this)[anon_builtin_9] <= charFromRef(par_maxVal))
+  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures |stringFromRef(v_ret)| == |stringFromRef(v_this)|
+  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < |stringFromRef(v_this)| ==>
+      charFromRef(par_minVal) <= stringFromRef(v_ret)[anon_builtin] &&
+      stringFromRef(v_ret)[anon_builtin] <= charFromRef(par_maxVal))
+  ensures (forall anon: Int ::1 <= anon && anon < |stringFromRef(v_this)| ==>
+      stringFromRef(v_ret)[anon - 1] <= stringFromRef(v_ret)[anon])
 
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSortRec:
-method chooseIndex([v$this]: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
-  requires |stringFromRef([v$this])| >= 1
-  ensures isSubtype(typeOf(ret), intType())
-  ensures 0 <= intFromRef(ret) &&
-    intFromRef(ret) < |stringFromRef([v$this])|
+method chooseIndex(v_this: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
+  requires |stringFromRef(v_this)| >= 1
+  ensures isSubtype(typeOf(v_ret), intType())
+  ensures 0 <= intFromRef(v_ret) &&
+    intFromRef(v_ret) < |stringFromRef(v_this)|
 
 
-method plus(this: Ref, other: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), stringType())
+  ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
-  returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
+method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
+  returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(minVal), charType())
   requires isSubtype(typeOf(maxVal), charType())
   requires (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef([v$this])| ==>
-      charFromRef(minVal) <= stringFromRef([v$this])[anon_builtin_6] &&
-      stringFromRef([v$this])[anon_builtin_6] <= charFromRef(maxVal))
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
-  ensures (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
-      anon_builtin_7 < |stringFromRef([v$this])| ==>
-      charFromRef(minVal) <= stringFromRef(ret_0)[anon_builtin_7] &&
-      stringFromRef(ret_0)[anon_builtin_7] <= charFromRef(maxVal))
-  ensures (forall anon_builtin: Int ::1 <= anon_builtin &&
-      anon_builtin < |stringFromRef([v$this])| ==>
-      stringFromRef(ret_0)[anon_builtin - 1] <=
-      stringFromRef(ret_0)[anon_builtin])
+      anon_builtin_6 < |stringFromRef(v_this)| ==>
+      charFromRef(minVal) <= stringFromRef(v_this)[anon_builtin_6] &&
+      stringFromRef(v_this)[anon_builtin_6] <= charFromRef(maxVal))
+  ensures isSubtype(typeOf(ret), stringType())
+  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
+  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < |stringFromRef(v_this)| ==>
+      charFromRef(minVal) <= stringFromRef(ret)[anon_builtin] &&
+      stringFromRef(ret)[anon_builtin] <= charFromRef(maxVal))
+  ensures (forall anon: Int ::1 <= anon && anon < |stringFromRef(v_this)| ==>
+      stringFromRef(ret)[anon - 1] <= stringFromRef(ret)[anon])
 {
   var medVal: Ref
   var anon_1: Ref
@@ -352,13 +167,13 @@ method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
   var eqString: Ref
   var anon_2: Ref
   var anon_4: Ref
-  var anon: Ref
-  if (|stringFromRef([v$this])| <= 1) {
-    ret_0 := [v$this]
-    goto lbl_ret_0
+  var anon_5: Ref
+  if (|stringFromRef(v_this)| <= 1) {
+    ret := v_this
+    goto ret_0
   }
-  anon_1 := chooseIndex([v$this])
-  medVal := stringGet([v$this], anon_1)
+  anon_1 := chooseIndex(v_this)
+  medVal := stringGet(v_this, anon_1)
   i := intToRef(0)
   lessString := stringToRef(Seq[Int]())
   greaterString := stringToRef(Seq[Int]())
@@ -372,7 +187,7 @@ method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
     invariant isSubtype(typeOf(minVal), charType())
     invariant isSubtype(typeOf(maxVal), charType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef([v$this])|
+      intFromRef(i) <= |stringFromRef(v_this)|
     invariant |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
       |stringFromRef(eqString)| ==
       intFromRef(i)
@@ -387,7 +202,7 @@ method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
     invariant (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
         anon_builtin_5 < |stringFromRef(eqString)| ==>
         stringFromRef(eqString)[anon_builtin_5] == charFromRef(medVal))
-  anon_2 := ltInts(i, stringLength([v$this]))
+  anon_2 := ltInts(i, stringLength(v_this))
   if (boolFromRef(anon_2)) {
     var curChar: Ref
     var anon_3: Ref
@@ -395,7 +210,7 @@ method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
     anon_0 := i
     i := plusInts(anon_0, intToRef(1))
     anon_3 := anon_0
-    curChar := stringGet([v$this], anon_3)
+    curChar := stringGet(v_this, anon_3)
     if (charFromRef(curChar) < charFromRef(medVal)) {
       lessString := addStringChar(lessString, curChar)
     } elseif (charFromRef(curChar) > charFromRef(medVal)) {
@@ -412,7 +227,7 @@ method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
   assert isSubtype(typeOf(eqString), stringType())
   assert isSubtype(typeOf(minVal), charType())
   assert isSubtype(typeOf(maxVal), charType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
   assert |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
     |stringFromRef(eqString)| ==
     intFromRef(i)
@@ -428,92 +243,8 @@ method quickSortRec([v$this]: Ref, minVal: Ref, maxVal: Ref)
       anon_builtin_5 < |stringFromRef(eqString)| ==>
       stringFromRef(eqString)[anon_builtin_5] == charFromRef(medVal))
   anon_4 := quickSortRec(lessString, minVal, medVal)
-  anon := quickSortRec(greaterString, medVal, maxVal)
-  ret_0 := addStrings(addStrings(anon_4, eqString), anon)
-  goto lbl_ret_0
-  label lbl_ret_0
+  anon_5 := quickSortRec(greaterString, medVal, maxVal)
+  ret := addStrings(addStrings(anon_4, eqString), anon_5)
+  goto ret_0
+  label ret_0
 }
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/quick_sort_of_string.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
@@ -1,56 +1,56 @@
 /quick_sort_of_string.kt: info: Generated Viper text for minOrMaxChar:
-method minOrMaxChar(v_this_dispatch: Ref, calcMin: Ref)
+method minOrMaxChar(v_this_extension: Ref, calcMin: Ref)
   returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(v_this_dispatch)| >= 1
+  requires |stringFromRef(v_this_extension)| >= 1
   ensures isSubtype(typeOf(v_ret_0), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_4 < |stringFromRef(v_this_extension)| ==>
       charFromRef(v_ret_0) <=
-      stringFromRef(v_this_dispatch)[anon_builtin_4])
+      stringFromRef(v_this_extension)[anon_builtin_4])
   ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
-      anon_builtin_5 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_5 < |stringFromRef(v_this_extension)| ==>
       charFromRef(v_ret_0) >=
-      stringFromRef(v_this_dispatch)[anon_builtin_5])
+      stringFromRef(v_this_extension)[anon_builtin_5])
 {
   var res: Ref
   var i: Ref
   var anon_0: Ref
-  res := stringGet(v_this_dispatch, intToRef(0))
+  res := stringGet(v_this_extension, intToRef(0))
   i := intToRef(1)
   label cont
     invariant isSubtype(typeOf(res), charType())
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(calcMin), boolType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(i) <= |stringFromRef(v_this_extension)|
     invariant boolFromRef(calcMin) ==>
       (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
-        charFromRef(res) <= stringFromRef(v_this_dispatch)[anon_builtin_2])
+        charFromRef(res) <= stringFromRef(v_this_extension)[anon_builtin_2])
     invariant !boolFromRef(calcMin) ==>
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < intFromRef(i) ==>
-        charFromRef(res) >= stringFromRef(v_this_dispatch)[anon_builtin_3])
-  anon_0 := ltInts(i, stringLength(v_this_dispatch))
+        charFromRef(res) >= stringFromRef(v_this_extension)[anon_builtin_3])
+  anon_0 := ltInts(i, stringLength(v_this_extension))
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
     var anon_2: Ref
     if (boolFromRef(calcMin)) {
-      anon_2 := ltChars(stringGet(v_this_dispatch, i), res)
+      anon_2 := ltChars(stringGet(v_this_extension, i), res)
     } else {
       anon_2 := boolToRef(false)}
     if (boolFromRef(anon_2)) {
       anon_1 := boolToRef(true)
     } elseif (!boolFromRef(calcMin)) {
-      anon_1 := gtChars(stringGet(v_this_dispatch, i), res)
+      anon_1 := gtChars(stringGet(v_this_extension, i), res)
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
-      res := stringGet(v_this_dispatch, i)
+      res := stringGet(v_this_extension, i)
     }
     i := plusInts(i, intToRef(1))
     goto cont
@@ -60,89 +60,89 @@ method minOrMaxChar(v_this_dispatch: Ref, calcMin: Ref)
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(calcMin), boolType())
   assert 0 <= intFromRef(i) &&
-    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(i) <= |stringFromRef(v_this_extension)|
   assert boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
-      charFromRef(res) <= stringFromRef(v_this_dispatch)[anon_builtin_2])
+      charFromRef(res) <= stringFromRef(v_this_extension)[anon_builtin_2])
   assert !boolFromRef(calcMin) ==>
     (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
       anon_builtin_3 < intFromRef(i) ==>
-      charFromRef(res) >= stringFromRef(v_this_dispatch)[anon_builtin_3])
+      charFromRef(res) >= stringFromRef(v_this_extension)[anon_builtin_3])
   v_ret_0 := res
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSort:
-method minOrMaxChar(v_this_dispatch: Ref, calcMin: Ref)
+method minOrMaxChar(v_this_extension: Ref, calcMin: Ref)
   returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(v_this_dispatch)| >= 1
+  requires |stringFromRef(v_this_extension)| >= 1
   ensures isSubtype(typeOf(v_ret), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
-      anon_builtin_7 < |stringFromRef(v_this_dispatch)| ==>
-      charFromRef(v_ret) <= stringFromRef(v_this_dispatch)[anon_builtin_7])
+      anon_builtin_7 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(v_ret) <= stringFromRef(v_this_extension)[anon_builtin_7])
   ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin_8: Int ::0 <= anon_builtin_8 &&
-      anon_builtin_8 < |stringFromRef(v_this_dispatch)| ==>
-      charFromRef(v_ret) >= stringFromRef(v_this_dispatch)[anon_builtin_8])
+      anon_builtin_8 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(v_ret) >= stringFromRef(v_this_extension)[anon_builtin_8])
 
 
-method quickSort(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method quickSort(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_6: Int ::1 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_6 < |stringFromRef(v_this_extension)| ==>
       stringFromRef(v_ret_0)[anon_builtin_6 - 1] <=
       stringFromRef(v_ret_0)[anon_builtin_6])
 {
   var l0_minVal: Ref
   var l0_maxVal: Ref
-  if (|stringFromRef(v_this_dispatch)| <= 1) {
-    v_ret_0 := v_this_dispatch
+  if (|stringFromRef(v_this_extension)| <= 1) {
+    v_ret_0 := v_this_extension
     goto lbl_ret_0
   }
-  l0_minVal := minOrMaxChar(v_this_dispatch, boolToRef(true))
-  l0_maxVal := minOrMaxChar(v_this_dispatch, boolToRef(false))
-  v_ret_0 := quickSortRec(v_this_dispatch, l0_minVal, l0_maxVal)
+  l0_minVal := minOrMaxChar(v_this_extension, boolToRef(true))
+  l0_maxVal := minOrMaxChar(v_this_extension, boolToRef(false))
+  v_ret_0 := quickSortRec(v_this_extension, l0_minVal, l0_maxVal)
   goto lbl_ret_0
   label lbl_ret_0
 }
 
-method quickSortRec(v_this_dispatch: Ref, par_minVal: Ref, par_maxVal: Ref)
+method quickSortRec(v_this_extension: Ref, par_minVal: Ref, par_maxVal: Ref)
   returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(par_minVal), charType())
   requires isSubtype(typeOf(par_maxVal), charType())
   requires (forall anon_builtin_9: Int ::0 <= anon_builtin_9 &&
-      anon_builtin_9 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_9 < |stringFromRef(v_this_extension)| ==>
       charFromRef(par_minVal) <=
-      stringFromRef(v_this_dispatch)[anon_builtin_9] &&
-      stringFromRef(v_this_dispatch)[anon_builtin_9] <=
+      stringFromRef(v_this_extension)[anon_builtin_9] &&
+      stringFromRef(v_this_extension)[anon_builtin_9] <=
       charFromRef(par_maxVal))
   ensures isSubtype(typeOf(v_ret), stringType())
-  ensures |stringFromRef(v_ret)| == |stringFromRef(v_this_dispatch)|
+  ensures |stringFromRef(v_ret)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_10: Int ::0 <= anon_builtin_10 &&
-      anon_builtin_10 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_10 < |stringFromRef(v_this_extension)| ==>
       charFromRef(par_minVal) <= stringFromRef(v_ret)[anon_builtin_10] &&
       stringFromRef(v_ret)[anon_builtin_10] <= charFromRef(par_maxVal))
   ensures (forall anon_builtin_11: Int ::1 <= anon_builtin_11 &&
-      anon_builtin_11 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_11 < |stringFromRef(v_this_extension)| ==>
       stringFromRef(v_ret)[anon_builtin_11 - 1] <=
       stringFromRef(v_ret)[anon_builtin_11])
 
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSortRec:
-method chooseIndex(v_this_dispatch: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
-  requires |stringFromRef(v_this_dispatch)| >= 1
+method chooseIndex(v_this_extension: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
+  requires |stringFromRef(v_this_extension)| >= 1
   ensures isSubtype(typeOf(v_ret), intType())
   ensures 0 <= intFromRef(v_ret) &&
-    intFromRef(v_ret) < |stringFromRef(v_this_dispatch)|
+    intFromRef(v_ret) < |stringFromRef(v_this_extension)|
 
 
 method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
@@ -151,23 +151,25 @@ method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method quickSortRec(v_this_dispatch: Ref, minVal: Ref, maxVal: Ref)
+method quickSortRec(v_this_extension: Ref, minVal: Ref, maxVal: Ref)
   returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(minVal), charType())
   requires isSubtype(typeOf(maxVal), charType())
   requires (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef(v_this_dispatch)| ==>
-      charFromRef(minVal) <= stringFromRef(v_this_dispatch)[anon_builtin_6] &&
-      stringFromRef(v_this_dispatch)[anon_builtin_6] <= charFromRef(maxVal))
+      anon_builtin_6 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(minVal) <=
+      stringFromRef(v_this_extension)[anon_builtin_6] &&
+      stringFromRef(v_this_extension)[anon_builtin_6] <=
+      charFromRef(maxVal))
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
-      anon_builtin_7 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_7 < |stringFromRef(v_this_extension)| ==>
       charFromRef(minVal) <= stringFromRef(v_ret_0)[anon_builtin_7] &&
       stringFromRef(v_ret_0)[anon_builtin_7] <= charFromRef(maxVal))
   ensures (forall anon_builtin_8: Int ::1 <= anon_builtin_8 &&
-      anon_builtin_8 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_8 < |stringFromRef(v_this_extension)| ==>
       stringFromRef(v_ret_0)[anon_builtin_8 - 1] <=
       stringFromRef(v_ret_0)[anon_builtin_8])
 {
@@ -180,12 +182,12 @@ method quickSortRec(v_this_dispatch: Ref, minVal: Ref, maxVal: Ref)
   var anon_2: Ref
   var anon_4: Ref
   var anon_5: Ref
-  if (|stringFromRef(v_this_dispatch)| <= 1) {
-    v_ret_0 := v_this_dispatch
+  if (|stringFromRef(v_this_extension)| <= 1) {
+    v_ret_0 := v_this_extension
     goto lbl_ret_0
   }
-  anon_1 := chooseIndex(v_this_dispatch)
-  medVal := stringGet(v_this_dispatch, anon_1)
+  anon_1 := chooseIndex(v_this_extension)
+  medVal := stringGet(v_this_extension, anon_1)
   i := intToRef(0)
   lessString := stringToRef(Seq[Int]())
   greaterString := stringToRef(Seq[Int]())
@@ -199,7 +201,7 @@ method quickSortRec(v_this_dispatch: Ref, minVal: Ref, maxVal: Ref)
     invariant isSubtype(typeOf(minVal), charType())
     invariant isSubtype(typeOf(maxVal), charType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(i) <= |stringFromRef(v_this_extension)|
     invariant |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
       |stringFromRef(eqString)| ==
       intFromRef(i)
@@ -214,7 +216,7 @@ method quickSortRec(v_this_dispatch: Ref, minVal: Ref, maxVal: Ref)
     invariant (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
         anon_builtin_5 < |stringFromRef(eqString)| ==>
         stringFromRef(eqString)[anon_builtin_5] == charFromRef(medVal))
-  anon_2 := ltInts(i, stringLength(v_this_dispatch))
+  anon_2 := ltInts(i, stringLength(v_this_extension))
   if (boolFromRef(anon_2)) {
     var curChar: Ref
     var anon_3: Ref
@@ -222,7 +224,7 @@ method quickSortRec(v_this_dispatch: Ref, minVal: Ref, maxVal: Ref)
     anon_0 := i
     i := plusInts(anon_0, intToRef(1))
     anon_3 := anon_0
-    curChar := stringGet(v_this_dispatch, anon_3)
+    curChar := stringGet(v_this_extension, anon_3)
     if (charFromRef(curChar) < charFromRef(medVal)) {
       lessString := addStringChar(lessString, curChar)
     } elseif (charFromRef(curChar) > charFromRef(medVal)) {
@@ -240,7 +242,7 @@ method quickSortRec(v_this_dispatch: Ref, minVal: Ref, maxVal: Ref)
   assert isSubtype(typeOf(minVal), charType())
   assert isSubtype(typeOf(maxVal), charType())
   assert 0 <= intFromRef(i) &&
-    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(i) <= |stringFromRef(v_this_extension)|
   assert |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
     |stringFromRef(eqString)| ==
     intFromRef(i)

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
@@ -1,52 +1,56 @@
 /quick_sort_of_string.kt: info: Generated Viper text for minOrMaxChar:
-method minOrMaxChar(v_this: Ref, calcMin: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method minOrMaxChar(v_this_dispatch: Ref, calcMin: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(v_this)| >= 1
-  ensures isSubtype(typeOf(ret), charType())
+  requires |stringFromRef(v_this_dispatch)| >= 1
+  ensures isSubtype(typeOf(v_ret_0), charType())
   ensures boolFromRef(calcMin) ==>
-    (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(v_this)| ==>
-      charFromRef(ret) <= stringFromRef(v_this)[anon_builtin])
+    (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
+      anon_builtin_4 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(v_ret_0) <=
+      stringFromRef(v_this_dispatch)[anon_builtin_4])
   ensures !boolFromRef(calcMin) ==>
-    (forall anon: Int ::0 <= anon && anon < |stringFromRef(v_this)| ==>
-      charFromRef(ret) >= stringFromRef(v_this)[anon])
+    (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
+      anon_builtin_5 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(v_ret_0) >=
+      stringFromRef(v_this_dispatch)[anon_builtin_5])
 {
   var res: Ref
   var i: Ref
   var anon_0: Ref
-  res := stringGet(v_this, intToRef(0))
+  res := stringGet(v_this_dispatch, intToRef(0))
   i := intToRef(1)
   label cont
     invariant isSubtype(typeOf(res), charType())
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(calcMin), boolType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this)|
+      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
     invariant boolFromRef(calcMin) ==>
       (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
-        charFromRef(res) <= stringFromRef(v_this)[anon_builtin_2])
+        charFromRef(res) <= stringFromRef(v_this_dispatch)[anon_builtin_2])
     invariant !boolFromRef(calcMin) ==>
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < intFromRef(i) ==>
-        charFromRef(res) >= stringFromRef(v_this)[anon_builtin_3])
-  anon_0 := ltInts(i, stringLength(v_this))
+        charFromRef(res) >= stringFromRef(v_this_dispatch)[anon_builtin_3])
+  anon_0 := ltInts(i, stringLength(v_this_dispatch))
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
     var anon_2: Ref
     if (boolFromRef(calcMin)) {
-      anon_2 := ltChars(stringGet(v_this, i), res)
+      anon_2 := ltChars(stringGet(v_this_dispatch, i), res)
     } else {
       anon_2 := boolToRef(false)}
     if (boolFromRef(anon_2)) {
       anon_1 := boolToRef(true)
     } elseif (!boolFromRef(calcMin)) {
-      anon_1 := gtChars(stringGet(v_this, i), res)
+      anon_1 := gtChars(stringGet(v_this_dispatch, i), res)
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
-      res := stringGet(v_this, i)
+      res := stringGet(v_this_dispatch, i)
     }
     i := plusInts(i, intToRef(1))
     goto cont
@@ -55,109 +59,117 @@ method minOrMaxChar(v_this: Ref, calcMin: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(res), charType())
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(calcMin), boolType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
+  assert 0 <= intFromRef(i) &&
+    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
   assert boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
-      charFromRef(res) <= stringFromRef(v_this)[anon_builtin_2])
+      charFromRef(res) <= stringFromRef(v_this_dispatch)[anon_builtin_2])
   assert !boolFromRef(calcMin) ==>
     (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
       anon_builtin_3 < intFromRef(i) ==>
-      charFromRef(res) >= stringFromRef(v_this)[anon_builtin_3])
-  ret := res
-  goto ret_0
-  label ret_0
+      charFromRef(res) >= stringFromRef(v_this_dispatch)[anon_builtin_3])
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSort:
-method minOrMaxChar(v_this: Ref, calcMin: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method minOrMaxChar(v_this_dispatch: Ref, calcMin: Ref)
+  returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(v_this)| >= 1
+  requires |stringFromRef(v_this_dispatch)| >= 1
   ensures isSubtype(typeOf(v_ret), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
-      anon_builtin_7 < |stringFromRef(v_this)| ==>
-      charFromRef(v_ret) <= stringFromRef(v_this)[anon_builtin_7])
+      anon_builtin_7 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(v_ret) <= stringFromRef(v_this_dispatch)[anon_builtin_7])
   ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin_8: Int ::0 <= anon_builtin_8 &&
-      anon_builtin_8 < |stringFromRef(v_this)| ==>
-      charFromRef(v_ret) >= stringFromRef(v_this)[anon_builtin_8])
+      anon_builtin_8 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(v_ret) >= stringFromRef(v_this_dispatch)[anon_builtin_8])
 
 
-method quickSort(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
+method quickSort(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
   ensures (forall anon_builtin_6: Int ::1 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef(v_this)| ==>
-      stringFromRef(ret)[anon_builtin_6 - 1] <=
-      stringFromRef(ret)[anon_builtin_6])
+      anon_builtin_6 < |stringFromRef(v_this_dispatch)| ==>
+      stringFromRef(v_ret_0)[anon_builtin_6 - 1] <=
+      stringFromRef(v_ret_0)[anon_builtin_6])
 {
-  var minVal: Ref
-  var maxVal: Ref
-  if (|stringFromRef(v_this)| <= 1) {
-    ret := v_this
-    goto ret_0
+  var l0_minVal: Ref
+  var l0_maxVal: Ref
+  if (|stringFromRef(v_this_dispatch)| <= 1) {
+    v_ret_0 := v_this_dispatch
+    goto lbl_ret_0
   }
-  minVal := minOrMaxChar(v_this, boolToRef(true))
-  maxVal := minOrMaxChar(v_this, boolToRef(false))
-  ret := quickSortRec(v_this, minVal, maxVal)
-  goto ret_0
-  label ret_0
+  l0_minVal := minOrMaxChar(v_this_dispatch, boolToRef(true))
+  l0_maxVal := minOrMaxChar(v_this_dispatch, boolToRef(false))
+  v_ret_0 := quickSortRec(v_this_dispatch, l0_minVal, l0_maxVal)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method quickSortRec(v_this: Ref, par_minVal: Ref, par_maxVal: Ref)
+method quickSortRec(v_this_dispatch: Ref, par_minVal: Ref, par_maxVal: Ref)
   returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(par_minVal), charType())
   requires isSubtype(typeOf(par_maxVal), charType())
   requires (forall anon_builtin_9: Int ::0 <= anon_builtin_9 &&
-      anon_builtin_9 < |stringFromRef(v_this)| ==>
-      charFromRef(par_minVal) <= stringFromRef(v_this)[anon_builtin_9] &&
-      stringFromRef(v_this)[anon_builtin_9] <= charFromRef(par_maxVal))
+      anon_builtin_9 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(par_minVal) <=
+      stringFromRef(v_this_dispatch)[anon_builtin_9] &&
+      stringFromRef(v_this_dispatch)[anon_builtin_9] <=
+      charFromRef(par_maxVal))
   ensures isSubtype(typeOf(v_ret), stringType())
-  ensures |stringFromRef(v_ret)| == |stringFromRef(v_this)|
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(v_this)| ==>
-      charFromRef(par_minVal) <= stringFromRef(v_ret)[anon_builtin] &&
-      stringFromRef(v_ret)[anon_builtin] <= charFromRef(par_maxVal))
-  ensures (forall anon: Int ::1 <= anon && anon < |stringFromRef(v_this)| ==>
-      stringFromRef(v_ret)[anon - 1] <= stringFromRef(v_ret)[anon])
+  ensures |stringFromRef(v_ret)| == |stringFromRef(v_this_dispatch)|
+  ensures (forall anon_builtin_10: Int ::0 <= anon_builtin_10 &&
+      anon_builtin_10 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(par_minVal) <= stringFromRef(v_ret)[anon_builtin_10] &&
+      stringFromRef(v_ret)[anon_builtin_10] <= charFromRef(par_maxVal))
+  ensures (forall anon_builtin_11: Int ::1 <= anon_builtin_11 &&
+      anon_builtin_11 < |stringFromRef(v_this_dispatch)| ==>
+      stringFromRef(v_ret)[anon_builtin_11 - 1] <=
+      stringFromRef(v_ret)[anon_builtin_11])
 
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSortRec:
-method chooseIndex(v_this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
-  requires |stringFromRef(v_this)| >= 1
+method chooseIndex(v_this_dispatch: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  requires |stringFromRef(v_this_dispatch)| >= 1
   ensures isSubtype(typeOf(v_ret), intType())
   ensures 0 <= intFromRef(v_ret) &&
-    intFromRef(v_ret) < |stringFromRef(v_this)|
+    intFromRef(v_ret) < |stringFromRef(v_this_dispatch)|
 
 
-method plus(this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
-  returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method quickSortRec(v_this_dispatch: Ref, minVal: Ref, maxVal: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(minVal), charType())
   requires isSubtype(typeOf(maxVal), charType())
   requires (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
-      anon_builtin_6 < |stringFromRef(v_this)| ==>
-      charFromRef(minVal) <= stringFromRef(v_this)[anon_builtin_6] &&
-      stringFromRef(v_this)[anon_builtin_6] <= charFromRef(maxVal))
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(v_this)| ==>
-      charFromRef(minVal) <= stringFromRef(ret)[anon_builtin] &&
-      stringFromRef(ret)[anon_builtin] <= charFromRef(maxVal))
-  ensures (forall anon: Int ::1 <= anon && anon < |stringFromRef(v_this)| ==>
-      stringFromRef(ret)[anon - 1] <= stringFromRef(ret)[anon])
+      anon_builtin_6 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(minVal) <= stringFromRef(v_this_dispatch)[anon_builtin_6] &&
+      stringFromRef(v_this_dispatch)[anon_builtin_6] <= charFromRef(maxVal))
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
+  ensures (forall anon_builtin_7: Int ::0 <= anon_builtin_7 &&
+      anon_builtin_7 < |stringFromRef(v_this_dispatch)| ==>
+      charFromRef(minVal) <= stringFromRef(v_ret_0)[anon_builtin_7] &&
+      stringFromRef(v_ret_0)[anon_builtin_7] <= charFromRef(maxVal))
+  ensures (forall anon_builtin_8: Int ::1 <= anon_builtin_8 &&
+      anon_builtin_8 < |stringFromRef(v_this_dispatch)| ==>
+      stringFromRef(v_ret_0)[anon_builtin_8 - 1] <=
+      stringFromRef(v_ret_0)[anon_builtin_8])
 {
   var medVal: Ref
   var anon_1: Ref
@@ -168,12 +180,12 @@ method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
   var anon_2: Ref
   var anon_4: Ref
   var anon_5: Ref
-  if (|stringFromRef(v_this)| <= 1) {
-    ret := v_this
-    goto ret_0
+  if (|stringFromRef(v_this_dispatch)| <= 1) {
+    v_ret_0 := v_this_dispatch
+    goto lbl_ret_0
   }
-  anon_1 := chooseIndex(v_this)
-  medVal := stringGet(v_this, anon_1)
+  anon_1 := chooseIndex(v_this_dispatch)
+  medVal := stringGet(v_this_dispatch, anon_1)
   i := intToRef(0)
   lessString := stringToRef(Seq[Int]())
   greaterString := stringToRef(Seq[Int]())
@@ -187,7 +199,7 @@ method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
     invariant isSubtype(typeOf(minVal), charType())
     invariant isSubtype(typeOf(maxVal), charType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this)|
+      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
     invariant |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
       |stringFromRef(eqString)| ==
       intFromRef(i)
@@ -202,7 +214,7 @@ method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
     invariant (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
         anon_builtin_5 < |stringFromRef(eqString)| ==>
         stringFromRef(eqString)[anon_builtin_5] == charFromRef(medVal))
-  anon_2 := ltInts(i, stringLength(v_this))
+  anon_2 := ltInts(i, stringLength(v_this_dispatch))
   if (boolFromRef(anon_2)) {
     var curChar: Ref
     var anon_3: Ref
@@ -210,7 +222,7 @@ method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
     anon_0 := i
     i := plusInts(anon_0, intToRef(1))
     anon_3 := anon_0
-    curChar := stringGet(v_this, anon_3)
+    curChar := stringGet(v_this_dispatch, anon_3)
     if (charFromRef(curChar) < charFromRef(medVal)) {
       lessString := addStringChar(lessString, curChar)
     } elseif (charFromRef(curChar) > charFromRef(medVal)) {
@@ -227,7 +239,8 @@ method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
   assert isSubtype(typeOf(eqString), stringType())
   assert isSubtype(typeOf(minVal), charType())
   assert isSubtype(typeOf(maxVal), charType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
+  assert 0 <= intFromRef(i) &&
+    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
   assert |stringFromRef(lessString)| + |stringFromRef(greaterString)| +
     |stringFromRef(eqString)| ==
     intFromRef(i)
@@ -244,7 +257,7 @@ method quickSortRec(v_this: Ref, minVal: Ref, maxVal: Ref)
       stringFromRef(eqString)[anon_builtin_5] == charFromRef(medVal))
   anon_4 := quickSortRec(lessString, minVal, medVal)
   anon_5 := quickSortRec(greaterString, medVal, maxVal)
-  ret := addStrings(addStrings(anon_4, eqString), anon_5)
-  goto ret_0
-  label ret_0
+  v_ret_0 := addStrings(addStrings(anon_4, eqString), anon_5)
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
@@ -26,24 +26,23 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
       !(stringFromRef(s)[anon_builtin_4 +
       (stringFromRef(res)[anon_builtin_4] - 48)] ==
       stringFromRef(s)[stringFromRef(res)[anon_builtin_4] - 48])))
-  requires (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
-      anon_builtin_6 < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
-      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin_6] ==
-      stringFromRef(s)[anon_builtin_6])
+  requires (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
+      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin] ==
+      stringFromRef(s)[anon_builtin])
   ensures isSubtype(typeOf(ret), intType())
   ensures intFromRef(i) <= intFromRef(ret) &&
     intFromRef(ret) <= |stringFromRef(s)|
-  ensures (forall anon_builtin: Int ::intFromRef(i) <= anon_builtin &&
-      anon_builtin < intFromRef(ret) ==>
-      stringFromRef(s)[anon_builtin - intFromRef(i)] ==
-      stringFromRef(s)[anon_builtin])
+  ensures (forall anon: Int ::intFromRef(i) <= anon &&
+      anon < intFromRef(ret) ==>
+      stringFromRef(s)[anon - intFromRef(i)] == stringFromRef(s)[anon])
 {
-  var anon: Ref
+  var anon_0: Ref
   if (intFromRef(checkedLeft) == 0) {
-    anon := boolToRef(true)
+    anon_0 := boolToRef(true)
   } else {
-    anon := leInts(checkedRight, i)}
-  if (boolFromRef(anon)) {
+    anon_0 := leInts(checkedRight, i)}
+  if (boolFromRef(anon_0)) {
     ret := i
   } else {
     var bound: Ref
@@ -58,23 +57,15 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
   label ret_0
 }
 
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /z_function.kt: info: Generated Viper text for zFunction:
-method plus(this: Ref, other: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), stringType())
+  ensures isSubtype(typeOf(v_ret), stringType())
 
 
 method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref)
-  returns (ret: Ref)
+  returns (v_ret: Ref)
   requires isSubtype(typeOf(s), stringType())
   requires isSubtype(typeOf(res), stringType())
   requires isSubtype(typeOf(i), intType())
@@ -100,50 +91,49 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
       !(stringFromRef(s)[anon_builtin_13 +
       (stringFromRef(res)[anon_builtin_13] - 48)] ==
       stringFromRef(s)[stringFromRef(res)[anon_builtin_13] - 48])))
-  requires (forall anon_builtin_15: Int ::0 <= anon_builtin_15 &&
-      anon_builtin_15 < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
-      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin_15] ==
-      stringFromRef(s)[anon_builtin_15])
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(i) <= intFromRef(ret) &&
-    intFromRef(ret) <= |stringFromRef(s)|
-  ensures (forall anon_builtin_16: Int ::intFromRef(i) <= anon_builtin_16 &&
-      anon_builtin_16 < intFromRef(ret) ==>
-      stringFromRef(s)[anon_builtin_16 - intFromRef(i)] ==
-      stringFromRef(s)[anon_builtin_16])
+  requires (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
+      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin] ==
+      stringFromRef(s)[anon_builtin])
+  ensures isSubtype(typeOf(v_ret), intType())
+  ensures intFromRef(i) <= intFromRef(v_ret) &&
+    intFromRef(v_ret) <= |stringFromRef(s)|
+  ensures (forall anon: Int ::intFromRef(i) <= anon &&
+      anon < intFromRef(v_ret) ==>
+      stringFromRef(s)[anon - intFromRef(i)] == stringFromRef(s)[anon])
 
 
-method zFunction([v$this]: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
+method zFunction(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
+  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
   ensures (forall anon_builtin_11: Int ::0 <= anon_builtin_11 &&
-      anon_builtin_11 < |stringFromRef([v$this])| ==>
-      48 <= stringFromRef(ret_0)[anon_builtin_11] &&
-      stringFromRef(ret_0)[anon_builtin_11] <=
-      48 + |stringFromRef([v$this])| - anon_builtin_11 &&
+      anon_builtin_11 < |stringFromRef(v_this)| ==>
+      48 <= stringFromRef(ret)[anon_builtin_11] &&
+      stringFromRef(ret)[anon_builtin_11] <=
+      48 + |stringFromRef(v_this)| - anon_builtin_11 &&
       (forall anon_builtin_12: Int ::0 <= anon_builtin_12 &&
-        anon_builtin_12 < stringFromRef(ret_0)[anon_builtin_11] - 48 ==>
-        stringFromRef([v$this])[anon_builtin_12] ==
-        stringFromRef([v$this])[anon_builtin_11 + anon_builtin_12]) &&
-      (stringFromRef(ret_0)[anon_builtin_11] - 48 ==
-      |stringFromRef([v$this])| - anon_builtin_11 ||
-      !(stringFromRef([v$this])[anon_builtin_11 +
-      (stringFromRef(ret_0)[anon_builtin_11] - 48)] ==
-      stringFromRef([v$this])[stringFromRef(ret_0)[anon_builtin_11] - 48])))
+        anon_builtin_12 < stringFromRef(ret)[anon_builtin_11] - 48 ==>
+        stringFromRef(v_this)[anon_builtin_12] ==
+        stringFromRef(v_this)[anon_builtin_11 + anon_builtin_12]) &&
+      (stringFromRef(ret)[anon_builtin_11] - 48 ==
+      |stringFromRef(v_this)| - anon_builtin_11 ||
+      !(stringFromRef(v_this)[anon_builtin_11 +
+      (stringFromRef(ret)[anon_builtin_11] - 48)] ==
+      stringFromRef(v_this)[stringFromRef(ret)[anon_builtin_11] - 48])))
 {
   var l0_i: Ref
   var l0_res: Ref
   var l0_checkedLeft: Ref
   var l0_checkedRight: Ref
   var anon_0: Ref
-  if (|stringFromRef([v$this])| == 0) {
-    ret_0 := [v$this]
-    goto lbl_ret_0
+  if (|stringFromRef(v_this)| == 0) {
+    ret := v_this
+    goto ret_0
   }
   l0_i := intToRef(1)
   l0_res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48),
-    stringLength([v$this])))
+    stringLength(v_this)))
   l0_checkedLeft := intToRef(0)
   l0_checkedRight := intToRef(0)
   label cont_0
@@ -153,35 +143,35 @@ method zFunction([v$this]: Ref) returns (ret_0: Ref)
     invariant isSubtype(typeOf(l0_checkedRight), intType())
     invariant |stringFromRef(l0_res)| == intFromRef(l0_i)
     invariant 1 <= intFromRef(l0_i) &&
-      intFromRef(l0_i) <= |stringFromRef([v$this])|
+      intFromRef(l0_i) <= |stringFromRef(v_this)|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(l0_i) ==>
         48 <= stringFromRef(l0_res)[anon_builtin_2] &&
         stringFromRef(l0_res)[anon_builtin_2] <=
-        48 + |stringFromRef([v$this])| - anon_builtin_2 &&
+        48 + |stringFromRef(v_this)| - anon_builtin_2 &&
         (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
           anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-          stringFromRef([v$this])[anon_builtin_3] ==
-          stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
+          stringFromRef(v_this)[anon_builtin_3] ==
+          stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-        |stringFromRef([v$this])| - anon_builtin_2 ||
-        !(stringFromRef([v$this])[anon_builtin_2 +
+        |stringFromRef(v_this)| - anon_builtin_2 ||
+        !(stringFromRef(v_this)[anon_builtin_2 +
         (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-        stringFromRef([v$this])[stringFromRef(l0_res)[anon_builtin_2] - 48])))
+        stringFromRef(v_this)[stringFromRef(l0_res)[anon_builtin_2] - 48])))
     invariant 0 <= intFromRef(l0_checkedLeft) &&
       intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-      intFromRef(l0_checkedRight) <= |stringFromRef([v$this])|
+      intFromRef(l0_checkedRight) <= |stringFromRef(v_this)|
     invariant intFromRef(l0_checkedLeft) < intFromRef(l0_i)
     invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
         anon_builtin_4 <
         intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-        stringFromRef([v$this])[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
-        stringFromRef([v$this])[anon_builtin_4])
-  anon_0 := ltInts(l0_i, stringLength([v$this]))
+        stringFromRef(v_this)[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
+        stringFromRef(v_this)[anon_builtin_4])
+  anon_0 := ltInts(l0_i, stringLength(v_this))
   if (boolFromRef(anon_0)) {
     var j: Ref
-    var anon: Ref
-    j := zFuncHelper([v$this], l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
+    var anon_1: Ref
+    j := zFuncHelper(v_this, l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
     label cont
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(l0_i), intType())
@@ -189,24 +179,24 @@ method zFunction([v$this]: Ref) returns (ret_0: Ref)
       invariant isSubtype(typeOf(l0_checkedLeft), intType())
       invariant isSubtype(typeOf(l0_checkedRight), intType())
       invariant intFromRef(l0_i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef([v$this])|
-      invariant (forall anon_builtin: Int ::intFromRef(l0_checkedLeft) <=
-          anon_builtin &&
-          anon_builtin < intFromRef(l0_checkedRight) ==>
-          stringFromRef([v$this])[anon_builtin - intFromRef(l0_checkedLeft)] ==
-          stringFromRef([v$this])[anon_builtin])
+        intFromRef(j) <= |stringFromRef(v_this)|
+      invariant (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
+          anon_builtin_9 &&
+          anon_builtin_9 < intFromRef(l0_checkedRight) ==>
+          stringFromRef(v_this)[anon_builtin_9 - intFromRef(l0_checkedLeft)] ==
+          stringFromRef(v_this)[anon_builtin_9])
       invariant (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
           anon_builtin_10 &&
           anon_builtin_10 < intFromRef(j) ==>
-          stringFromRef([v$this])[anon_builtin_10 - intFromRef(l0_i)] ==
-          stringFromRef([v$this])[anon_builtin_10])
-    if (intFromRef(j) < |stringFromRef([v$this])|) {
-      anon := boolToRef(stringFromRef([v$this])[intFromRef(j) -
+          stringFromRef(v_this)[anon_builtin_10 - intFromRef(l0_i)] ==
+          stringFromRef(v_this)[anon_builtin_10])
+    if (intFromRef(j) < |stringFromRef(v_this)|) {
+      anon_1 := boolToRef(stringFromRef(v_this)[intFromRef(j) -
         intFromRef(l0_i)] ==
-        stringFromRef([v$this])[intFromRef(j)])
+        stringFromRef(v_this)[intFromRef(j)])
     } else {
-      anon := boolToRef(false)}
-    if (boolFromRef(anon)) {
+      anon_1 := boolToRef(false)}
+    if (boolFromRef(anon_1)) {
       j := plusInts(j, intToRef(1))
       goto cont
     }
@@ -217,17 +207,17 @@ method zFunction([v$this]: Ref) returns (ret_0: Ref)
     assert isSubtype(typeOf(l0_checkedLeft), intType())
     assert isSubtype(typeOf(l0_checkedRight), intType())
     assert intFromRef(l0_i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef([v$this])|
-    assert (forall anon_builtin: Int ::intFromRef(l0_checkedLeft) <=
-        anon_builtin &&
-        anon_builtin < intFromRef(l0_checkedRight) ==>
-        stringFromRef([v$this])[anon_builtin - intFromRef(l0_checkedLeft)] ==
-        stringFromRef([v$this])[anon_builtin])
+      intFromRef(j) <= |stringFromRef(v_this)|
+    assert (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
+        anon_builtin_9 &&
+        anon_builtin_9 < intFromRef(l0_checkedRight) ==>
+        stringFromRef(v_this)[anon_builtin_9 - intFromRef(l0_checkedLeft)] ==
+        stringFromRef(v_this)[anon_builtin_9])
     assert (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
         anon_builtin_10 &&
         anon_builtin_10 < intFromRef(j) ==>
-        stringFromRef([v$this])[anon_builtin_10 - intFromRef(l0_i)] ==
-        stringFromRef([v$this])[anon_builtin_10])
+        stringFromRef(v_this)[anon_builtin_10 - intFromRef(l0_i)] ==
+        stringFromRef(v_this)[anon_builtin_10])
     l0_res := addStringChar(l0_res, addCharInt(charToRef(48), minusInts(j, l0_i)))
     if (intFromRef(j) > intFromRef(l0_checkedRight)) {
       l0_checkedLeft := l0_i
@@ -243,364 +233,112 @@ method zFunction([v$this]: Ref) returns (ret_0: Ref)
   assert isSubtype(typeOf(l0_checkedRight), intType())
   assert |stringFromRef(l0_res)| == intFromRef(l0_i)
   assert 1 <= intFromRef(l0_i) &&
-    intFromRef(l0_i) <= |stringFromRef([v$this])|
+    intFromRef(l0_i) <= |stringFromRef(v_this)|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(l0_i) ==>
       48 <= stringFromRef(l0_res)[anon_builtin_2] &&
       stringFromRef(l0_res)[anon_builtin_2] <=
-      48 + |stringFromRef([v$this])| - anon_builtin_2 &&
+      48 + |stringFromRef(v_this)| - anon_builtin_2 &&
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-        stringFromRef([v$this])[anon_builtin_3] ==
-        stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
+        stringFromRef(v_this)[anon_builtin_3] ==
+        stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-      |stringFromRef([v$this])| - anon_builtin_2 ||
-      !(stringFromRef([v$this])[anon_builtin_2 +
+      |stringFromRef(v_this)| - anon_builtin_2 ||
+      !(stringFromRef(v_this)[anon_builtin_2 +
       (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-      stringFromRef([v$this])[stringFromRef(l0_res)[anon_builtin_2] - 48])))
+      stringFromRef(v_this)[stringFromRef(l0_res)[anon_builtin_2] - 48])))
   assert 0 <= intFromRef(l0_checkedLeft) &&
     intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-    intFromRef(l0_checkedRight) <= |stringFromRef([v$this])|
+    intFromRef(l0_checkedRight) <= |stringFromRef(v_this)|
   assert intFromRef(l0_checkedLeft) < intFromRef(l0_i)
   assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
       anon_builtin_4 <
       intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-      stringFromRef([v$this])[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
-      stringFromRef([v$this])[anon_builtin_4])
-  ret_0 := l0_res
-  goto lbl_ret_0
-  label lbl_ret_0
+      stringFromRef(v_this)[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
+      stringFromRef(v_this)[anon_builtin_4])
+  ret := l0_res
+  goto ret_0
+  label ret_0
 }
 
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /z_function.kt: info: Generated Viper text for zFunctionNaive:
-method plus(this: Ref, other: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), stringType())
+
+
+method zFunctionNaive(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   ensures isSubtype(typeOf(ret), stringType())
-
-
-method zFunctionNaive([v$this]: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
-  ensures (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
-      anon_builtin_5 < |stringFromRef([v$this])| ==>
-      48 <= stringFromRef(ret_0)[anon_builtin_5] &&
-      stringFromRef(ret_0)[anon_builtin_5] <=
-      48 + |stringFromRef([v$this])| - anon_builtin_5 &&
-      (forall anon_builtin: Int ::0 <= anon_builtin &&
-        anon_builtin < stringFromRef(ret_0)[anon_builtin_5] - 48 ==>
-        stringFromRef([v$this])[anon_builtin] ==
-        stringFromRef([v$this])[anon_builtin_5 + anon_builtin]) &&
-      (stringFromRef(ret_0)[anon_builtin_5] - 48 ==
-      |stringFromRef([v$this])| - anon_builtin_5 ||
-      !(stringFromRef([v$this])[anon_builtin_5 +
-      (stringFromRef(ret_0)[anon_builtin_5] - 48)] ==
-      stringFromRef([v$this])[stringFromRef(ret_0)[anon_builtin_5] - 48])))
+  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
+  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < |stringFromRef(v_this)| ==>
+      48 <= stringFromRef(ret)[anon_builtin] &&
+      stringFromRef(ret)[anon_builtin] <=
+      48 + |stringFromRef(v_this)| - anon_builtin &&
+      (forall anon: Int ::0 <= anon &&
+        anon < stringFromRef(ret)[anon_builtin] - 48 ==>
+        stringFromRef(v_this)[anon] ==
+        stringFromRef(v_this)[anon_builtin + anon]) &&
+      (stringFromRef(ret)[anon_builtin] - 48 ==
+      |stringFromRef(v_this)| - anon_builtin ||
+      !(stringFromRef(v_this)[anon_builtin +
+      (stringFromRef(ret)[anon_builtin] - 48)] ==
+      stringFromRef(v_this)[stringFromRef(ret)[anon_builtin] - 48])))
 {
   var i: Ref
   var res: Ref
   var anon_0: Ref
-  if (|stringFromRef([v$this])| == 0) {
-    ret_0 := [v$this]
-    goto lbl_ret_0
+  if (|stringFromRef(v_this)| == 0) {
+    ret := v_this
+    goto ret_0
   }
   i := intToRef(1)
-  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength([v$this])))
+  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength(v_this)))
   label cont_0
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(res), stringType())
     invariant |stringFromRef(res)| == intFromRef(i)
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef([v$this])|
+      intFromRef(i) <= |stringFromRef(v_this)|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
         48 <= stringFromRef(res)[anon_builtin_2] &&
         stringFromRef(res)[anon_builtin_2] <=
-        48 + |stringFromRef([v$this])| - anon_builtin_2 &&
+        48 + |stringFromRef(v_this)| - anon_builtin_2 &&
         (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
           anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
-          stringFromRef([v$this])[anon_builtin_3] ==
-          stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
+          stringFromRef(v_this)[anon_builtin_3] ==
+          stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(res)[anon_builtin_2] - 48 ==
-        |stringFromRef([v$this])| - anon_builtin_2 ||
-        !(stringFromRef([v$this])[anon_builtin_2 +
+        |stringFromRef(v_this)| - anon_builtin_2 ||
+        !(stringFromRef(v_this)[anon_builtin_2 +
         (stringFromRef(res)[anon_builtin_2] - 48)] ==
-        stringFromRef([v$this])[stringFromRef(res)[anon_builtin_2] - 48])))
-  anon_0 := ltInts(i, stringLength([v$this]))
+        stringFromRef(v_this)[stringFromRef(res)[anon_builtin_2] - 48])))
+  anon_0 := ltInts(i, stringLength(v_this))
   if (boolFromRef(anon_0)) {
     var j: Ref
-    var anon: Ref
+    var anon_1: Ref
     j := i
     label cont
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(i), intType())
       invariant isSubtype(typeOf(res), stringType())
       invariant intFromRef(i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef([v$this])|
+        intFromRef(j) <= |stringFromRef(v_this)|
       invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
           anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
-          stringFromRef([v$this])[intFromRef(i) + anon_builtin_4] ==
-          stringFromRef([v$this])[anon_builtin_4])
-    if (intFromRef(j) < |stringFromRef([v$this])|) {
-      anon := boolToRef(stringFromRef([v$this])[intFromRef(j) -
+          stringFromRef(v_this)[intFromRef(i) + anon_builtin_4] ==
+          stringFromRef(v_this)[anon_builtin_4])
+    if (intFromRef(j) < |stringFromRef(v_this)|) {
+      anon_1 := boolToRef(stringFromRef(v_this)[intFromRef(j) -
         intFromRef(i)] ==
-        stringFromRef([v$this])[intFromRef(j)])
+        stringFromRef(v_this)[intFromRef(j)])
     } else {
-      anon := boolToRef(false)}
-    if (boolFromRef(anon)) {
+      anon_1 := boolToRef(false)}
+    if (boolFromRef(anon_1)) {
       j := plusInts(j, intToRef(1))
       goto cont
     }
@@ -609,11 +347,11 @@ method zFunctionNaive([v$this]: Ref) returns (ret_0: Ref)
     assert isSubtype(typeOf(i), intType())
     assert isSubtype(typeOf(res), stringType())
     assert intFromRef(i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef([v$this])|
+      intFromRef(j) <= |stringFromRef(v_this)|
     assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
         anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
-        stringFromRef([v$this])[intFromRef(i) + anon_builtin_4] ==
-        stringFromRef([v$this])[anon_builtin_4])
+        stringFromRef(v_this)[intFromRef(i) + anon_builtin_4] ==
+        stringFromRef(v_this)[anon_builtin_4])
     res := addStringChar(res, addCharInt(charToRef(48), minusInts(j, i)))
     i := plusInts(i, intToRef(1))
     goto cont_0
@@ -622,202 +360,22 @@ method zFunctionNaive([v$this]: Ref) returns (ret_0: Ref)
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(res), stringType())
   assert |stringFromRef(res)| == intFromRef(i)
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
       48 <= stringFromRef(res)[anon_builtin_2] &&
       stringFromRef(res)[anon_builtin_2] <=
-      48 + |stringFromRef([v$this])| - anon_builtin_2 &&
+      48 + |stringFromRef(v_this)| - anon_builtin_2 &&
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
-        stringFromRef([v$this])[anon_builtin_3] ==
-        stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
+        stringFromRef(v_this)[anon_builtin_3] ==
+        stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(res)[anon_builtin_2] - 48 ==
-      |stringFromRef([v$this])| - anon_builtin_2 ||
-      !(stringFromRef([v$this])[anon_builtin_2 +
+      |stringFromRef(v_this)| - anon_builtin_2 ||
+      !(stringFromRef(v_this)[anon_builtin_2 +
       (stringFromRef(res)[anon_builtin_2] - 48)] ==
-      stringFromRef([v$this])[stringFromRef(res)[anon_builtin_2] - 48])))
-  ret_0 := res
-  goto lbl_ret_0
-  label lbl_ret_0
+      stringFromRef(v_this)[stringFromRef(res)[anon_builtin_2] - 48])))
+  ret := res
+  goto ret_0
+  label ret_0
 }
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/z_function.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
@@ -58,15 +58,23 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
   label ret_0
 }
 
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /z_function.kt: info: Generated Viper text for zFunction:
-method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method plus(this: Ref, other: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
 
 
 method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref)
-  returns (v_ret: Ref)
+  returns (ret: Ref)
   requires isSubtype(typeOf(s), stringType())
   requires isSubtype(typeOf(res), stringType())
   requires isSubtype(typeOf(i), intType())
@@ -92,49 +100,50 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
       !(stringFromRef(s)[anon_builtin_13 +
       (stringFromRef(res)[anon_builtin_13] - 48)] ==
       stringFromRef(s)[stringFromRef(res)[anon_builtin_13] - 48])))
-  requires (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
-      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin] ==
-      stringFromRef(s)[anon_builtin])
-  ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(i) <= intFromRef(v_ret) &&
-    intFromRef(v_ret) <= |stringFromRef(s)|
-  ensures (forall anon: Int ::intFromRef(i) <= anon &&
-      anon < intFromRef(v_ret) ==>
-      stringFromRef(s)[anon - intFromRef(i)] == stringFromRef(s)[anon])
+  requires (forall anon_builtin_15: Int ::0 <= anon_builtin_15 &&
+      anon_builtin_15 < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
+      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin_15] ==
+      stringFromRef(s)[anon_builtin_15])
+  ensures isSubtype(typeOf(ret), intType())
+  ensures intFromRef(i) <= intFromRef(ret) &&
+    intFromRef(ret) <= |stringFromRef(s)|
+  ensures (forall anon_builtin_16: Int ::intFromRef(i) <= anon_builtin_16 &&
+      anon_builtin_16 < intFromRef(ret) ==>
+      stringFromRef(s)[anon_builtin_16 - intFromRef(i)] ==
+      stringFromRef(s)[anon_builtin_16])
 
 
-method zFunction(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(this)|
+method zFunction([v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
+  ensures isSubtype(typeOf(ret_0), stringType())
+  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
   ensures (forall anon_builtin_11: Int ::0 <= anon_builtin_11 &&
-      anon_builtin_11 < |stringFromRef(this)| ==>
-      48 <= stringFromRef(ret)[anon_builtin_11] &&
-      stringFromRef(ret)[anon_builtin_11] <=
-      48 + |stringFromRef(this)| - anon_builtin_11 &&
+      anon_builtin_11 < |stringFromRef([v$this])| ==>
+      48 <= stringFromRef(ret_0)[anon_builtin_11] &&
+      stringFromRef(ret_0)[anon_builtin_11] <=
+      48 + |stringFromRef([v$this])| - anon_builtin_11 &&
       (forall anon_builtin_12: Int ::0 <= anon_builtin_12 &&
-        anon_builtin_12 < stringFromRef(ret)[anon_builtin_11] - 48 ==>
-        stringFromRef(this)[anon_builtin_12] ==
-        stringFromRef(this)[anon_builtin_11 + anon_builtin_12]) &&
-      (stringFromRef(ret)[anon_builtin_11] - 48 ==
-      |stringFromRef(this)| - anon_builtin_11 ||
-      !(stringFromRef(this)[anon_builtin_11 +
-      (stringFromRef(ret)[anon_builtin_11] - 48)] ==
-      stringFromRef(this)[stringFromRef(ret)[anon_builtin_11] - 48])))
+        anon_builtin_12 < stringFromRef(ret_0)[anon_builtin_11] - 48 ==>
+        stringFromRef([v$this])[anon_builtin_12] ==
+        stringFromRef([v$this])[anon_builtin_11 + anon_builtin_12]) &&
+      (stringFromRef(ret_0)[anon_builtin_11] - 48 ==
+      |stringFromRef([v$this])| - anon_builtin_11 ||
+      !(stringFromRef([v$this])[anon_builtin_11 +
+      (stringFromRef(ret_0)[anon_builtin_11] - 48)] ==
+      stringFromRef([v$this])[stringFromRef(ret_0)[anon_builtin_11] - 48])))
 {
   var l0_i: Ref
   var l0_res: Ref
   var l0_checkedLeft: Ref
   var l0_checkedRight: Ref
   var anon_0: Ref
-  if (|stringFromRef(this)| == 0) {
-    ret := this
-    goto ret_0
+  if (|stringFromRef([v$this])| == 0) {
+    ret_0 := [v$this]
+    goto lbl_ret_0
   }
   l0_i := intToRef(1)
   l0_res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48),
-    stringLength(this)))
+    stringLength([v$this])))
   l0_checkedLeft := intToRef(0)
   l0_checkedRight := intToRef(0)
   label cont_0
@@ -144,35 +153,35 @@ method zFunction(this: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(l0_checkedRight), intType())
     invariant |stringFromRef(l0_res)| == intFromRef(l0_i)
     invariant 1 <= intFromRef(l0_i) &&
-      intFromRef(l0_i) <= |stringFromRef(this)|
+      intFromRef(l0_i) <= |stringFromRef([v$this])|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(l0_i) ==>
         48 <= stringFromRef(l0_res)[anon_builtin_2] &&
         stringFromRef(l0_res)[anon_builtin_2] <=
-        48 + |stringFromRef(this)| - anon_builtin_2 &&
+        48 + |stringFromRef([v$this])| - anon_builtin_2 &&
         (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
           anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-          stringFromRef(this)[anon_builtin_3] ==
-          stringFromRef(this)[anon_builtin_2 + anon_builtin_3]) &&
+          stringFromRef([v$this])[anon_builtin_3] ==
+          stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-        |stringFromRef(this)| - anon_builtin_2 ||
-        !(stringFromRef(this)[anon_builtin_2 +
+        |stringFromRef([v$this])| - anon_builtin_2 ||
+        !(stringFromRef([v$this])[anon_builtin_2 +
         (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-        stringFromRef(this)[stringFromRef(l0_res)[anon_builtin_2] - 48])))
+        stringFromRef([v$this])[stringFromRef(l0_res)[anon_builtin_2] - 48])))
     invariant 0 <= intFromRef(l0_checkedLeft) &&
       intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-      intFromRef(l0_checkedRight) <= |stringFromRef(this)|
+      intFromRef(l0_checkedRight) <= |stringFromRef([v$this])|
     invariant intFromRef(l0_checkedLeft) < intFromRef(l0_i)
     invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
         anon_builtin_4 <
         intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-        stringFromRef(this)[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
-        stringFromRef(this)[anon_builtin_4])
-  anon_0 := ltInts(l0_i, stringLength(this))
+        stringFromRef([v$this])[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
+        stringFromRef([v$this])[anon_builtin_4])
+  anon_0 := ltInts(l0_i, stringLength([v$this]))
   if (boolFromRef(anon_0)) {
     var j: Ref
-    var anon_1: Ref
-    j := zFuncHelper(this, l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
+    var anon: Ref
+    j := zFuncHelper([v$this], l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
     label cont
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(l0_i), intType())
@@ -180,24 +189,24 @@ method zFunction(this: Ref) returns (ret: Ref)
       invariant isSubtype(typeOf(l0_checkedLeft), intType())
       invariant isSubtype(typeOf(l0_checkedRight), intType())
       invariant intFromRef(l0_i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef(this)|
-      invariant (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
-          anon_builtin_9 &&
-          anon_builtin_9 < intFromRef(l0_checkedRight) ==>
-          stringFromRef(this)[anon_builtin_9 - intFromRef(l0_checkedLeft)] ==
-          stringFromRef(this)[anon_builtin_9])
+        intFromRef(j) <= |stringFromRef([v$this])|
+      invariant (forall anon_builtin: Int ::intFromRef(l0_checkedLeft) <=
+          anon_builtin &&
+          anon_builtin < intFromRef(l0_checkedRight) ==>
+          stringFromRef([v$this])[anon_builtin - intFromRef(l0_checkedLeft)] ==
+          stringFromRef([v$this])[anon_builtin])
       invariant (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
           anon_builtin_10 &&
           anon_builtin_10 < intFromRef(j) ==>
-          stringFromRef(this)[anon_builtin_10 - intFromRef(l0_i)] ==
-          stringFromRef(this)[anon_builtin_10])
-    if (intFromRef(j) < |stringFromRef(this)|) {
-      anon_1 := boolToRef(stringFromRef(this)[intFromRef(j) -
+          stringFromRef([v$this])[anon_builtin_10 - intFromRef(l0_i)] ==
+          stringFromRef([v$this])[anon_builtin_10])
+    if (intFromRef(j) < |stringFromRef([v$this])|) {
+      anon := boolToRef(stringFromRef([v$this])[intFromRef(j) -
         intFromRef(l0_i)] ==
-        stringFromRef(this)[intFromRef(j)])
+        stringFromRef([v$this])[intFromRef(j)])
     } else {
-      anon_1 := boolToRef(false)}
-    if (boolFromRef(anon_1)) {
+      anon := boolToRef(false)}
+    if (boolFromRef(anon)) {
       j := plusInts(j, intToRef(1))
       goto cont
     }
@@ -208,17 +217,17 @@ method zFunction(this: Ref) returns (ret: Ref)
     assert isSubtype(typeOf(l0_checkedLeft), intType())
     assert isSubtype(typeOf(l0_checkedRight), intType())
     assert intFromRef(l0_i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef(this)|
-    assert (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
-        anon_builtin_9 &&
-        anon_builtin_9 < intFromRef(l0_checkedRight) ==>
-        stringFromRef(this)[anon_builtin_9 - intFromRef(l0_checkedLeft)] ==
-        stringFromRef(this)[anon_builtin_9])
+      intFromRef(j) <= |stringFromRef([v$this])|
+    assert (forall anon_builtin: Int ::intFromRef(l0_checkedLeft) <=
+        anon_builtin &&
+        anon_builtin < intFromRef(l0_checkedRight) ==>
+        stringFromRef([v$this])[anon_builtin - intFromRef(l0_checkedLeft)] ==
+        stringFromRef([v$this])[anon_builtin])
     assert (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
         anon_builtin_10 &&
         anon_builtin_10 < intFromRef(j) ==>
-        stringFromRef(this)[anon_builtin_10 - intFromRef(l0_i)] ==
-        stringFromRef(this)[anon_builtin_10])
+        stringFromRef([v$this])[anon_builtin_10 - intFromRef(l0_i)] ==
+        stringFromRef([v$this])[anon_builtin_10])
     l0_res := addStringChar(l0_res, addCharInt(charToRef(48), minusInts(j, l0_i)))
     if (intFromRef(j) > intFromRef(l0_checkedRight)) {
       l0_checkedLeft := l0_i
@@ -233,110 +242,365 @@ method zFunction(this: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(l0_checkedLeft), intType())
   assert isSubtype(typeOf(l0_checkedRight), intType())
   assert |stringFromRef(l0_res)| == intFromRef(l0_i)
-  assert 1 <= intFromRef(l0_i) && intFromRef(l0_i) <= |stringFromRef(this)|
+  assert 1 <= intFromRef(l0_i) &&
+    intFromRef(l0_i) <= |stringFromRef([v$this])|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(l0_i) ==>
       48 <= stringFromRef(l0_res)[anon_builtin_2] &&
       stringFromRef(l0_res)[anon_builtin_2] <=
-      48 + |stringFromRef(this)| - anon_builtin_2 &&
+      48 + |stringFromRef([v$this])| - anon_builtin_2 &&
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-        stringFromRef(this)[anon_builtin_3] ==
-        stringFromRef(this)[anon_builtin_2 + anon_builtin_3]) &&
+        stringFromRef([v$this])[anon_builtin_3] ==
+        stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-      |stringFromRef(this)| - anon_builtin_2 ||
-      !(stringFromRef(this)[anon_builtin_2 +
+      |stringFromRef([v$this])| - anon_builtin_2 ||
+      !(stringFromRef([v$this])[anon_builtin_2 +
       (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-      stringFromRef(this)[stringFromRef(l0_res)[anon_builtin_2] - 48])))
+      stringFromRef([v$this])[stringFromRef(l0_res)[anon_builtin_2] - 48])))
   assert 0 <= intFromRef(l0_checkedLeft) &&
     intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-    intFromRef(l0_checkedRight) <= |stringFromRef(this)|
+    intFromRef(l0_checkedRight) <= |stringFromRef([v$this])|
   assert intFromRef(l0_checkedLeft) < intFromRef(l0_i)
   assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
       anon_builtin_4 <
       intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-      stringFromRef(this)[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
-      stringFromRef(this)[anon_builtin_4])
-  ret := l0_res
-  goto ret_0
-  label ret_0
+      stringFromRef([v$this])[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
+      stringFromRef([v$this])[anon_builtin_4])
+  ret_0 := l0_res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /z_function.kt: info: Generated Viper text for zFunctionNaive:
-method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
-  requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), stringType())
-
-
-method zFunctionNaive(this: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), stringType())
+  requires isSubtype(typeOf(other), nullable(anyType()))
   ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(this)|
+
+
+method zFunctionNaive([v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
+  ensures isSubtype(typeOf(ret_0), stringType())
+  ensures |stringFromRef(ret_0)| == |stringFromRef([v$this])|
   ensures (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
-      anon_builtin_5 < |stringFromRef(this)| ==>
-      48 <= stringFromRef(ret)[anon_builtin_5] &&
-      stringFromRef(ret)[anon_builtin_5] <=
-      48 + |stringFromRef(this)| - anon_builtin_5 &&
-      (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
-        anon_builtin_6 < stringFromRef(ret)[anon_builtin_5] - 48 ==>
-        stringFromRef(this)[anon_builtin_6] ==
-        stringFromRef(this)[anon_builtin_5 + anon_builtin_6]) &&
-      (stringFromRef(ret)[anon_builtin_5] - 48 ==
-      |stringFromRef(this)| - anon_builtin_5 ||
-      !(stringFromRef(this)[anon_builtin_5 +
-      (stringFromRef(ret)[anon_builtin_5] - 48)] ==
-      stringFromRef(this)[stringFromRef(ret)[anon_builtin_5] - 48])))
+      anon_builtin_5 < |stringFromRef([v$this])| ==>
+      48 <= stringFromRef(ret_0)[anon_builtin_5] &&
+      stringFromRef(ret_0)[anon_builtin_5] <=
+      48 + |stringFromRef([v$this])| - anon_builtin_5 &&
+      (forall anon_builtin: Int ::0 <= anon_builtin &&
+        anon_builtin < stringFromRef(ret_0)[anon_builtin_5] - 48 ==>
+        stringFromRef([v$this])[anon_builtin] ==
+        stringFromRef([v$this])[anon_builtin_5 + anon_builtin]) &&
+      (stringFromRef(ret_0)[anon_builtin_5] - 48 ==
+      |stringFromRef([v$this])| - anon_builtin_5 ||
+      !(stringFromRef([v$this])[anon_builtin_5 +
+      (stringFromRef(ret_0)[anon_builtin_5] - 48)] ==
+      stringFromRef([v$this])[stringFromRef(ret_0)[anon_builtin_5] - 48])))
 {
   var i: Ref
   var res: Ref
   var anon_0: Ref
-  if (|stringFromRef(this)| == 0) {
-    ret := this
-    goto ret_0
+  if (|stringFromRef([v$this])| == 0) {
+    ret_0 := [v$this]
+    goto lbl_ret_0
   }
   i := intToRef(1)
-  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength(this)))
+  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength([v$this])))
   label cont_0
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(res), stringType())
     invariant |stringFromRef(res)| == intFromRef(i)
-    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+    invariant 0 <= intFromRef(i) &&
+      intFromRef(i) <= |stringFromRef([v$this])|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
         48 <= stringFromRef(res)[anon_builtin_2] &&
         stringFromRef(res)[anon_builtin_2] <=
-        48 + |stringFromRef(this)| - anon_builtin_2 &&
-        (forall anon_builtin: Int ::0 <= anon_builtin &&
-          anon_builtin < stringFromRef(res)[anon_builtin_2] - 48 ==>
-          stringFromRef(this)[anon_builtin] ==
-          stringFromRef(this)[anon_builtin_2 + anon_builtin]) &&
+        48 + |stringFromRef([v$this])| - anon_builtin_2 &&
+        (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
+          anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
+          stringFromRef([v$this])[anon_builtin_3] ==
+          stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(res)[anon_builtin_2] - 48 ==
-        |stringFromRef(this)| - anon_builtin_2 ||
-        !(stringFromRef(this)[anon_builtin_2 +
+        |stringFromRef([v$this])| - anon_builtin_2 ||
+        !(stringFromRef([v$this])[anon_builtin_2 +
         (stringFromRef(res)[anon_builtin_2] - 48)] ==
-        stringFromRef(this)[stringFromRef(res)[anon_builtin_2] - 48])))
-  anon_0 := ltInts(i, stringLength(this))
+        stringFromRef([v$this])[stringFromRef(res)[anon_builtin_2] - 48])))
+  anon_0 := ltInts(i, stringLength([v$this]))
   if (boolFromRef(anon_0)) {
     var j: Ref
-    var anon_1: Ref
+    var anon: Ref
     j := i
     label cont
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(i), intType())
       invariant isSubtype(typeOf(res), stringType())
       invariant intFromRef(i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef(this)|
-      invariant (forall anon: Int ::0 <= anon &&
-          anon < intFromRef(j) - intFromRef(i) ==>
-          stringFromRef(this)[intFromRef(i) + anon] ==
-          stringFromRef(this)[anon])
-    if (intFromRef(j) < |stringFromRef(this)|) {
-      anon_1 := boolToRef(stringFromRef(this)[intFromRef(j) - intFromRef(i)] ==
-        stringFromRef(this)[intFromRef(j)])
+        intFromRef(j) <= |stringFromRef([v$this])|
+      invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
+          anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
+          stringFromRef([v$this])[intFromRef(i) + anon_builtin_4] ==
+          stringFromRef([v$this])[anon_builtin_4])
+    if (intFromRef(j) < |stringFromRef([v$this])|) {
+      anon := boolToRef(stringFromRef([v$this])[intFromRef(j) -
+        intFromRef(i)] ==
+        stringFromRef([v$this])[intFromRef(j)])
     } else {
-      anon_1 := boolToRef(false)}
-    if (boolFromRef(anon_1)) {
+      anon := boolToRef(false)}
+    if (boolFromRef(anon)) {
       j := plusInts(j, intToRef(1))
       goto cont
     }
@@ -345,11 +609,11 @@ method zFunctionNaive(this: Ref) returns (ret: Ref)
     assert isSubtype(typeOf(i), intType())
     assert isSubtype(typeOf(res), stringType())
     assert intFromRef(i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef(this)|
-    assert (forall anon: Int ::0 <= anon &&
-        anon < intFromRef(j) - intFromRef(i) ==>
-        stringFromRef(this)[intFromRef(i) + anon] ==
-        stringFromRef(this)[anon])
+      intFromRef(j) <= |stringFromRef([v$this])|
+    assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
+        anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
+        stringFromRef([v$this])[intFromRef(i) + anon_builtin_4] ==
+        stringFromRef([v$this])[anon_builtin_4])
     res := addStringChar(res, addCharInt(charToRef(48), minusInts(j, i)))
     i := plusInts(i, intToRef(1))
     goto cont_0
@@ -358,22 +622,202 @@ method zFunctionNaive(this: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(res), stringType())
   assert |stringFromRef(res)| == intFromRef(i)
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
       48 <= stringFromRef(res)[anon_builtin_2] &&
       stringFromRef(res)[anon_builtin_2] <=
-      48 + |stringFromRef(this)| - anon_builtin_2 &&
-      (forall anon_builtin: Int ::0 <= anon_builtin &&
-        anon_builtin < stringFromRef(res)[anon_builtin_2] - 48 ==>
-        stringFromRef(this)[anon_builtin] ==
-        stringFromRef(this)[anon_builtin_2 + anon_builtin]) &&
+      48 + |stringFromRef([v$this])| - anon_builtin_2 &&
+      (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
+        anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
+        stringFromRef([v$this])[anon_builtin_3] ==
+        stringFromRef([v$this])[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(res)[anon_builtin_2] - 48 ==
-      |stringFromRef(this)| - anon_builtin_2 ||
-      !(stringFromRef(this)[anon_builtin_2 +
+      |stringFromRef([v$this])| - anon_builtin_2 ||
+      !(stringFromRef([v$this])[anon_builtin_2 +
       (stringFromRef(res)[anon_builtin_2] - 48)] ==
-      stringFromRef(this)[stringFromRef(res)[anon_builtin_2] - 48])))
-  ret := res
-  goto ret_0
-  label ret_0
+      stringFromRef([v$this])[stringFromRef(res)[anon_builtin_2] - 48])))
+  ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/z_function.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
@@ -107,24 +107,24 @@ method zFuncHelper(s: Ref, par_res: Ref, par_i: Ref, par_checkedLeft: Ref, par_c
       stringFromRef(s)[anon_builtin_16])
 
 
-method zFunction(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method zFunction(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_11: Int ::0 <= anon_builtin_11 &&
-      anon_builtin_11 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_11 < |stringFromRef(v_this_extension)| ==>
       48 <= stringFromRef(v_ret_0)[anon_builtin_11] &&
       stringFromRef(v_ret_0)[anon_builtin_11] <=
-      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_11 &&
+      48 + |stringFromRef(v_this_extension)| - anon_builtin_11 &&
       (forall anon_builtin_12: Int ::0 <= anon_builtin_12 &&
         anon_builtin_12 < stringFromRef(v_ret_0)[anon_builtin_11] - 48 ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_12] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_11 + anon_builtin_12]) &&
+        stringFromRef(v_this_extension)[anon_builtin_12] ==
+        stringFromRef(v_this_extension)[anon_builtin_11 + anon_builtin_12]) &&
       (stringFromRef(v_ret_0)[anon_builtin_11] - 48 ==
-      |stringFromRef(v_this_dispatch)| - anon_builtin_11 ||
-      !(stringFromRef(v_this_dispatch)[anon_builtin_11 +
+      |stringFromRef(v_this_extension)| - anon_builtin_11 ||
+      !(stringFromRef(v_this_extension)[anon_builtin_11 +
       (stringFromRef(v_ret_0)[anon_builtin_11] - 48)] ==
-      stringFromRef(v_this_dispatch)[stringFromRef(v_ret_0)[anon_builtin_11] -
+      stringFromRef(v_this_extension)[stringFromRef(v_ret_0)[anon_builtin_11] -
       48])))
 {
   var l0_i: Ref
@@ -132,13 +132,13 @@ method zFunction(v_this_dispatch: Ref) returns (v_ret_0: Ref)
   var l0_checkedLeft: Ref
   var l0_checkedRight: Ref
   var anon_0: Ref
-  if (|stringFromRef(v_this_dispatch)| == 0) {
-    v_ret_0 := v_this_dispatch
+  if (|stringFromRef(v_this_extension)| == 0) {
+    v_ret_0 := v_this_extension
     goto lbl_ret_0
   }
   l0_i := intToRef(1)
   l0_res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48),
-    stringLength(v_this_dispatch)))
+    stringLength(v_this_extension)))
   l0_checkedLeft := intToRef(0)
   l0_checkedRight := intToRef(0)
   label cont_0
@@ -148,37 +148,37 @@ method zFunction(v_this_dispatch: Ref) returns (v_ret_0: Ref)
     invariant isSubtype(typeOf(l0_checkedRight), intType())
     invariant |stringFromRef(l0_res)| == intFromRef(l0_i)
     invariant 1 <= intFromRef(l0_i) &&
-      intFromRef(l0_i) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(l0_i) <= |stringFromRef(v_this_extension)|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(l0_i) ==>
         48 <= stringFromRef(l0_res)[anon_builtin_2] &&
         stringFromRef(l0_res)[anon_builtin_2] <=
-        48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
+        48 + |stringFromRef(v_this_extension)| - anon_builtin_2 &&
         (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
           anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-          stringFromRef(v_this_dispatch)[anon_builtin_3] ==
-          stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
+          stringFromRef(v_this_extension)[anon_builtin_3] ==
+          stringFromRef(v_this_extension)[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-        |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
-        !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
+        |stringFromRef(v_this_extension)| - anon_builtin_2 ||
+        !(stringFromRef(v_this_extension)[anon_builtin_2 +
         (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-        stringFromRef(v_this_dispatch)[stringFromRef(l0_res)[anon_builtin_2] -
+        stringFromRef(v_this_extension)[stringFromRef(l0_res)[anon_builtin_2] -
         48])))
     invariant 0 <= intFromRef(l0_checkedLeft) &&
       intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-      intFromRef(l0_checkedRight) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(l0_checkedRight) <= |stringFromRef(v_this_extension)|
     invariant intFromRef(l0_checkedLeft) < intFromRef(l0_i)
     invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
         anon_builtin_4 <
         intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-        stringFromRef(v_this_dispatch)[intFromRef(l0_checkedLeft) +
+        stringFromRef(v_this_extension)[intFromRef(l0_checkedLeft) +
         anon_builtin_4] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_4])
-  anon_0 := ltInts(l0_i, stringLength(v_this_dispatch))
+        stringFromRef(v_this_extension)[anon_builtin_4])
+  anon_0 := ltInts(l0_i, stringLength(v_this_extension))
   if (boolFromRef(anon_0)) {
     var j: Ref
     var anon_1: Ref
-    j := zFuncHelper(v_this_dispatch, l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
+    j := zFuncHelper(v_this_extension, l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
     label cont_1
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(l0_i), intType())
@@ -186,22 +186,23 @@ method zFunction(v_this_dispatch: Ref) returns (v_ret_0: Ref)
       invariant isSubtype(typeOf(l0_checkedLeft), intType())
       invariant isSubtype(typeOf(l0_checkedRight), intType())
       invariant intFromRef(l0_i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef(v_this_dispatch)|
+        intFromRef(j) <= |stringFromRef(v_this_extension)|
       invariant (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
           anon_builtin_9 &&
           anon_builtin_9 < intFromRef(l0_checkedRight) ==>
-          stringFromRef(v_this_dispatch)[anon_builtin_9 -
+          stringFromRef(v_this_extension)[anon_builtin_9 -
           intFromRef(l0_checkedLeft)] ==
-          stringFromRef(v_this_dispatch)[anon_builtin_9])
+          stringFromRef(v_this_extension)[anon_builtin_9])
       invariant (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
           anon_builtin_10 &&
           anon_builtin_10 < intFromRef(j) ==>
-          stringFromRef(v_this_dispatch)[anon_builtin_10 - intFromRef(l0_i)] ==
-          stringFromRef(v_this_dispatch)[anon_builtin_10])
-    if (intFromRef(j) < |stringFromRef(v_this_dispatch)|) {
-      anon_1 := boolToRef(stringFromRef(v_this_dispatch)[intFromRef(j) -
+          stringFromRef(v_this_extension)[anon_builtin_10 -
+          intFromRef(l0_i)] ==
+          stringFromRef(v_this_extension)[anon_builtin_10])
+    if (intFromRef(j) < |stringFromRef(v_this_extension)|) {
+      anon_1 := boolToRef(stringFromRef(v_this_extension)[intFromRef(j) -
         intFromRef(l0_i)] ==
-        stringFromRef(v_this_dispatch)[intFromRef(j)])
+        stringFromRef(v_this_extension)[intFromRef(j)])
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
@@ -215,18 +216,18 @@ method zFunction(v_this_dispatch: Ref) returns (v_ret_0: Ref)
     assert isSubtype(typeOf(l0_checkedLeft), intType())
     assert isSubtype(typeOf(l0_checkedRight), intType())
     assert intFromRef(l0_i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(j) <= |stringFromRef(v_this_extension)|
     assert (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
         anon_builtin_9 &&
         anon_builtin_9 < intFromRef(l0_checkedRight) ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_9 -
+        stringFromRef(v_this_extension)[anon_builtin_9 -
         intFromRef(l0_checkedLeft)] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_9])
+        stringFromRef(v_this_extension)[anon_builtin_9])
     assert (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
         anon_builtin_10 &&
         anon_builtin_10 < intFromRef(j) ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_10 - intFromRef(l0_i)] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_10])
+        stringFromRef(v_this_extension)[anon_builtin_10 - intFromRef(l0_i)] ==
+        stringFromRef(v_this_extension)[anon_builtin_10])
     l0_res := addStringChar(l0_res, addCharInt(charToRef(48), minusInts(j, l0_i)))
     if (intFromRef(j) > intFromRef(l0_checkedRight)) {
       l0_checkedLeft := l0_i
@@ -242,32 +243,32 @@ method zFunction(v_this_dispatch: Ref) returns (v_ret_0: Ref)
   assert isSubtype(typeOf(l0_checkedRight), intType())
   assert |stringFromRef(l0_res)| == intFromRef(l0_i)
   assert 1 <= intFromRef(l0_i) &&
-    intFromRef(l0_i) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(l0_i) <= |stringFromRef(v_this_extension)|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(l0_i) ==>
       48 <= stringFromRef(l0_res)[anon_builtin_2] &&
       stringFromRef(l0_res)[anon_builtin_2] <=
-      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
+      48 + |stringFromRef(v_this_extension)| - anon_builtin_2 &&
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_3] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
+        stringFromRef(v_this_extension)[anon_builtin_3] ==
+        stringFromRef(v_this_extension)[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-      |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
-      !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
+      |stringFromRef(v_this_extension)| - anon_builtin_2 ||
+      !(stringFromRef(v_this_extension)[anon_builtin_2 +
       (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-      stringFromRef(v_this_dispatch)[stringFromRef(l0_res)[anon_builtin_2] -
+      stringFromRef(v_this_extension)[stringFromRef(l0_res)[anon_builtin_2] -
       48])))
   assert 0 <= intFromRef(l0_checkedLeft) &&
     intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-    intFromRef(l0_checkedRight) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(l0_checkedRight) <= |stringFromRef(v_this_extension)|
   assert intFromRef(l0_checkedLeft) < intFromRef(l0_i)
   assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
       anon_builtin_4 <
       intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-      stringFromRef(v_this_dispatch)[intFromRef(l0_checkedLeft) +
+      stringFromRef(v_this_extension)[intFromRef(l0_checkedLeft) +
       anon_builtin_4] ==
-      stringFromRef(v_this_dispatch)[anon_builtin_4])
+      stringFromRef(v_this_extension)[anon_builtin_4])
   v_ret_0 := l0_res
   goto lbl_ret_0
   label lbl_ret_0
@@ -280,57 +281,57 @@ method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method zFunctionNaive(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method zFunctionNaive(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
-      anon_builtin_5 < |stringFromRef(v_this_dispatch)| ==>
+      anon_builtin_5 < |stringFromRef(v_this_extension)| ==>
       48 <= stringFromRef(v_ret_0)[anon_builtin_5] &&
       stringFromRef(v_ret_0)[anon_builtin_5] <=
-      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_5 &&
+      48 + |stringFromRef(v_this_extension)| - anon_builtin_5 &&
       (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
         anon_builtin_6 < stringFromRef(v_ret_0)[anon_builtin_5] - 48 ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_6] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_5 + anon_builtin_6]) &&
+        stringFromRef(v_this_extension)[anon_builtin_6] ==
+        stringFromRef(v_this_extension)[anon_builtin_5 + anon_builtin_6]) &&
       (stringFromRef(v_ret_0)[anon_builtin_5] - 48 ==
-      |stringFromRef(v_this_dispatch)| - anon_builtin_5 ||
-      !(stringFromRef(v_this_dispatch)[anon_builtin_5 +
+      |stringFromRef(v_this_extension)| - anon_builtin_5 ||
+      !(stringFromRef(v_this_extension)[anon_builtin_5 +
       (stringFromRef(v_ret_0)[anon_builtin_5] - 48)] ==
-      stringFromRef(v_this_dispatch)[stringFromRef(v_ret_0)[anon_builtin_5] -
+      stringFromRef(v_this_extension)[stringFromRef(v_ret_0)[anon_builtin_5] -
       48])))
 {
   var i: Ref
   var res: Ref
   var anon_0: Ref
-  if (|stringFromRef(v_this_dispatch)| == 0) {
-    v_ret_0 := v_this_dispatch
+  if (|stringFromRef(v_this_extension)| == 0) {
+    v_ret_0 := v_this_extension
     goto lbl_ret_0
   }
   i := intToRef(1)
-  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength(v_this_dispatch)))
+  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength(v_this_extension)))
   label cont_0
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(res), stringType())
     invariant |stringFromRef(res)| == intFromRef(i)
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(i) <= |stringFromRef(v_this_extension)|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
         48 <= stringFromRef(res)[anon_builtin_2] &&
         stringFromRef(res)[anon_builtin_2] <=
-        48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
+        48 + |stringFromRef(v_this_extension)| - anon_builtin_2 &&
         (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
           anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
-          stringFromRef(v_this_dispatch)[anon_builtin_3] ==
-          stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
+          stringFromRef(v_this_extension)[anon_builtin_3] ==
+          stringFromRef(v_this_extension)[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(res)[anon_builtin_2] - 48 ==
-        |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
-        !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
+        |stringFromRef(v_this_extension)| - anon_builtin_2 ||
+        !(stringFromRef(v_this_extension)[anon_builtin_2 +
         (stringFromRef(res)[anon_builtin_2] - 48)] ==
-        stringFromRef(v_this_dispatch)[stringFromRef(res)[anon_builtin_2] -
+        stringFromRef(v_this_extension)[stringFromRef(res)[anon_builtin_2] -
         48])))
-  anon_0 := ltInts(i, stringLength(v_this_dispatch))
+  anon_0 := ltInts(i, stringLength(v_this_extension))
   if (boolFromRef(anon_0)) {
     var j: Ref
     var anon_1: Ref
@@ -340,15 +341,15 @@ method zFunctionNaive(v_this_dispatch: Ref) returns (v_ret_0: Ref)
       invariant isSubtype(typeOf(i), intType())
       invariant isSubtype(typeOf(res), stringType())
       invariant intFromRef(i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef(v_this_dispatch)|
+        intFromRef(j) <= |stringFromRef(v_this_extension)|
       invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
           anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
-          stringFromRef(v_this_dispatch)[intFromRef(i) + anon_builtin_4] ==
-          stringFromRef(v_this_dispatch)[anon_builtin_4])
-    if (intFromRef(j) < |stringFromRef(v_this_dispatch)|) {
-      anon_1 := boolToRef(stringFromRef(v_this_dispatch)[intFromRef(j) -
+          stringFromRef(v_this_extension)[intFromRef(i) + anon_builtin_4] ==
+          stringFromRef(v_this_extension)[anon_builtin_4])
+    if (intFromRef(j) < |stringFromRef(v_this_extension)|) {
+      anon_1 := boolToRef(stringFromRef(v_this_extension)[intFromRef(j) -
         intFromRef(i)] ==
-        stringFromRef(v_this_dispatch)[intFromRef(j)])
+        stringFromRef(v_this_extension)[intFromRef(j)])
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
@@ -360,11 +361,11 @@ method zFunctionNaive(v_this_dispatch: Ref) returns (v_ret_0: Ref)
     assert isSubtype(typeOf(i), intType())
     assert isSubtype(typeOf(res), stringType())
     assert intFromRef(i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(j) <= |stringFromRef(v_this_extension)|
     assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
         anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
-        stringFromRef(v_this_dispatch)[intFromRef(i) + anon_builtin_4] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_4])
+        stringFromRef(v_this_extension)[intFromRef(i) + anon_builtin_4] ==
+        stringFromRef(v_this_extension)[anon_builtin_4])
     res := addStringChar(res, addCharInt(charToRef(48), minusInts(j, i)))
     i := plusInts(i, intToRef(1))
     goto cont_0
@@ -374,21 +375,21 @@ method zFunctionNaive(v_this_dispatch: Ref) returns (v_ret_0: Ref)
   assert isSubtype(typeOf(res), stringType())
   assert |stringFromRef(res)| == intFromRef(i)
   assert 0 <= intFromRef(i) &&
-    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(i) <= |stringFromRef(v_this_extension)|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
       48 <= stringFromRef(res)[anon_builtin_2] &&
       stringFromRef(res)[anon_builtin_2] <=
-      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
+      48 + |stringFromRef(v_this_extension)| - anon_builtin_2 &&
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_3] ==
-        stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
+        stringFromRef(v_this_extension)[anon_builtin_3] ==
+        stringFromRef(v_this_extension)[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(res)[anon_builtin_2] - 48 ==
-      |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
-      !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
+      |stringFromRef(v_this_extension)| - anon_builtin_2 ||
+      !(stringFromRef(v_this_extension)[anon_builtin_2 +
       (stringFromRef(res)[anon_builtin_2] - 48)] ==
-      stringFromRef(v_this_dispatch)[stringFromRef(res)[anon_builtin_2] -
+      stringFromRef(v_this_extension)[stringFromRef(res)[anon_builtin_2] -
       48])))
   v_ret_0 := res
   goto lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
@@ -1,6 +1,6 @@
 /z_function.kt: info: Generated Viper text for zFuncHelper:
 method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref)
-  returns (ret: Ref)
+  returns (v_ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
   requires isSubtype(typeOf(res), stringType())
   requires isSubtype(typeOf(i), intType())
@@ -26,16 +26,17 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
       !(stringFromRef(s)[anon_builtin_4 +
       (stringFromRef(res)[anon_builtin_4] - 48)] ==
       stringFromRef(s)[stringFromRef(res)[anon_builtin_4] - 48])))
-  requires (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
-      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin] ==
-      stringFromRef(s)[anon_builtin])
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(i) <= intFromRef(ret) &&
-    intFromRef(ret) <= |stringFromRef(s)|
-  ensures (forall anon: Int ::intFromRef(i) <= anon &&
-      anon < intFromRef(ret) ==>
-      stringFromRef(s)[anon - intFromRef(i)] == stringFromRef(s)[anon])
+  requires (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
+      anon_builtin_6 < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
+      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin_6] ==
+      stringFromRef(s)[anon_builtin_6])
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(i) <= intFromRef(v_ret_0) &&
+    intFromRef(v_ret_0) <= |stringFromRef(s)|
+  ensures (forall anon_builtin_7: Int ::intFromRef(i) <= anon_builtin_7 &&
+      anon_builtin_7 < intFromRef(v_ret_0) ==>
+      stringFromRef(s)[anon_builtin_7 - intFromRef(i)] ==
+      stringFromRef(s)[anon_builtin_7])
 {
   var anon_0: Ref
   if (intFromRef(checkedLeft) == 0) {
@@ -43,97 +44,101 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
   } else {
     anon_0 := leInts(checkedRight, i)}
   if (boolFromRef(anon_0)) {
-    ret := i
+    v_ret_0 := i
   } else {
     var bound: Ref
     bound := plusInts(i, subChars(stringGet(res, minusInts(i, checkedLeft)),
       charToRef(48)))
     if (intFromRef(bound) < intFromRef(checkedRight)) {
-      ret := bound
+      v_ret_0 := bound
     } else {
-      ret := checkedRight}
+      v_ret_0 := checkedRight}
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /z_function.kt: info: Generated Viper text for zFunction:
-method plus(this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref)
+method zFuncHelper(s: Ref, par_res: Ref, par_i: Ref, par_checkedLeft: Ref, par_checkedRight: Ref)
   returns (v_ret: Ref)
   requires isSubtype(typeOf(s), stringType())
-  requires isSubtype(typeOf(res), stringType())
-  requires isSubtype(typeOf(i), intType())
-  requires isSubtype(typeOf(checkedLeft), intType())
-  requires isSubtype(typeOf(checkedRight), intType())
-  requires 1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(s)|
-  requires |stringFromRef(res)| == intFromRef(i)
-  requires 0 <= intFromRef(checkedLeft) &&
-    intFromRef(checkedLeft) <= intFromRef(checkedRight) &&
-    intFromRef(checkedRight) <= |stringFromRef(s)|
-  requires intFromRef(checkedLeft) < intFromRef(i)
+  requires isSubtype(typeOf(par_res), stringType())
+  requires isSubtype(typeOf(par_i), intType())
+  requires isSubtype(typeOf(par_checkedLeft), intType())
+  requires isSubtype(typeOf(par_checkedRight), intType())
+  requires 1 <= intFromRef(par_i) && intFromRef(par_i) < |stringFromRef(s)|
+  requires |stringFromRef(par_res)| == intFromRef(par_i)
+  requires 0 <= intFromRef(par_checkedLeft) &&
+    intFromRef(par_checkedLeft) <= intFromRef(par_checkedRight) &&
+    intFromRef(par_checkedRight) <= |stringFromRef(s)|
+  requires intFromRef(par_checkedLeft) < intFromRef(par_i)
   requires (forall anon_builtin_13: Int ::0 <= anon_builtin_13 &&
-      anon_builtin_13 < intFromRef(i) ==>
-      48 <= stringFromRef(res)[anon_builtin_13] &&
-      stringFromRef(res)[anon_builtin_13] <=
+      anon_builtin_13 < intFromRef(par_i) ==>
+      48 <= stringFromRef(par_res)[anon_builtin_13] &&
+      stringFromRef(par_res)[anon_builtin_13] <=
       48 + |stringFromRef(s)| - anon_builtin_13 &&
       (forall anon_builtin_14: Int ::0 <= anon_builtin_14 &&
-        anon_builtin_14 < stringFromRef(res)[anon_builtin_13] - 48 ==>
+        anon_builtin_14 < stringFromRef(par_res)[anon_builtin_13] - 48 ==>
         stringFromRef(s)[anon_builtin_14] ==
         stringFromRef(s)[anon_builtin_13 + anon_builtin_14]) &&
-      (stringFromRef(res)[anon_builtin_13] - 48 ==
+      (stringFromRef(par_res)[anon_builtin_13] - 48 ==
       |stringFromRef(s)| - anon_builtin_13 ||
       !(stringFromRef(s)[anon_builtin_13 +
-      (stringFromRef(res)[anon_builtin_13] - 48)] ==
-      stringFromRef(s)[stringFromRef(res)[anon_builtin_13] - 48])))
-  requires (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < intFromRef(checkedRight) - intFromRef(checkedLeft) ==>
-      stringFromRef(s)[intFromRef(checkedLeft) + anon_builtin] ==
-      stringFromRef(s)[anon_builtin])
+      (stringFromRef(par_res)[anon_builtin_13] - 48)] ==
+      stringFromRef(s)[stringFromRef(par_res)[anon_builtin_13] - 48])))
+  requires (forall anon_builtin_15: Int ::0 <= anon_builtin_15 &&
+      anon_builtin_15 <
+      intFromRef(par_checkedRight) - intFromRef(par_checkedLeft) ==>
+      stringFromRef(s)[intFromRef(par_checkedLeft) + anon_builtin_15] ==
+      stringFromRef(s)[anon_builtin_15])
   ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(i) <= intFromRef(v_ret) &&
+  ensures intFromRef(par_i) <= intFromRef(v_ret) &&
     intFromRef(v_ret) <= |stringFromRef(s)|
-  ensures (forall anon: Int ::intFromRef(i) <= anon &&
-      anon < intFromRef(v_ret) ==>
-      stringFromRef(s)[anon - intFromRef(i)] == stringFromRef(s)[anon])
+  ensures (forall anon_builtin_16: Int ::intFromRef(par_i) <=
+      anon_builtin_16 &&
+      anon_builtin_16 < intFromRef(v_ret) ==>
+      stringFromRef(s)[anon_builtin_16 - intFromRef(par_i)] ==
+      stringFromRef(s)[anon_builtin_16])
 
 
-method zFunction(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
+method zFunction(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
   ensures (forall anon_builtin_11: Int ::0 <= anon_builtin_11 &&
-      anon_builtin_11 < |stringFromRef(v_this)| ==>
-      48 <= stringFromRef(ret)[anon_builtin_11] &&
-      stringFromRef(ret)[anon_builtin_11] <=
-      48 + |stringFromRef(v_this)| - anon_builtin_11 &&
+      anon_builtin_11 < |stringFromRef(v_this_dispatch)| ==>
+      48 <= stringFromRef(v_ret_0)[anon_builtin_11] &&
+      stringFromRef(v_ret_0)[anon_builtin_11] <=
+      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_11 &&
       (forall anon_builtin_12: Int ::0 <= anon_builtin_12 &&
-        anon_builtin_12 < stringFromRef(ret)[anon_builtin_11] - 48 ==>
-        stringFromRef(v_this)[anon_builtin_12] ==
-        stringFromRef(v_this)[anon_builtin_11 + anon_builtin_12]) &&
-      (stringFromRef(ret)[anon_builtin_11] - 48 ==
-      |stringFromRef(v_this)| - anon_builtin_11 ||
-      !(stringFromRef(v_this)[anon_builtin_11 +
-      (stringFromRef(ret)[anon_builtin_11] - 48)] ==
-      stringFromRef(v_this)[stringFromRef(ret)[anon_builtin_11] - 48])))
+        anon_builtin_12 < stringFromRef(v_ret_0)[anon_builtin_11] - 48 ==>
+        stringFromRef(v_this_dispatch)[anon_builtin_12] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_11 + anon_builtin_12]) &&
+      (stringFromRef(v_ret_0)[anon_builtin_11] - 48 ==
+      |stringFromRef(v_this_dispatch)| - anon_builtin_11 ||
+      !(stringFromRef(v_this_dispatch)[anon_builtin_11 +
+      (stringFromRef(v_ret_0)[anon_builtin_11] - 48)] ==
+      stringFromRef(v_this_dispatch)[stringFromRef(v_ret_0)[anon_builtin_11] -
+      48])))
 {
   var l0_i: Ref
   var l0_res: Ref
   var l0_checkedLeft: Ref
   var l0_checkedRight: Ref
   var anon_0: Ref
-  if (|stringFromRef(v_this)| == 0) {
-    ret := v_this
-    goto ret_0
+  if (|stringFromRef(v_this_dispatch)| == 0) {
+    v_ret_0 := v_this_dispatch
+    goto lbl_ret_0
   }
   l0_i := intToRef(1)
   l0_res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48),
-    stringLength(v_this)))
+    stringLength(v_this_dispatch)))
   l0_checkedLeft := intToRef(0)
   l0_checkedRight := intToRef(0)
   label cont_0
@@ -143,81 +148,85 @@ method zFunction(v_this: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(l0_checkedRight), intType())
     invariant |stringFromRef(l0_res)| == intFromRef(l0_i)
     invariant 1 <= intFromRef(l0_i) &&
-      intFromRef(l0_i) <= |stringFromRef(v_this)|
+      intFromRef(l0_i) <= |stringFromRef(v_this_dispatch)|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(l0_i) ==>
         48 <= stringFromRef(l0_res)[anon_builtin_2] &&
         stringFromRef(l0_res)[anon_builtin_2] <=
-        48 + |stringFromRef(v_this)| - anon_builtin_2 &&
+        48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
         (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
           anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-          stringFromRef(v_this)[anon_builtin_3] ==
-          stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
+          stringFromRef(v_this_dispatch)[anon_builtin_3] ==
+          stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-        |stringFromRef(v_this)| - anon_builtin_2 ||
-        !(stringFromRef(v_this)[anon_builtin_2 +
+        |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
+        !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
         (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-        stringFromRef(v_this)[stringFromRef(l0_res)[anon_builtin_2] - 48])))
+        stringFromRef(v_this_dispatch)[stringFromRef(l0_res)[anon_builtin_2] -
+        48])))
     invariant 0 <= intFromRef(l0_checkedLeft) &&
       intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-      intFromRef(l0_checkedRight) <= |stringFromRef(v_this)|
+      intFromRef(l0_checkedRight) <= |stringFromRef(v_this_dispatch)|
     invariant intFromRef(l0_checkedLeft) < intFromRef(l0_i)
     invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
         anon_builtin_4 <
         intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-        stringFromRef(v_this)[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
-        stringFromRef(v_this)[anon_builtin_4])
-  anon_0 := ltInts(l0_i, stringLength(v_this))
+        stringFromRef(v_this_dispatch)[intFromRef(l0_checkedLeft) +
+        anon_builtin_4] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_4])
+  anon_0 := ltInts(l0_i, stringLength(v_this_dispatch))
   if (boolFromRef(anon_0)) {
     var j: Ref
     var anon_1: Ref
-    j := zFuncHelper(v_this, l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
-    label cont
+    j := zFuncHelper(v_this_dispatch, l0_res, l0_i, l0_checkedLeft, l0_checkedRight)
+    label cont_1
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(l0_i), intType())
       invariant isSubtype(typeOf(l0_res), stringType())
       invariant isSubtype(typeOf(l0_checkedLeft), intType())
       invariant isSubtype(typeOf(l0_checkedRight), intType())
       invariant intFromRef(l0_i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef(v_this)|
+        intFromRef(j) <= |stringFromRef(v_this_dispatch)|
       invariant (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
           anon_builtin_9 &&
           anon_builtin_9 < intFromRef(l0_checkedRight) ==>
-          stringFromRef(v_this)[anon_builtin_9 - intFromRef(l0_checkedLeft)] ==
-          stringFromRef(v_this)[anon_builtin_9])
+          stringFromRef(v_this_dispatch)[anon_builtin_9 -
+          intFromRef(l0_checkedLeft)] ==
+          stringFromRef(v_this_dispatch)[anon_builtin_9])
       invariant (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
           anon_builtin_10 &&
           anon_builtin_10 < intFromRef(j) ==>
-          stringFromRef(v_this)[anon_builtin_10 - intFromRef(l0_i)] ==
-          stringFromRef(v_this)[anon_builtin_10])
-    if (intFromRef(j) < |stringFromRef(v_this)|) {
-      anon_1 := boolToRef(stringFromRef(v_this)[intFromRef(j) -
+          stringFromRef(v_this_dispatch)[anon_builtin_10 - intFromRef(l0_i)] ==
+          stringFromRef(v_this_dispatch)[anon_builtin_10])
+    if (intFromRef(j) < |stringFromRef(v_this_dispatch)|) {
+      anon_1 := boolToRef(stringFromRef(v_this_dispatch)[intFromRef(j) -
         intFromRef(l0_i)] ==
-        stringFromRef(v_this)[intFromRef(j)])
+        stringFromRef(v_this_dispatch)[intFromRef(j)])
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
       j := plusInts(j, intToRef(1))
-      goto cont
+      goto cont_1
     }
-    label break
+    label break_1
     assert isSubtype(typeOf(j), intType())
     assert isSubtype(typeOf(l0_i), intType())
     assert isSubtype(typeOf(l0_res), stringType())
     assert isSubtype(typeOf(l0_checkedLeft), intType())
     assert isSubtype(typeOf(l0_checkedRight), intType())
     assert intFromRef(l0_i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef(v_this)|
+      intFromRef(j) <= |stringFromRef(v_this_dispatch)|
     assert (forall anon_builtin_9: Int ::intFromRef(l0_checkedLeft) <=
         anon_builtin_9 &&
         anon_builtin_9 < intFromRef(l0_checkedRight) ==>
-        stringFromRef(v_this)[anon_builtin_9 - intFromRef(l0_checkedLeft)] ==
-        stringFromRef(v_this)[anon_builtin_9])
+        stringFromRef(v_this_dispatch)[anon_builtin_9 -
+        intFromRef(l0_checkedLeft)] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_9])
     assert (forall anon_builtin_10: Int ::intFromRef(l0_i) <=
         anon_builtin_10 &&
         anon_builtin_10 < intFromRef(j) ==>
-        stringFromRef(v_this)[anon_builtin_10 - intFromRef(l0_i)] ==
-        stringFromRef(v_this)[anon_builtin_10])
+        stringFromRef(v_this_dispatch)[anon_builtin_10 - intFromRef(l0_i)] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_10])
     l0_res := addStringChar(l0_res, addCharInt(charToRef(48), minusInts(j, l0_i)))
     if (intFromRef(j) > intFromRef(l0_checkedRight)) {
       l0_checkedLeft := l0_i
@@ -233,125 +242,129 @@ method zFunction(v_this: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(l0_checkedRight), intType())
   assert |stringFromRef(l0_res)| == intFromRef(l0_i)
   assert 1 <= intFromRef(l0_i) &&
-    intFromRef(l0_i) <= |stringFromRef(v_this)|
+    intFromRef(l0_i) <= |stringFromRef(v_this_dispatch)|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(l0_i) ==>
       48 <= stringFromRef(l0_res)[anon_builtin_2] &&
       stringFromRef(l0_res)[anon_builtin_2] <=
-      48 + |stringFromRef(v_this)| - anon_builtin_2 &&
+      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < stringFromRef(l0_res)[anon_builtin_2] - 48 ==>
-        stringFromRef(v_this)[anon_builtin_3] ==
-        stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
+        stringFromRef(v_this_dispatch)[anon_builtin_3] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(l0_res)[anon_builtin_2] - 48 ==
-      |stringFromRef(v_this)| - anon_builtin_2 ||
-      !(stringFromRef(v_this)[anon_builtin_2 +
+      |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
+      !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
       (stringFromRef(l0_res)[anon_builtin_2] - 48)] ==
-      stringFromRef(v_this)[stringFromRef(l0_res)[anon_builtin_2] - 48])))
+      stringFromRef(v_this_dispatch)[stringFromRef(l0_res)[anon_builtin_2] -
+      48])))
   assert 0 <= intFromRef(l0_checkedLeft) &&
     intFromRef(l0_checkedLeft) <= intFromRef(l0_checkedRight) &&
-    intFromRef(l0_checkedRight) <= |stringFromRef(v_this)|
+    intFromRef(l0_checkedRight) <= |stringFromRef(v_this_dispatch)|
   assert intFromRef(l0_checkedLeft) < intFromRef(l0_i)
   assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
       anon_builtin_4 <
       intFromRef(l0_checkedRight) - intFromRef(l0_checkedLeft) ==>
-      stringFromRef(v_this)[intFromRef(l0_checkedLeft) + anon_builtin_4] ==
-      stringFromRef(v_this)[anon_builtin_4])
-  ret := l0_res
-  goto ret_0
-  label ret_0
+      stringFromRef(v_this_dispatch)[intFromRef(l0_checkedLeft) +
+      anon_builtin_4] ==
+      stringFromRef(v_this_dispatch)[anon_builtin_4])
+  v_ret_0 := l0_res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /z_function.kt: info: Generated Viper text for zFunctionNaive:
-method plus(this: Ref, other: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method plus(v_this: Ref, other: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method zFunctionNaive(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(v_this)|
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < |stringFromRef(v_this)| ==>
-      48 <= stringFromRef(ret)[anon_builtin] &&
-      stringFromRef(ret)[anon_builtin] <=
-      48 + |stringFromRef(v_this)| - anon_builtin &&
-      (forall anon: Int ::0 <= anon &&
-        anon < stringFromRef(ret)[anon_builtin] - 48 ==>
-        stringFromRef(v_this)[anon] ==
-        stringFromRef(v_this)[anon_builtin + anon]) &&
-      (stringFromRef(ret)[anon_builtin] - 48 ==
-      |stringFromRef(v_this)| - anon_builtin ||
-      !(stringFromRef(v_this)[anon_builtin +
-      (stringFromRef(ret)[anon_builtin] - 48)] ==
-      stringFromRef(v_this)[stringFromRef(ret)[anon_builtin] - 48])))
+method zFunctionNaive(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_dispatch)|
+  ensures (forall anon_builtin_5: Int ::0 <= anon_builtin_5 &&
+      anon_builtin_5 < |stringFromRef(v_this_dispatch)| ==>
+      48 <= stringFromRef(v_ret_0)[anon_builtin_5] &&
+      stringFromRef(v_ret_0)[anon_builtin_5] <=
+      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_5 &&
+      (forall anon_builtin_6: Int ::0 <= anon_builtin_6 &&
+        anon_builtin_6 < stringFromRef(v_ret_0)[anon_builtin_5] - 48 ==>
+        stringFromRef(v_this_dispatch)[anon_builtin_6] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_5 + anon_builtin_6]) &&
+      (stringFromRef(v_ret_0)[anon_builtin_5] - 48 ==
+      |stringFromRef(v_this_dispatch)| - anon_builtin_5 ||
+      !(stringFromRef(v_this_dispatch)[anon_builtin_5 +
+      (stringFromRef(v_ret_0)[anon_builtin_5] - 48)] ==
+      stringFromRef(v_this_dispatch)[stringFromRef(v_ret_0)[anon_builtin_5] -
+      48])))
 {
   var i: Ref
   var res: Ref
   var anon_0: Ref
-  if (|stringFromRef(v_this)| == 0) {
-    ret := v_this
-    goto ret_0
+  if (|stringFromRef(v_this_dispatch)| == 0) {
+    v_ret_0 := v_this_dispatch
+    goto lbl_ret_0
   }
   i := intToRef(1)
-  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength(v_this)))
+  res := addStringChar(stringToRef(Seq[Int]()), addCharInt(charToRef(48), stringLength(v_this_dispatch)))
   label cont_0
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(res), stringType())
     invariant |stringFromRef(res)| == intFromRef(i)
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this)|
+      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
     invariant (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
         48 <= stringFromRef(res)[anon_builtin_2] &&
         stringFromRef(res)[anon_builtin_2] <=
-        48 + |stringFromRef(v_this)| - anon_builtin_2 &&
+        48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
         (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
           anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
-          stringFromRef(v_this)[anon_builtin_3] ==
-          stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
+          stringFromRef(v_this_dispatch)[anon_builtin_3] ==
+          stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
         (stringFromRef(res)[anon_builtin_2] - 48 ==
-        |stringFromRef(v_this)| - anon_builtin_2 ||
-        !(stringFromRef(v_this)[anon_builtin_2 +
+        |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
+        !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
         (stringFromRef(res)[anon_builtin_2] - 48)] ==
-        stringFromRef(v_this)[stringFromRef(res)[anon_builtin_2] - 48])))
-  anon_0 := ltInts(i, stringLength(v_this))
+        stringFromRef(v_this_dispatch)[stringFromRef(res)[anon_builtin_2] -
+        48])))
+  anon_0 := ltInts(i, stringLength(v_this_dispatch))
   if (boolFromRef(anon_0)) {
     var j: Ref
     var anon_1: Ref
     j := i
-    label cont
+    label cont_1
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(i), intType())
       invariant isSubtype(typeOf(res), stringType())
       invariant intFromRef(i) <= intFromRef(j) &&
-        intFromRef(j) <= |stringFromRef(v_this)|
+        intFromRef(j) <= |stringFromRef(v_this_dispatch)|
       invariant (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
           anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
-          stringFromRef(v_this)[intFromRef(i) + anon_builtin_4] ==
-          stringFromRef(v_this)[anon_builtin_4])
-    if (intFromRef(j) < |stringFromRef(v_this)|) {
-      anon_1 := boolToRef(stringFromRef(v_this)[intFromRef(j) -
+          stringFromRef(v_this_dispatch)[intFromRef(i) + anon_builtin_4] ==
+          stringFromRef(v_this_dispatch)[anon_builtin_4])
+    if (intFromRef(j) < |stringFromRef(v_this_dispatch)|) {
+      anon_1 := boolToRef(stringFromRef(v_this_dispatch)[intFromRef(j) -
         intFromRef(i)] ==
-        stringFromRef(v_this)[intFromRef(j)])
+        stringFromRef(v_this_dispatch)[intFromRef(j)])
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
       j := plusInts(j, intToRef(1))
-      goto cont
+      goto cont_1
     }
-    label break
+    label break_1
     assert isSubtype(typeOf(j), intType())
     assert isSubtype(typeOf(i), intType())
     assert isSubtype(typeOf(res), stringType())
     assert intFromRef(i) <= intFromRef(j) &&
-      intFromRef(j) <= |stringFromRef(v_this)|
+      intFromRef(j) <= |stringFromRef(v_this_dispatch)|
     assert (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
         anon_builtin_4 < intFromRef(j) - intFromRef(i) ==>
-        stringFromRef(v_this)[intFromRef(i) + anon_builtin_4] ==
-        stringFromRef(v_this)[anon_builtin_4])
+        stringFromRef(v_this_dispatch)[intFromRef(i) + anon_builtin_4] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_4])
     res := addStringChar(res, addCharInt(charToRef(48), minusInts(j, i)))
     i := plusInts(i, intToRef(1))
     goto cont_0
@@ -360,22 +373,24 @@ method zFunctionNaive(v_this: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(res), stringType())
   assert |stringFromRef(res)| == intFromRef(i)
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
+  assert 0 <= intFromRef(i) &&
+    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
   assert (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
       48 <= stringFromRef(res)[anon_builtin_2] &&
       stringFromRef(res)[anon_builtin_2] <=
-      48 + |stringFromRef(v_this)| - anon_builtin_2 &&
+      48 + |stringFromRef(v_this_dispatch)| - anon_builtin_2 &&
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < stringFromRef(res)[anon_builtin_2] - 48 ==>
-        stringFromRef(v_this)[anon_builtin_3] ==
-        stringFromRef(v_this)[anon_builtin_2 + anon_builtin_3]) &&
+        stringFromRef(v_this_dispatch)[anon_builtin_3] ==
+        stringFromRef(v_this_dispatch)[anon_builtin_2 + anon_builtin_3]) &&
       (stringFromRef(res)[anon_builtin_2] - 48 ==
-      |stringFromRef(v_this)| - anon_builtin_2 ||
-      !(stringFromRef(v_this)[anon_builtin_2 +
+      |stringFromRef(v_this_dispatch)| - anon_builtin_2 ||
+      !(stringFromRef(v_this_dispatch)[anon_builtin_2 +
       (stringFromRef(res)[anon_builtin_2] - 48)] ==
-      stringFromRef(v_this)[stringFromRef(res)[anon_builtin_2] - 48])))
-  ret := res
-  goto ret_0
-  label ret_0
+      stringFromRef(v_this_dispatch)[stringFromRef(res)[anon_builtin_2] -
+      48])))
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
@@ -3,19 +3,19 @@ field y: Ref
 
 field z: Ref
 
-method cascadeGet(x: Ref) returns (ret_0: Ref)
+method cascadeGet(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), c_X())
-  ensures isSubtype(typeOf(ret_0), c_Z())
-  ensures acc(shared(ret_0), wildcard)
+  ensures isSubtype(typeOf(ret), c_Z())
+  ensures acc(shared(ret), wildcard)
 {
   var anon: Ref
   inhale acc(_c_X_shared(x), wildcard)
   unfold acc(_c_X_shared(x), wildcard)
   anon := x.y
   unfold acc(_c_Y_shared(anon), wildcard)
-  ret_0 := anon.z
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := anon.z
+  goto ret_0
+  label ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for receiverNotNullProved:
@@ -23,10 +23,10 @@ field y: Ref
 
 field z: Ref
 
-method receiverNotNullProved(x: Ref) returns (ret_0: Ref)
+method receiverNotNullProved(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), nullable(c_X()))
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true ==> x != nullValue()
+  ensures isSubtype(typeOf(ret), boolType())
+  ensures boolFromRef(ret) == true ==> x != nullValue()
 {
   var anon_0: Ref
   inhale x != nullValue() ==> acc(_c_X_shared(x), wildcard)
@@ -37,9 +37,9 @@ method receiverNotNullProved(x: Ref) returns (ret_0: Ref)
     anon_0 := anon
   } else {
     anon_0 := nullValue()}
-  ret_0 := notBool(boolToRef(anon_0 == nullValue()))
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := notBool(boolToRef(anon_0 == nullValue()))
+  goto ret_0
+  label ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for cascadeNullableGet:
@@ -47,11 +47,11 @@ field y: Ref
 
 field z: Ref
 
-method cascadeNullableGet(x: Ref) returns (ret_0: Ref)
+method cascadeNullableGet(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), nullable(c_NullableX()))
-  ensures isSubtype(typeOf(ret_0), nullable(c_Z()))
-  ensures ret_0 != nullValue() ==> acc(_c_Z_shared(ret_0), wildcard)
-  ensures ret_0 != nullValue() ==> x != nullValue()
+  ensures isSubtype(typeOf(ret), nullable(c_Z()))
+  ensures ret != nullValue() ==> acc(_c_Z_shared(ret), wildcard)
+  ensures ret != nullValue() ==> x != nullValue()
 {
   var anon: Ref
   inhale x != nullValue() ==> acc(_c_NullableX_shared(x), wildcard)
@@ -62,11 +62,11 @@ method cascadeNullableGet(x: Ref) returns (ret_0: Ref)
     anon := nullValue()}
   if (anon != nullValue()) {
     unfold acc(_c_NullableY_shared(anon), wildcard)
-    ret_0 := anon.z
+    ret := anon.z
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for cascadeNullableSmartcastGet:
@@ -74,17 +74,17 @@ field y: Ref
 
 field z: Ref
 
-method cascadeNullableSmartcastGet(x: Ref) returns (ret_0: Ref)
+method cascadeNullableSmartcastGet(x: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), nullable(c_NullableX()))
-  ensures isSubtype(typeOf(ret_0), nullable(c_Z()))
-  ensures ret_0 != nullValue() ==> acc(_c_Z_shared(ret_0), wildcard)
-  ensures ret_0 != nullValue() ==> x != nullValue()
+  ensures isSubtype(typeOf(ret), nullable(c_Z()))
+  ensures ret != nullValue() ==> acc(_c_Z_shared(ret), wildcard)
+  ensures ret != nullValue() ==> x != nullValue()
 {
   inhale x != nullValue() ==> acc(_c_NullableX_shared(x), wildcard)
   if (x == nullValue()) {
     var anon_0: Ref
     anon_0 := nullValue()
-    ret_0 := anon_0
+    ret := anon_0
   } else {
     var anon_1: Ref
     unfold acc(_c_NullableX_shared(x), wildcard)
@@ -92,17 +92,17 @@ method cascadeNullableSmartcastGet(x: Ref) returns (ret_0: Ref)
     if (anon_1 == nullValue()) {
       var anon_2: Ref
       anon_2 := nullValue()
-      ret_0 := anon_2
+      ret := anon_2
     } else {
       var anon: Ref
       unfold acc(_c_NullableX_shared(x), wildcard)
       anon := x.y
       unfold acc(_c_NullableY_shared(anon), wildcard)
-      ret_0 := anon.z
+      ret := anon.z
     }
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for nullableReceiverNotNullSafeGet:
@@ -110,14 +110,14 @@ field size: Ref
 
 field x: Ref
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Baz())
-  ensures acc(_c_Baz_shared(ret), wildcard)
-  ensures acc(_c_Baz_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Baz())
+  ensures acc(_c_Baz_shared(v_ret), wildcard)
+  ensures acc(_c_Baz_unique(v_ret), write)
 
 
-method nullableReceiverNotNullSafeGet() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method nullableReceiverNotNullSafeGet() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var f: Ref
   var anon_0: Ref
@@ -134,8 +134,8 @@ method nullableReceiverNotNullSafeGet() returns (ret_0: Ref)
     anon_1 := nullValue()}
   cond1 := notBool(boolToRef(anon_1 == nullValue()))
   assert boolFromRef(cond1)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /backing_field_getters.kt: info: Generated Viper text for nullableReceiverNullSafeGet:
@@ -143,8 +143,8 @@ field size: Ref
 
 field x: Ref
 
-method nullableReceiverNullSafeGet() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method nullableReceiverNullSafeGet() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var f: Ref
   var cond1: Ref
@@ -159,8 +159,8 @@ method nullableReceiverNullSafeGet() returns (ret_0: Ref)
     anon_0 := nullValue()}
   cond1 := boolToRef(anon_0 == nullValue())
   assert boolFromRef(cond1)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /backing_field_getters.kt: info: Generated Viper text for nonNullableReceiverSafeGet:
@@ -168,14 +168,14 @@ field size: Ref
 
 field x: Ref
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Baz())
-  ensures acc(_c_Baz_shared(ret), wildcard)
-  ensures acc(_c_Baz_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Baz())
+  ensures acc(_c_Baz_shared(v_ret), wildcard)
+  ensures acc(_c_Baz_unique(v_ret), write)
 
 
-method nonNullableReceiverSafeGet() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method nonNullableReceiverSafeGet() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var f: Ref
   var cond1: Ref
@@ -190,8 +190,8 @@ method nonNullableReceiverSafeGet() returns (ret_0: Ref)
     anon_0 := nullValue()}
   cond1 := notBool(boolToRef(anon_0 == nullValue()))
   assert boolFromRef(cond1)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /backing_field_getters.kt: info: Generated Viper text for checkPrimary:
@@ -203,10 +203,10 @@ field bf_z: Ref
 
 field size: Ref
 
-method checkPrimary(x: Ref, y: Ref) returns (ret_0: Ref)
+method checkPrimary(x: Ref, y: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var classI: Ref
   var l0_z: Ref
@@ -233,36 +233,37 @@ method checkPrimary(x: Ref, y: Ref) returns (ret_0: Ref)
   cond2 := boolToRef(anon_2 == l0_z)
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Z())
-  ensures acc(_c_Z_shared(ret), wildcard)
-  ensures acc(_c_Z_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Z())
+  ensures acc(_c_Z_shared(v_ret), wildcard)
+  ensures acc(_c_Z_unique(v_ret), write)
 
 
-method con_c_ClassI(x: Ref, y: Ref) returns (ret: Ref)
+method con_c_ClassI(x: Ref, y: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), c_ClassI())
-  ensures acc(_c_ClassI_shared(ret), wildcard)
-  ensures acc(_c_ClassI_unique(ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassI_shared(ret), wildcard) in
-      ret.bf_x)) ==
+  ensures isSubtype(typeOf(v_ret), c_ClassI())
+  ensures acc(_c_ClassI_shared(v_ret), wildcard)
+  ensures acc(_c_ClassI_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassI_shared(v_ret), wildcard) in
+      v_ret.bf_x)) ==
     intFromRef(x) &&
-    intFromRef((unfolding acc(_c_ClassI_shared(ret), wildcard) in ret.bf_y)) ==
+    intFromRef((unfolding acc(_c_ClassI_shared(v_ret), wildcard) in
+      v_ret.bf_y)) ==
     intFromRef(y)
 
 
-method con_c_ClassII(z: Ref) returns (ret: Ref)
+method con_c_ClassII(z: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(z), c_Z())
-  ensures isSubtype(typeOf(ret), c_ClassII())
-  ensures acc(_c_ClassII_shared(ret), wildcard)
-  ensures acc(_c_ClassII_unique(ret), write)
-  ensures (unfolding acc(_c_ClassII_shared(ret), wildcard) in ret.bf_z) ==
+  ensures isSubtype(typeOf(v_ret), c_ClassII())
+  ensures acc(_c_ClassII_shared(v_ret), wildcard)
+  ensures acc(_c_ClassII_unique(v_ret), write)
+  ensures (unfolding acc(_c_ClassII_shared(v_ret), wildcard) in v_ret.bf_z) ==
     z
 
 
-method g_z(this: Ref) returns (ret: Ref)
+method g_z(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
@@ -4,15 +4,15 @@ field y: Ref
 field z: Ref
 
 method cascadeGet(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), _c_X())
-  ensures isSubtype(typeOf(ret_0), _c_Z())
+  requires isSubtype(typeOf(x), c_X())
+  ensures isSubtype(typeOf(ret_0), c_Z())
   ensures acc(shared(ret_0), wildcard)
 {
   var anon: Ref
-  inhale acc(c_X_shared(x), wildcard)
-  unfold acc(c_X_shared(x), wildcard)
+  inhale acc(_c_X_shared(x), wildcard)
+  unfold acc(_c_X_shared(x), wildcard)
   anon := x.y
-  unfold acc(c_Y_shared(anon), wildcard)
+  unfold acc(_c_Y_shared(anon), wildcard)
   ret_0 := anon.z
   goto lbl_ret_0
   label lbl_ret_0
@@ -24,15 +24,15 @@ field y: Ref
 field z: Ref
 
 method receiverNotNullProved(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), nullable(_c_X()))
+  requires isSubtype(typeOf(x), nullable(c_X()))
   ensures isSubtype(typeOf(ret_0), boolType())
   ensures boolFromRef(ret_0) == true ==> x != nullValue()
 {
   var anon_0: Ref
-  inhale x != nullValue() ==> acc(c_X_shared(x), wildcard)
+  inhale x != nullValue() ==> acc(_c_X_shared(x), wildcard)
   if (x != nullValue()) {
     var anon: Ref
-    unfold acc(c_X_shared(x), wildcard)
+    unfold acc(_c_X_shared(x), wildcard)
     anon := x.y
     anon_0 := anon
   } else {
@@ -48,20 +48,20 @@ field y: Ref
 field z: Ref
 
 method cascadeNullableGet(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), nullable(_c_NullableX()))
-  ensures isSubtype(typeOf(ret_0), nullable(_c_Z()))
-  ensures ret_0 != nullValue() ==> acc(c_Z_shared(ret_0), wildcard)
+  requires isSubtype(typeOf(x), nullable(c_NullableX()))
+  ensures isSubtype(typeOf(ret_0), nullable(c_Z()))
+  ensures ret_0 != nullValue() ==> acc(_c_Z_shared(ret_0), wildcard)
   ensures ret_0 != nullValue() ==> x != nullValue()
 {
   var anon: Ref
-  inhale x != nullValue() ==> acc(c_NullableX_shared(x), wildcard)
+  inhale x != nullValue() ==> acc(_c_NullableX_shared(x), wildcard)
   if (x != nullValue()) {
-    unfold acc(c_NullableX_shared(x), wildcard)
+    unfold acc(_c_NullableX_shared(x), wildcard)
     anon := x.y
   } else {
     anon := nullValue()}
   if (anon != nullValue()) {
-    unfold acc(c_NullableY_shared(anon), wildcard)
+    unfold acc(_c_NullableY_shared(anon), wildcard)
     ret_0 := anon.z
   } else {
     ret_0 := nullValue()}
@@ -75,19 +75,19 @@ field y: Ref
 field z: Ref
 
 method cascadeNullableSmartcastGet(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), nullable(_c_NullableX()))
-  ensures isSubtype(typeOf(ret_0), nullable(_c_Z()))
-  ensures ret_0 != nullValue() ==> acc(c_Z_shared(ret_0), wildcard)
+  requires isSubtype(typeOf(x), nullable(c_NullableX()))
+  ensures isSubtype(typeOf(ret_0), nullable(c_Z()))
+  ensures ret_0 != nullValue() ==> acc(_c_Z_shared(ret_0), wildcard)
   ensures ret_0 != nullValue() ==> x != nullValue()
 {
-  inhale x != nullValue() ==> acc(c_NullableX_shared(x), wildcard)
+  inhale x != nullValue() ==> acc(_c_NullableX_shared(x), wildcard)
   if (x == nullValue()) {
     var anon_0: Ref
     anon_0 := nullValue()
     ret_0 := anon_0
   } else {
     var anon_1: Ref
-    unfold acc(c_NullableX_shared(x), wildcard)
+    unfold acc(_c_NullableX_shared(x), wildcard)
     anon_1 := x.y
     if (anon_1 == nullValue()) {
       var anon_2: Ref
@@ -95,9 +95,9 @@ method cascadeNullableSmartcastGet(x: Ref) returns (ret_0: Ref)
       ret_0 := anon_2
     } else {
       var anon: Ref
-      unfold acc(c_NullableX_shared(x), wildcard)
+      unfold acc(_c_NullableX_shared(x), wildcard)
       anon := x.y
-      unfold acc(c_NullableY_shared(anon), wildcard)
+      unfold acc(_c_NullableY_shared(anon), wildcard)
       ret_0 := anon.z
     }
   }
@@ -111,9 +111,9 @@ field size: Ref
 field x: Ref
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Baz())
-  ensures acc(c_Baz_shared(ret), wildcard)
-  ensures acc(c_Baz_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_Baz())
+  ensures acc(_c_Baz_shared(ret), wildcard)
+  ensures acc(_c_Baz_unique(ret), write)
 
 
 method nullableReceiverNotNullSafeGet() returns (ret_0: Ref)
@@ -127,7 +127,7 @@ method nullableReceiverNotNullSafeGet() returns (ret_0: Ref)
   f := anon_0
   if (f != nullValue()) {
     var anon: Ref
-    unfold acc(c_Baz_shared(f), wildcard)
+    unfold acc(_c_Baz_shared(f), wildcard)
     anon := f.x
     anon_1 := anon
   } else {
@@ -152,7 +152,7 @@ method nullableReceiverNullSafeGet() returns (ret_0: Ref)
   f := nullValue()
   if (f != nullValue()) {
     var anon: Ref
-    unfold acc(c_Baz_shared(f), wildcard)
+    unfold acc(_c_Baz_shared(f), wildcard)
     anon := f.x
     anon_0 := anon
   } else {
@@ -169,9 +169,9 @@ field size: Ref
 field x: Ref
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Baz())
-  ensures acc(c_Baz_shared(ret), wildcard)
-  ensures acc(c_Baz_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_Baz())
+  ensures acc(_c_Baz_shared(ret), wildcard)
+  ensures acc(_c_Baz_unique(ret), write)
 
 
 method nonNullableReceiverSafeGet() returns (ret_0: Ref)
@@ -183,7 +183,7 @@ method nonNullableReceiverSafeGet() returns (ret_0: Ref)
   f := con()
   if (f != nullValue()) {
     var anon: Ref
-    unfold acc(c_Baz_shared(f), wildcard)
+    unfold acc(_c_Baz_shared(f), wildcard)
     anon := f.x
     anon_0 := anon
   } else {
@@ -213,23 +213,23 @@ method checkPrimary(x: Ref, y: Ref) returns (ret_0: Ref)
   var cond1: Ref
   var cond2: Ref
   var anon_2: Ref
-  var anon_3: Ref
-  classI := con__c_ClassI(x, y)
-  l0_z := con__c_Z()
+  var anon: Ref
+  classI := con_c_ClassI(x, y)
+  l0_z := con()
   if (!(intFromRef(x) == intFromRef(y))) {
     cond1 := boolToRef(true)
   } else {
     var anon_0: Ref
-    var anon: Ref
-    unfold acc(c_ClassI_shared(classI), wildcard)
+    var anon_1: Ref
+    unfold acc(_c_ClassI_shared(classI), wildcard)
     anon_0 := classI.bf_x
-    unfold acc(c_ClassI_shared(classI), wildcard)
-    anon := classI.bf_y
-    cond1 := boolToRef(intFromRef(anon_0) == intFromRef(anon))
+    unfold acc(_c_ClassI_shared(classI), wildcard)
+    anon_1 := classI.bf_y
+    cond1 := boolToRef(intFromRef(anon_0) == intFromRef(anon_1))
   }
-  anon_3 := con(l0_z)
-  unfold acc(c_ClassII_shared(anon_3), wildcard)
-  anon_2 := anon_3.bf_z
+  anon := con_c_ClassII(l0_z)
+  unfold acc(_c_ClassII_shared(anon), wildcard)
+  anon_2 := anon.bf_z
   cond2 := boolToRef(anon_2 == l0_z)
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
@@ -237,31 +237,32 @@ method checkPrimary(x: Ref, y: Ref) returns (ret_0: Ref)
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method con(z: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(z), _c_Z())
-  ensures isSubtype(typeOf(ret), _c_ClassII())
-  ensures acc(c_ClassII_shared(ret), wildcard)
-  ensures acc(c_ClassII_unique(ret), write)
-  ensures (unfolding acc(c_ClassII_shared(ret), wildcard) in ret.bf_z) == z
+method con() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_Z())
+  ensures acc(_c_Z_shared(ret), wildcard)
+  ensures acc(_c_Z_unique(ret), write)
 
 
-method con__c_ClassI(x: Ref, y: Ref) returns (ret: Ref)
+method con_c_ClassI(x: Ref, y: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), _c_ClassI())
-  ensures acc(c_ClassI_shared(ret), wildcard)
-  ensures acc(c_ClassI_unique(ret), write)
-  ensures intFromRef((unfolding acc(c_ClassI_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_ClassI())
+  ensures acc(_c_ClassI_shared(ret), wildcard)
+  ensures acc(_c_ClassI_unique(ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassI_shared(ret), wildcard) in
       ret.bf_x)) ==
     intFromRef(x) &&
-    intFromRef((unfolding acc(c_ClassI_shared(ret), wildcard) in ret.bf_y)) ==
+    intFromRef((unfolding acc(_c_ClassI_shared(ret), wildcard) in ret.bf_y)) ==
     intFromRef(y)
 
 
-method con__c_Z() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Z())
-  ensures acc(c_Z_shared(ret), wildcard)
-  ensures acc(c_Z_unique(ret), write)
+method con_c_ClassII(z: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(z), c_Z())
+  ensures isSubtype(typeOf(ret), c_ClassII())
+  ensures acc(_c_ClassII_shared(ret), wildcard)
+  ensures acc(_c_ClassII_unique(ret), write)
+  ensures (unfolding acc(_c_ClassII_shared(ret), wildcard) in ret.bf_z) ==
+    z
 
 
 method g_z(this: Ref) returns (ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
@@ -3,19 +3,19 @@ field y: Ref
 
 field z: Ref
 
-method cascadeGet(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), c_X())
-  ensures isSubtype(typeOf(ret), c_Z())
-  ensures acc(shared(ret), wildcard)
+method cascadeGet(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), X())
+  ensures isSubtype(typeOf(v_ret_0), Z())
+  ensures acc(Z_shared(v_ret_0), wildcard)
 {
   var anon: Ref
-  inhale acc(_c_X_shared(x), wildcard)
-  unfold acc(_c_X_shared(x), wildcard)
+  inhale acc(X_shared(x), wildcard)
+  unfold acc(X_shared(x), wildcard)
   anon := x.y
-  unfold acc(_c_Y_shared(anon), wildcard)
-  ret := anon.z
-  goto ret_0
-  label ret_0
+  unfold acc(Y_shared(anon), wildcard)
+  v_ret_0 := anon.z
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for receiverNotNullProved:
@@ -23,23 +23,23 @@ field y: Ref
 
 field z: Ref
 
-method receiverNotNullProved(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), nullable(c_X()))
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> x != nullValue()
+method receiverNotNullProved(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), nullable(X()))
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==> x != nullValue()
 {
   var anon_0: Ref
-  inhale x != nullValue() ==> acc(_c_X_shared(x), wildcard)
+  inhale x != nullValue() ==> acc(X_shared(x), wildcard)
   if (x != nullValue()) {
-    var anon: Ref
-    unfold acc(_c_X_shared(x), wildcard)
-    anon := x.y
-    anon_0 := anon
+    var anon_1: Ref
+    unfold acc(X_shared(x), wildcard)
+    anon_1 := x.y
+    anon_0 := anon_1
   } else {
     anon_0 := nullValue()}
-  ret := notBool(boolToRef(anon_0 == nullValue()))
-  goto ret_0
-  label ret_0
+  v_ret_0 := notBool(boolToRef(anon_0 == nullValue()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for cascadeNullableGet:
@@ -47,26 +47,26 @@ field y: Ref
 
 field z: Ref
 
-method cascadeNullableGet(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), nullable(c_NullableX()))
-  ensures isSubtype(typeOf(ret), nullable(c_Z()))
-  ensures ret != nullValue() ==> acc(_c_Z_shared(ret), wildcard)
-  ensures ret != nullValue() ==> x != nullValue()
+method cascadeNullableGet(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), nullable(NullableX()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(Z()))
+  ensures v_ret_0 != nullValue() ==> acc(Z_shared(v_ret_0), wildcard)
+  ensures v_ret_0 != nullValue() ==> x != nullValue()
 {
   var anon: Ref
-  inhale x != nullValue() ==> acc(_c_NullableX_shared(x), wildcard)
+  inhale x != nullValue() ==> acc(NullableX_shared(x), wildcard)
   if (x != nullValue()) {
-    unfold acc(_c_NullableX_shared(x), wildcard)
+    unfold acc(NullableX_shared(x), wildcard)
     anon := x.y
   } else {
     anon := nullValue()}
   if (anon != nullValue()) {
-    unfold acc(_c_NullableY_shared(anon), wildcard)
-    ret := anon.z
+    unfold acc(NullableY_shared(anon), wildcard)
+    v_ret_0 := anon.z
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for cascadeNullableSmartcastGet:
@@ -74,35 +74,35 @@ field y: Ref
 
 field z: Ref
 
-method cascadeNullableSmartcastGet(x: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), nullable(c_NullableX()))
-  ensures isSubtype(typeOf(ret), nullable(c_Z()))
-  ensures ret != nullValue() ==> acc(_c_Z_shared(ret), wildcard)
-  ensures ret != nullValue() ==> x != nullValue()
+method cascadeNullableSmartcastGet(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), nullable(NullableX()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(Z()))
+  ensures v_ret_0 != nullValue() ==> acc(Z_shared(v_ret_0), wildcard)
+  ensures v_ret_0 != nullValue() ==> x != nullValue()
 {
-  inhale x != nullValue() ==> acc(_c_NullableX_shared(x), wildcard)
+  inhale x != nullValue() ==> acc(NullableX_shared(x), wildcard)
   if (x == nullValue()) {
     var anon_0: Ref
     anon_0 := nullValue()
-    ret := anon_0
+    v_ret_0 := anon_0
   } else {
     var anon_1: Ref
-    unfold acc(_c_NullableX_shared(x), wildcard)
+    unfold acc(NullableX_shared(x), wildcard)
     anon_1 := x.y
     if (anon_1 == nullValue()) {
       var anon_2: Ref
       anon_2 := nullValue()
-      ret := anon_2
+      v_ret_0 := anon_2
     } else {
-      var anon: Ref
-      unfold acc(_c_NullableX_shared(x), wildcard)
-      anon := x.y
-      unfold acc(_c_NullableY_shared(anon), wildcard)
-      ret := anon.z
+      var anon_3: Ref
+      unfold acc(NullableX_shared(x), wildcard)
+      anon_3 := x.y
+      unfold acc(NullableY_shared(anon_3), wildcard)
+      v_ret_0 := anon_3.z
     }
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /backing_field_getters.kt: info: Generated Viper text for nullableReceiverNotNullSafeGet:
@@ -111,13 +111,13 @@ field size: Ref
 field x: Ref
 
 method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Baz())
-  ensures acc(_c_Baz_shared(v_ret), wildcard)
-  ensures acc(_c_Baz_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), Baz())
+  ensures acc(Baz_shared(v_ret), wildcard)
+  ensures acc(Baz_unique(v_ret), write)
 
 
-method nullableReceiverNotNullSafeGet() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method nullableReceiverNotNullSafeGet() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var f: Ref
   var anon_0: Ref
@@ -126,16 +126,16 @@ method nullableReceiverNotNullSafeGet() returns (ret: Ref)
   anon_0 := con()
   f := anon_0
   if (f != nullValue()) {
-    var anon: Ref
-    unfold acc(_c_Baz_shared(f), wildcard)
-    anon := f.x
-    anon_1 := anon
+    var anon_2: Ref
+    unfold acc(Baz_shared(f), wildcard)
+    anon_2 := f.x
+    anon_1 := anon_2
   } else {
     anon_1 := nullValue()}
   cond1 := notBool(boolToRef(anon_1 == nullValue()))
   assert boolFromRef(cond1)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /backing_field_getters.kt: info: Generated Viper text for nullableReceiverNullSafeGet:
@@ -143,24 +143,24 @@ field size: Ref
 
 field x: Ref
 
-method nullableReceiverNullSafeGet() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method nullableReceiverNullSafeGet() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var f: Ref
   var cond1: Ref
   var anon_0: Ref
   f := nullValue()
   if (f != nullValue()) {
-    var anon: Ref
-    unfold acc(_c_Baz_shared(f), wildcard)
-    anon := f.x
-    anon_0 := anon
+    var anon_1: Ref
+    unfold acc(Baz_shared(f), wildcard)
+    anon_1 := f.x
+    anon_0 := anon_1
   } else {
     anon_0 := nullValue()}
   cond1 := boolToRef(anon_0 == nullValue())
   assert boolFromRef(cond1)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /backing_field_getters.kt: info: Generated Viper text for nonNullableReceiverSafeGet:
@@ -169,29 +169,29 @@ field size: Ref
 field x: Ref
 
 method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Baz())
-  ensures acc(_c_Baz_shared(v_ret), wildcard)
-  ensures acc(_c_Baz_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), Baz())
+  ensures acc(Baz_shared(v_ret), wildcard)
+  ensures acc(Baz_unique(v_ret), write)
 
 
-method nonNullableReceiverSafeGet() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method nonNullableReceiverSafeGet() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var f: Ref
   var cond1: Ref
   var anon_0: Ref
   f := con()
   if (f != nullValue()) {
-    var anon: Ref
-    unfold acc(_c_Baz_shared(f), wildcard)
-    anon := f.x
-    anon_0 := anon
+    var anon_1: Ref
+    unfold acc(Baz_shared(f), wildcard)
+    anon_1 := f.x
+    anon_0 := anon_1
   } else {
     anon_0 := nullValue()}
   cond1 := notBool(boolToRef(anon_0 == nullValue()))
   assert boolFromRef(cond1)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /backing_field_getters.kt: info: Generated Viper text for checkPrimary:
@@ -203,67 +203,67 @@ field bf_z: Ref
 
 field size: Ref
 
-method checkPrimary(x: Ref, y: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(x), intType())
-  requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+method checkPrimary(par_x: Ref, par_y: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  requires isSubtype(typeOf(par_y), intType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var classI: Ref
   var l0_z: Ref
   var cond1: Ref
   var cond2: Ref
   var anon_2: Ref
-  var anon: Ref
-  classI := con_c_ClassI(x, y)
-  l0_z := con()
-  if (!(intFromRef(x) == intFromRef(y))) {
+  var anon_3: Ref
+  classI := con_ClassI(par_x, par_y)
+  l0_z := con_Z()
+  if (!(intFromRef(par_x) == intFromRef(par_y))) {
     cond1 := boolToRef(true)
   } else {
     var anon_0: Ref
     var anon_1: Ref
-    unfold acc(_c_ClassI_shared(classI), wildcard)
+    unfold acc(ClassI_shared(classI), wildcard)
     anon_0 := classI.bf_x
-    unfold acc(_c_ClassI_shared(classI), wildcard)
+    unfold acc(ClassI_shared(classI), wildcard)
     anon_1 := classI.bf_y
     cond1 := boolToRef(intFromRef(anon_0) == intFromRef(anon_1))
   }
-  anon := con_c_ClassII(l0_z)
-  unfold acc(_c_ClassII_shared(anon), wildcard)
-  anon_2 := anon.bf_z
+  anon_3 := con_ClassII(l0_z)
+  unfold acc(ClassII_shared(anon_3), wildcard)
+  anon_2 := anon_3.bf_z
   cond2 := boolToRef(anon_2 == l0_z)
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Z())
-  ensures acc(_c_Z_shared(v_ret), wildcard)
-  ensures acc(_c_Z_unique(v_ret), write)
-
-
-method con_c_ClassI(x: Ref, y: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(x), intType())
-  requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(v_ret), c_ClassI())
-  ensures acc(_c_ClassI_shared(v_ret), wildcard)
-  ensures acc(_c_ClassI_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassI_shared(v_ret), wildcard) in
+method con_ClassI(par_x: Ref, par_y: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_x), intType())
+  requires isSubtype(typeOf(par_y), intType())
+  ensures isSubtype(typeOf(v_ret), ClassI())
+  ensures acc(ClassI_shared(v_ret), wildcard)
+  ensures acc(ClassI_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(ClassI_shared(v_ret), wildcard) in
       v_ret.bf_x)) ==
-    intFromRef(x) &&
-    intFromRef((unfolding acc(_c_ClassI_shared(v_ret), wildcard) in
+    intFromRef(par_x) &&
+    intFromRef((unfolding acc(ClassI_shared(v_ret), wildcard) in
       v_ret.bf_y)) ==
-    intFromRef(y)
+    intFromRef(par_y)
 
 
-method con_c_ClassII(z: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(z), c_Z())
-  ensures isSubtype(typeOf(v_ret), c_ClassII())
-  ensures acc(_c_ClassII_shared(v_ret), wildcard)
-  ensures acc(_c_ClassII_unique(v_ret), write)
-  ensures (unfolding acc(_c_ClassII_shared(v_ret), wildcard) in v_ret.bf_z) ==
-    z
+method con_ClassII(par_z: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_z), Z())
+  ensures isSubtype(typeOf(v_ret), ClassII())
+  ensures acc(ClassII_shared(v_ret), wildcard)
+  ensures acc(ClassII_unique(v_ret), write)
+  ensures (unfolding acc(ClassII_shared(v_ret), wildcard) in v_ret.bf_z) ==
+    par_z
+
+
+method con_Z() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Z())
+  ensures acc(Z_shared(v_ret), wildcard)
+  ensures acc(Z_unique(v_ret), write)
 
 
 method g_z(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
@@ -1,7 +1,7 @@
 /binary_search.kt: info: Generated Viper text for safe_binary_search:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -10,30 +10,30 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method safe_binary_search(arr: Ref, target: Ref) returns (ret_0: Ref)
+method safe_binary_search(arr: Ref, target: Ref) returns (ret: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
   requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var l0_size: Ref
   var mid: Ref
@@ -47,31 +47,32 @@ method safe_binary_search(arr: Ref, target: Ref) returns (ret_0: Ref)
   mid := divInts(anon_0, intToRef(2))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret_0 := boolToRef(false)
+    ret := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret_0 := boolToRef(true)
+      ret := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret_0 := safe_binary_search(anon_4, target)
+        ret := safe_binary_search(anon_4, target)
       } else {
         var anon: Ref
         anon := subList(arr, intToRef(0), mid)
-        ret_0 := safe_binary_search(anon, target)
+        ret := safe_binary_search(anon, target)
       }
     }
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
+method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
+  returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -82,19 +83,19 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(ret.size) ==
+  ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
 /binary_search.kt: info: Generated Viper text for unsafe_binary_search_fixed:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -103,12 +104,12 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
 method unsafe_binary_search_fixed(arr: Ref, target: Ref, left: Ref, right: Ref)
-  returns (ret_0: Ref)
+  returns (ret: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
   requires isSubtype(typeOf(arr), c_List())
@@ -117,7 +118,7 @@ method unsafe_binary_search_fixed(arr: Ref, target: Ref, left: Ref, right: Ref)
   requires isSubtype(typeOf(right), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var anon_0: Ref
   var anon_1: Ref
@@ -137,23 +138,22 @@ method unsafe_binary_search_fixed(arr: Ref, target: Ref, left: Ref, right: Ref)
     anon_0 := geInts(right, anon_2)
   }
   if (boolFromRef(anon_0)) {
-    ret_0 := boolToRef(false)
-    goto lbl_ret_0
+    ret := boolToRef(false)
+    goto ret_0
   }
   mid := plusInts(left, divInts(minusInts(right, left), intToRef(2)))
   anon_3 := get(arr, mid)
   if (intFromRef(anon_3) == intFromRef(target)) {
-    ret_0 := boolToRef(true)
+    ret := boolToRef(true)
   } else {
     var anon: Ref
     anon := get(arr, mid)
     if (intFromRef(anon) < intFromRef(target)) {
-      ret_0 := unsafe_binary_search_fixed(arr, target, plusInts(mid, intToRef(1)),
+      ret := unsafe_binary_search_fixed(arr, target, plusInts(mid, intToRef(1)),
         right)
     } else {
-      ret_0 := unsafe_binary_search_fixed(arr, target, left, minusInts(mid,
-        intToRef(1)))}
+      ret := unsafe_binary_search_fixed(arr, target, left, minusInts(mid, intToRef(1)))}
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
@@ -4,7 +4,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -17,7 +17,7 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method isEmpty(this: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())
@@ -29,7 +29,7 @@ method isEmpty(this: Ref) returns (ret: Ref)
 method safe_binary_search(arr: Ref, target: Ref) returns (ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), collections_c_List())
+  requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
@@ -39,7 +39,7 @@ method safe_binary_search(arr: Ref, target: Ref) returns (ret_0: Ref)
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(c_List_shared(arr), wildcard)
+  inhale acc(shared(arr), wildcard)
   l0_size := arr.size
   inhale isSubtype(typeOf(l0_size), intType())
   anon_0 := arr.size
@@ -74,7 +74,7 @@ method safe_binary_search(arr: Ref, target: Ref) returns (ret_0: Ref)
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -82,10 +82,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
@@ -97,7 +97,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -111,7 +111,7 @@ method unsafe_binary_search_fixed(arr: Ref, target: Ref, left: Ref, right: Ref)
   returns (ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), collections_c_List())
+  requires isSubtype(typeOf(arr), c_List())
   requires isSubtype(typeOf(target), intType())
   requires isSubtype(typeOf(left), intType())
   requires isSubtype(typeOf(right), intType())
@@ -123,7 +123,7 @@ method unsafe_binary_search_fixed(arr: Ref, target: Ref, left: Ref, right: Ref)
   var anon_1: Ref
   var mid: Ref
   var anon_3: Ref
-  inhale acc(c_List_shared(arr), wildcard)
+  inhale acc(shared(arr), wildcard)
   if (intFromRef(left) > intFromRef(right)) {
     anon_1 := boolToRef(true)
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
@@ -1,94 +1,94 @@
 /binary_search.kt: info: Generated Viper text for safe_binary_search:
-field size: Ref
+field p_size: Ref
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
-  requires intFromRef(this.size) > intFromRef(index)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires intFromRef(this.p_size) > intFromRef(index)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
 
 
 method isEmpty(this: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures boolFromRef(v_ret) ==> intFromRef(this.p_size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.p_size) > 0
 
 
-method safe_binary_search(arr: Ref, target: Ref) returns (ret: Ref)
-  requires acc(arr.size, write)
-  requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), c_List())
+method safe_binary_search(arr: Ref, target: Ref) returns (v_ret_0: Ref)
+  requires acc(arr.p_size, write)
+  requires intFromRef(arr.p_size) >= 0
+  requires isSubtype(typeOf(arr), List())
   requires isSubtype(typeOf(target), intType())
-  ensures acc(arr.size, write)
-  ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures acc(arr.p_size, write)
+  ensures intFromRef(arr.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var l0_size: Ref
   var mid: Ref
   var anon_0: Ref
   var anon_1: Ref
-  inhale acc(shared(arr), wildcard)
-  l0_size := arr.size
+  inhale acc(List_shared(arr), wildcard)
+  l0_size := arr.p_size
   inhale isSubtype(typeOf(l0_size), intType())
-  anon_0 := arr.size
+  anon_0 := arr.p_size
   inhale isSubtype(typeOf(anon_0), intType())
   mid := divInts(anon_0, intToRef(2))
   anon_1 := isEmpty(arr)
   if (boolFromRef(anon_1)) {
-    ret := boolToRef(false)
+    v_ret_0 := boolToRef(false)
   } else {
     var anon_2: Ref
     anon_2 := get(arr, mid)
     if (intFromRef(anon_2) == intFromRef(target)) {
-      ret := boolToRef(true)
+      v_ret_0 := boolToRef(true)
     } else {
       var anon_3: Ref
       anon_3 := get(arr, mid)
       if (intFromRef(anon_3) < intFromRef(target)) {
         var anon_4: Ref
         anon_4 := subList(arr, plusInts(mid, intToRef(1)), l0_size)
-        ret := safe_binary_search(anon_4, target)
+        v_ret_0 := safe_binary_search(anon_4, target)
       } else {
-        var anon: Ref
-        anon := subList(arr, intToRef(0), mid)
-        ret := safe_binary_search(anon, target)
+        var anon_5: Ref
+        anon_5 := subList(arr, intToRef(0), mid)
+        v_ret_0 := safe_binary_search(anon_5, target)
       }
     }
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
   requires intFromRef(fromIndex) >= 0
-  requires intFromRef(toIndex) <= intFromRef(this.size)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(v_ret), c_List())
-  ensures acc(v_ret.size, write)
-  ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(v_ret.size) ==
+  requires intFromRef(toIndex) <= intFromRef(this.p_size)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret), List())
+  ensures acc(v_ret.p_size, write)
+  ensures intFromRef(v_ret.p_size) >= 0
+  ensures acc(List_shared(v_ret), wildcard)
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures intFromRef(v_ret.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
@@ -98,7 +98,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -109,22 +109,22 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
 
 
 method unsafe_binary_search_fixed(arr: Ref, target: Ref, left: Ref, right: Ref)
-  returns (ret: Ref)
+  returns (v_ret_0: Ref)
   requires acc(arr.size, write)
   requires intFromRef(arr.size) >= 0
-  requires isSubtype(typeOf(arr), c_List())
+  requires isSubtype(typeOf(arr), List())
   requires isSubtype(typeOf(target), intType())
   requires isSubtype(typeOf(left), intType())
   requires isSubtype(typeOf(right), intType())
   ensures acc(arr.size, write)
   ensures intFromRef(arr.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var anon_0: Ref
   var anon_1: Ref
   var mid: Ref
   var anon_3: Ref
-  inhale acc(shared(arr), wildcard)
+  inhale acc(List_shared(arr), wildcard)
   if (intFromRef(left) > intFromRef(right)) {
     anon_1 := boolToRef(true)
   } else {
@@ -138,22 +138,23 @@ method unsafe_binary_search_fixed(arr: Ref, target: Ref, left: Ref, right: Ref)
     anon_0 := geInts(right, anon_2)
   }
   if (boolFromRef(anon_0)) {
-    ret := boolToRef(false)
-    goto ret_0
+    v_ret_0 := boolToRef(false)
+    goto lbl_ret_0
   }
   mid := plusInts(left, divInts(minusInts(right, left), intToRef(2)))
   anon_3 := get(arr, mid)
   if (intFromRef(anon_3) == intFromRef(target)) {
-    ret := boolToRef(true)
+    v_ret_0 := boolToRef(true)
   } else {
-    var anon: Ref
-    anon := get(arr, mid)
-    if (intFromRef(anon) < intFromRef(target)) {
-      ret := unsafe_binary_search_fixed(arr, target, plusInts(mid, intToRef(1)),
+    var anon_4: Ref
+    anon_4 := get(arr, mid)
+    if (intFromRef(anon_4) < intFromRef(target)) {
+      v_ret_0 := unsafe_binary_search_fixed(arr, target, plusInts(mid, intToRef(1)),
         right)
     } else {
-      ret := unsafe_binary_search_fixed(arr, target, left, minusInts(mid, intToRef(1)))}
+      v_ret_0 := unsafe_binary_search_fixed(arr, target, left, minusInts(mid,
+        intToRef(1)))}
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
@@ -6,7 +6,7 @@ field value: Ref
 method get(this: Ref, index: Ref) returns (ret_0: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), _c_CustomList())
+  requires isSubtype(typeOf(this), c_CustomList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -15,8 +15,8 @@ method get(this: Ref, index: Ref) returns (ret_0: Ref)
   ensures isSubtype(typeOf(ret_0), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 {
-  inhale acc(c_CustomList_shared(this), wildcard)
-  unfold acc(c_CustomList_shared(this), wildcard)
+  inhale acc(_c_CustomList_shared(this), wildcard)
+  unfold acc(_c_CustomList_shared(this), wildcard)
   ret_0 := this.value
   goto lbl_ret_0
   label lbl_ret_0
@@ -30,17 +30,17 @@ field size: Ref
 method con(par_size: Ref, value: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(par_size), intType())
   requires isSubtype(typeOf(value), intType())
-  ensures isSubtype(typeOf(ret), _c_CustomList())
+  ensures isSubtype(typeOf(ret), c_CustomList())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_CustomList_shared(ret), wildcard)
-  ensures acc(c_CustomList_unique(ret), write)
+  ensures acc(_c_CustomList_shared(ret), wildcard)
+  ensures acc(_c_CustomList_unique(ret), write)
 
 
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), _c_CustomList())
+  requires isSubtype(typeOf(this), c_CustomList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -53,7 +53,7 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method isEmpty(this: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), _c_CustomList())
+  requires isSubtype(typeOf(this), c_CustomList())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
@@ -3,40 +3,6 @@ field size: Ref
 
 field value: Ref
 
-method get(this: Ref, index: Ref) returns (ret_0: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_CustomList())
-  requires isSubtype(typeOf(index), intType())
-  requires intFromRef(index) >= 0
-  requires intFromRef(this.size) > intFromRef(index)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret_0), intType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-{
-  inhale acc(_c_CustomList_shared(this), wildcard)
-  unfold acc(_c_CustomList_shared(this), wildcard)
-  ret_0 := this.value
-  goto lbl_ret_0
-  label lbl_ret_0
-}
-
-/custom_list.kt: info: Generated Viper text for test:
-field bf_value: Ref
-
-field size: Ref
-
-method con(par_size: Ref, value: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(par_size), intType())
-  requires isSubtype(typeOf(value), intType())
-  ensures isSubtype(typeOf(ret), c_CustomList())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(_c_CustomList_shared(ret), wildcard)
-  ensures acc(_c_CustomList_unique(ret), write)
-
-
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
@@ -48,23 +14,57 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
+{
+  inhale acc(_c_CustomList_shared(this), wildcard)
+  unfold acc(_c_CustomList_shared(this), wildcard)
+  ret := this.value
+  goto ret_0
+  label ret_0
+}
+
+/custom_list.kt: info: Generated Viper text for test:
+field bf_value: Ref
+
+field size: Ref
+
+method con(par_size: Ref, value: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_size), intType())
+  requires isSubtype(typeOf(value), intType())
+  ensures isSubtype(typeOf(v_ret), c_CustomList())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(_c_CustomList_shared(v_ret), wildcard)
+  ensures acc(_c_CustomList_unique(v_ret), write)
 
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
+  requires acc(this.size, write)
+  requires intFromRef(this.size) >= 0
+  requires isSubtype(typeOf(this), c_CustomList())
+  requires isSubtype(typeOf(index), intType())
+  requires intFromRef(index) >= 0
+  requires intFromRef(this.size) > intFromRef(index)
+  ensures acc(this.size, write)
+  ensures intFromRef(this.size) >= 0
+  ensures isSubtype(typeOf(v_ret), intType())
+  ensures intFromRef(this.size) == old(intFromRef(this.size))
+
+
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_CustomList())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method test(n: Ref) returns (ret_0: Ref)
+method test(n: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(n), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var customList: Ref
   var anon_0: Ref
@@ -79,6 +79,6 @@ method test(n: Ref) returns (ret_0: Ref)
     anon_1 := get(customList, minusInts(anon_2, intToRef(1)))
     anon := get(customList, intToRef(0))
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
@@ -3,68 +3,68 @@ field size: Ref
 
 field value: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret_0: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_CustomList())
+  requires isSubtype(typeOf(this), CustomList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 {
-  inhale acc(_c_CustomList_shared(this), wildcard)
-  unfold acc(_c_CustomList_shared(this), wildcard)
-  ret := this.value
-  goto ret_0
-  label ret_0
+  inhale acc(CustomList_shared(this), wildcard)
+  unfold acc(CustomList_shared(this), wildcard)
+  v_ret_0 := this.value
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /custom_list.kt: info: Generated Viper text for test:
 field bf_value: Ref
 
-field size: Ref
+field p_size: Ref
 
-method con(par_size: Ref, value: Ref) returns (v_ret: Ref)
+method con(par_size: Ref, par_value: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_size), intType())
-  requires isSubtype(typeOf(value), intType())
-  ensures isSubtype(typeOf(v_ret), c_CustomList())
-  ensures acc(v_ret.size, write)
-  ensures intFromRef(v_ret.size) >= 0
-  ensures acc(_c_CustomList_shared(v_ret), wildcard)
-  ensures acc(_c_CustomList_unique(v_ret), write)
+  requires isSubtype(typeOf(par_value), intType())
+  ensures isSubtype(typeOf(v_ret), CustomList())
+  ensures acc(v_ret.p_size, write)
+  ensures intFromRef(v_ret.p_size) >= 0
+  ensures acc(CustomList_shared(v_ret), wildcard)
+  ensures acc(CustomList_unique(v_ret), write)
 
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_CustomList())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), CustomList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
-  requires intFromRef(this.size) > intFromRef(index)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires intFromRef(this.p_size) > intFromRef(index)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
 
 
 method isEmpty(this: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_CustomList())
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), CustomList())
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
+  ensures boolFromRef(v_ret) ==> intFromRef(this.p_size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.p_size) > 0
 
 
-method test(n: Ref) returns (ret: Ref)
+method test(n: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(n), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var customList: Ref
   var anon_0: Ref
@@ -73,12 +73,12 @@ method test(n: Ref) returns (ret: Ref)
   if (!boolFromRef(anon_0)) {
     var anon_1: Ref
     var anon_2: Ref
-    var anon: Ref
-    anon_2 := customList.size
+    var anon_3: Ref
+    anon_2 := customList.p_size
     inhale isSubtype(typeOf(anon_2), intType())
     anon_1 := get(customList, minusInts(anon_2, intToRef(1)))
-    anon := get(customList, intToRef(0))
+    anon_3 := get(customList, intToRef(0))
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
@@ -1,76 +1,76 @@
 /list.kt: info: Generated Viper text for declaration:
 field size: Ref
 
-method declaration() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method declaration() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l1: Ref
   var l2: Ref
   var l3: Ref
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /list.kt: info: Generated Viper text for initialization:
 field size: Ref
 
-method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
-  ensures intFromRef(ret.size) == 0
+method emptyList() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
+  ensures intFromRef(v_ret.size) == 0
 
 
-method initialization(l: Ref) returns (ret_0: Ref)
+method initialization(l: Ref) returns (ret: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
   requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var myList: Ref
   var myEmptyList: Ref
   inhale acc(shared(l), wildcard)
   myList := l
   myEmptyList := emptyList()
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /list.kt: info: Generated Viper text for add_get:
 field size: Ref
 
-method add(this: Ref, element: Ref) returns (ret: Ref)
+method add(this: Ref, element: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_MutableList())
   requires isSubtype(typeOf(element), intType())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size)) + 1
 
 
-method add_get(l: Ref) returns (ret_0: Ref)
+method add_get(l: Ref) returns (ret: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
   requires isSubtype(typeOf(l), c_MutableList())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   var n: Ref
-  inhale acc(shared(l), wildcard)
+  inhale acc(collections_c_MutableList_shared(l), wildcard)
   anon := add(l, intToRef(1))
   n := get(l, intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_MutableList())
@@ -79,14 +79,14 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
 /list.kt: info: Generated Viper text for last_or_null:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -95,17 +95,17 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method last_or_null(l: Ref) returns (ret_0: Ref)
+method last_or_null(l: Ref) returns (ret: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
   requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures isSubtype(typeOf(ret), nullable(intType()))
 {
   var l0_size: Ref
   inhale acc(shared(l), wildcard)
@@ -114,19 +114,19 @@ method last_or_null(l: Ref) returns (ret_0: Ref)
   if (!(intFromRef(l0_size) == 0)) {
     var anon: Ref
     anon := get(l, minusInts(l0_size, intToRef(1)))
-    ret_0 := anon
-    goto lbl_ret_0
+    ret := anon
+    goto ret_0
   } else {
-    ret_0 := nullValue()
-    goto lbl_ret_0
+    ret := nullValue()
+    goto ret_0
   }
-  label lbl_ret_0
+  label ret_0
 }
 
 /list.kt: info: Generated Viper text for is_empty:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -135,45 +135,45 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method is_empty(l: Ref) returns (ret_0: Ref)
+method is_empty(l: Ref) returns (ret: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
   requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   var anon: Ref
   inhale acc(shared(l), wildcard)
   anon := isEmpty(l)
   if (!boolFromRef(anon)) {
-    ret_0 := get(l, intToRef(0))
+    ret := get(l, intToRef(0))
   } else {
-    ret_0 := intToRef(1)}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := intToRef(1)}
+  goto ret_0
+  label ret_0
 }
 
 /list.kt: info: Generated Viper text for nullable_list:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -182,29 +182,29 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method nullable_list(l: Ref) returns (ret_0: Ref)
+method nullable_list(l: Ref) returns (ret: Ref)
   requires l != nullValue() ==> acc(l.size, write)
   requires l != nullValue() ==> intFromRef(l.size) >= 0
   requires isSubtype(typeOf(l), nullable(c_List()))
   ensures l != nullValue() ==> acc(l.size, write)
   ensures l != nullValue() ==> intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   inhale l != nullValue() ==> acc(shared(l), wildcard)
@@ -221,6 +221,6 @@ method nullable_list(l: Ref) returns (ret_0: Ref)
     inhale isSubtype(typeOf(anon), intType())
     x := get(l, minusInts(anon, intToRef(1)))
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
@@ -15,24 +15,24 @@ method declaration() returns (ret_0: Ref)
 field size: Ref
 
 method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(ret.size) == 0
 
 
 method initialization(l: Ref) returns (ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), collections_c_List())
+  requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var myList: Ref
   var myEmptyList: Ref
-  inhale acc(c_List_shared(l), wildcard)
+  inhale acc(shared(l), wildcard)
   myList := l
   myEmptyList := emptyList()
   label lbl_ret_0
@@ -45,7 +45,7 @@ field size: Ref
 method add(this: Ref, element: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_MutableList())
+  requires isSubtype(typeOf(this), c_MutableList())
   requires isSubtype(typeOf(element), intType())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
@@ -56,14 +56,14 @@ method add(this: Ref, element: Ref) returns (ret: Ref)
 method add_get(l: Ref) returns (ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), collections_c_MutableList())
+  requires isSubtype(typeOf(l), c_MutableList())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
   var n: Ref
-  inhale acc(c_MutableList_shared(l), wildcard)
+  inhale acc(shared(l), wildcard)
   anon := add(l, intToRef(1))
   n := get(l, intToRef(0))
   label lbl_ret_0
@@ -73,7 +73,7 @@ method add_get(l: Ref) returns (ret_0: Ref)
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_MutableList())
+  requires isSubtype(typeOf(this), c_MutableList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -89,7 +89,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -102,13 +102,13 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method last_or_null(l: Ref) returns (ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), collections_c_List())
+  requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
 {
   var l0_size: Ref
-  inhale acc(c_List_shared(l), wildcard)
+  inhale acc(shared(l), wildcard)
   l0_size := l.size
   inhale isSubtype(typeOf(l0_size), intType())
   if (!(intFromRef(l0_size) == 0)) {
@@ -129,7 +129,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -142,7 +142,7 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method isEmpty(this: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())
@@ -154,13 +154,13 @@ method isEmpty(this: Ref) returns (ret: Ref)
 method is_empty(l: Ref) returns (ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), collections_c_List())
+  requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var anon: Ref
-  inhale acc(c_List_shared(l), wildcard)
+  inhale acc(shared(l), wildcard)
   anon := isEmpty(l)
   if (!boolFromRef(anon)) {
     ret_0 := get(l, intToRef(0))
@@ -176,7 +176,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -189,7 +189,7 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method isEmpty(this: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())
@@ -201,13 +201,13 @@ method isEmpty(this: Ref) returns (ret: Ref)
 method nullable_list(l: Ref) returns (ret_0: Ref)
   requires l != nullValue() ==> acc(l.size, write)
   requires l != nullValue() ==> intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), nullable(collections_c_List()))
+  requires isSubtype(typeOf(l), nullable(c_List()))
   ensures l != nullValue() ==> acc(l.size, write)
   ensures l != nullValue() ==> intFromRef(l.size) >= 0
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
-  inhale l != nullValue() ==> acc(c_List_shared(l), wildcard)
+  inhale l != nullValue() ==> acc(shared(l), wildcard)
   if (!(l == nullValue())) {
     var anon_1: Ref
     anon_1 := isEmpty(l)

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/list.fir.diag.txt
@@ -1,42 +1,42 @@
 /list.kt: info: Generated Viper text for declaration:
 field size: Ref
 
-method declaration() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method declaration() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l1: Ref
   var l2: Ref
   var l3: Ref
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /list.kt: info: Generated Viper text for initialization:
 field size: Ref
 
 method emptyList() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures isSubtype(typeOf(v_ret), List())
   ensures acc(v_ret.size, write)
   ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
+  ensures acc(List_shared(v_ret), wildcard)
   ensures intFromRef(v_ret.size) == 0
 
 
-method initialization(l: Ref) returns (ret: Ref)
+method initialization(l: Ref) returns (v_ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), c_List())
+  requires isSubtype(typeOf(l), List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var myList: Ref
   var myEmptyList: Ref
-  inhale acc(shared(l), wildcard)
+  inhale acc(List_shared(l), wildcard)
   myList := l
   myEmptyList := emptyList()
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /list.kt: info: Generated Viper text for add_get:
@@ -45,7 +45,7 @@ field size: Ref
 method add(this: Ref, element: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_MutableList())
+  requires isSubtype(typeOf(this), MutableList())
   requires isSubtype(typeOf(element), intType())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
@@ -53,27 +53,27 @@ method add(this: Ref, element: Ref) returns (v_ret: Ref)
   ensures intFromRef(this.size) == old(intFromRef(this.size)) + 1
 
 
-method add_get(l: Ref) returns (ret: Ref)
+method add_get(l: Ref) returns (v_ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), c_MutableList())
+  requires isSubtype(typeOf(l), MutableList())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   var n: Ref
-  inhale acc(collections_c_MutableList_shared(l), wildcard)
+  inhale acc(MutableList_shared(l), wildcard)
   anon := add(l, intToRef(1))
   n := get(l, intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_MutableList())
+  requires isSubtype(typeOf(this), MutableList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -84,43 +84,43 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
 
 
 /list.kt: info: Generated Viper text for last_or_null:
-field size: Ref
+field p_size: Ref
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires acc(this.p_size, write)
+  requires intFromRef(this.p_size) >= 0
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
-  requires intFromRef(this.size) > intFromRef(index)
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+  requires intFromRef(this.p_size) > intFromRef(index)
+  ensures acc(this.p_size, write)
+  ensures intFromRef(this.p_size) >= 0
   ensures isSubtype(typeOf(v_ret), intType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
+  ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
 
 
-method last_or_null(l: Ref) returns (ret: Ref)
-  requires acc(l.size, write)
-  requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), c_List())
-  ensures acc(l.size, write)
-  ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method last_or_null(l: Ref) returns (v_ret_0: Ref)
+  requires acc(l.p_size, write)
+  requires intFromRef(l.p_size) >= 0
+  requires isSubtype(typeOf(l), List())
+  ensures acc(l.p_size, write)
+  ensures intFromRef(l.p_size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
   var l0_size: Ref
-  inhale acc(shared(l), wildcard)
-  l0_size := l.size
+  inhale acc(List_shared(l), wildcard)
+  l0_size := l.p_size
   inhale isSubtype(typeOf(l0_size), intType())
   if (!(intFromRef(l0_size) == 0)) {
     var anon: Ref
     anon := get(l, minusInts(l0_size, intToRef(1)))
-    ret := anon
-    goto ret_0
+    v_ret_0 := anon
+    goto lbl_ret_0
   } else {
-    ret := nullValue()
-    goto ret_0
+    v_ret_0 := nullValue()
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /list.kt: info: Generated Viper text for is_empty:
@@ -129,7 +129,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -142,7 +142,7 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
 method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
@@ -151,23 +151,23 @@ method isEmpty(this: Ref) returns (v_ret: Ref)
   ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method is_empty(l: Ref) returns (ret: Ref)
+method is_empty(l: Ref) returns (v_ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), c_List())
+  requires isSubtype(typeOf(l), List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
-  inhale acc(shared(l), wildcard)
+  inhale acc(List_shared(l), wildcard)
   anon := isEmpty(l)
   if (!boolFromRef(anon)) {
-    ret := get(l, intToRef(0))
+    v_ret_0 := get(l, intToRef(0))
   } else {
-    ret := intToRef(1)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := intToRef(1)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /list.kt: info: Generated Viper text for nullable_list:
@@ -176,7 +176,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -189,7 +189,7 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
 method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
@@ -198,16 +198,16 @@ method isEmpty(this: Ref) returns (v_ret: Ref)
   ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method nullable_list(l: Ref) returns (ret: Ref)
+method nullable_list(l: Ref) returns (v_ret_0: Ref)
   requires l != nullValue() ==> acc(l.size, write)
   requires l != nullValue() ==> intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), nullable(c_List()))
+  requires isSubtype(typeOf(l), nullable(List()))
   ensures l != nullValue() ==> acc(l.size, write)
   ensures l != nullValue() ==> intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  inhale l != nullValue() ==> acc(shared(l), wildcard)
+  inhale l != nullValue() ==> acc(List_shared(l), wildcard)
   if (!(l == nullValue())) {
     var anon_1: Ref
     anon_1 := isEmpty(l)
@@ -216,11 +216,11 @@ method nullable_list(l: Ref) returns (ret: Ref)
     anon_0 := boolToRef(false)}
   if (boolFromRef(anon_0)) {
     var x: Ref
-    var anon: Ref
-    anon := l.size
-    inhale isSubtype(typeOf(anon), intType())
-    x := get(l, minusInts(anon, intToRef(1)))
+    var anon_2: Ref
+    anon_2 := l.size
+    inhale isSubtype(typeOf(anon_2), intType())
+    x := get(l, minusInts(anon_2, intToRef(1)))
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
@@ -34,9 +34,9 @@ method useRuns(x: Ref) returns (ret_0: Ref)
   var anon_6: Ref
   var ret_3: Ref
   var anon_0: Ref
-  var anon_7: Ref
-  var ret_4: Ref
   var anon: Ref
+  var ret_4: Ref
+  var anon_1: Ref
   ret_2 := plusInts(x, intToRef(1))
   goto lbl_ret_2
   label lbl_ret_2
@@ -52,12 +52,12 @@ method useRuns(x: Ref) returns (ret_0: Ref)
   inhale isSubtype(typeOf(x), nullable(anyType()))
   anon_0 := x
   inhale isSubtype(typeOf(anon_0), intType())
-  anon := anon_0
-  ret_4 := plusInts(anon, intToRef(1))
+  anon_1 := anon_0
+  ret_4 := plusInts(anon_1, intToRef(1))
   goto lbl_ret_4
   label lbl_ret_4
-  anon_7 := ret_4
-  ret_3 := anon_7
+  anon := ret_4
+  ret_3 := anon
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
@@ -79,23 +79,23 @@ method useAlso(x: Ref) returns (ret_0: Ref)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_2: Ref
-  var anon_3: Ref
+  var anon: Ref
   var ret_1: Ref
   var anon_0: Ref
   var ret_2: Ref
-  var anon: Ref
+  var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
-  anon := anon_0
-  assert intFromRef(anon) == 1 + intFromRef(x)
+  anon_1 := anon_0
+  assert intFromRef(anon_1) == 1 + intFromRef(x)
   label lbl_ret_2
   inhale isSubtype(typeOf(ret_2), unitType())
   ret_1 := anon_0
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
-  anon_2 := anon_3
+  anon := ret_1
+  anon_2 := anon
   inhale isSubtype(typeOf(anon_2), intType())
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
@@ -113,18 +113,18 @@ method useLet(x: Ref) returns (ret_0: Ref)
   var anon_3: Ref
   var ret_1: Ref
   var anon_0: Ref
-  var anon_4: Ref
-  var ret_2: Ref
   var anon: Ref
+  var ret_2: Ref
+  var anon_1: Ref
   inhale isSubtype(typeOf(x), nullable(anyType()))
   anon_0 := x
   inhale isSubtype(typeOf(anon_0), intType())
-  anon := anon_0
-  ret_2 := plusInts(anon, intToRef(1))
+  anon_1 := anon_0
+  ret_2 := plusInts(anon_1, intToRef(1))
   goto lbl_ret_2
   label lbl_ret_2
-  anon_4 := ret_2
-  ret_1 := anon_4
+  anon := ret_2
+  ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
@@ -148,18 +148,18 @@ method useWith(x: Ref) returns (ret_0: Ref)
   var anon_3: Ref
   var ret_1: Ref
   var anon_0: Ref
-  var anon_4: Ref
-  var ret_2: Ref
   var anon: Ref
+  var ret_2: Ref
+  var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
-  anon := anon_0
-  assert intFromRef(anon) == 1 + intFromRef(x)
+  anon_1 := anon_0
+  assert intFromRef(anon_1) == 1 + intFromRef(x)
   label lbl_ret_2
   inhale isSubtype(typeOf(ret_2), unitType())
-  anon_4 := ret_2
-  ret_1 := anon_4
+  anon := ret_2
+  ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
@@ -178,23 +178,23 @@ method useApply(x: Ref) returns (ret_0: Ref)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_2: Ref
-  var anon_3: Ref
+  var anon: Ref
   var ret_1: Ref
   var anon_0: Ref
   var ret_2: Ref
-  var anon: Ref
+  var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
-  anon := anon_0
-  assert intFromRef(anon) == 1 + intFromRef(x)
+  anon_1 := anon_0
+  assert intFromRef(anon_1) == 1 + intFromRef(x)
   label lbl_ret_2
   inhale isSubtype(typeOf(ret_2), unitType())
   ret_1 := anon_0
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
-  anon_2 := anon_3
+  anon := ret_1
+  anon_2 := anon
   inhale isSubtype(typeOf(anon_2), intType())
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
@@ -35,7 +35,7 @@ method useRuns(x: Ref) returns (ret_0: Ref)
   var ret_3: Ref
   var anon_0: Ref
   var anon: Ref
-  var ret_4: Ref
+  var ret: Ref
   var anon_1: Ref
   ret_2 := plusInts(x, intToRef(1))
   goto lbl_ret_2
@@ -53,10 +53,10 @@ method useRuns(x: Ref) returns (ret_0: Ref)
   anon_0 := x
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
-  ret_4 := plusInts(anon_1, intToRef(1))
-  goto lbl_ret_4
-  label lbl_ret_4
-  anon := ret_4
+  ret := plusInts(anon_1, intToRef(1))
+  goto ret_4
+  label ret_4
+  anon := ret
   ret_3 := anon
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3
@@ -82,15 +82,15 @@ method useAlso(x: Ref) returns (ret_0: Ref)
   var anon: Ref
   var ret_1: Ref
   var anon_0: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == 1 + intFromRef(x)
-  label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
+  label ret_2
+  inhale isSubtype(typeOf(ret), unitType())
   ret_1 := anon_0
   goto lbl_ret_1
   label lbl_ret_1
@@ -114,16 +114,16 @@ method useLet(x: Ref) returns (ret_0: Ref)
   var ret_1: Ref
   var anon_0: Ref
   var anon: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   inhale isSubtype(typeOf(x), nullable(anyType()))
   anon_0 := x
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
-  ret_2 := plusInts(anon_1, intToRef(1))
-  goto lbl_ret_2
-  label lbl_ret_2
-  anon := ret_2
+  ret := plusInts(anon_1, intToRef(1))
+  goto ret_2
+  label ret_2
+  anon := ret
   ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
@@ -149,16 +149,16 @@ method useWith(x: Ref) returns (ret_0: Ref)
   var ret_1: Ref
   var anon_0: Ref
   var anon: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == 1 + intFromRef(x)
-  label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
-  anon := ret_2
+  label ret_2
+  inhale isSubtype(typeOf(ret), unitType())
+  anon := ret
   ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
@@ -181,15 +181,15 @@ method useApply(x: Ref) returns (ret_0: Ref)
   var anon: Ref
   var ret_1: Ref
   var anon_0: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == 1 + intFromRef(x)
-  label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
+  label ret_2
+  inhale isSubtype(typeOf(ret), unitType())
   ret_1 := anon_0
   goto lbl_ret_1
   label lbl_ret_1

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/stdlib_replacement_tests.fir.diag.txt
@@ -1,51 +1,51 @@
 /stdlib_replacement_tests.kt: info: Generated Viper text for useChecks:
-method useChecks() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method useChecks() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var ret: Ref
-  var anon: Ref
+  var v_ret_2: Ref
+  var anon_1: Ref
   anon_0 := boolToRef(true)
   label lbl_ret_1
-  inhale isSubtype(typeOf(ret_1), unitType())
-  anon := boolToRef(true)
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale isSubtype(typeOf(v_ret_1), unitType())
+  anon_1 := boolToRef(true)
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /stdlib_replacement_tests.kt: info: Generated Viper text for useRuns:
 field size: Ref
 
-method useRuns(x: Ref) returns (ret_0: Ref)
+method useRuns(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
   var anon_2: Ref
   var anon_3: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_4: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var cond2: Ref
   var anon_5: Ref
   var anon_6: Ref
-  var ret_3: Ref
+  var v_ret_3: Ref
   var anon_0: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_7: Ref
+  var v_ret_4: Ref
   var anon_1: Ref
-  ret_2 := plusInts(x, intToRef(1))
+  v_ret_2 := plusInts(x, intToRef(1))
   goto lbl_ret_2
   label lbl_ret_2
-  anon_4 := ret_2
-  ret_1 := anon_4
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  anon_4 := v_ret_2
+  v_ret_1 := anon_4
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
+  anon_3 := v_ret_1
   anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), intType())
   cond1 := boolToRef(intFromRef(anon_2) == 1 + intFromRef(x))
@@ -53,149 +53,149 @@ method useRuns(x: Ref) returns (ret_0: Ref)
   anon_0 := x
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
-  ret := plusInts(anon_1, intToRef(1))
-  goto ret_4
-  label ret_4
-  anon := ret
-  ret_3 := anon
-  inhale isSubtype(typeOf(ret_3), nullable(anyType()))
+  v_ret_4 := plusInts(anon_1, intToRef(1))
+  goto lbl_ret_4
+  label lbl_ret_4
+  anon_7 := v_ret_4
+  v_ret_3 := anon_7
+  inhale isSubtype(typeOf(v_ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_6 := ret_3
+  anon_6 := v_ret_3
   anon_5 := anon_6
   inhale isSubtype(typeOf(anon_5), intType())
   cond2 := boolToRef(intFromRef(anon_5) == 1 + intFromRef(x))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /stdlib_replacement_tests.kt: info: Generated Viper text for useAlso:
 field size: Ref
 
-method useAlso(x: Ref) returns (ret_0: Ref)
+method useAlso(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_2: Ref
-  var anon: Ref
-  var ret_1: Ref
+  var anon_3: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var ret: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == 1 + intFromRef(x)
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
-  ret_1 := anon_0
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
+  v_ret_1 := anon_0
   goto lbl_ret_1
   label lbl_ret_1
-  anon := ret_1
-  anon_2 := anon
+  anon_3 := v_ret_1
+  anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), intType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /stdlib_replacement_tests.kt: info: Generated Viper text for useLet:
 field size: Ref
 
-method useLet(x: Ref) returns (ret_0: Ref)
+method useLet(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
   var anon_2: Ref
   var anon_3: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_4: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   inhale isSubtype(typeOf(x), nullable(anyType()))
   anon_0 := x
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
-  ret := plusInts(anon_1, intToRef(1))
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := anon
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  v_ret_2 := plusInts(anon_1, intToRef(1))
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon_4 := v_ret_2
+  v_ret_1 := anon_4
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
+  anon_3 := v_ret_1
   anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), intType())
   cond1 := boolToRef(intFromRef(anon_2) == 1 + intFromRef(x))
   assert boolFromRef(cond1)
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /stdlib_replacement_tests.kt: info: Generated Viper text for useWith:
 field size: Ref
 
-method useWith(x: Ref) returns (ret_0: Ref)
+method useWith(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_2: Ref
   var anon_3: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_4: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == 1 + intFromRef(x)
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
-  anon := ret
-  ret_1 := anon
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
+  anon_4 := v_ret_2
+  v_ret_1 := anon_4
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
+  anon_3 := v_ret_1
   anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /stdlib_replacement_tests.kt: info: Generated Viper text for useApply:
 field size: Ref
 
-method useApply(x: Ref) returns (ret_0: Ref)
+method useApply(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_2: Ref
-  var anon: Ref
-  var ret_1: Ref
+  var anon_3: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var ret: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   anon_0 := plusInts(x, intToRef(1))
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == 1 + intFromRef(x)
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
-  ret_1 := anon_0
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
+  v_ret_1 := anon_0
   goto lbl_ret_1
   label lbl_ret_1
-  anon := ret_1
-  anon_2 := anon
+  anon_3 := v_ret_1
+  anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), intType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
@@ -3,19 +3,19 @@ field bf_char: Ref
 
 field size: Ref
 
-method con(char: Ref) returns (ret: Ref)
+method con(char: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(char), charType())
-  ensures isSubtype(typeOf(ret), c_CharBox())
-  ensures acc(_c_CharBox_shared(ret), wildcard)
-  ensures acc(_c_CharBox_unique(ret), write)
-  ensures charFromRef((unfolding acc(_c_CharBox_shared(ret), wildcard) in
-      ret.bf_char)) ==
+  ensures isSubtype(typeOf(v_ret), c_CharBox())
+  ensures acc(_c_CharBox_shared(v_ret), wildcard)
+  ensures acc(_c_CharBox_unique(v_ret), write)
+  ensures charFromRef((unfolding acc(_c_CharBox_shared(v_ret), wildcard) in
+      v_ret.bf_char)) ==
     charFromRef(char)
 
 
-method testChars(c: Ref) returns (ret_0: Ref)
+method testChars(c: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(c), charType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var box: Ref
   var charA: Ref
@@ -36,6 +36,6 @@ method testChars(c: Ref) returns (ret_0: Ref)
   assert charFromRef(charA) < charFromRef(charZ)
   assert charFromRef(charZ) > charFromRef(charA)
   assert charFromRef(charZ) >= charFromRef(charZ)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
@@ -5,10 +5,10 @@ field size: Ref
 
 method con(char: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(char), charType())
-  ensures isSubtype(typeOf(ret), _c_CharBox())
-  ensures acc(c_CharBox_shared(ret), wildcard)
-  ensures acc(c_CharBox_unique(ret), write)
-  ensures charFromRef((unfolding acc(c_CharBox_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_CharBox())
+  ensures acc(_c_CharBox_shared(ret), wildcard)
+  ensures acc(_c_CharBox_unique(ret), write)
+  ensures charFromRef((unfolding acc(_c_CharBox_shared(ret), wildcard) in
       ret.bf_char)) ==
     charFromRef(char)
 
@@ -24,7 +24,7 @@ method testChars(c: Ref) returns (ret_0: Ref)
   var charZ: Ref
   box := con(charToRef(97))
   charA := charToRef(97)
-  unfold acc(c_CharBox_shared(box), wildcard)
+  unfold acc(_c_CharBox_shared(box), wildcard)
   anon := box.bf_char
   cond1 := boolToRef(charFromRef(charA) == charFromRef(anon))
   assert boolFromRef(cond1)

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
@@ -3,19 +3,19 @@ field bf_char: Ref
 
 field size: Ref
 
-method con(char: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(char), charType())
-  ensures isSubtype(typeOf(v_ret), c_CharBox())
-  ensures acc(_c_CharBox_shared(v_ret), wildcard)
-  ensures acc(_c_CharBox_unique(v_ret), write)
-  ensures charFromRef((unfolding acc(_c_CharBox_shared(v_ret), wildcard) in
+method con(par_char: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_char), charType())
+  ensures isSubtype(typeOf(v_ret), CharBox())
+  ensures acc(CharBox_shared(v_ret), wildcard)
+  ensures acc(CharBox_unique(v_ret), write)
+  ensures charFromRef((unfolding acc(CharBox_shared(v_ret), wildcard) in
       v_ret.bf_char)) ==
-    charFromRef(char)
+    charFromRef(par_char)
 
 
-method testChars(c: Ref) returns (ret: Ref)
+method testChars(c: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(c), charType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var box: Ref
   var charA: Ref
@@ -24,7 +24,7 @@ method testChars(c: Ref) returns (ret: Ref)
   var charZ: Ref
   box := con(charToRef(97))
   charA := charToRef(97)
-  unfold acc(_c_CharBox_shared(box), wildcard)
+  unfold acc(CharBox_shared(box), wildcard)
   anon := box.bf_char
   cond1 := boolToRef(charFromRef(charA) == charFromRef(anon))
   assert boolFromRef(cond1)
@@ -36,6 +36,6 @@ method testChars(c: Ref) returns (ret: Ref)
   assert charFromRef(charA) < charFromRef(charZ)
   assert charFromRef(charZ) > charFromRef(charA)
   assert charFromRef(charZ) >= charFromRef(charZ)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
@@ -3,38 +3,38 @@ field bf_str: Ref
 
 field size: Ref
 
-predicate c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_shared(this), wildcard) &&
-  acc(shared(this), wildcard)
-}
-
-predicate c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_unique(this), write) &&
-  acc(c_Serializable_unique(this), write)
-}
-
-predicate c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate c_Serializable_unique(this: Ref) {
-  true
-}
-
-predicate c_StringBox_shared(this: Ref) {
+predicate _c_StringBox_shared(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
 }
 
-predicate c_StringBox_unique(this: Ref) {
+predicate _c_StringBox_unique(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
+}
+
+predicate io_c_Serializable_shared(this: Ref) {
+  true
+}
+
+predicate io_c_Serializable_unique(this: Ref) {
+  true
+}
+
+predicate kotlin_c_BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
+}
+
+predicate kotlin_c_BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_unique(this), write) &&
+  acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_unique(this: Ref) {
+  true
 }
 
 predicate shared(this: Ref) {
@@ -43,10 +43,10 @@ predicate shared(this: Ref) {
 
 method con(str: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(ret), _c_StringBox())
-  ensures acc(c_StringBox_shared(ret), wildcard)
-  ensures acc(c_StringBox_unique(ret), write)
-  ensures stringFromRef((unfolding acc(c_StringBox_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_StringBox())
+  ensures acc(_c_StringBox_shared(ret), wildcard)
+  ensures acc(_c_StringBox_unique(ret), write)
+  ensures stringFromRef((unfolding acc(_c_StringBox_shared(ret), wildcard) in
       ret.bf_str)) ==
     stringFromRef(str)
 
@@ -62,11 +62,11 @@ method testType(s: Ref) returns (ret_0: Ref)
   var anon_2: Ref
   var anon: Ref
   anon_1 := con(s)
-  unfold acc(c_StringBox_shared(anon_1), wildcard)
+  unfold acc(_c_StringBox_shared(anon_1), wildcard)
   anon_0 := anon_1.bf_str
   cond1 := boolToRef(stringFromRef(anon_0) == stringFromRef(s))
   anon := con(stringToRef(Seq(115, 116, 114)))
-  unfold acc(c_StringBox_shared(anon), wildcard)
+  unfold acc(_c_StringBox_shared(anon), wildcard)
   anon_2 := anon.bf_str
   cond2 := boolToRef(stringFromRef(anon_2) == Seq(115, 116, 114))
   assert boolFromRef(cond1)
@@ -80,38 +80,38 @@ field bf_str: Ref
 
 field size: Ref
 
-predicate c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_shared(this), wildcard) &&
-  acc(shared(this), wildcard)
-}
-
-predicate c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_unique(this), write) &&
-  acc(c_Serializable_unique(this), write)
-}
-
-predicate c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate c_Serializable_unique(this: Ref) {
-  true
-}
-
-predicate c_StringBox_shared(this: Ref) {
+predicate _c_StringBox_shared(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
 }
 
-predicate c_StringBox_unique(this: Ref) {
+predicate _c_StringBox_unique(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
+}
+
+predicate io_c_Serializable_shared(this: Ref) {
+  true
+}
+
+predicate io_c_Serializable_unique(this: Ref) {
+  true
+}
+
+predicate kotlin_c_BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
+}
+
+predicate kotlin_c_BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_unique(this), write) &&
+  acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_unique(this: Ref) {
+  true
 }
 
 predicate shared(this: Ref) {
@@ -120,10 +120,10 @@ predicate shared(this: Ref) {
 
 method con(str: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(ret), _c_StringBox())
-  ensures acc(c_StringBox_shared(ret), wildcard)
-  ensures acc(c_StringBox_unique(ret), write)
-  ensures stringFromRef((unfolding acc(c_StringBox_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_StringBox())
+  ensures acc(_c_StringBox_shared(ret), wildcard)
+  ensures acc(_c_StringBox_unique(ret), write)
+  ensures stringFromRef((unfolding acc(_c_StringBox_shared(ret), wildcard) in
       ret.bf_str)) ==
     stringFromRef(str)
 
@@ -138,7 +138,7 @@ method testLengthField(s: Ref) returns (ret_0: Ref)
   var anon: Ref
   len := stringLength(s)
   anon := con(stringToRef(Seq(115, 116, 114)))
-  unfold acc(c_StringBox_shared(anon), wildcard)
+  unfold acc(_c_StringBox_shared(anon), wildcard)
   anon_0 := anon.bf_str
   cond1 := boolToRef(|stringFromRef(anon_0)| == 3)
   assert boolFromRef(cond1)
@@ -149,27 +149,27 @@ method testLengthField(s: Ref) returns (ret_0: Ref)
 /strings.kt: info: Generated Viper text for testOps:
 field size: Ref
 
-predicate c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_shared(this), wildcard) &&
-  acc(shared(this), wildcard)
-}
-
-predicate c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_unique(this), write) &&
-  acc(c_Serializable_unique(this), write)
-}
-
-predicate c_Cloneable_shared(this: Ref) {
+predicate io_c_Serializable_shared(this: Ref) {
   true
 }
 
-predicate c_Cloneable_unique(this: Ref) {
+predicate io_c_Serializable_unique(this: Ref) {
   true
 }
 
-predicate c_Serializable_unique(this: Ref) {
+predicate kotlin_c_BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
+}
+
+predicate kotlin_c_BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_unique(this), write) &&
+  acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_unique(this: Ref) {
   true
 }
 
@@ -177,15 +177,15 @@ predicate shared(this: Ref) {
   true
 }
 
-method plus(this: Ref, other: Ref) returns (v_ret: Ref)
+method plus(this: Ref, other: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
 
 
-method testOps(s: Ref) returns (ret: Ref)
+method testOps(s: Ref) returns (ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var c: Ref
   var anon: Ref
@@ -212,6 +212,6 @@ method testOps(s: Ref) returns (ret: Ref)
   assert stringFromRef(helloWorld) ==
     Seq(72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33)
   stringPlusInteger := plus(stringToRef(Seq(52, 50)), intToRef(42))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
@@ -21,16 +21,14 @@ predicate io_c_Serializable_unique(this: Ref) {
   true
 }
 
-predicate kotlin_c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
 predicate kotlin_c_BooleanArray_unique(this: Ref) {
   acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
   acc(kotlin_c_Cloneable_unique(this), write) &&
   acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_shared(this: Ref) {
+  true
 }
 
 predicate kotlin_c_Cloneable_unique(this: Ref) {
@@ -38,22 +36,24 @@ predicate kotlin_c_Cloneable_unique(this: Ref) {
 }
 
 predicate shared(this: Ref) {
-  true
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
 }
 
-method con(str: Ref) returns (ret: Ref)
+method con(str: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(ret), c_StringBox())
-  ensures acc(_c_StringBox_shared(ret), wildcard)
-  ensures acc(_c_StringBox_unique(ret), write)
-  ensures stringFromRef((unfolding acc(_c_StringBox_shared(ret), wildcard) in
-      ret.bf_str)) ==
+  ensures isSubtype(typeOf(v_ret), c_StringBox())
+  ensures acc(_c_StringBox_shared(v_ret), wildcard)
+  ensures acc(_c_StringBox_unique(v_ret), write)
+  ensures stringFromRef((unfolding acc(_c_StringBox_shared(v_ret), wildcard) in
+      v_ret.bf_str)) ==
     stringFromRef(str)
 
 
-method testType(s: Ref) returns (ret_0: Ref)
+method testType(s: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var cond1: Ref
   var anon_0: Ref
@@ -71,8 +71,8 @@ method testType(s: Ref) returns (ret_0: Ref)
   cond2 := boolToRef(stringFromRef(anon_2) == Seq(115, 116, 114))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /strings.kt: info: Generated Viper text for testLengthField:
@@ -98,16 +98,14 @@ predicate io_c_Serializable_unique(this: Ref) {
   true
 }
 
-predicate kotlin_c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
 predicate kotlin_c_BooleanArray_unique(this: Ref) {
   acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
   acc(kotlin_c_Cloneable_unique(this), write) &&
   acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_shared(this: Ref) {
+  true
 }
 
 predicate kotlin_c_Cloneable_unique(this: Ref) {
@@ -115,22 +113,24 @@ predicate kotlin_c_Cloneable_unique(this: Ref) {
 }
 
 predicate shared(this: Ref) {
-  true
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
 }
 
-method con(str: Ref) returns (ret: Ref)
+method con(str: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(ret), c_StringBox())
-  ensures acc(_c_StringBox_shared(ret), wildcard)
-  ensures acc(_c_StringBox_unique(ret), write)
-  ensures stringFromRef((unfolding acc(_c_StringBox_shared(ret), wildcard) in
-      ret.bf_str)) ==
+  ensures isSubtype(typeOf(v_ret), c_StringBox())
+  ensures acc(_c_StringBox_shared(v_ret), wildcard)
+  ensures acc(_c_StringBox_unique(v_ret), write)
+  ensures stringFromRef((unfolding acc(_c_StringBox_shared(v_ret), wildcard) in
+      v_ret.bf_str)) ==
     stringFromRef(str)
 
 
-method testLengthField(s: Ref) returns (ret_0: Ref)
+method testLengthField(s: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var len: Ref
   var cond1: Ref
@@ -142,8 +142,8 @@ method testLengthField(s: Ref) returns (ret_0: Ref)
   anon_0 := anon.bf_str
   cond1 := boolToRef(|stringFromRef(anon_0)| == 3)
   assert boolFromRef(cond1)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /strings.kt: info: Generated Viper text for testOps:
@@ -157,16 +157,14 @@ predicate io_c_Serializable_unique(this: Ref) {
   true
 }
 
-predicate kotlin_c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
 predicate kotlin_c_BooleanArray_unique(this: Ref) {
   acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
   acc(kotlin_c_Cloneable_unique(this), write) &&
   acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_shared(this: Ref) {
+  true
 }
 
 predicate kotlin_c_Cloneable_unique(this: Ref) {
@@ -174,18 +172,20 @@ predicate kotlin_c_Cloneable_unique(this: Ref) {
 }
 
 predicate shared(this: Ref) {
-  true
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
 }
 
-method plus(this: Ref, other: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), stringType())
+  ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method testOps(s: Ref) returns (ret_0: Ref)
+method testOps(s: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var c: Ref
   var anon: Ref
@@ -212,6 +212,6 @@ method testOps(s: Ref) returns (ret_0: Ref)
   assert stringFromRef(helloWorld) ==
     Seq(72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33)
   stringPlusInteger := plus(stringToRef(Seq(52, 50)), intToRef(42))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
@@ -3,76 +3,76 @@ field bf_str: Ref
 
 field size: Ref
 
-predicate _c_StringBox_shared(this: Ref) {
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate StringBox_shared(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
 }
 
-predicate _c_StringBox_unique(this: Ref) {
+predicate StringBox_unique(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
 }
 
-predicate io_c_Serializable_shared(this: Ref) {
-  true
-}
-
-predicate io_c_Serializable_unique(this: Ref) {
-  true
-}
-
-predicate kotlin_c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_unique(this), write) &&
-  acc(io_c_Serializable_unique(this), write)
-}
-
-predicate kotlin_c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate kotlin_c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
-method con(str: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(v_ret), c_StringBox())
-  ensures acc(_c_StringBox_shared(v_ret), wildcard)
-  ensures acc(_c_StringBox_unique(v_ret), write)
-  ensures stringFromRef((unfolding acc(_c_StringBox_shared(v_ret), wildcard) in
+method con(par_str: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_str), stringType())
+  ensures isSubtype(typeOf(v_ret), StringBox())
+  ensures acc(StringBox_shared(v_ret), wildcard)
+  ensures acc(StringBox_unique(v_ret), write)
+  ensures stringFromRef((unfolding acc(StringBox_shared(v_ret), wildcard) in
       v_ret.bf_str)) ==
-    stringFromRef(str)
+    stringFromRef(par_str)
 
 
-method testType(s: Ref) returns (ret: Ref)
+method testType(s: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
   var anon_0: Ref
   var anon_1: Ref
   var cond2: Ref
   var anon_2: Ref
-  var anon: Ref
+  var anon_3: Ref
   anon_1 := con(s)
-  unfold acc(_c_StringBox_shared(anon_1), wildcard)
+  unfold acc(StringBox_shared(anon_1), wildcard)
   anon_0 := anon_1.bf_str
   cond1 := boolToRef(stringFromRef(anon_0) == stringFromRef(s))
-  anon := con(stringToRef(Seq(115, 116, 114)))
-  unfold acc(_c_StringBox_shared(anon), wildcard)
-  anon_2 := anon.bf_str
+  anon_3 := con(stringToRef(Seq(115, 116, 114)))
+  unfold acc(StringBox_shared(anon_3), wildcard)
+  anon_2 := anon_3.bf_str
   cond2 := boolToRef(stringFromRef(anon_2) == Seq(115, 116, 114))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /strings.kt: info: Generated Viper text for testLengthField:
@@ -80,101 +80,101 @@ field bf_str: Ref
 
 field size: Ref
 
-predicate _c_StringBox_shared(this: Ref) {
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate StringBox_shared(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
 }
 
-predicate _c_StringBox_unique(this: Ref) {
+predicate StringBox_unique(this: Ref) {
   acc(this.bf_str, wildcard) &&
   isSubtype(typeOf(this.bf_str), stringType())
 }
 
-predicate io_c_Serializable_shared(this: Ref) {
-  true
-}
-
-predicate io_c_Serializable_unique(this: Ref) {
-  true
-}
-
-predicate kotlin_c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_unique(this), write) &&
-  acc(io_c_Serializable_unique(this), write)
-}
-
-predicate kotlin_c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate kotlin_c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
-method con(str: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(v_ret), c_StringBox())
-  ensures acc(_c_StringBox_shared(v_ret), wildcard)
-  ensures acc(_c_StringBox_unique(v_ret), write)
-  ensures stringFromRef((unfolding acc(_c_StringBox_shared(v_ret), wildcard) in
+method con(par_str: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_str), stringType())
+  ensures isSubtype(typeOf(v_ret), StringBox())
+  ensures acc(StringBox_shared(v_ret), wildcard)
+  ensures acc(StringBox_unique(v_ret), write)
+  ensures stringFromRef((unfolding acc(StringBox_shared(v_ret), wildcard) in
       v_ret.bf_str)) ==
-    stringFromRef(str)
+    stringFromRef(par_str)
 
 
-method testLengthField(s: Ref) returns (ret: Ref)
+method testLengthField(s: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var len: Ref
   var cond1: Ref
   var anon_0: Ref
-  var anon: Ref
+  var anon_1: Ref
   len := stringLength(s)
-  anon := con(stringToRef(Seq(115, 116, 114)))
-  unfold acc(_c_StringBox_shared(anon), wildcard)
-  anon_0 := anon.bf_str
+  anon_1 := con(stringToRef(Seq(115, 116, 114)))
+  unfold acc(StringBox_shared(anon_1), wildcard)
+  anon_0 := anon_1.bf_str
   cond1 := boolToRef(|stringFromRef(anon_0)| == 3)
   assert boolFromRef(cond1)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /strings.kt: info: Generated Viper text for testOps:
 field size: Ref
 
-predicate io_c_Serializable_shared(this: Ref) {
-  true
-}
-
-predicate io_c_Serializable_unique(this: Ref) {
-  true
-}
-
-predicate kotlin_c_BooleanArray_unique(this: Ref) {
+predicate BooleanArray_shared(this: Ref) {
   acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_unique(this), write) &&
-  acc(io_c_Serializable_unique(this), write)
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
 }
 
-predicate kotlin_c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate kotlin_c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate shared(this: Ref) {
+predicate BooleanArray_unique(this: Ref) {
   acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
 }
 
 method plus(this: Ref, other: Ref) returns (v_ret: Ref)
@@ -183,9 +183,9 @@ method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), stringType())
 
 
-method testOps(s: Ref) returns (ret: Ref)
+method testOps(s: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var c: Ref
   var anon: Ref
@@ -212,6 +212,6 @@ method testOps(s: Ref) returns (ret: Ref)
   assert stringFromRef(helloWorld) ==
     Seq(72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33)
   stringPlusInteger := plus(stringToRef(Seq(52, 50)), intToRef(42))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/adts/singleton.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/adts/singleton.fir.diag.txt
@@ -1,14 +1,14 @@
 /singleton.kt: info: Generated Viper text for nullableRed:
 field size: Ref
 
-method nullableRed() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), nullable(Red()))
+method nullableRed() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), nullable(Red()))
 {
   var l0_r: Ref
   l0_r := nullValue()
   l0_r := RedToRef(constr_Red())
   assert !(l0_r == nullValue())
-  ret_0 := l0_r
+  v_ret_0 := l0_r
   goto lbl_ret_0
   label lbl_ret_0
 }
@@ -20,13 +20,13 @@ adt adt_Red {
 /singleton.kt: info: Generated Viper text for returnsRed:
 field size: Ref
 
-method returnsRed() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), Red())
+method returnsRed() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), Red())
 {
   var x: Ref
   x := RedToRef(constr_Red())
   assert RedFromRef(x) == constr_Red()
-  ret_0 := x
+  v_ret_0 := x
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
@@ -1,10 +1,10 @@
 /multiple_interfaces.kt: info: Generated Viper text for take1:
-method g_field(this: Ref) returns (v_ret: Ref)
+method g_field(this: Ref) returns (ret: Ref)
 
 
-method take1(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), _c_InterfaceWithImplementation1())
-  ensures isSubtype(typeOf(ret), unitType())
+method take1(obj: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(obj), c_InterfaceWithImplementation1())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -12,17 +12,17 @@ method take1(obj: Ref) returns (ret: Ref)
   anon := g_field(obj)
   anon_0 := anon
   inhale isSubtype(typeOf(anon_0), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take2:
-method g_field(this: Ref) returns (v_ret: Ref)
+method g_field(this: Ref) returns (ret: Ref)
 
 
-method take2(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), _c_InterfaceWithoutImplementation2())
-  ensures isSubtype(typeOf(ret), unitType())
+method take2(obj: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(obj), c_InterfaceWithoutImplementation2())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -30,15 +30,15 @@ method take2(obj: Ref) returns (ret: Ref)
   anon := g_field(obj)
   anon_0 := anon
   inhale isSubtype(typeOf(anon_0), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take3:
 field bf_field: Ref
 
 method take3(obj: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(obj), _c_AbstractWithFinalImplementation3())
+  requires isSubtype(typeOf(obj), c_AbstractWithFinalImplementation3())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   inhale acc(shared(obj), wildcard)
@@ -47,12 +47,12 @@ method take3(obj: Ref) returns (ret_0: Ref)
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take4:
-method g_field(this: Ref) returns (v_ret: Ref)
+method g_field(this: Ref) returns (ret: Ref)
 
 
-method take4(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), _c_AbstractWithOpenImplementation4())
-  ensures isSubtype(typeOf(ret), unitType())
+method take4(obj: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(obj), c_AbstractWithOpenImplementation4())
+  ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -60,8 +60,8 @@ method take4(obj: Ref) returns (ret: Ref)
   anon := g_field(obj)
   anon_0 := anon
   inhale isSubtype(typeOf(anon_0), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(ret_0), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for createImpls:
@@ -70,38 +70,38 @@ field bf_field: Ref
 field size: Ref
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Impl14())
-  ensures acc(c_Impl14_shared(ret), wildcard)
-  ensures acc(c_Impl14_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_Impl3())
+  ensures acc(_c_Impl3_shared(ret), wildcard)
+  ensures acc(_c_Impl3_unique(ret), write)
 
 
-method con__c_Impl12() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Impl12())
-  ensures acc(c_Impl12_shared(ret), wildcard)
-  ensures acc(c_Impl12_unique(ret), write)
+method con_c_Impl12() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_Impl12())
+  ensures acc(_c_Impl12_shared(ret), wildcard)
+  ensures acc(_c_Impl12_unique(ret), write)
 
 
-method con__c_Impl23() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Impl23())
-  ensures acc(c_Impl23_shared(ret), wildcard)
-  ensures acc(c_Impl23_unique(ret), write)
+method con_c_Impl14() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_Impl14())
+  ensures acc(_c_Impl14_shared(ret), wildcard)
+  ensures acc(_c_Impl14_unique(ret), write)
 
 
-method con__c_Impl24() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Impl24())
-  ensures acc(c_Impl24_shared(ret), wildcard)
-  ensures acc(c_Impl24_unique(ret), write)
+method con_c_Impl23() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_Impl23())
+  ensures acc(_c_Impl23_shared(ret), wildcard)
+  ensures acc(_c_Impl23_unique(ret), write)
 
 
-method con__c_Impl3() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Impl3())
-  ensures acc(c_Impl3_shared(ret), wildcard)
-  ensures acc(c_Impl3_unique(ret), write)
+method con_c_Impl24() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_Impl24())
+  ensures acc(_c_Impl24_shared(ret), wildcard)
+  ensures acc(_c_Impl24_unique(ret), write)
 
 
 method create6() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_InheritingInterfaceWithoutImplementation6())
-  ensures acc(c_InheritingInterfaceWithoutImplementation6_shared(ret), wildcard)
+  ensures isSubtype(typeOf(ret), c_InheritingInterfaceWithoutImplementation6())
+  ensures acc(_c_InheritingInterfaceWithoutImplementation6_shared(ret), wildcard)
 
 
 method createImpls() returns (ret_0: Ref)
@@ -124,7 +124,7 @@ method createImpls() returns (ret_0: Ref)
   var impl24: Ref
   var start24: Ref
   var anon_8: Ref
-  var anon_9: Ref
+  var anon: Ref
   var anon_10: Ref
   var anon_11: Ref
   var impl14: Ref
@@ -143,36 +143,36 @@ method createImpls() returns (ret_0: Ref)
   var cond3: Ref
   var anon_19: Ref
   var cond4: Ref
-  var anon: Ref
+  var anon_20: Ref
   var cond5: Ref
-  impl12 := con__c_Impl12()
-  unfold acc(c_Impl12_shared(impl12), wildcard)
+  impl12 := con_c_Impl12()
+  unfold acc(_c_Impl12_shared(impl12), wildcard)
   anon_0 := impl12.bf_field
   start12 := minusInts(plusInts(anon_0, intToRef(1)), intToRef(1))
   anon_1 := take1(impl12)
   anon_2 := take2(impl12)
-  impl23 := con__c_Impl23()
-  unfold acc(c_Impl23_shared(impl23), wildcard)
-  unfold acc(c_AbstractWithFinalImplementation3_shared(impl23), wildcard)
+  impl23 := con_c_Impl23()
+  unfold acc(_c_Impl23_shared(impl23), wildcard)
+  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl23), wildcard)
   anon_3 := impl23.bf_field
   start23 := minusInts(plusInts(anon_3, intToRef(1)), intToRef(1))
   anon_4 := take2(impl23)
   anon_5 := take3(impl23)
-  impl3 := con__c_Impl3()
-  unfold acc(c_Impl3_shared(impl3), wildcard)
-  unfold acc(c_AbstractWithFinalImplementation3_shared(impl3), wildcard)
+  impl3 := con()
+  unfold acc(_c_Impl3_shared(impl3), wildcard)
+  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl3), wildcard)
   anon_6 := impl3.bf_field
   start3 := minusInts(plusInts(anon_6, intToRef(1)), intToRef(1))
   anon_7 := take3(impl3)
-  impl24 := con__c_Impl24()
-  anon_9 := g_field(impl24)
-  anon_8 := anon_9
+  impl24 := con_c_Impl24()
+  anon := g_field(impl24)
+  anon_8 := anon
   inhale isSubtype(typeOf(anon_8), intType())
   start24 := minusInts(plusInts(anon_8, intToRef(1)), intToRef(1))
   anon_10 := take2(impl24)
   anon_11 := take4(impl24)
-  impl14 := con()
-  unfold acc(c_Impl14_shared(impl14), wildcard)
+  impl14 := con_c_Impl14()
+  unfold acc(_c_Impl14_shared(impl14), wildcard)
   anon_12 := impl14.bf_field
   start14 := minusInts(plusInts(anon_12, intToRef(1)), intToRef(1))
   anon_13 := take1(impl14)
@@ -182,20 +182,20 @@ method createImpls() returns (ret_0: Ref)
   anon_15 := anon_16
   inhale isSubtype(typeOf(anon_15), intType())
   start6 := minusInts(plusInts(anon_15, intToRef(1)), intToRef(1))
-  unfold acc(c_Impl12_shared(impl12), wildcard)
+  unfold acc(_c_Impl12_shared(impl12), wildcard)
   anon_17 := impl12.bf_field
   cond1 := boolToRef(intFromRef(start12) == intFromRef(anon_17))
-  unfold acc(c_Impl23_shared(impl23), wildcard)
-  unfold acc(c_AbstractWithFinalImplementation3_shared(impl23), wildcard)
+  unfold acc(_c_Impl23_shared(impl23), wildcard)
+  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl23), wildcard)
   anon_18 := impl23.bf_field
   cond2 := boolToRef(intFromRef(start23) == intFromRef(anon_18))
-  unfold acc(c_Impl3_shared(impl3), wildcard)
-  unfold acc(c_AbstractWithFinalImplementation3_shared(impl3), wildcard)
+  unfold acc(_c_Impl3_shared(impl3), wildcard)
+  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl3), wildcard)
   anon_19 := impl3.bf_field
   cond3 := boolToRef(intFromRef(start3) == intFromRef(anon_19))
-  unfold acc(c_Impl14_shared(impl14), wildcard)
-  anon := impl14.bf_field
-  cond4 := boolToRef(intFromRef(start14) == intFromRef(anon))
+  unfold acc(_c_Impl14_shared(impl14), wildcard)
+  anon_20 := impl14.bf_field
+  cond4 := boolToRef(intFromRef(start14) == intFromRef(anon_20))
   cond5 := boolToRef(isSubtype(typeOf(start6), intType()))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
@@ -210,20 +210,20 @@ method g_field(this: Ref) returns (ret: Ref)
 
 
 method take1(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), _c_InterfaceWithImplementation1())
+  requires isSubtype(typeOf(obj), c_InterfaceWithImplementation1())
   ensures isSubtype(typeOf(ret), unitType())
 
 
 method take2(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), _c_InterfaceWithoutImplementation2())
+  requires isSubtype(typeOf(obj), c_InterfaceWithoutImplementation2())
   ensures isSubtype(typeOf(ret), unitType())
 
 
 method take3(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), _c_AbstractWithFinalImplementation3())
+  requires isSubtype(typeOf(obj), c_AbstractWithFinalImplementation3())
   ensures isSubtype(typeOf(ret), unitType())
 
 
 method take4(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), _c_AbstractWithOpenImplementation4())
+  requires isSubtype(typeOf(obj), c_AbstractWithOpenImplementation4())
   ensures isSubtype(typeOf(ret), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
@@ -1,10 +1,10 @@
 /multiple_interfaces.kt: info: Generated Viper text for take1:
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method take1(obj: Ref) returns (ret_0: Ref)
+method take1(obj: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(obj), c_InterfaceWithImplementation1())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -12,17 +12,17 @@ method take1(obj: Ref) returns (ret_0: Ref)
   anon := g_field(obj)
   anon_0 := anon
   inhale isSubtype(typeOf(anon_0), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take2:
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method take2(obj: Ref) returns (ret_0: Ref)
+method take2(obj: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(obj), c_InterfaceWithoutImplementation2())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -30,29 +30,29 @@ method take2(obj: Ref) returns (ret_0: Ref)
   anon := g_field(obj)
   anon_0 := anon
   inhale isSubtype(typeOf(anon_0), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take3:
 field bf_field: Ref
 
-method take3(obj: Ref) returns (ret_0: Ref)
+method take3(obj: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(obj), c_AbstractWithFinalImplementation3())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   inhale acc(shared(obj), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take4:
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method take4(obj: Ref) returns (ret_0: Ref)
+method take4(obj: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(obj), c_AbstractWithOpenImplementation4())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon_0: Ref
   var anon: Ref
@@ -60,8 +60,8 @@ method take4(obj: Ref) returns (ret_0: Ref)
   anon := g_field(obj)
   anon_0 := anon
   inhale isSubtype(typeOf(anon_0), intType())
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for createImpls:
@@ -69,43 +69,43 @@ field bf_field: Ref
 
 field size: Ref
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Impl3())
-  ensures acc(_c_Impl3_shared(ret), wildcard)
-  ensures acc(_c_Impl3_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Impl3())
+  ensures acc(_c_Impl3_shared(v_ret), wildcard)
+  ensures acc(_c_Impl3_unique(v_ret), write)
 
 
-method con_c_Impl12() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Impl12())
-  ensures acc(_c_Impl12_shared(ret), wildcard)
-  ensures acc(_c_Impl12_unique(ret), write)
+method con_c_Impl12() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Impl12())
+  ensures acc(_c_Impl12_shared(v_ret), wildcard)
+  ensures acc(_c_Impl12_unique(v_ret), write)
 
 
-method con_c_Impl14() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Impl14())
-  ensures acc(_c_Impl14_shared(ret), wildcard)
-  ensures acc(_c_Impl14_unique(ret), write)
+method con_c_Impl14() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Impl14())
+  ensures acc(_c_Impl14_shared(v_ret), wildcard)
+  ensures acc(_c_Impl14_unique(v_ret), write)
 
 
-method con_c_Impl23() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Impl23())
-  ensures acc(_c_Impl23_shared(ret), wildcard)
-  ensures acc(_c_Impl23_unique(ret), write)
+method con_c_Impl23() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Impl23())
+  ensures acc(_c_Impl23_shared(v_ret), wildcard)
+  ensures acc(_c_Impl23_unique(v_ret), write)
 
 
-method con_c_Impl24() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Impl24())
-  ensures acc(_c_Impl24_shared(ret), wildcard)
-  ensures acc(_c_Impl24_unique(ret), write)
+method con_c_Impl24() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Impl24())
+  ensures acc(_c_Impl24_shared(v_ret), wildcard)
+  ensures acc(_c_Impl24_unique(v_ret), write)
 
 
-method create6() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_InheritingInterfaceWithoutImplementation6())
-  ensures acc(_c_InheritingInterfaceWithoutImplementation6_shared(ret), wildcard)
+method create6() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_InheritingInterfaceWithoutImplementation6())
+  ensures acc(_c_InheritingInterfaceWithoutImplementation6_shared(v_ret), wildcard)
 
 
-method createImpls() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method createImpls() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var impl12: Ref
   var start12: Ref
@@ -124,7 +124,7 @@ method createImpls() returns (ret_0: Ref)
   var impl24: Ref
   var start24: Ref
   var anon_8: Ref
-  var anon: Ref
+  var anon_9: Ref
   var anon_10: Ref
   var anon_11: Ref
   var impl14: Ref
@@ -143,7 +143,7 @@ method createImpls() returns (ret_0: Ref)
   var cond3: Ref
   var anon_19: Ref
   var cond4: Ref
-  var anon_20: Ref
+  var anon: Ref
   var cond5: Ref
   impl12 := con_c_Impl12()
   unfold acc(_c_Impl12_shared(impl12), wildcard)
@@ -165,8 +165,8 @@ method createImpls() returns (ret_0: Ref)
   start3 := minusInts(plusInts(anon_6, intToRef(1)), intToRef(1))
   anon_7 := take3(impl3)
   impl24 := con_c_Impl24()
-  anon := g_field(impl24)
-  anon_8 := anon
+  anon_9 := g_field(impl24)
+  anon_8 := anon_9
   inhale isSubtype(typeOf(anon_8), intType())
   start24 := minusInts(plusInts(anon_8, intToRef(1)), intToRef(1))
   anon_10 := take2(impl24)
@@ -194,36 +194,36 @@ method createImpls() returns (ret_0: Ref)
   anon_19 := impl3.bf_field
   cond3 := boolToRef(intFromRef(start3) == intFromRef(anon_19))
   unfold acc(_c_Impl14_shared(impl14), wildcard)
-  anon_20 := impl14.bf_field
-  cond4 := boolToRef(intFromRef(start14) == intFromRef(anon_20))
+  anon := impl14.bf_field
+  cond4 := boolToRef(intFromRef(start14) == intFromRef(anon))
   cond5 := boolToRef(isSubtype(typeOf(start6), intType()))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
   assert boolFromRef(cond3)
   assert boolFromRef(cond4)
   assert boolFromRef(cond5)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method take1(obj: Ref) returns (ret: Ref)
+method take1(obj: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(obj), c_InterfaceWithImplementation1())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method take2(obj: Ref) returns (ret: Ref)
+method take2(obj: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(obj), c_InterfaceWithoutImplementation2())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method take3(obj: Ref) returns (ret: Ref)
+method take3(obj: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(obj), c_AbstractWithFinalImplementation3())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method take4(obj: Ref) returns (ret: Ref)
+method take4(obj: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(obj), c_AbstractWithOpenImplementation4())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/multiple_interfaces.fir.diag.txt
@@ -2,66 +2,66 @@
 method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method take1(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), c_InterfaceWithImplementation1())
-  ensures isSubtype(typeOf(ret), unitType())
+method take1(obj: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(obj), InterfaceWithImplementation1())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var anon: Ref
+  var anon_1: Ref
   inhale acc(shared(obj), wildcard)
-  anon := g_field(obj)
-  anon_0 := anon
+  anon_1 := g_field(obj)
+  anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take2:
 method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method take2(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), c_InterfaceWithoutImplementation2())
-  ensures isSubtype(typeOf(ret), unitType())
+method take2(obj: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(obj), InterfaceWithoutImplementation2())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var anon: Ref
+  var anon_1: Ref
   inhale acc(shared(obj), wildcard)
-  anon := g_field(obj)
-  anon_0 := anon
+  anon_1 := g_field(obj)
+  anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take3:
 field bf_field: Ref
 
-method take3(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), c_AbstractWithFinalImplementation3())
-  ensures isSubtype(typeOf(ret), unitType())
+method take3(obj: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(obj), AbstractWithFinalImplementation3())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   inhale acc(shared(obj), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for take4:
 method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method take4(obj: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(obj), c_AbstractWithOpenImplementation4())
-  ensures isSubtype(typeOf(ret), unitType())
+method take4(obj: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(obj), AbstractWithOpenImplementation4())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
-  var anon: Ref
+  var anon_1: Ref
   inhale acc(shared(obj), wildcard)
-  anon := g_field(obj)
-  anon_0 := anon
+  anon_1 := g_field(obj)
+  anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /multiple_interfaces.kt: info: Generated Viper text for createImpls:
@@ -69,43 +69,43 @@ field bf_field: Ref
 
 field size: Ref
 
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Impl3())
-  ensures acc(_c_Impl3_shared(v_ret), wildcard)
-  ensures acc(_c_Impl3_unique(v_ret), write)
+method con_Impl12() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Impl12())
+  ensures acc(Impl12_shared(v_ret), wildcard)
+  ensures acc(Impl12_unique(v_ret), write)
 
 
-method con_c_Impl12() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Impl12())
-  ensures acc(_c_Impl12_shared(v_ret), wildcard)
-  ensures acc(_c_Impl12_unique(v_ret), write)
+method con_Impl14() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Impl14())
+  ensures acc(Impl14_shared(v_ret), wildcard)
+  ensures acc(Impl14_unique(v_ret), write)
 
 
-method con_c_Impl14() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Impl14())
-  ensures acc(_c_Impl14_shared(v_ret), wildcard)
-  ensures acc(_c_Impl14_unique(v_ret), write)
+method con_Impl23() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Impl23())
+  ensures acc(Impl23_shared(v_ret), wildcard)
+  ensures acc(Impl23_unique(v_ret), write)
 
 
-method con_c_Impl23() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Impl23())
-  ensures acc(_c_Impl23_shared(v_ret), wildcard)
-  ensures acc(_c_Impl23_unique(v_ret), write)
+method con_Impl24() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Impl24())
+  ensures acc(Impl24_shared(v_ret), wildcard)
+  ensures acc(Impl24_unique(v_ret), write)
 
 
-method con_c_Impl24() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Impl24())
-  ensures acc(_c_Impl24_shared(v_ret), wildcard)
-  ensures acc(_c_Impl24_unique(v_ret), write)
+method con_Impl3() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), Impl3())
+  ensures acc(Impl3_shared(v_ret), wildcard)
+  ensures acc(Impl3_unique(v_ret), write)
 
 
 method create6() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_InheritingInterfaceWithoutImplementation6())
-  ensures acc(_c_InheritingInterfaceWithoutImplementation6_shared(v_ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), InheritingInterfaceWithoutImplementation6())
+  ensures acc(InheritingInterfaceWithoutImplementation6_shared(v_ret), wildcard)
 
 
-method createImpls() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method createImpls() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var impl12: Ref
   var start12: Ref
@@ -143,36 +143,36 @@ method createImpls() returns (ret: Ref)
   var cond3: Ref
   var anon_19: Ref
   var cond4: Ref
-  var anon: Ref
+  var anon_20: Ref
   var cond5: Ref
-  impl12 := con_c_Impl12()
-  unfold acc(_c_Impl12_shared(impl12), wildcard)
+  impl12 := con_Impl12()
+  unfold acc(Impl12_shared(impl12), wildcard)
   anon_0 := impl12.bf_field
   start12 := minusInts(plusInts(anon_0, intToRef(1)), intToRef(1))
   anon_1 := take1(impl12)
   anon_2 := take2(impl12)
-  impl23 := con_c_Impl23()
-  unfold acc(_c_Impl23_shared(impl23), wildcard)
-  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl23), wildcard)
+  impl23 := con_Impl23()
+  unfold acc(Impl23_shared(impl23), wildcard)
+  unfold acc(AbstractWithFinalImplementation3_shared(impl23), wildcard)
   anon_3 := impl23.bf_field
   start23 := minusInts(plusInts(anon_3, intToRef(1)), intToRef(1))
   anon_4 := take2(impl23)
   anon_5 := take3(impl23)
-  impl3 := con()
-  unfold acc(_c_Impl3_shared(impl3), wildcard)
-  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl3), wildcard)
+  impl3 := con_Impl3()
+  unfold acc(Impl3_shared(impl3), wildcard)
+  unfold acc(AbstractWithFinalImplementation3_shared(impl3), wildcard)
   anon_6 := impl3.bf_field
   start3 := minusInts(plusInts(anon_6, intToRef(1)), intToRef(1))
   anon_7 := take3(impl3)
-  impl24 := con_c_Impl24()
+  impl24 := con_Impl24()
   anon_9 := g_field(impl24)
   anon_8 := anon_9
   inhale isSubtype(typeOf(anon_8), intType())
   start24 := minusInts(plusInts(anon_8, intToRef(1)), intToRef(1))
   anon_10 := take2(impl24)
   anon_11 := take4(impl24)
-  impl14 := con_c_Impl14()
-  unfold acc(_c_Impl14_shared(impl14), wildcard)
+  impl14 := con_Impl14()
+  unfold acc(Impl14_shared(impl14), wildcard)
   anon_12 := impl14.bf_field
   start14 := minusInts(plusInts(anon_12, intToRef(1)), intToRef(1))
   anon_13 := take1(impl14)
@@ -182,48 +182,48 @@ method createImpls() returns (ret: Ref)
   anon_15 := anon_16
   inhale isSubtype(typeOf(anon_15), intType())
   start6 := minusInts(plusInts(anon_15, intToRef(1)), intToRef(1))
-  unfold acc(_c_Impl12_shared(impl12), wildcard)
+  unfold acc(Impl12_shared(impl12), wildcard)
   anon_17 := impl12.bf_field
   cond1 := boolToRef(intFromRef(start12) == intFromRef(anon_17))
-  unfold acc(_c_Impl23_shared(impl23), wildcard)
-  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl23), wildcard)
+  unfold acc(Impl23_shared(impl23), wildcard)
+  unfold acc(AbstractWithFinalImplementation3_shared(impl23), wildcard)
   anon_18 := impl23.bf_field
   cond2 := boolToRef(intFromRef(start23) == intFromRef(anon_18))
-  unfold acc(_c_Impl3_shared(impl3), wildcard)
-  unfold acc(_c_AbstractWithFinalImplementation3_shared(impl3), wildcard)
+  unfold acc(Impl3_shared(impl3), wildcard)
+  unfold acc(AbstractWithFinalImplementation3_shared(impl3), wildcard)
   anon_19 := impl3.bf_field
   cond3 := boolToRef(intFromRef(start3) == intFromRef(anon_19))
-  unfold acc(_c_Impl14_shared(impl14), wildcard)
-  anon := impl14.bf_field
-  cond4 := boolToRef(intFromRef(start14) == intFromRef(anon))
+  unfold acc(Impl14_shared(impl14), wildcard)
+  anon_20 := impl14.bf_field
+  cond4 := boolToRef(intFromRef(start14) == intFromRef(anon_20))
   cond5 := boolToRef(isSubtype(typeOf(start6), intType()))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
   assert boolFromRef(cond3)
   assert boolFromRef(cond4)
   assert boolFromRef(cond5)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method g_field(this: Ref) returns (v_ret: Ref)
 
 
 method take1(obj: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(obj), c_InterfaceWithImplementation1())
+  requires isSubtype(typeOf(obj), InterfaceWithImplementation1())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
 method take2(obj: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(obj), c_InterfaceWithoutImplementation2())
+  requires isSubtype(typeOf(obj), InterfaceWithoutImplementation2())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
 method take3(obj: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(obj), c_AbstractWithFinalImplementation3())
+  requires isSubtype(typeOf(obj), AbstractWithFinalImplementation3())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
 method take4(obj: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(obj), c_AbstractWithOpenImplementation4())
+  requires isSubtype(typeOf(obj), AbstractWithOpenImplementation4())
   ensures isSubtype(typeOf(v_ret), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
@@ -1,44 +1,44 @@
 /override_properties_types.kt: info: Generated Viper text for extractInt:
 field bf_field: Ref
 
-method extractInt(base: Ref, returnNull: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(base), _c_Base())
+method extractInt(base: Ref, returnNull: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(base), c_Base())
   requires isSubtype(typeOf(returnNull), boolType())
-  ensures isSubtype(typeOf(ret), nullable(intType()))
-  ensures ret == nullValue() ==> boolFromRef(returnNull)
+  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures ret_0 == nullValue() ==> boolFromRef(returnNull)
 {
-  inhale acc(c_Base_shared(base), wildcard)
+  inhale acc(_c_Base_shared(base), wildcard)
   if (boolFromRef(returnNull)) {
     var anon_0: Ref
     anon_0 := nullValue()
-    ret := anon_0
+    ret_0 := anon_0
   } else {
     var anon_1: Ref
-    if (isSubtype(typeOf(base), _c_OpenClassOpenFieldVarDerived())) {
+    if (isSubtype(typeOf(base), c_OpenClassOpenFieldVarDerived())) {
       var anon: Ref
-      inhale acc(c_OpenClassOpenFieldVarDerived_shared(base), wildcard)
+      inhale acc(_c_OpenClassOpenFieldVarDerived_shared(base), wildcard)
       anon := g_field(base)
       anon_1 := anon
       inhale isSubtype(typeOf(anon_1), intType())
-    } elseif (isSubtype(typeOf(base), _c_FinalClassOpenFieldVarDerived())) {
-      inhale acc(c_FinalClassOpenFieldVarDerived_shared(base), wildcard)
+    } elseif (isSubtype(typeOf(base), c_FinalClassOpenFieldVarDerived())) {
+      inhale acc(_c_FinalClassOpenFieldVarDerived_shared(base), wildcard)
       anon_1 := havoc()
-    } elseif (isSubtype(typeOf(base), _c_FinalClassFinalFieldValDerived())) {
-      inhale acc(c_FinalClassFinalFieldValDerived_shared(base), wildcard)
-      unfold acc(c_FinalClassFinalFieldValDerived_shared(base), wildcard)
+    } elseif (isSubtype(typeOf(base), c_FinalClassFinalFieldValDerived())) {
+      inhale acc(_c_FinalClassFinalFieldValDerived_shared(base), wildcard)
+      unfold acc(_c_FinalClassFinalFieldValDerived_shared(base), wildcard)
       anon_1 := base.bf_field
-    } elseif (isSubtype(typeOf(base), _c_OpenClassFinalFieldVarDerived())) {
-      inhale acc(c_OpenClassFinalFieldVarDerived_shared(base), wildcard)
+    } elseif (isSubtype(typeOf(base), c_OpenClassFinalFieldVarDerived())) {
+      inhale acc(_c_OpenClassFinalFieldVarDerived_shared(base), wildcard)
       anon_1 := havoc()
     } else {
       anon_1 := intToRef(0)}
-    ret := anon_1
+    ret_0 := anon_1
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method g_field(this: Ref) returns (v_ret: Ref)
+method g_field(this: Ref) returns (ret: Ref)
 
 
-method s_field(this: Ref, anon_0: Ref) returns (v_ret: Ref)
+method s_field(this: Ref, anon_0: Ref) returns (ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
@@ -1,17 +1,17 @@
 /override_properties_types.kt: info: Generated Viper text for extractInt:
 field bf_field: Ref
 
-method extractInt(base: Ref, returnNull: Ref) returns (ret_0: Ref)
+method extractInt(base: Ref, returnNull: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(base), c_Base())
   requires isSubtype(typeOf(returnNull), boolType())
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
-  ensures ret_0 == nullValue() ==> boolFromRef(returnNull)
+  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures ret == nullValue() ==> boolFromRef(returnNull)
 {
   inhale acc(_c_Base_shared(base), wildcard)
   if (boolFromRef(returnNull)) {
     var anon_0: Ref
     anon_0 := nullValue()
-    ret_0 := anon_0
+    ret := anon_0
   } else {
     var anon_1: Ref
     if (isSubtype(typeOf(base), c_OpenClassOpenFieldVarDerived())) {
@@ -24,21 +24,21 @@ method extractInt(base: Ref, returnNull: Ref) returns (ret_0: Ref)
       inhale acc(_c_FinalClassOpenFieldVarDerived_shared(base), wildcard)
       anon_1 := havoc()
     } elseif (isSubtype(typeOf(base), c_FinalClassFinalFieldValDerived())) {
-      inhale acc(_c_FinalClassFinalFieldValDerived_shared(base), wildcard)
-      unfold acc(_c_FinalClassFinalFieldValDerived_shared(base), wildcard)
+      inhale acc(shared(base), wildcard)
+      unfold acc(shared(base), wildcard)
       anon_1 := base.bf_field
     } elseif (isSubtype(typeOf(base), c_OpenClassFinalFieldVarDerived())) {
       inhale acc(_c_OpenClassFinalFieldVarDerived_shared(base), wildcard)
       anon_1 := havoc()
     } else {
       anon_1 := intToRef(0)}
-    ret_0 := anon_1
+    ret := anon_1
   }
-  goto lbl_ret_0
-  label lbl_ret_0
+  goto ret_0
+  label ret_0
 }
 
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method s_field(this: Ref, anon_0: Ref) returns (ret: Ref)
+method s_field(this: Ref, anon_0: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/override_properties_types.fir.diag.txt
@@ -1,41 +1,41 @@
 /override_properties_types.kt: info: Generated Viper text for extractInt:
 field bf_field: Ref
 
-method extractInt(base: Ref, returnNull: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(base), c_Base())
+method extractInt(base: Ref, returnNull: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(base), Base())
   requires isSubtype(typeOf(returnNull), boolType())
-  ensures isSubtype(typeOf(ret), nullable(intType()))
-  ensures ret == nullValue() ==> boolFromRef(returnNull)
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
+  ensures v_ret_0 == nullValue() ==> boolFromRef(returnNull)
 {
-  inhale acc(_c_Base_shared(base), wildcard)
+  inhale acc(Base_shared(base), wildcard)
   if (boolFromRef(returnNull)) {
     var anon_0: Ref
     anon_0 := nullValue()
-    ret := anon_0
+    v_ret_0 := anon_0
   } else {
     var anon_1: Ref
-    if (isSubtype(typeOf(base), c_OpenClassOpenFieldVarDerived())) {
-      var anon: Ref
-      inhale acc(_c_OpenClassOpenFieldVarDerived_shared(base), wildcard)
-      anon := g_field(base)
-      anon_1 := anon
+    if (isSubtype(typeOf(base), OpenClassOpenFieldVarDerived())) {
+      var anon_2: Ref
+      inhale acc(OpenClassOpenFieldVarDerived_shared(base), wildcard)
+      anon_2 := g_field(base)
+      anon_1 := anon_2
       inhale isSubtype(typeOf(anon_1), intType())
-    } elseif (isSubtype(typeOf(base), c_FinalClassOpenFieldVarDerived())) {
-      inhale acc(_c_FinalClassOpenFieldVarDerived_shared(base), wildcard)
+    } elseif (isSubtype(typeOf(base), FinalClassOpenFieldVarDerived())) {
+      inhale acc(FinalClassOpenFieldVarDerived_shared(base), wildcard)
       anon_1 := havoc()
-    } elseif (isSubtype(typeOf(base), c_FinalClassFinalFieldValDerived())) {
-      inhale acc(shared(base), wildcard)
-      unfold acc(shared(base), wildcard)
+    } elseif (isSubtype(typeOf(base), FinalClassFinalFieldValDerived())) {
+      inhale acc(FinalClassFinalFieldValDerived_shared(base), wildcard)
+      unfold acc(FinalClassFinalFieldValDerived_shared(base), wildcard)
       anon_1 := base.bf_field
-    } elseif (isSubtype(typeOf(base), c_OpenClassFinalFieldVarDerived())) {
-      inhale acc(_c_OpenClassFinalFieldVarDerived_shared(base), wildcard)
+    } elseif (isSubtype(typeOf(base), OpenClassFinalFieldVarDerived())) {
+      inhale acc(OpenClassFinalFieldVarDerived_shared(base), wildcard)
       anon_1 := havoc()
     } else {
       anon_1 := intToRef(0)}
-    ret := anon_1
+    v_ret_0 := anon_1
   }
-  goto ret_0
-  label ret_0
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method g_field(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
@@ -1,41 +1,41 @@
 /private_properties.kt: info: Generated Viper text for getBooleanField:
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method getBooleanField(this: Ref) returns (ret_0: Ref)
+method getBooleanField(this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_A())
-  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures isSubtype(typeOf(ret), boolType())
 {
   var anon: Ref
   inhale acc(shared(this), wildcard)
   anon := g_field(this)
-  ret_0 := anon
-  inhale isSubtype(typeOf(ret_0), boolType())
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := anon
+  inhale isSubtype(typeOf(ret), boolType())
+  goto ret_0
+  label ret_0
 }
 
-method s_field(this: Ref, anon: Ref) returns (ret: Ref)
+method s_field(this: Ref, anon: Ref) returns (v_ret: Ref)
 
 
 /private_properties.kt: info: Generated Viper text for getStringField:
 field bf_field: Ref
 
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method getStringField(this: Ref) returns (ret_0: Ref)
+method getStringField(this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_B())
-  ensures isSubtype(typeOf(ret_0), stringType())
+  ensures isSubtype(typeOf(ret), stringType())
 {
   inhale acc(shared(this), wildcard)
   unfold acc(shared(this), wildcard)
-  ret_0 := this.bf_field
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := this.bf_field
+  goto ret_0
+  label ret_0
 }
 
-method s_field(this: Ref, anon: Ref) returns (ret: Ref)
+method s_field(this: Ref, anon: Ref) returns (v_ret: Ref)
 
 
 /private_properties.kt: info: Generated Viper text for extractPublic:
@@ -45,20 +45,20 @@ field private_bf_field: Ref
 
 field size: Ref
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_D())
-  ensures acc(_c_D_shared(ret), wildcard)
-  ensures acc(_c_D_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_D())
+  ensures acc(_c_D_shared(v_ret), wildcard)
+  ensures acc(_c_D_unique(v_ret), write)
 
 
-method con_c_C() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_C())
-  ensures acc(_c_C_shared(ret), wildcard)
-  ensures acc(_c_C_unique(ret), write)
+method con_c_C() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_C())
+  ensures acc(_c_C_shared(v_ret), wildcard)
+  ensures acc(_c_C_unique(v_ret), write)
 
 
-method extractPublic() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method extractPublic() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var cond1: Ref
   var anon_0: Ref
@@ -75,11 +75,11 @@ method extractPublic() returns (ret_0: Ref)
   cond2 := boolToRef(isSubtype(typeOf(anon_2), intType()))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method g_field(this: Ref) returns (ret: Ref)
+method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method s_field(this: Ref, anon_0: Ref) returns (ret: Ref)
+method s_field(this: Ref, anon_0: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
@@ -1,60 +1,60 @@
 /private_properties.kt: info: Generated Viper text for getBooleanField:
-method g_field(this: Ref) returns (v_ret: Ref)
+method g_field(this: Ref) returns (ret: Ref)
 
 
-method getBooleanField(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_A())
-  ensures isSubtype(typeOf(ret), boolType())
+method getBooleanField(this: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(this), c_A())
+  ensures isSubtype(typeOf(ret_0), boolType())
 {
   var anon: Ref
   inhale acc(shared(this), wildcard)
   anon := g_field(this)
-  ret := anon
-  inhale isSubtype(typeOf(ret), boolType())
-  goto ret_0
-  label ret_0
+  ret_0 := anon
+  inhale isSubtype(typeOf(ret_0), boolType())
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method s_field(this: Ref, anon: Ref) returns (v_ret: Ref)
+method s_field(this: Ref, anon: Ref) returns (ret: Ref)
 
 
 /private_properties.kt: info: Generated Viper text for getStringField:
 field bf_field: Ref
 
-method g_field(this: Ref) returns (v_ret: Ref)
+method g_field(this: Ref) returns (ret: Ref)
 
 
-method getStringField(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_B())
-  ensures isSubtype(typeOf(ret), stringType())
+method getStringField(this: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(this), c_B())
+  ensures isSubtype(typeOf(ret_0), stringType())
 {
-  inhale acc(c_B_shared(this), wildcard)
-  unfold acc(c_B_shared(this), wildcard)
-  ret := this.bf_field
-  goto ret_0
-  label ret_0
+  inhale acc(shared(this), wildcard)
+  unfold acc(shared(this), wildcard)
+  ret_0 := this.bf_field
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method s_field(this: Ref, anon: Ref) returns (v_ret: Ref)
+method s_field(this: Ref, anon: Ref) returns (ret: Ref)
 
 
 /private_properties.kt: info: Generated Viper text for extractPublic:
 field bf_field: Ref
 
-field c_B_private_bf_field: Ref
+field private_bf_field: Ref
 
 field size: Ref
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_D())
-  ensures acc(c_D_shared(ret), wildcard)
-  ensures acc(c_D_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_D())
+  ensures acc(_c_D_shared(ret), wildcard)
+  ensures acc(_c_D_unique(ret), write)
 
 
-method con__c_C() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_C())
-  ensures acc(c_C_shared(ret), wildcard)
-  ensures acc(c_C_unique(ret), write)
+method con_c_C() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), c_C())
+  ensures acc(_c_C_shared(ret), wildcard)
+  ensures acc(_c_C_unique(ret), write)
 
 
 method extractPublic() returns (ret_0: Ref)
@@ -66,11 +66,11 @@ method extractPublic() returns (ret_0: Ref)
   var cond2: Ref
   var anon_2: Ref
   var anon: Ref
-  anon_1 := con__c_C()
+  anon_1 := con_c_C()
   anon_0 := havoc_Int()
   cond1 := boolToRef(isSubtype(typeOf(anon_0), intType()))
   anon := con()
-  unfold acc(c_D_shared(anon), wildcard)
+  unfold acc(_c_D_shared(anon), wildcard)
   anon_2 := anon.bf_field
   cond2 := boolToRef(isSubtype(typeOf(anon_2), intType()))
   assert boolFromRef(cond1)

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
@@ -2,17 +2,17 @@
 method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method getBooleanField(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_A())
-  ensures isSubtype(typeOf(ret), boolType())
+method getBooleanField(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), A())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
 {
   var anon: Ref
   inhale acc(shared(this), wildcard)
   anon := g_field(this)
-  ret := anon
-  inhale isSubtype(typeOf(ret), boolType())
-  goto ret_0
-  label ret_0
+  v_ret_0 := anon
+  inhale isSubtype(typeOf(v_ret_0), boolType())
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method s_field(this: Ref, anon: Ref) returns (v_ret: Ref)
@@ -24,15 +24,15 @@ field bf_field: Ref
 method g_field(this: Ref) returns (v_ret: Ref)
 
 
-method getStringField(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_B())
-  ensures isSubtype(typeOf(ret), stringType())
+method getStringField(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), B())
+  ensures isSubtype(typeOf(v_ret_0), stringType())
 {
-  inhale acc(shared(this), wildcard)
-  unfold acc(shared(this), wildcard)
-  ret := this.bf_field
-  goto ret_0
-  label ret_0
+  inhale acc(B_shared(this), wildcard)
+  unfold acc(B_shared(this), wildcard)
+  v_ret_0 := this.bf_field
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method s_field(this: Ref, anon: Ref) returns (v_ret: Ref)
@@ -45,38 +45,38 @@ field private_bf_field: Ref
 
 field size: Ref
 
-method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_D())
-  ensures acc(_c_D_shared(v_ret), wildcard)
-  ensures acc(_c_D_unique(v_ret), write)
+method con_C() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), C())
+  ensures acc(C_shared(v_ret), wildcard)
+  ensures acc(C_unique(v_ret), write)
 
 
-method con_c_C() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_C())
-  ensures acc(_c_C_shared(v_ret), wildcard)
-  ensures acc(_c_C_unique(v_ret), write)
+method con_D() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), D())
+  ensures acc(D_shared(v_ret), wildcard)
+  ensures acc(D_unique(v_ret), write)
 
 
-method extractPublic() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method extractPublic() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
   var anon_0: Ref
   var anon_1: Ref
   var cond2: Ref
   var anon_2: Ref
-  var anon: Ref
-  anon_1 := con_c_C()
+  var anon_3: Ref
+  anon_1 := con_C()
   anon_0 := havoc_Int()
   cond1 := boolToRef(isSubtype(typeOf(anon_0), intType()))
-  anon := con()
-  unfold acc(_c_D_shared(anon), wildcard)
-  anon_2 := anon.bf_field
+  anon_3 := con_D()
+  unfold acc(D_shared(anon_3), wildcard)
+  anon_2 := anon_3.bf_field
   cond2 := boolToRef(isSubtype(typeOf(anon_2), intType()))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method g_field(this: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
@@ -1,10 +1,10 @@
 /as_type_contract.kt: info: Generated Viper text for getX:
 field x: Ref
 
-method getX(a: Ref) returns (ret_0: Ref)
+method getX(a: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), anyType())
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
-  ensures ret_0 != nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
+  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures ret != nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
 {
   var anon_0: Ref
   if (isSubtype(typeOf(a), c_IntHolder())) {
@@ -18,9 +18,9 @@ method getX(a: Ref) returns (ret_0: Ref)
     var anon: Ref
     unfold acc(_c_IntHolder_shared(anon_0), wildcard)
     anon := anon_0.x
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
@@ -4,19 +4,19 @@ field x: Ref
 method getX(a: Ref) returns (ret_0: Ref)
   requires isSubtype(typeOf(a), anyType())
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
-  ensures ret_0 != nullValue() ==> !isSubtype(typeOf(a), _c_IntHolder())
+  ensures ret_0 != nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
 {
   var anon_0: Ref
-  if (isSubtype(typeOf(a), _c_IntHolder())) {
+  if (isSubtype(typeOf(a), c_IntHolder())) {
     anon_0 := a
   } else {
     anon_0 := nullValue()}
-  inhale isSubtype(typeOf(anon_0), nullable(_c_IntHolder()))
+  inhale isSubtype(typeOf(anon_0), nullable(c_IntHolder()))
   inhale anon_0 != nullValue() ==>
-    acc(c_IntHolder_shared(anon_0), wildcard)
+    acc(_c_IntHolder_shared(anon_0), wildcard)
   if (anon_0 != nullValue()) {
     var anon: Ref
-    unfold acc(c_IntHolder_shared(anon_0), wildcard)
+    unfold acc(_c_IntHolder_shared(anon_0), wildcard)
     anon := anon_0.x
     ret_0 := anon
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/as_type_contract.fir.diag.txt
@@ -1,26 +1,25 @@
 /as_type_contract.kt: info: Generated Viper text for getX:
 field x: Ref
 
-method getX(a: Ref) returns (ret: Ref)
+method getX(a: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), anyType())
-  ensures isSubtype(typeOf(ret), nullable(intType()))
-  ensures ret != nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
+  ensures v_ret_0 != nullValue() ==> !isSubtype(typeOf(a), IntHolder())
 {
   var anon_0: Ref
-  if (isSubtype(typeOf(a), c_IntHolder())) {
+  if (isSubtype(typeOf(a), IntHolder())) {
     anon_0 := a
   } else {
     anon_0 := nullValue()}
-  inhale isSubtype(typeOf(anon_0), nullable(c_IntHolder()))
-  inhale anon_0 != nullValue() ==>
-    acc(_c_IntHolder_shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), nullable(IntHolder()))
+  inhale anon_0 != nullValue() ==> acc(IntHolder_shared(anon_0), wildcard)
   if (anon_0 != nullValue()) {
-    var anon: Ref
-    unfold acc(_c_IntHolder_shared(anon_0), wildcard)
-    anon := anon_0.x
-    ret := anon
+    var anon_1: Ref
+    unfold acc(IntHolder_shared(anon_0), wildcard)
+    anon_1 := anon_0.x
+    v_ret_0 := anon_1
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
@@ -31,26 +31,27 @@ method mayReturnNull(x: Ref) returns (ret: Ref)
 }
 
 /cond_effects.kt: info: Generated Viper text for isNullOrEmptyWrong:
-method isNullOrEmptyWrong(seq: Ref) returns (ret_0: Ref)
+method isNullOrEmptyWrong(seq: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(seq), nullable(c_CharSequence()))
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == false ==> seq != nullValue()
+  ensures isSubtype(typeOf(ret), boolType())
+  ensures boolFromRef(ret) == false ==> seq != nullValue()
 {
-  inhale seq != nullValue() ==> acc(shared(seq), wildcard)
+  inhale seq != nullValue() ==>
+    acc(kotlin_c_CharSequence_shared(seq), wildcard)
   if (!(seq == nullValue())) {
     var anon_0: Ref
     var anon: Ref
     anon := length(seq)
     anon_0 := anon
     inhale isSubtype(typeOf(anon_0), intType())
-    ret_0 := notBool(boolToRef(intFromRef(anon_0) == 0))
+    ret := notBool(boolToRef(intFromRef(anon_0) == 0))
   } else {
-    ret_0 := boolToRef(false)}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := boolToRef(false)}
+  goto ret_0
+  label ret_0
 }
 
-method length(this: Ref) returns (ret: Ref)
+method length(this: Ref) returns (v_ret: Ref)
 
 
 /cond_effects.kt: info: Generated Viper text for recursiveContract:

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
@@ -31,26 +31,26 @@ method mayReturnNull(x: Ref) returns (ret: Ref)
 }
 
 /cond_effects.kt: info: Generated Viper text for isNullOrEmptyWrong:
-method isNullOrEmptyWrong(seq: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(seq), nullable(kotlin_c_CharSequence()))
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == false ==> seq != nullValue()
+method isNullOrEmptyWrong(seq: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(seq), nullable(c_CharSequence()))
+  ensures isSubtype(typeOf(ret_0), boolType())
+  ensures boolFromRef(ret_0) == false ==> seq != nullValue()
 {
-  inhale seq != nullValue() ==> acc(c_CharSequence_shared(seq), wildcard)
+  inhale seq != nullValue() ==> acc(shared(seq), wildcard)
   if (!(seq == nullValue())) {
     var anon_0: Ref
     var anon: Ref
     anon := length(seq)
     anon_0 := anon
     inhale isSubtype(typeOf(anon_0), intType())
-    ret := notBool(boolToRef(intFromRef(anon_0) == 0))
+    ret_0 := notBool(boolToRef(intFromRef(anon_0) == 0))
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method length(this: Ref) returns (v_ret: Ref)
+method length(this: Ref) returns (ret: Ref)
 
 
 /cond_effects.kt: info: Generated Viper text for recursiveContract:

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/cond_effects.fir.diag.txt
@@ -1,70 +1,70 @@
 /cond_effects.kt: info: Generated Viper text for compoundConditionalEffect:
-method compoundConditionalEffect(b: Ref) returns (ret: Ref)
+method compoundConditionalEffect(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
   ensures true ==> boolFromRef(b) && false
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /cond_effects.kt: info: Generated Viper text for mayReturnNonNull:
-method mayReturnNonNull(x: Ref) returns (ret: Ref)
+method mayReturnNonNull(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
-  ensures ret == nullValue() ==> isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret_0), nullable(anyType()))
+  ensures v_ret_0 == nullValue() ==> isSubtype(typeOf(x), intType())
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /cond_effects.kt: info: Generated Viper text for mayReturnNull:
-method mayReturnNull(x: Ref) returns (ret: Ref)
+method mayReturnNull(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
-  ensures ret != nullValue() ==> isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret_0), nullable(anyType()))
+  ensures v_ret_0 != nullValue() ==> isSubtype(typeOf(x), intType())
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /cond_effects.kt: info: Generated Viper text for isNullOrEmptyWrong:
-method isNullOrEmptyWrong(seq: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(seq), nullable(c_CharSequence()))
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == false ==> seq != nullValue()
+method isNullOrEmptyWrong(seq: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(seq), nullable(CharSequence()))
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == false ==> seq != nullValue()
 {
-  inhale seq != nullValue() ==>
-    acc(kotlin_c_CharSequence_shared(seq), wildcard)
+  inhale seq != nullValue() ==> acc(CharSequence_shared(seq), wildcard)
   if (!(seq == nullValue())) {
     var anon_0: Ref
-    var anon: Ref
-    anon := length(seq)
-    anon_0 := anon
+    var anon_1: Ref
+    anon_1 := length(seq)
+    anon_0 := anon_1
     inhale isSubtype(typeOf(anon_0), intType())
-    ret := notBool(boolToRef(intFromRef(anon_0) == 0))
+    v_ret_0 := notBool(boolToRef(intFromRef(anon_0) == 0))
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method length(this: Ref) returns (v_ret: Ref)
 
 
 /cond_effects.kt: info: Generated Viper text for recursiveContract:
-method recursiveContract(n: Ref, x: Ref) returns (ret: Ref)
+method recursiveContract(n: Ref, x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(n), intType())
   requires isSubtype(typeOf(x), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(x), stringType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    isSubtype(typeOf(x), stringType())
 {
   if (intFromRef(n) == 0) {
-    ret := boolToRef(isSubtype(typeOf(x), intType()))
+    v_ret_0 := boolToRef(isSubtype(typeOf(x), intType()))
   } else {
-    ret := recursiveContract(minusInts(n, intToRef(1)), x)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := recursiveContract(minusInts(n, intToRef(1)), x)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
@@ -10,70 +10,28 @@ method is2(this: Ref) returns (ret: Ref)
   label ret_0
 }
 
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(this: Ref, [v$this]: Ref) returns (ret: Ref)
+method is1butWithDispatch(this: Ref, v_this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Class())
-  requires isSubtype(typeOf([v$this]), c_Class())
+  requires isSubtype(typeOf(v_this), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==>
-    isSubtype(typeOf([v$this]), c_Impl2())
+  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl2())
 {
   inhale acc(_c_Class_shared(this), wildcard)
-  inhale acc(_c_Class_shared([v$this]), wildcard)
-  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
+  inhale acc(_c_Class_shared(v_this), wildcard)
+  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
   goto ret_0
   label ret_0
 }
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1([v$this]: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), c_Class())
+method is1(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==>
-    isSubtype(typeOf([v$this]), c_Impl2())
+  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl2())
 {
-  inhale acc(_c_Class_shared([v$this]), wildcard)
-  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
+  inhale acc(_c_Class_shared(v_this), wildcard)
+  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
   goto ret_0
   label ret_0
 }
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
@@ -1,37 +1,79 @@
 /contracts_with_receivers.kt: info: Generated Viper text for is2:
 method is2(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Class())
+  requires isSubtype(typeOf(this), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), _c_Impl1())
+  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), c_Impl1())
 {
-  inhale acc(c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), _c_Impl2()))
+  inhale acc(_c_Class_shared(this), wildcard)
+  ret := boolToRef(isSubtype(typeOf(this), c_Impl2()))
   goto ret_0
   label ret_0
 }
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(v_this: Ref, this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), _c_Class())
-  requires isSubtype(typeOf(this), _c_Class())
+method is1butWithDispatch(this: Ref, [v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(this), c_Class())
+  requires isSubtype(typeOf([v$this]), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), _c_Impl2())
+  ensures boolFromRef(ret) == true ==>
+    isSubtype(typeOf([v$this]), c_Impl2())
 {
-  inhale acc(c_Class_shared(v_this), wildcard)
-  inhale acc(c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), _c_Impl1()))
+  inhale acc(_c_Class_shared(this), wildcard)
+  inhale acc(_c_Class_shared([v$this]), wildcard)
+  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
   goto ret_0
   label ret_0
 }
 
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Class())
+method is1([v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), _c_Impl2())
+  ensures boolFromRef(ret) == true ==>
+    isSubtype(typeOf([v$this]), c_Impl2())
 {
-  inhale acc(c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), _c_Impl1()))
+  inhale acc(_c_Class_shared([v$this]), wildcard)
+  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
   goto ret_0
   label ret_0
 }
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
@@ -11,30 +11,30 @@ method is2(this: Ref) returns (v_ret_0: Ref)
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(v_this: Ref, v_this_dispatch: Ref)
+method is1butWithDispatch(v_this: Ref, v_this_extension: Ref)
   returns (v_ret_0: Ref)
   requires isSubtype(typeOf(v_this), Class())
-  requires isSubtype(typeOf(v_this_dispatch), Class())
+  requires isSubtype(typeOf(v_this_extension), Class())
   ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures boolFromRef(v_ret_0) == true ==>
-    isSubtype(typeOf(v_this_dispatch), Impl2())
+    isSubtype(typeOf(v_this_extension), Impl2())
 {
   inhale acc(Class_shared(v_this), wildcard)
-  inhale acc(Class_shared(v_this_dispatch), wildcard)
-  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  inhale acc(Class_shared(v_this_extension), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_extension), Impl1()))
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), Class())
+method is1(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), Class())
   ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures boolFromRef(v_ret_0) == true ==>
-    isSubtype(typeOf(v_this_dispatch), Impl2())
+    isSubtype(typeOf(v_this_extension), Impl2())
 {
-  inhale acc(Class_shared(v_this_dispatch), wildcard)
-  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  inhale acc(Class_shared(v_this_extension), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_extension), Impl1()))
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/contracts_with_receivers.fir.diag.txt
@@ -1,37 +1,40 @@
 /contracts_with_receivers.kt: info: Generated Viper text for is2:
-method is2(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Class())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), c_Impl1())
+method is2(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Class())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==> isSubtype(typeOf(this), Impl1())
 {
-  inhale acc(_c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), c_Impl2()))
-  goto ret_0
-  label ret_0
+  inhale acc(Class_shared(this), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(this), Impl2()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(this: Ref, v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Class())
-  requires isSubtype(typeOf(v_this), c_Class())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl2())
+method is1butWithDispatch(v_this: Ref, v_this_dispatch: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this), Class())
+  requires isSubtype(typeOf(v_this_dispatch), Class())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    isSubtype(typeOf(v_this_dispatch), Impl2())
 {
-  inhale acc(_c_Class_shared(this), wildcard)
-  inhale acc(_c_Class_shared(v_this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
-  goto ret_0
-  label ret_0
+  inhale acc(Class_shared(v_this), wildcard)
+  inhale acc(Class_shared(v_this_dispatch), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), c_Class())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl2())
+method is1(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), Class())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    isSubtype(typeOf(v_this_dispatch), Impl2())
 {
-  inhale acc(_c_Class_shared(v_this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
-  goto ret_0
-  label ret_0
+  inhale acc(Class_shared(v_this_dispatch), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/is_type_contract.fir.diag.txt
@@ -1,20 +1,20 @@
 /is_type_contract.kt: info: Generated Viper text for unverifiableTypeCheck:
-method unverifiableTypeCheck(x: Ref) returns (ret: Ref)
+method unverifiableTypeCheck(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures true ==> isSubtype(typeOf(x), unitType())
 {
-  ret := boolToRef(isSubtype(typeOf(x), stringType()))
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(isSubtype(typeOf(x), stringType()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /is_type_contract.kt: info: Generated Viper text for nullableNotNonNullable:
-method nullableNotNonNullable(x: Ref) returns (ret: Ref)
+method nullableNotNonNullable(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
   ensures true ==> isSubtype(typeOf(x), intType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
@@ -1,26 +1,26 @@
 /list.kt: info: Generated Viper text for empty_list_expr_get:
 field size: Ref
 
-method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
-  ensures intFromRef(ret.size) == 0
+method emptyList() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
+  ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_expr_get() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method empty_list_expr_get() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var s: Ref
   var anon: Ref
   anon := emptyList()
   s := get(anon, intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -29,33 +29,33 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
 /list.kt: info: Generated Viper text for empty_list_get:
 field size: Ref
 
-method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
-  ensures intFromRef(ret.size) == 0
+method emptyList() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
+  ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_get() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method empty_list_get() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var myList: Ref
   var s: Ref
   myList := emptyList()
   s := get(myList, intToRef(0))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -64,14 +64,14 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
 /list.kt: info: Generated Viper text for unsafe_last:
 field size: Ref
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -80,59 +80,59 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method unsafe_last(l: Ref) returns (ret_0: Ref)
+method unsafe_last(l: Ref) returns (ret: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
   requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   var anon: Ref
   inhale acc(shared(l), wildcard)
   anon := l.size
   inhale isSubtype(typeOf(anon), intType())
-  ret_0 := get(l, minusInts(anon, intToRef(1)))
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := get(l, minusInts(anon, intToRef(1)))
+  goto ret_0
+  label ret_0
 }
 
 /list.kt: info: Generated Viper text for add_get:
 field size: Ref
 
-method add(this: Ref, element: Ref) returns (ret: Ref)
+method add(this: Ref, element: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_MutableList())
   requires isSubtype(typeOf(element), intType())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size)) + 1
 
 
-method add_get(l: Ref) returns (ret_0: Ref)
+method add_get(l: Ref) returns (ret: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
   requires isSubtype(typeOf(l), c_MutableList())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   var n: Ref
-  inhale acc(shared(l), wildcard)
+  inhale acc(collections_c_MutableList_shared(l), wildcard)
   anon := add(l, intToRef(1))
   n := get(l, intToRef(1))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method get(this: Ref, index: Ref) returns (ret: Ref)
+method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_MutableList())
@@ -141,33 +141,34 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
   requires intFromRef(this.size) > intFromRef(index)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
 /list.kt: info: Generated Viper text for empty_list_sub:
 field size: Ref
 
-method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
-  ensures intFromRef(ret.size) == 0
+method emptyList() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
+  ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_sub() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method empty_list_sub() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l: Ref
   var anon: Ref
   anon := emptyList()
   l := subList(anon, intToRef(0), intToRef(1))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
+method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
+  returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -178,38 +179,39 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(ret.size) ==
+  ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
 /list.kt: info: Generated Viper text for empty_list_sub_negative:
 field size: Ref
 
-method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
-  ensures intFromRef(ret.size) == 0
+method emptyList() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
+  ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_sub_negative() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method empty_list_sub_negative() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l: Ref
   var anon: Ref
   anon := emptyList()
   l := subList(anon, intToRef(-1), intToRef(1))
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
+method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
+  returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_List())
@@ -220,10 +222,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), c_List())
-  ensures acc(ret.size, write)
-  ensures intFromRef(ret.size) >= 0
-  ensures acc(shared(ret), wildcard)
+  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures acc(v_ret.size, write)
+  ensures intFromRef(v_ret.size) >= 0
+  ensures acc(shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures intFromRef(ret.size) ==
+  ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
@@ -2,10 +2,10 @@
 field size: Ref
 
 method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(ret.size) == 0
 
 
@@ -23,7 +23,7 @@ method empty_list_expr_get() returns (ret_0: Ref)
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -37,10 +37,10 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 field size: Ref
 
 method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(ret.size) == 0
 
 
@@ -58,7 +58,7 @@ method empty_list_get() returns (ret_0: Ref)
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -74,7 +74,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -87,13 +87,13 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 method unsafe_last(l: Ref) returns (ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), collections_c_List())
+  requires isSubtype(typeOf(l), c_List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
   ensures isSubtype(typeOf(ret_0), intType())
 {
   var anon: Ref
-  inhale acc(c_List_shared(l), wildcard)
+  inhale acc(shared(l), wildcard)
   anon := l.size
   inhale isSubtype(typeOf(anon), intType())
   ret_0 := get(l, minusInts(anon, intToRef(1)))
@@ -107,7 +107,7 @@ field size: Ref
 method add(this: Ref, element: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_MutableList())
+  requires isSubtype(typeOf(this), c_MutableList())
   requires isSubtype(typeOf(element), intType())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
@@ -118,14 +118,14 @@ method add(this: Ref, element: Ref) returns (ret: Ref)
 method add_get(l: Ref) returns (ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), collections_c_MutableList())
+  requires isSubtype(typeOf(l), c_MutableList())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon: Ref
   var n: Ref
-  inhale acc(c_MutableList_shared(l), wildcard)
+  inhale acc(shared(l), wildcard)
   anon := add(l, intToRef(1))
   n := get(l, intToRef(1))
   label lbl_ret_0
@@ -135,7 +135,7 @@ method add_get(l: Ref) returns (ret_0: Ref)
 method get(this: Ref, index: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_MutableList())
+  requires isSubtype(typeOf(this), c_MutableList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -149,10 +149,10 @@ method get(this: Ref, index: Ref) returns (ret: Ref)
 field size: Ref
 
 method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(ret.size) == 0
 
 
@@ -170,7 +170,7 @@ method empty_list_sub() returns (ret_0: Ref)
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -178,10 +178,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
@@ -191,10 +191,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
 field size: Ref
 
 method emptyList() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(ret.size) == 0
 
 
@@ -212,7 +212,7 @@ method empty_list_sub_negative() returns (ret_0: Ref)
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), collections_c_List())
+  requires isSubtype(typeOf(this), c_List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -220,10 +220,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref) returns (ret: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), collections_c_List())
+  ensures isSubtype(typeOf(ret), c_List())
   ensures acc(ret.size, write)
   ensures intFromRef(ret.size) >= 0
-  ensures acc(c_List_shared(ret), wildcard)
+  ensures acc(shared(ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/list.fir.diag.txt
@@ -2,28 +2,28 @@
 field size: Ref
 
 method emptyList() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures isSubtype(typeOf(v_ret), List())
   ensures acc(v_ret.size, write)
   ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
+  ensures acc(List_shared(v_ret), wildcard)
   ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_expr_get() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method empty_list_expr_get() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var s: Ref
   var anon: Ref
   anon := emptyList()
   s := get(anon, intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -37,28 +37,28 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
 field size: Ref
 
 method emptyList() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures isSubtype(typeOf(v_ret), List())
   ensures acc(v_ret.size, write)
   ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
+  ensures acc(List_shared(v_ret), wildcard)
   ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_get() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method empty_list_get() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var myList: Ref
   var s: Ref
   myList := emptyList()
   s := get(myList, intToRef(0))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -74,7 +74,7 @@ field size: Ref
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -84,21 +84,21 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
 
 
-method unsafe_last(l: Ref) returns (ret: Ref)
+method unsafe_last(l: Ref) returns (v_ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), c_List())
+  requires isSubtype(typeOf(l), List())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
-  inhale acc(shared(l), wildcard)
+  inhale acc(List_shared(l), wildcard)
   anon := l.size
   inhale isSubtype(typeOf(anon), intType())
-  ret := get(l, minusInts(anon, intToRef(1)))
-  goto ret_0
-  label ret_0
+  v_ret_0 := get(l, minusInts(anon, intToRef(1)))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /list.kt: info: Generated Viper text for add_get:
@@ -107,7 +107,7 @@ field size: Ref
 method add(this: Ref, element: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_MutableList())
+  requires isSubtype(typeOf(this), MutableList())
   requires isSubtype(typeOf(element), intType())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
@@ -115,27 +115,27 @@ method add(this: Ref, element: Ref) returns (v_ret: Ref)
   ensures intFromRef(this.size) == old(intFromRef(this.size)) + 1
 
 
-method add_get(l: Ref) returns (ret: Ref)
+method add_get(l: Ref) returns (v_ret_0: Ref)
   requires acc(l.size, write)
   requires intFromRef(l.size) >= 0
-  requires isSubtype(typeOf(l), c_MutableList())
+  requires isSubtype(typeOf(l), MutableList())
   ensures acc(l.size, write)
   ensures intFromRef(l.size) >= 0
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   var n: Ref
-  inhale acc(collections_c_MutableList_shared(l), wildcard)
+  inhale acc(MutableList_shared(l), wildcard)
   anon := add(l, intToRef(1))
   n := get(l, intToRef(1))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method get(this: Ref, index: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_MutableList())
+  requires isSubtype(typeOf(this), MutableList())
   requires isSubtype(typeOf(index), intType())
   requires intFromRef(index) >= 0
   requires intFromRef(this.size) > intFromRef(index)
@@ -149,29 +149,29 @@ method get(this: Ref, index: Ref) returns (v_ret: Ref)
 field size: Ref
 
 method emptyList() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures isSubtype(typeOf(v_ret), List())
   ensures acc(v_ret.size, write)
   ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
+  ensures acc(List_shared(v_ret), wildcard)
   ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_sub() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method empty_list_sub() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l: Ref
   var anon: Ref
   anon := emptyList()
   l := subList(anon, intToRef(0), intToRef(1))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -179,10 +179,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures isSubtype(typeOf(v_ret), List())
   ensures acc(v_ret.size, write)
   ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
+  ensures acc(List_shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
@@ -192,29 +192,29 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
 field size: Ref
 
 method emptyList() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures isSubtype(typeOf(v_ret), List())
   ensures acc(v_ret.size, write)
   ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
+  ensures acc(List_shared(v_ret), wildcard)
   ensures intFromRef(v_ret.size) == 0
 
 
-method empty_list_sub_negative() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method empty_list_sub_negative() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l: Ref
   var anon: Ref
   anon := emptyList()
   l := subList(anon, intToRef(-1), intToRef(1))
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_List())
+  requires isSubtype(typeOf(this), List())
   requires isSubtype(typeOf(fromIndex), intType())
   requires isSubtype(typeOf(toIndex), intType())
   requires intFromRef(fromIndex) <= intFromRef(toIndex)
@@ -222,10 +222,10 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.size)
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(v_ret), c_List())
+  ensures isSubtype(typeOf(v_ret), List())
   ensures acc(v_ret.size, write)
   ensures intFromRef(v_ret.size) >= 0
-  ensures acc(shared(v_ret), wildcard)
+  ensures acc(List_shared(v_ret), wildcard)
   ensures intFromRef(this.size) == old(intFromRef(this.size))
   ensures intFromRef(v_ret.size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_booleans.fir.diag.txt
@@ -1,19 +1,19 @@
 /returns_booleans.kt: info: Generated Viper text for incorrectly_returns_false:
-method incorrectly_returns_false() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true
+method incorrectly_returns_false() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  ret := boolToRef(false)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(false)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_booleans.kt: info: Generated Viper text for incorrectly_returns_true:
-method incorrectly_returns_true() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == false
+method incorrectly_returns_true() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == false
 {
-  ret := boolToRef(true)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(true)
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_not_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_not_null.fir.diag.txt
@@ -1,9 +1,9 @@
 /returns_not_null.kt: info: Generated Viper text for returns_null:
-method returns_null() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(intType()))
-  ensures ret != nullValue()
+method returns_null() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
+  ensures v_ret_0 != nullValue()
 {
-  ret := nullValue()
-  goto ret_0
-  label ret_0
+  v_ret_0 := nullValue()
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/returns_null.fir.diag.txt
@@ -1,21 +1,21 @@
 /returns_null.kt: info: Generated Viper text for returns_null_unverifiable:
-method returns_null_unverifiable(x: Ref) returns (ret: Ref)
+method returns_null_unverifiable(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
   ensures true ==> false
 {
-  ret := nullValue()
-  goto ret_0
-  label ret_0
+  v_ret_0 := nullValue()
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_null.kt: info: Generated Viper text for non_nullable_returns_null:
-method non_nullable_returns_null(x: Ref) returns (ret: Ref)
+method non_nullable_returns_null(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
-  ensures ret == nullValue()
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures v_ret_0 == nullValue()
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
@@ -1,19 +1,19 @@
 /viper_verify.kt: info: Generated Viper text for verify_false:
 field size: Ref
 
-method verify_false() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method verify_false() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   assert false
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /viper_verify.kt: info: Generated Viper text for verify_compound:
 field size: Ref
 
-method verify_compound() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method verify_compound() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var anon: Ref
   if (true) {
@@ -21,6 +21,6 @@ method verify_compound() returns (ret_0: Ref)
   } else {
     anon := boolToRef(false)}
   assert boolFromRef(anon)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
@@ -1,19 +1,19 @@
 /viper_verify.kt: info: Generated Viper text for verify_false:
 field size: Ref
 
-method verify_false() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method verify_false() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   assert false
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /viper_verify.kt: info: Generated Viper text for verify_compound:
 field size: Ref
 
-method verify_compound() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method verify_compound() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon: Ref
   if (true) {
@@ -21,6 +21,6 @@ method verify_compound() returns (ret: Ref)
   } else {
     anon := boolToRef(false)}
   assert boolFromRef(anon)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
@@ -31,11 +31,11 @@ method safeAsOperator(foo: Ref) returns (ret: Ref)
 /as_type_contract.kt: info: Generated Viper text for getX:
 field x: Ref
 
-method getX(a: Ref) returns (ret_0: Ref)
+method getX(a: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(a), anyType())
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
-  ensures ret_0 != nullValue() ==> isSubtype(typeOf(a), c_IntHolder())
-  ensures ret_0 == nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
+  ensures isSubtype(typeOf(ret), nullable(intType()))
+  ensures ret != nullValue() ==> isSubtype(typeOf(a), c_IntHolder())
+  ensures ret == nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
 {
   var anon_0: Ref
   if (isSubtype(typeOf(a), c_IntHolder())) {
@@ -49,9 +49,9 @@ method getX(a: Ref) returns (ret_0: Ref)
     var anon: Ref
     unfold acc(_c_IntHolder_shared(anon_0), wildcard)
     anon := anon_0.x
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
@@ -1,13 +1,13 @@
 /as_type_contract.kt: info: Generated Viper text for asOperator:
 method asOperator(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
-  ensures isSubtype(typeOf(ret), _c_Bar())
-  ensures acc(c_Bar_shared(ret), wildcard)
-  ensures true ==> isSubtype(typeOf(foo), _c_Bar())
+  requires isSubtype(typeOf(foo), c_Foo())
+  ensures isSubtype(typeOf(ret), c_Bar())
+  ensures acc(_c_Bar_shared(ret), wildcard)
+  ensures true ==> isSubtype(typeOf(foo), c_Bar())
 {
-  inhale acc(c_Foo_shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), _c_Bar())
-  inhale acc(c_Bar_shared(foo), wildcard)
+  inhale acc(_c_Foo_shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), c_Bar())
+  inhale acc(_c_Bar_shared(foo), wildcard)
   ret := foo
   goto ret_0
   label ret_0
@@ -15,14 +15,14 @@ method asOperator(foo: Ref) returns (ret: Ref)
 
 /as_type_contract.kt: info: Generated Viper text for safeAsOperator:
 method safeAsOperator(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
-  ensures isSubtype(typeOf(ret), nullable(_c_Bar()))
-  ensures ret != nullValue() ==> acc(c_Bar_shared(ret), wildcard)
-  ensures ret != nullValue() ==> isSubtype(typeOf(foo), _c_Bar())
+  requires isSubtype(typeOf(foo), c_Foo())
+  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
+  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
+  ensures ret != nullValue() ==> isSubtype(typeOf(foo), c_Bar())
 {
-  inhale acc(c_Foo_shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), nullable(_c_Bar()))
-  inhale foo != nullValue() ==> acc(c_Bar_shared(foo), wildcard)
+  inhale acc(_c_Foo_shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), nullable(c_Bar()))
+  inhale foo != nullValue() ==> acc(_c_Bar_shared(foo), wildcard)
   ret := foo
   goto ret_0
   label ret_0
@@ -34,20 +34,20 @@ field x: Ref
 method getX(a: Ref) returns (ret_0: Ref)
   requires isSubtype(typeOf(a), anyType())
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
-  ensures ret_0 != nullValue() ==> isSubtype(typeOf(a), _c_IntHolder())
-  ensures ret_0 == nullValue() ==> !isSubtype(typeOf(a), _c_IntHolder())
+  ensures ret_0 != nullValue() ==> isSubtype(typeOf(a), c_IntHolder())
+  ensures ret_0 == nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
 {
   var anon_0: Ref
-  if (isSubtype(typeOf(a), _c_IntHolder())) {
+  if (isSubtype(typeOf(a), c_IntHolder())) {
     anon_0 := a
   } else {
     anon_0 := nullValue()}
-  inhale isSubtype(typeOf(anon_0), nullable(_c_IntHolder()))
+  inhale isSubtype(typeOf(anon_0), nullable(c_IntHolder()))
   inhale anon_0 != nullValue() ==>
-    acc(c_IntHolder_shared(anon_0), wildcard)
+    acc(_c_IntHolder_shared(anon_0), wildcard)
   if (anon_0 != nullValue()) {
     var anon: Ref
-    unfold acc(c_IntHolder_shared(anon_0), wildcard)
+    unfold acc(_c_IntHolder_shared(anon_0), wildcard)
     anon := anon_0.x
     ret_0 := anon
   } else {

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/as_type_contract.fir.diag.txt
@@ -1,57 +1,56 @@
 /as_type_contract.kt: info: Generated Viper text for asOperator:
-method asOperator(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), c_Bar())
-  ensures acc(_c_Bar_shared(ret), wildcard)
-  ensures true ==> isSubtype(typeOf(foo), c_Bar())
+method asOperator(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), Bar())
+  ensures acc(Bar_shared(v_ret_0), wildcard)
+  ensures true ==> isSubtype(typeOf(foo), Bar())
 {
-  inhale acc(_c_Foo_shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), c_Bar())
-  inhale acc(_c_Bar_shared(foo), wildcard)
-  ret := foo
-  goto ret_0
-  label ret_0
+  inhale acc(Foo_shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), Bar())
+  inhale acc(Bar_shared(foo), wildcard)
+  v_ret_0 := foo
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /as_type_contract.kt: info: Generated Viper text for safeAsOperator:
-method safeAsOperator(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), nullable(c_Bar()))
-  ensures ret != nullValue() ==> acc(_c_Bar_shared(ret), wildcard)
-  ensures ret != nullValue() ==> isSubtype(typeOf(foo), c_Bar())
+method safeAsOperator(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), nullable(Bar()))
+  ensures v_ret_0 != nullValue() ==> acc(Bar_shared(v_ret_0), wildcard)
+  ensures v_ret_0 != nullValue() ==> isSubtype(typeOf(foo), Bar())
 {
-  inhale acc(_c_Foo_shared(foo), wildcard)
-  inhale isSubtype(typeOf(foo), nullable(c_Bar()))
-  inhale foo != nullValue() ==> acc(_c_Bar_shared(foo), wildcard)
-  ret := foo
-  goto ret_0
-  label ret_0
+  inhale acc(Foo_shared(foo), wildcard)
+  inhale isSubtype(typeOf(foo), nullable(Bar()))
+  inhale foo != nullValue() ==> acc(Bar_shared(foo), wildcard)
+  v_ret_0 := foo
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /as_type_contract.kt: info: Generated Viper text for getX:
 field x: Ref
 
-method getX(a: Ref) returns (ret: Ref)
+method getX(a: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), anyType())
-  ensures isSubtype(typeOf(ret), nullable(intType()))
-  ensures ret != nullValue() ==> isSubtype(typeOf(a), c_IntHolder())
-  ensures ret == nullValue() ==> !isSubtype(typeOf(a), c_IntHolder())
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
+  ensures v_ret_0 != nullValue() ==> isSubtype(typeOf(a), IntHolder())
+  ensures v_ret_0 == nullValue() ==> !isSubtype(typeOf(a), IntHolder())
 {
   var anon_0: Ref
-  if (isSubtype(typeOf(a), c_IntHolder())) {
+  if (isSubtype(typeOf(a), IntHolder())) {
     anon_0 := a
   } else {
     anon_0 := nullValue()}
-  inhale isSubtype(typeOf(anon_0), nullable(c_IntHolder()))
-  inhale anon_0 != nullValue() ==>
-    acc(_c_IntHolder_shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), nullable(IntHolder()))
+  inhale anon_0 != nullValue() ==> acc(IntHolder_shared(anon_0), wildcard)
   if (anon_0 != nullValue()) {
-    var anon: Ref
-    unfold acc(_c_IntHolder_shared(anon_0), wildcard)
-    anon := anon_0.x
-    ret := anon
+    var anon_1: Ref
+    unfold acc(IntHolder_shared(anon_0), wildcard)
+    anon_1 := anon_0.x
+    v_ret_0 := anon_1
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
@@ -1,37 +1,79 @@
 /contracts_with_receivers.kt: info: Generated Viper text for is2:
 method is2(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Class())
+  requires isSubtype(typeOf(this), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), _c_Impl2())
+  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), c_Impl2())
 {
-  inhale acc(c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), _c_Impl2()))
+  inhale acc(_c_Class_shared(this), wildcard)
+  ret := boolToRef(isSubtype(typeOf(this), c_Impl2()))
   goto ret_0
   label ret_0
 }
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(v_this: Ref, this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), _c_Class())
-  requires isSubtype(typeOf(this), _c_Class())
+method is1butWithDispatch(this: Ref, [v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(this), c_Class())
+  requires isSubtype(typeOf([v$this]), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), _c_Impl1())
+  ensures boolFromRef(ret) == true ==>
+    isSubtype(typeOf([v$this]), c_Impl1())
 {
-  inhale acc(c_Class_shared(v_this), wildcard)
-  inhale acc(c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), _c_Impl1()))
+  inhale acc(_c_Class_shared(this), wildcard)
+  inhale acc(_c_Class_shared([v$this]), wildcard)
+  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
   goto ret_0
   label ret_0
 }
 
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_Class())
+method is1([v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), _c_Impl1())
+  ensures boolFromRef(ret) == true ==>
+    isSubtype(typeOf([v$this]), c_Impl1())
 {
-  inhale acc(c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), _c_Impl1()))
+  inhale acc(_c_Class_shared([v$this]), wildcard)
+  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
   goto ret_0
   label ret_0
 }
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/contracts_with_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
@@ -10,70 +10,28 @@ method is2(this: Ref) returns (ret: Ref)
   label ret_0
 }
 
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(this: Ref, [v$this]: Ref) returns (ret: Ref)
+method is1butWithDispatch(this: Ref, v_this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_Class())
-  requires isSubtype(typeOf([v$this]), c_Class())
+  requires isSubtype(typeOf(v_this), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==>
-    isSubtype(typeOf([v$this]), c_Impl1())
+  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl1())
 {
   inhale acc(_c_Class_shared(this), wildcard)
-  inhale acc(_c_Class_shared([v$this]), wildcard)
-  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
+  inhale acc(_c_Class_shared(v_this), wildcard)
+  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
   goto ret_0
   label ret_0
 }
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1([v$this]: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), c_Class())
+method is1(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), c_Class())
   ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==>
-    isSubtype(typeOf([v$this]), c_Impl1())
+  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl1())
 {
-  inhale acc(_c_Class_shared([v$this]), wildcard)
-  ret := boolToRef(isSubtype(typeOf([v$this]), c_Impl1()))
+  inhale acc(_c_Class_shared(v_this), wildcard)
+  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
   goto ret_0
   label ret_0
 }
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/contracts_with_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
@@ -11,30 +11,30 @@ method is2(this: Ref) returns (v_ret_0: Ref)
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(v_this: Ref, v_this_dispatch: Ref)
+method is1butWithDispatch(v_this: Ref, v_this_extension: Ref)
   returns (v_ret_0: Ref)
   requires isSubtype(typeOf(v_this), Class())
-  requires isSubtype(typeOf(v_this_dispatch), Class())
+  requires isSubtype(typeOf(v_this_extension), Class())
   ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures boolFromRef(v_ret_0) == true ==>
-    isSubtype(typeOf(v_this_dispatch), Impl1())
+    isSubtype(typeOf(v_this_extension), Impl1())
 {
   inhale acc(Class_shared(v_this), wildcard)
-  inhale acc(Class_shared(v_this_dispatch), wildcard)
-  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  inhale acc(Class_shared(v_this_extension), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_extension), Impl1()))
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), Class())
+method is1(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), Class())
   ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures boolFromRef(v_ret_0) == true ==>
-    isSubtype(typeOf(v_this_dispatch), Impl1())
+    isSubtype(typeOf(v_this_extension), Impl1())
 {
-  inhale acc(Class_shared(v_this_dispatch), wildcard)
-  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  inhale acc(Class_shared(v_this_extension), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_extension), Impl1()))
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/contracts_with_receivers.fir.diag.txt
@@ -1,37 +1,40 @@
 /contracts_with_receivers.kt: info: Generated Viper text for is2:
-method is2(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Class())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(this), c_Impl2())
+method is2(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), Class())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==> isSubtype(typeOf(this), Impl2())
 {
-  inhale acc(_c_Class_shared(this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(this), c_Impl2()))
-  goto ret_0
-  label ret_0
+  inhale acc(Class_shared(this), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(this), Impl2()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1butWithDispatch:
-method is1butWithDispatch(this: Ref, v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_Class())
-  requires isSubtype(typeOf(v_this), c_Class())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl1())
+method is1butWithDispatch(v_this: Ref, v_this_dispatch: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this), Class())
+  requires isSubtype(typeOf(v_this_dispatch), Class())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    isSubtype(typeOf(v_this_dispatch), Impl1())
 {
-  inhale acc(_c_Class_shared(this), wildcard)
-  inhale acc(_c_Class_shared(v_this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
-  goto ret_0
-  label ret_0
+  inhale acc(Class_shared(v_this), wildcard)
+  inhale acc(Class_shared(v_this_dispatch), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /contracts_with_receivers.kt: info: Generated Viper text for is1:
-method is1(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), c_Class())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(v_this), c_Impl1())
+method is1(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), Class())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    isSubtype(typeOf(v_this_dispatch), Impl1())
 {
-  inhale acc(_c_Class_shared(v_this), wildcard)
-  ret := boolToRef(isSubtype(typeOf(v_this), c_Impl1()))
-  goto ret_0
-  label ret_0
+  inhale acc(Class_shared(v_this_dispatch), wildcard)
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), Impl1()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -9,33 +9,17 @@ method isString(x: Ref) returns (ret: Ref)
   label ret_0
 }
 
-/is_type_contract.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/is_type_contract.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /is_type_contract.kt: info: Generated Viper text for isString:
-method isString([v$this]: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), anyType())
+method isString(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), anyType())
   ensures isSubtype(typeOf(ret), boolType())
   ensures boolFromRef(ret) == true ==>
-    isSubtype(typeOf([v$this]), stringType())
+    isSubtype(typeOf(v_this), stringType())
 {
-  ret := boolToRef(isSubtype(typeOf([v$this]), stringType()))
+  ret := boolToRef(isSubtype(typeOf(v_this), stringType()))
   goto ret_0
   label ret_0
 }
-
-/is_type_contract.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/is_type_contract.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /is_type_contract.kt: info: Generated Viper text for subtypeTransitive:
 method f_subtypeTransitive(x: Ref) returns (ret: Ref)
@@ -50,49 +34,49 @@ method f_subtypeTransitive(x: Ref) returns (ret: Ref)
 /is_type_contract.kt: info: Generated Viper text for constructorReturnType:
 field bar: Ref
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_Foo())
-  ensures acc(_c_Foo_shared(ret), wildcard)
-  ensures acc(_c_Foo_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_Foo())
+  ensures acc(_c_Foo_shared(v_ret), wildcard)
+  ensures acc(_c_Foo_unique(v_ret), write)
 
 
-method constructorReturnType() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method constructorReturnType() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), boolType())
+  ensures boolFromRef(ret) == true
 {
   var anon: Ref
   anon := con()
-  ret_0 := boolToRef(isSubtype(typeOf(anon), c_Foo()))
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := boolToRef(isSubtype(typeOf(anon), c_Foo()))
+  goto ret_0
+  label ret_0
 }
 
 /is_type_contract.kt: info: Generated Viper text for subtypeSuperType:
 field bf_bar: Ref
 
-method subtypeSuperType(bar: Ref) returns (ret_0: Ref)
+method subtypeSuperType(bar: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
   ensures true ==> isSubtype(typeOf(bar), c_Foo())
 {
   inhale acc(_c_Bar_shared(bar), wildcard)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /is_type_contract.kt: info: Generated Viper text for typeOfField:
 field bar: Ref
 
-method typeOfField(foo: Ref) returns (ret_0: Ref)
+method typeOfField(foo: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+  ensures isSubtype(typeOf(ret), boolType())
+  ensures boolFromRef(ret) == true
 {
   var anon: Ref
   inhale acc(_c_Foo_shared(foo), wildcard)
   unfold acc(_c_Foo_shared(foo), wildcard)
   anon := foo.bar
-  ret_0 := boolToRef(isSubtype(typeOf(anon), c_Bar()))
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := boolToRef(isSubtype(typeOf(anon), c_Bar()))
+  goto ret_0
+  label ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -9,17 +9,33 @@ method isString(x: Ref) returns (ret: Ref)
   label ret_0
 }
 
+/is_type_contract.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/is_type_contract.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /is_type_contract.kt: info: Generated Viper text for isString:
-method isString(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), anyType())
+method isString([v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), anyType())
   ensures isSubtype(typeOf(ret), boolType())
   ensures boolFromRef(ret) == true ==>
-    isSubtype(typeOf(this), stringType())
+    isSubtype(typeOf([v$this]), stringType())
 {
-  ret := boolToRef(isSubtype(typeOf(this), stringType()))
+  ret := boolToRef(isSubtype(typeOf([v$this]), stringType()))
   goto ret_0
   label ret_0
 }
+
+/is_type_contract.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/is_type_contract.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
 
 /is_type_contract.kt: info: Generated Viper text for subtypeTransitive:
 method f_subtypeTransitive(x: Ref) returns (ret: Ref)
@@ -35,9 +51,9 @@ method f_subtypeTransitive(x: Ref) returns (ret: Ref)
 field bar: Ref
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_Foo())
-  ensures acc(c_Foo_shared(ret), wildcard)
-  ensures acc(c_Foo_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_Foo())
+  ensures acc(_c_Foo_shared(ret), wildcard)
+  ensures acc(_c_Foo_unique(ret), write)
 
 
 method constructorReturnType() returns (ret_0: Ref)
@@ -46,7 +62,7 @@ method constructorReturnType() returns (ret_0: Ref)
 {
   var anon: Ref
   anon := con()
-  ret_0 := boolToRef(isSubtype(typeOf(anon), _c_Foo()))
+  ret_0 := boolToRef(isSubtype(typeOf(anon), c_Foo()))
   goto lbl_ret_0
   label lbl_ret_0
 }
@@ -55,11 +71,11 @@ method constructorReturnType() returns (ret_0: Ref)
 field bf_bar: Ref
 
 method subtypeSuperType(bar: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(bar), _c_Bar())
+  requires isSubtype(typeOf(bar), c_Bar())
   ensures isSubtype(typeOf(ret_0), unitType())
-  ensures true ==> isSubtype(typeOf(bar), _c_Foo())
+  ensures true ==> isSubtype(typeOf(bar), c_Foo())
 {
-  inhale acc(c_Bar_shared(bar), wildcard)
+  inhale acc(_c_Bar_shared(bar), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -68,15 +84,15 @@ method subtypeSuperType(bar: Ref) returns (ret_0: Ref)
 field bar: Ref
 
 method typeOfField(foo: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(foo), _c_Foo())
+  requires isSubtype(typeOf(foo), c_Foo())
   ensures isSubtype(typeOf(ret_0), boolType())
   ensures boolFromRef(ret_0) == true
 {
   var anon: Ref
-  inhale acc(c_Foo_shared(foo), wildcard)
-  unfold acc(c_Foo_shared(foo), wildcard)
+  inhale acc(_c_Foo_shared(foo), wildcard)
+  unfold acc(_c_Foo_shared(foo), wildcard)
   anon := foo.bar
-  ret_0 := boolToRef(isSubtype(typeOf(anon), _c_Bar()))
+  ret_0 := boolToRef(isSubtype(typeOf(anon), c_Bar()))
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -1,82 +1,83 @@
 /is_type_contract.kt: info: Generated Viper text for isString:
-method isString(x: Ref) returns (ret: Ref)
+method isString(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> isSubtype(typeOf(x), stringType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    isSubtype(typeOf(x), stringType())
 {
-  ret := boolToRef(isSubtype(typeOf(x), stringType()))
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(isSubtype(typeOf(x), stringType()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /is_type_contract.kt: info: Generated Viper text for isString:
-method isString(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), anyType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==>
-    isSubtype(typeOf(v_this), stringType())
+method isString(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), anyType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    isSubtype(typeOf(v_this_dispatch), stringType())
 {
-  ret := boolToRef(isSubtype(typeOf(v_this), stringType()))
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), stringType()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /is_type_contract.kt: info: Generated Viper text for subtypeTransitive:
-method f_subtypeTransitive(x: Ref) returns (ret: Ref)
+method f_subtypeTransitive(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), unitType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
   ensures true ==> isSubtype(typeOf(x), nullable(anyType()))
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /is_type_contract.kt: info: Generated Viper text for constructorReturnType:
 field bar: Ref
 
 method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_Foo())
-  ensures acc(_c_Foo_shared(v_ret), wildcard)
-  ensures acc(_c_Foo_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), Foo())
+  ensures acc(Foo_shared(v_ret), wildcard)
+  ensures acc(Foo_unique(v_ret), write)
 
 
-method constructorReturnType() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true
+method constructorReturnType() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
   var anon: Ref
   anon := con()
-  ret := boolToRef(isSubtype(typeOf(anon), c_Foo()))
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(isSubtype(typeOf(anon), Foo()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /is_type_contract.kt: info: Generated Viper text for subtypeSuperType:
 field bf_bar: Ref
 
-method subtypeSuperType(bar: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(bar), c_Bar())
-  ensures isSubtype(typeOf(ret), unitType())
-  ensures true ==> isSubtype(typeOf(bar), c_Foo())
+method subtypeSuperType(par_bar: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_bar), Bar())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+  ensures true ==> isSubtype(typeOf(par_bar), Foo())
 {
-  inhale acc(_c_Bar_shared(bar), wildcard)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  inhale acc(Bar_shared(par_bar), wildcard)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /is_type_contract.kt: info: Generated Viper text for typeOfField:
 field bar: Ref
 
-method typeOfField(foo: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(foo), c_Foo())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true
+method typeOfField(foo: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(foo), Foo())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
   var anon: Ref
-  inhale acc(_c_Foo_shared(foo), wildcard)
-  unfold acc(_c_Foo_shared(foo), wildcard)
+  inhale acc(Foo_shared(foo), wildcard)
+  unfold acc(Foo_shared(foo), wildcard)
   anon := foo.bar
-  ret := boolToRef(isSubtype(typeOf(anon), c_Bar()))
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(isSubtype(typeOf(anon), Bar()))
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -11,13 +11,13 @@ method isString(x: Ref) returns (v_ret_0: Ref)
 }
 
 /is_type_contract.kt: info: Generated Viper text for isString:
-method isString(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), anyType())
+method isString(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), anyType())
   ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures boolFromRef(v_ret_0) == true ==>
-    isSubtype(typeOf(v_this_dispatch), stringType())
+    isSubtype(typeOf(v_this_extension), stringType())
 {
-  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_dispatch), stringType()))
+  v_ret_0 := boolToRef(isSubtype(typeOf(v_this_extension), stringType()))
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
@@ -80,35 +80,96 @@ method call_fun_with_contracts(b: Ref) returns (ret_0: Ref)
   label lbl_ret_0
 }
 
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /returns_booleans.kt: info: Generated Viper text for isNullOrEmpty:
 field size: Ref
 
-method isEmpty(v_this: Ref) returns (ret: Ref)
-  requires acc(v_this.size, write)
-  requires intFromRef(v_this.size) >= 0
-  requires isSubtype(typeOf(v_this), collections_c_Collection())
-  ensures acc(v_this.size, write)
-  ensures intFromRef(v_this.size) >= 0
+method isEmpty(this: Ref) returns (ret: Ref)
+  requires acc(this.size, write)
+  requires intFromRef(this.size) >= 0
+  requires isSubtype(typeOf(this), c_Collection())
+  ensures acc(this.size, write)
+  ensures intFromRef(this.size) >= 0
   ensures isSubtype(typeOf(ret), boolType())
-  ensures intFromRef(v_this.size) == old(intFromRef(v_this.size))
-  ensures boolFromRef(ret) ==> intFromRef(v_this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(v_this.size) > 0
+  ensures intFromRef(this.size) == old(intFromRef(this.size))
+  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
 
 
-method isNullOrEmpty(this: Ref) returns (ret_0: Ref)
-  requires this != nullValue() ==> acc(this.size, write)
-  requires this != nullValue() ==> intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), nullable(collections_c_Collection()))
-  ensures this != nullValue() ==> acc(this.size, write)
-  ensures this != nullValue() ==> intFromRef(this.size) >= 0
+method isNullOrEmpty([v$this]: Ref) returns (ret_0: Ref)
+  requires [v$this] != nullValue() ==> acc([v$this].size, write)
+  requires [v$this] != nullValue() ==> intFromRef([v$this].size) >= 0
+  requires isSubtype(typeOf([v$this]), nullable(c_Collection()))
+  ensures [v$this] != nullValue() ==> acc([v$this].size, write)
+  ensures [v$this] != nullValue() ==> intFromRef([v$this].size) >= 0
   ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == false ==> this != nullValue()
+  ensures boolFromRef(ret_0) == false ==> [v$this] != nullValue()
 {
-  inhale this != nullValue() ==> acc(c_Collection_shared(this), wildcard)
-  if (this == nullValue()) {
+  inhale [v$this] != nullValue() ==>
+    acc(collections_c_Collection_shared([v$this]), wildcard)
+  if ([v$this] == nullValue()) {
     ret_0 := boolToRef(true)
   } else {
-    ret_0 := isEmpty(this)}
+    ret_0 := isEmpty([v$this])}
   goto lbl_ret_0
   label lbl_ret_0
 }
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/returns_booleans.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
@@ -59,117 +59,57 @@ method logical_not(b: Ref) returns (ret: Ref)
 }
 
 /returns_booleans.kt: info: Generated Viper text for call_fun_with_contracts:
-method binary_logic_expressions(a: Ref, b: Ref) returns (ret: Ref)
+method binary_logic_expressions(a: Ref, b: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(a), boolType())
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == false ==> boolFromRef(b) && false
-  ensures boolFromRef(ret) == true ==>
+  ensures isSubtype(typeOf(v_ret), boolType())
+  ensures boolFromRef(v_ret) == false ==> boolFromRef(b) && false
+  ensures boolFromRef(v_ret) == true ==>
     (true || boolFromRef(a)) && (boolFromRef(b) || true)
 
 
-method call_fun_with_contracts(b: Ref) returns (ret_0: Ref)
+method call_fun_with_contracts(b: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+  ensures isSubtype(typeOf(ret), boolType())
+  ensures boolFromRef(ret) == true
 {
   var l0_a: Ref
   l0_a := binary_logic_expressions(b, b)
-  ret_0 := l0_a
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := l0_a
+  goto ret_0
+  label ret_0
 }
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /returns_booleans.kt: info: Generated Viper text for isNullOrEmpty:
 field size: Ref
 
-method isEmpty(this: Ref) returns (ret: Ref)
+method isEmpty(this: Ref) returns (v_ret: Ref)
   requires acc(this.size, write)
   requires intFromRef(this.size) >= 0
   requires isSubtype(typeOf(this), c_Collection())
   ensures acc(this.size, write)
   ensures intFromRef(this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
   ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(ret) ==> intFromRef(this.size) > 0
+  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
 
 
-method isNullOrEmpty([v$this]: Ref) returns (ret_0: Ref)
-  requires [v$this] != nullValue() ==> acc([v$this].size, write)
-  requires [v$this] != nullValue() ==> intFromRef([v$this].size) >= 0
-  requires isSubtype(typeOf([v$this]), nullable(c_Collection()))
-  ensures [v$this] != nullValue() ==> acc([v$this].size, write)
-  ensures [v$this] != nullValue() ==> intFromRef([v$this].size) >= 0
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == false ==> [v$this] != nullValue()
+method isNullOrEmpty(v_this: Ref) returns (ret: Ref)
+  requires v_this != nullValue() ==> acc(v_this.size, write)
+  requires v_this != nullValue() ==> intFromRef(v_this.size) >= 0
+  requires isSubtype(typeOf(v_this), nullable(c_Collection()))
+  ensures v_this != nullValue() ==> acc(v_this.size, write)
+  ensures v_this != nullValue() ==> intFromRef(v_this.size) >= 0
+  ensures isSubtype(typeOf(ret), boolType())
+  ensures boolFromRef(ret) == false ==> v_this != nullValue()
 {
-  inhale [v$this] != nullValue() ==>
-    acc(collections_c_Collection_shared([v$this]), wildcard)
-  if ([v$this] == nullValue()) {
-    ret_0 := boolToRef(true)
+  inhale v_this != nullValue() ==>
+    acc(collections_c_Collection_shared(v_this), wildcard)
+  if (v_this == nullValue()) {
+    ret := boolToRef(true)
   } else {
-    ret_0 := isEmpty([v$this])}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := isEmpty(v_this)}
+  goto ret_0
+  label ret_0
 }
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/returns_booleans.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
@@ -1,115 +1,121 @@
 /returns_booleans.kt: info: Generated Viper text for returns_true:
-method returns_true() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
+method returns_true() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures true
-  ensures boolFromRef(ret) == true
+  ensures boolFromRef(v_ret_0) == true
 {
-  ret := boolToRef(true)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(true)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_booleans.kt: info: Generated Viper text for returns_false:
-method returns_false() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), boolType())
+method returns_false() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures true
-  ensures boolFromRef(ret) == false
+  ensures boolFromRef(v_ret_0) == false
 {
-  ret := boolToRef(false)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(false)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_booleans.kt: info: Generated Viper text for conditional_basic:
-method conditional_basic(b: Ref) returns (ret: Ref)
+method conditional_basic(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> true
-  ensures boolFromRef(ret) == false ==> boolFromRef(b)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==> true
+  ensures boolFromRef(v_ret_0) == false ==> boolFromRef(b)
 {
-  ret := boolToRef(true)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(true)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_booleans.kt: info: Generated Viper text for binary_logic_expressions:
-method binary_logic_expressions(a: Ref, b: Ref) returns (ret: Ref)
+method binary_logic_expressions(a: Ref, b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(a), boolType())
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == false ==> boolFromRef(b) && false
-  ensures boolFromRef(ret) == true ==>
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == false ==> boolFromRef(b) && false
+  ensures boolFromRef(v_ret_0) == true ==>
     (true || boolFromRef(a)) && (boolFromRef(b) || true)
 {
-  ret := boolToRef(true)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(true)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_booleans.kt: info: Generated Viper text for logical_not:
-method logical_not(b: Ref) returns (ret: Ref)
+method logical_not(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true ==> !boolFromRef(b) && boolFromRef(b)
-  ensures boolFromRef(ret) == false ==> boolFromRef(b) || !boolFromRef(b)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==>
+    !boolFromRef(b) && boolFromRef(b)
+  ensures boolFromRef(v_ret_0) == false ==>
+    boolFromRef(b) || !boolFromRef(b)
 {
-  ret := boolToRef(false)
-  goto ret_0
-  label ret_0
+  v_ret_0 := boolToRef(false)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_booleans.kt: info: Generated Viper text for call_fun_with_contracts:
-method binary_logic_expressions(a: Ref, b: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(a), boolType())
+method binary_logic_expressions(par_a: Ref, b: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_a), boolType())
   requires isSubtype(typeOf(b), boolType())
   ensures isSubtype(typeOf(v_ret), boolType())
   ensures boolFromRef(v_ret) == false ==> boolFromRef(b) && false
   ensures boolFromRef(v_ret) == true ==>
-    (true || boolFromRef(a)) && (boolFromRef(b) || true)
+    (true || boolFromRef(par_a)) && (boolFromRef(b) || true)
 
 
-method call_fun_with_contracts(b: Ref) returns (ret: Ref)
+method call_fun_with_contracts(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == true
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
   var l0_a: Ref
   l0_a := binary_logic_expressions(b, b)
-  ret := l0_a
-  goto ret_0
-  label ret_0
+  v_ret_0 := l0_a
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_booleans.kt: info: Generated Viper text for isNullOrEmpty:
 field size: Ref
 
-method isEmpty(this: Ref) returns (v_ret: Ref)
-  requires acc(this.size, write)
-  requires intFromRef(this.size) >= 0
-  requires isSubtype(typeOf(this), c_Collection())
-  ensures acc(this.size, write)
-  ensures intFromRef(this.size) >= 0
+method isEmpty(v_this: Ref) returns (v_ret: Ref)
+  requires acc(v_this.size, write)
+  requires intFromRef(v_this.size) >= 0
+  requires isSubtype(typeOf(v_this), Collection())
+  ensures acc(v_this.size, write)
+  ensures intFromRef(v_this.size) >= 0
   ensures isSubtype(typeOf(v_ret), boolType())
-  ensures intFromRef(this.size) == old(intFromRef(this.size))
-  ensures boolFromRef(v_ret) ==> intFromRef(this.size) == 0
-  ensures !boolFromRef(v_ret) ==> intFromRef(this.size) > 0
+  ensures intFromRef(v_this.size) == old(intFromRef(v_this.size))
+  ensures boolFromRef(v_ret) ==> intFromRef(v_this.size) == 0
+  ensures !boolFromRef(v_ret) ==> intFromRef(v_this.size) > 0
 
 
-method isNullOrEmpty(v_this: Ref) returns (ret: Ref)
-  requires v_this != nullValue() ==> acc(v_this.size, write)
-  requires v_this != nullValue() ==> intFromRef(v_this.size) >= 0
-  requires isSubtype(typeOf(v_this), nullable(c_Collection()))
-  ensures v_this != nullValue() ==> acc(v_this.size, write)
-  ensures v_this != nullValue() ==> intFromRef(v_this.size) >= 0
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) == false ==> v_this != nullValue()
+method isNullOrEmpty(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires v_this_dispatch != nullValue() ==>
+    acc(v_this_dispatch.size, write)
+  requires v_this_dispatch != nullValue() ==>
+    intFromRef(v_this_dispatch.size) >= 0
+  requires isSubtype(typeOf(v_this_dispatch), nullable(Collection()))
+  ensures v_this_dispatch != nullValue() ==>
+    acc(v_this_dispatch.size, write)
+  ensures v_this_dispatch != nullValue() ==>
+    intFromRef(v_this_dispatch.size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == false ==> v_this_dispatch != nullValue()
 {
-  inhale v_this != nullValue() ==>
-    acc(collections_c_Collection_shared(v_this), wildcard)
-  if (v_this == nullValue()) {
-    ret := boolToRef(true)
+  inhale v_this_dispatch != nullValue() ==>
+    acc(Collection_shared(v_this_dispatch), wildcard)
+  if (v_this_dispatch == nullValue()) {
+    v_ret_0 := boolToRef(true)
   } else {
-    ret := isEmpty(v_this)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := isEmpty(v_this_dispatch)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_booleans.fir.diag.txt
@@ -97,25 +97,25 @@ method isEmpty(v_this: Ref) returns (v_ret: Ref)
   ensures !boolFromRef(v_ret) ==> intFromRef(v_this.size) > 0
 
 
-method isNullOrEmpty(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires v_this_dispatch != nullValue() ==>
-    acc(v_this_dispatch.size, write)
-  requires v_this_dispatch != nullValue() ==>
-    intFromRef(v_this_dispatch.size) >= 0
-  requires isSubtype(typeOf(v_this_dispatch), nullable(Collection()))
-  ensures v_this_dispatch != nullValue() ==>
-    acc(v_this_dispatch.size, write)
-  ensures v_this_dispatch != nullValue() ==>
-    intFromRef(v_this_dispatch.size) >= 0
+method isNullOrEmpty(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires v_this_extension != nullValue() ==>
+    acc(v_this_extension.size, write)
+  requires v_this_extension != nullValue() ==>
+    intFromRef(v_this_extension.size) >= 0
+  requires isSubtype(typeOf(v_this_extension), nullable(Collection()))
+  ensures v_this_extension != nullValue() ==>
+    acc(v_this_extension.size, write)
+  ensures v_this_extension != nullValue() ==>
+    intFromRef(v_this_extension.size) >= 0
   ensures isSubtype(typeOf(v_ret_0), boolType())
-  ensures boolFromRef(v_ret_0) == false ==> v_this_dispatch != nullValue()
+  ensures boolFromRef(v_ret_0) == false ==> v_this_extension != nullValue()
 {
-  inhale v_this_dispatch != nullValue() ==>
-    acc(Collection_shared(v_this_dispatch), wildcard)
-  if (v_this_dispatch == nullValue()) {
+  inhale v_this_extension != nullValue() ==>
+    acc(Collection_shared(v_this_extension), wildcard)
+  if (v_this_extension == nullValue()) {
     v_ret_0 := boolToRef(true)
   } else {
-    v_ret_0 := isEmpty(v_this_dispatch)}
+    v_ret_0 := isEmpty(v_this_extension)}
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_null.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/returns_null.fir.diag.txt
@@ -1,68 +1,68 @@
 /returns_null.kt: info: Generated Viper text for simple_returns_null:
-method simple_returns_null(x: Ref) returns (ret: Ref)
+method simple_returns_null(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
-  ensures ret == nullValue()
-  ensures ret != nullValue() ==> false
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
+  ensures v_ret_0 == nullValue()
+  ensures v_ret_0 != nullValue() ==> false
 {
-  ret := nullValue()
-  goto ret_0
-  label ret_0
+  v_ret_0 := nullValue()
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_null.kt: info: Generated Viper text for returns_null_implies:
-method returns_null_implies(x: Ref) returns (ret: Ref)
+method returns_null_implies(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(boolType()))
-  ensures isSubtype(typeOf(ret), nullable(boolType()))
-  ensures ret == nullValue() ==> x == nullValue()
-  ensures ret != nullValue() ==> x != nullValue()
+  ensures isSubtype(typeOf(v_ret_0), nullable(boolType()))
+  ensures v_ret_0 == nullValue() ==> x == nullValue()
+  ensures v_ret_0 != nullValue() ==> x != nullValue()
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_null.kt: info: Generated Viper text for returns_null_with_if:
-method returns_null_with_if(x: Ref, y: Ref, z: Ref) returns (ret: Ref)
+method returns_null_with_if(x: Ref, y: Ref, z: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), nullable(intType()))
   requires isSubtype(typeOf(y), nullable(intType()))
   requires isSubtype(typeOf(z), nullable(intType()))
-  ensures isSubtype(typeOf(ret), nullable(intType()))
-  ensures ret == nullValue() ==>
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
+  ensures v_ret_0 == nullValue() ==>
     x == nullValue() && y == nullValue() || z == nullValue()
-  ensures ret != nullValue() ==> x != nullValue() || y != nullValue()
+  ensures v_ret_0 != nullValue() ==> x != nullValue() || y != nullValue()
 {
   if (x == nullValue()) {
-    ret := y
-    goto ret_0
+    v_ret_0 := y
+    goto lbl_ret_0
   } else {
-    ret := z
-    goto ret_0
+    v_ret_0 := z
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /returns_null.kt: info: Generated Viper text for non_nullable_returns_not_null:
-method non_nullable_returns_not_null(x: Ref) returns (ret: Ref)
+method non_nullable_returns_not_null(x: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
-  ensures isSubtype(typeOf(ret), intType())
-  ensures ret != nullValue()
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures v_ret_0 != nullValue()
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_null.kt: info: Generated Viper text for non_nullable_compared_to_null:
-method non_nullable_compared_to_null(x: Ref, y: Ref) returns (ret: Ref)
+method non_nullable_compared_to_null(x: Ref, y: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(x), intType())
   requires isSubtype(typeOf(y), intType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
   ensures true ==> y == nullValue() || x != nullValue()
 {
-  ret := x
-  goto ret_0
-  label ret_0
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /returns_null.kt: warning: Condition is always 'false'.

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/simple.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/simple.fir.diag.txt
@@ -1,16 +1,16 @@
 /simple.kt: info: Generated Viper text for without_contract:
-method without_contract() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method without_contract() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /simple.kt: info: Generated Viper text for with_contract:
-method with_contract() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method with_contract() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
   ensures true
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
@@ -92,7 +92,7 @@ method useRun() returns (ret_0: Ref)
   var ret_35: Ref
   var anon_4: Ref
   var cond4: Ref
-  var anon_45: Ref
+  var anon: Ref
   var ret_36: Ref
   var l36_result: Ref
   var ret_37: Ref
@@ -110,8 +110,8 @@ method useRun() returns (ret_0: Ref)
   var cond7: Ref
   var ret_42: Ref
   var l42_result: Ref
-  var ret_44: Ref
-  var anon: Ref
+  var ret: Ref
+  var anon_9: Ref
   var ret_43: Ref
   var anon_8: Ref
   ret_2 := intToRef(1)
@@ -305,8 +305,8 @@ method useRun() returns (ret_0: Ref)
   ret_36 := boolToRef(intFromRef(l36_result) == 3)
   goto lbl_ret_36
   label lbl_ret_36
-  anon_45 := ret_36
-  cond4 := notBool(anon_45)
+  anon := ret_36
+  cond4 := notBool(anon)
   anon_6 := intToRef(1)
   ret_39 := plusInts(anon_6, intToRef(2))
   goto lbl_ret_39
@@ -329,11 +329,11 @@ method useRun() returns (ret_0: Ref)
   ret_43 := plusInts(anon_8, intToRef(1))
   goto lbl_ret_43
   label lbl_ret_43
-  anon := ret_43
-  ret_44 := plusInts(anon, intToRef(1))
-  goto lbl_ret_44
-  label lbl_ret_44
-  l42_result := ret_44
+  anon_9 := ret_43
+  ret := plusInts(anon_9, intToRef(1))
+  goto ret_44
+  label ret_44
+  l42_result := ret
   ret_42 := boolToRef(intFromRef(l42_result) == 3)
   goto lbl_ret_42
   label lbl_ret_42
@@ -380,7 +380,7 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     var ret_6: Ref
     var anon_2: Ref
     var ret_7: Ref
-    var ret: Ref
+    var ret_9: Ref
     var anon_3: Ref
     var ret_8: Ref
     anon_0 := intToRef(1)
@@ -392,10 +392,10 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     goto lbl_ret_8
     label lbl_ret_8
     anon_3 := ret_8
-    ret := plusInts(anon_3, intToRef(1))
-    goto ret_9
-    label ret_9
-    ret_7 := ret
+    ret_9 := plusInts(anon_3, intToRef(1))
+    goto lbl_ret_9
+    label lbl_ret_9
+    ret_7 := ret_9
     goto lbl_ret_7
     label lbl_ret_7
     ret_6 := ret_7
@@ -457,9 +457,9 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     var anon_8: Ref
     var anon_24: Ref
     var ret_18: Ref
+    var anon_9: Ref
     var anon: Ref
-    var anon_25: Ref
-    var ret_19: Ref
+    var ret: Ref
     var anon_10: Ref
     anon_4 := intToRef(1)
     inhale isSubtype(typeOf(anon_4), nullable(anyType()))
@@ -470,15 +470,15 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     inhale isSubtype(typeOf(anon_7), nullable(anyType()))
     inhale isSubtype(typeOf(anon_7), intType())
     anon_8 := anon_7
-    anon := plusInts(anon_8, intToRef(1))
-    inhale isSubtype(typeOf(anon), nullable(anyType()))
-    inhale isSubtype(typeOf(anon), intType())
-    anon_10 := anon
-    ret_19 := plusInts(anon_10, intToRef(1))
-    goto lbl_ret_19
-    label lbl_ret_19
-    anon_25 := ret_19
-    ret_18 := anon_25
+    anon_9 := plusInts(anon_8, intToRef(1))
+    inhale isSubtype(typeOf(anon_9), nullable(anyType()))
+    inhale isSubtype(typeOf(anon_9), intType())
+    anon_10 := anon_9
+    ret := plusInts(anon_10, intToRef(1))
+    goto ret_19
+    label ret_19
+    anon := ret
+    ret_18 := anon
     inhale isSubtype(typeOf(ret_18), nullable(anyType()))
     goto lbl_ret_18
     label lbl_ret_18
@@ -532,10 +532,10 @@ field member: Ref
 
 field size: Ref
 
-method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), c_CustomClass())
-  ensures acc(_c_CustomClass_shared(ret), wildcard)
-  ensures acc(_c_CustomClass_unique(ret), write)
+method con() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), c_CustomClass())
+  ensures acc(_c_CustomClass_shared(v_ret), wildcard)
+  ensures acc(_c_CustomClass_unique(v_ret), write)
 
 
 method testCustomClass() returns (ret_0: Ref)
@@ -552,7 +552,7 @@ method testCustomClass() returns (ret_0: Ref)
   var anon_4: Ref
   var ret_3: Ref
   var anon: Ref
-  var ret_4: Ref
+  var ret: Ref
   custom := con()
   unfold acc(_c_CustomClass_shared(custom), wildcard)
   ret_2 := custom.member
@@ -567,10 +567,10 @@ method testCustomClass() returns (ret_0: Ref)
   anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())
   unfold acc(_c_CustomClass_shared(custom), wildcard)
-  ret_4 := custom.member
-  goto lbl_ret_4
-  label lbl_ret_4
-  anon := ret_4
+  ret := custom.member
+  goto ret_4
+  label ret_4
+  anon := ret
   ret_3 := anon
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
@@ -111,9 +111,9 @@ method useRun() returns (ret_0: Ref)
   var ret_42: Ref
   var l42_result: Ref
   var ret_44: Ref
-  var anon_9: Ref
-  var ret_43: Ref
   var anon: Ref
+  var ret_43: Ref
+  var anon_8: Ref
   ret_2 := intToRef(1)
   goto lbl_ret_2
   label lbl_ret_2
@@ -325,12 +325,12 @@ method useRun() returns (ret_0: Ref)
   goto lbl_ret_40
   label lbl_ret_40
   cond6 := ret_40
-  anon := intToRef(1)
-  ret_43 := plusInts(anon, intToRef(1))
+  anon_8 := intToRef(1)
+  ret_43 := plusInts(anon_8, intToRef(1))
   goto lbl_ret_43
   label lbl_ret_43
-  anon_9 := ret_43
-  ret_44 := plusInts(anon_9, intToRef(1))
+  anon := ret_43
+  ret_44 := plusInts(anon, intToRef(1))
   goto lbl_ret_44
   label lbl_ret_44
   l42_result := ret_44
@@ -380,7 +380,7 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     var ret_6: Ref
     var anon_2: Ref
     var ret_7: Ref
-    var ret_9: Ref
+    var ret: Ref
     var anon_3: Ref
     var ret_8: Ref
     anon_0 := intToRef(1)
@@ -392,10 +392,10 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     goto lbl_ret_8
     label lbl_ret_8
     anon_3 := ret_8
-    ret_9 := plusInts(anon_3, intToRef(1))
-    goto lbl_ret_9
-    label lbl_ret_9
-    ret_7 := ret_9
+    ret := plusInts(anon_3, intToRef(1))
+    goto ret_9
+    label ret_9
+    ret_7 := ret
     goto lbl_ret_7
     label lbl_ret_7
     ret_6 := ret_7
@@ -457,10 +457,10 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     var anon_8: Ref
     var anon_24: Ref
     var ret_18: Ref
-    var anon_9: Ref
-    var anon_25: Ref
-    var ret: Ref
     var anon: Ref
+    var anon_25: Ref
+    var ret_19: Ref
+    var anon_10: Ref
     anon_4 := intToRef(1)
     inhale isSubtype(typeOf(anon_4), nullable(anyType()))
     anon_5 := anon_4
@@ -470,14 +470,14 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     inhale isSubtype(typeOf(anon_7), nullable(anyType()))
     inhale isSubtype(typeOf(anon_7), intType())
     anon_8 := anon_7
-    anon_9 := plusInts(anon_8, intToRef(1))
-    inhale isSubtype(typeOf(anon_9), nullable(anyType()))
-    inhale isSubtype(typeOf(anon_9), intType())
-    anon := anon_9
-    ret := plusInts(anon, intToRef(1))
-    goto ret_19
-    label ret_19
-    anon_25 := ret
+    anon := plusInts(anon_8, intToRef(1))
+    inhale isSubtype(typeOf(anon), nullable(anyType()))
+    inhale isSubtype(typeOf(anon), intType())
+    anon_10 := anon
+    ret_19 := plusInts(anon_10, intToRef(1))
+    goto lbl_ret_19
+    label lbl_ret_19
+    anon_25 := ret_19
     ret_18 := anon_25
     inhale isSubtype(typeOf(ret_18), nullable(anyType()))
     goto lbl_ret_18
@@ -533,9 +533,9 @@ field member: Ref
 field size: Ref
 
 method con() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), _c_CustomClass())
-  ensures acc(c_CustomClass_shared(ret), wildcard)
-  ensures acc(c_CustomClass_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_CustomClass())
+  ensures acc(_c_CustomClass_shared(ret), wildcard)
+  ensures acc(_c_CustomClass_unique(ret), write)
 
 
 method testCustomClass() returns (ret_0: Ref)
@@ -554,7 +554,7 @@ method testCustomClass() returns (ret_0: Ref)
   var anon: Ref
   var ret_4: Ref
   custom := con()
-  unfold acc(c_CustomClass_shared(custom), wildcard)
+  unfold acc(_c_CustomClass_shared(custom), wildcard)
   ret_2 := custom.member
   goto lbl_ret_2
   label lbl_ret_2
@@ -566,7 +566,7 @@ method testCustomClass() returns (ret_0: Ref)
   anon_1 := ret_1
   anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())
-  unfold acc(c_CustomClass_shared(custom), wildcard)
+  unfold acc(_c_CustomClass_shared(custom), wildcard)
   ret_4 := custom.member
   goto lbl_ret_4
   label lbl_ret_4

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
@@ -1,343 +1,343 @@
 /custom_run_functions.kt: info: Generated Viper text for useRun:
 field size: Ref
 
-method useRun() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method useRun() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var genericResult: Ref
   var anon_10: Ref
   var anon_11: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_12: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var anon_13: Ref
   var anon_14: Ref
-  var ret_3: Ref
+  var v_ret_3: Ref
   var anon_15: Ref
-  var ret_4: Ref
+  var v_ret_4: Ref
   var anon_16: Ref
   var anon_17: Ref
-  var ret_5: Ref
+  var v_ret_5: Ref
   var anon_18: Ref
-  var ret_6: Ref
+  var v_ret_6: Ref
   var capturedResult: Ref
   var anon_19: Ref
   var anon_20: Ref
-  var ret_7: Ref
+  var v_ret_7: Ref
   var anon_21: Ref
-  var ret_8: Ref
+  var v_ret_8: Ref
   var anon_22: Ref
   var anon_23: Ref
-  var ret_9: Ref
+  var v_ret_9: Ref
   var anon_24: Ref
-  var ret_10: Ref
+  var v_ret_10: Ref
   var anon_25: Ref
   var anon_26: Ref
-  var ret_11: Ref
+  var v_ret_11: Ref
   var anon_27: Ref
-  var ret_12: Ref
+  var v_ret_12: Ref
   var intResult: Ref
   var anon_28: Ref
-  var ret_13: Ref
-  var ret_14: Ref
+  var v_ret_13: Ref
+  var v_ret_14: Ref
   var anon_29: Ref
-  var ret_15: Ref
-  var ret_16: Ref
+  var v_ret_15: Ref
+  var v_ret_16: Ref
   var anon_30: Ref
-  var ret_17: Ref
-  var ret_18: Ref
+  var v_ret_17: Ref
+  var v_ret_18: Ref
   var stdlibResult: Ref
   var anon_31: Ref
   var anon_32: Ref
-  var ret_19: Ref
+  var v_ret_19: Ref
   var anon_33: Ref
-  var ret_20: Ref
+  var v_ret_20: Ref
   var anon_34: Ref
   var anon_35: Ref
-  var ret_21: Ref
+  var v_ret_21: Ref
   var anon_36: Ref
-  var ret_22: Ref
+  var v_ret_22: Ref
   var anon_37: Ref
   var anon_38: Ref
-  var ret_23: Ref
+  var v_ret_23: Ref
   var anon_39: Ref
-  var ret_24: Ref
+  var v_ret_24: Ref
   var doubleIntRunResult: Ref
   var anon_40: Ref
-  var ret_25: Ref
+  var v_ret_25: Ref
   var anon_0: Ref
-  var ret_27: Ref
+  var v_ret_27: Ref
   var anon_1: Ref
-  var ret_26: Ref
+  var v_ret_26: Ref
   var genericReceiverResult: Ref
   var anon_41: Ref
   var anon_42: Ref
-  var ret_28: Ref
+  var v_ret_28: Ref
   var anon_2: Ref
   var anon_43: Ref
-  var ret_29: Ref
+  var v_ret_29: Ref
   var anon_3: Ref
   var cond1: Ref
-  var ret_30: Ref
+  var v_ret_30: Ref
   var l30_result: Ref
-  var ret_31: Ref
+  var v_ret_31: Ref
   var cond2: Ref
   var anon_44: Ref
-  var ret_32: Ref
+  var v_ret_32: Ref
   var l32_result: Ref
-  var ret_33: Ref
+  var v_ret_33: Ref
   var cond3: Ref
-  var ret_34: Ref
+  var v_ret_34: Ref
   var l34_result: Ref
-  var ret_35: Ref
+  var v_ret_35: Ref
   var anon_4: Ref
   var cond4: Ref
-  var anon: Ref
-  var ret_36: Ref
+  var anon_45: Ref
+  var v_ret_36: Ref
   var l36_result: Ref
-  var ret_37: Ref
+  var v_ret_37: Ref
   var anon_5: Ref
   var cond5: Ref
-  var ret_38: Ref
+  var v_ret_38: Ref
   var l38_result: Ref
-  var ret_39: Ref
+  var v_ret_39: Ref
   var anon_6: Ref
   var cond6: Ref
-  var ret_40: Ref
+  var v_ret_40: Ref
   var l40_result: Ref
-  var ret_41: Ref
+  var v_ret_41: Ref
   var anon_7: Ref
   var cond7: Ref
-  var ret_42: Ref
+  var v_ret_42: Ref
   var l42_result: Ref
-  var ret: Ref
+  var v_ret_44: Ref
   var anon_9: Ref
-  var ret_43: Ref
+  var v_ret_43: Ref
   var anon_8: Ref
-  ret_2 := intToRef(1)
+  v_ret_2 := intToRef(1)
   goto lbl_ret_2
   label lbl_ret_2
-  anon_12 := ret_2
-  ret_1 := anon_12
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  anon_12 := v_ret_2
+  v_ret_1 := anon_12
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_11 := ret_1
+  anon_11 := v_ret_1
   anon_10 := anon_11
   inhale isSubtype(typeOf(anon_10), intType())
-  ret_4 := intToRef(2)
+  v_ret_4 := intToRef(2)
   goto lbl_ret_4
   label lbl_ret_4
-  anon_15 := ret_4
-  ret_3 := anon_15
-  inhale isSubtype(typeOf(ret_3), nullable(anyType()))
+  anon_15 := v_ret_4
+  v_ret_3 := anon_15
+  inhale isSubtype(typeOf(v_ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_14 := ret_3
+  anon_14 := v_ret_3
   anon_13 := anon_14
   inhale isSubtype(typeOf(anon_13), intType())
-  ret_6 := intToRef(3)
+  v_ret_6 := intToRef(3)
   goto lbl_ret_6
   label lbl_ret_6
-  anon_18 := ret_6
-  ret_5 := anon_18
-  inhale isSubtype(typeOf(ret_5), nullable(anyType()))
+  anon_18 := v_ret_6
+  v_ret_5 := anon_18
+  inhale isSubtype(typeOf(v_ret_5), nullable(anyType()))
   goto lbl_ret_5
   label lbl_ret_5
-  anon_17 := ret_5
+  anon_17 := v_ret_5
   anon_16 := anon_17
   inhale isSubtype(typeOf(anon_16), intType())
   genericResult := boolToRef(intFromRef(anon_10) + intFromRef(anon_13) ==
     intFromRef(anon_16))
-  ret_8 := intToRef(1)
+  v_ret_8 := intToRef(1)
   goto lbl_ret_8
   label lbl_ret_8
-  anon_21 := ret_8
-  ret_7 := anon_21
-  inhale isSubtype(typeOf(ret_7), nullable(anyType()))
+  anon_21 := v_ret_8
+  v_ret_7 := anon_21
+  inhale isSubtype(typeOf(v_ret_7), nullable(anyType()))
   goto lbl_ret_7
   label lbl_ret_7
-  anon_20 := ret_7
+  anon_20 := v_ret_7
   anon_19 := anon_20
   inhale isSubtype(typeOf(anon_19), intType())
-  ret_10 := intToRef(2)
+  v_ret_10 := intToRef(2)
   goto lbl_ret_10
   label lbl_ret_10
-  anon_24 := ret_10
-  ret_9 := anon_24
-  inhale isSubtype(typeOf(ret_9), nullable(anyType()))
+  anon_24 := v_ret_10
+  v_ret_9 := anon_24
+  inhale isSubtype(typeOf(v_ret_9), nullable(anyType()))
   goto lbl_ret_9
   label lbl_ret_9
-  anon_23 := ret_9
+  anon_23 := v_ret_9
   anon_22 := anon_23
   inhale isSubtype(typeOf(anon_22), intType())
-  ret_12 := intToRef(3)
+  v_ret_12 := intToRef(3)
   goto lbl_ret_12
   label lbl_ret_12
-  anon_27 := ret_12
-  ret_11 := anon_27
-  inhale isSubtype(typeOf(ret_11), nullable(anyType()))
+  anon_27 := v_ret_12
+  v_ret_11 := anon_27
+  inhale isSubtype(typeOf(v_ret_11), nullable(anyType()))
   goto lbl_ret_11
   label lbl_ret_11
-  anon_26 := ret_11
+  anon_26 := v_ret_11
   anon_25 := anon_26
   inhale isSubtype(typeOf(anon_25), intType())
   capturedResult := boolToRef(intFromRef(anon_19) + intFromRef(anon_22) ==
     intFromRef(anon_25))
-  ret_14 := intToRef(1)
+  v_ret_14 := intToRef(1)
   goto lbl_ret_14
   label lbl_ret_14
-  ret_13 := ret_14
+  v_ret_13 := v_ret_14
   goto lbl_ret_13
   label lbl_ret_13
-  anon_28 := ret_13
-  ret_16 := intToRef(2)
+  anon_28 := v_ret_13
+  v_ret_16 := intToRef(2)
   goto lbl_ret_16
   label lbl_ret_16
-  ret_15 := ret_16
+  v_ret_15 := v_ret_16
   goto lbl_ret_15
   label lbl_ret_15
-  anon_29 := ret_15
-  ret_18 := intToRef(3)
+  anon_29 := v_ret_15
+  v_ret_18 := intToRef(3)
   goto lbl_ret_18
   label lbl_ret_18
-  ret_17 := ret_18
+  v_ret_17 := v_ret_18
   goto lbl_ret_17
   label lbl_ret_17
-  anon_30 := ret_17
+  anon_30 := v_ret_17
   intResult := boolToRef(intFromRef(anon_28) + intFromRef(anon_29) ==
     intFromRef(anon_30))
-  ret_20 := intToRef(1)
+  v_ret_20 := intToRef(1)
   goto lbl_ret_20
   label lbl_ret_20
-  anon_33 := ret_20
-  ret_19 := anon_33
-  inhale isSubtype(typeOf(ret_19), nullable(anyType()))
+  anon_33 := v_ret_20
+  v_ret_19 := anon_33
+  inhale isSubtype(typeOf(v_ret_19), nullable(anyType()))
   goto lbl_ret_19
   label lbl_ret_19
-  anon_32 := ret_19
+  anon_32 := v_ret_19
   anon_31 := anon_32
   inhale isSubtype(typeOf(anon_31), intType())
-  ret_22 := intToRef(2)
+  v_ret_22 := intToRef(2)
   goto lbl_ret_22
   label lbl_ret_22
-  anon_36 := ret_22
-  ret_21 := anon_36
-  inhale isSubtype(typeOf(ret_21), nullable(anyType()))
+  anon_36 := v_ret_22
+  v_ret_21 := anon_36
+  inhale isSubtype(typeOf(v_ret_21), nullable(anyType()))
   goto lbl_ret_21
   label lbl_ret_21
-  anon_35 := ret_21
+  anon_35 := v_ret_21
   anon_34 := anon_35
   inhale isSubtype(typeOf(anon_34), intType())
-  ret_24 := intToRef(3)
+  v_ret_24 := intToRef(3)
   goto lbl_ret_24
   label lbl_ret_24
-  anon_39 := ret_24
-  ret_23 := anon_39
-  inhale isSubtype(typeOf(ret_23), nullable(anyType()))
+  anon_39 := v_ret_24
+  v_ret_23 := anon_39
+  inhale isSubtype(typeOf(v_ret_23), nullable(anyType()))
   goto lbl_ret_23
   label lbl_ret_23
-  anon_38 := ret_23
+  anon_38 := v_ret_23
   anon_37 := anon_38
   inhale isSubtype(typeOf(anon_37), intType())
   stdlibResult := boolToRef(intFromRef(anon_31) + intFromRef(anon_34) ==
     intFromRef(anon_37))
   anon_0 := intToRef(1)
-  ret_26 := plusInts(anon_0, intToRef(1))
+  v_ret_26 := plusInts(anon_0, intToRef(1))
   goto lbl_ret_26
   label lbl_ret_26
-  anon_1 := ret_26
-  ret_27 := plusInts(anon_1, intToRef(1))
+  anon_1 := v_ret_26
+  v_ret_27 := plusInts(anon_1, intToRef(1))
   goto lbl_ret_27
   label lbl_ret_27
-  ret_25 := ret_27
+  v_ret_25 := v_ret_27
   goto lbl_ret_25
   label lbl_ret_25
-  anon_40 := ret_25
+  anon_40 := v_ret_25
   doubleIntRunResult := boolToRef(intFromRef(anon_40) == 3)
   anon_2 := intToRef(1)
   inhale isSubtype(typeOf(anon_2), nullable(anyType()))
   inhale isSubtype(typeOf(anon_2), intType())
   anon_3 := anon_2
-  ret_29 := plusInts(anon_3, intToRef(2))
+  v_ret_29 := plusInts(anon_3, intToRef(2))
   goto lbl_ret_29
   label lbl_ret_29
-  anon_43 := ret_29
-  ret_28 := anon_43
-  inhale isSubtype(typeOf(ret_28), nullable(anyType()))
+  anon_43 := v_ret_29
+  v_ret_28 := anon_43
+  inhale isSubtype(typeOf(v_ret_28), nullable(anyType()))
   goto lbl_ret_28
   label lbl_ret_28
-  anon_42 := ret_28
+  anon_42 := v_ret_28
   anon_41 := anon_42
   inhale isSubtype(typeOf(anon_41), intType())
   genericReceiverResult := boolToRef(intFromRef(anon_41) == 3)
-  ret_31 := plusInts(intToRef(1), intToRef(2))
+  v_ret_31 := plusInts(intToRef(1), intToRef(2))
   goto lbl_ret_31
   label lbl_ret_31
-  l30_result := ret_31
-  ret_30 := boolToRef(intFromRef(l30_result) == 3)
+  l30_result := v_ret_31
+  v_ret_30 := boolToRef(intFromRef(l30_result) == 3)
   goto lbl_ret_30
   label lbl_ret_30
-  cond1 := ret_30
-  ret_33 := intToRef(4)
+  cond1 := v_ret_30
+  v_ret_33 := intToRef(4)
   goto lbl_ret_33
   label lbl_ret_33
-  l32_result := ret_33
-  ret_32 := boolToRef(intFromRef(l32_result) == 3)
+  l32_result := v_ret_33
+  v_ret_32 := boolToRef(intFromRef(l32_result) == 3)
   goto lbl_ret_32
   label lbl_ret_32
-  anon_44 := ret_32
+  anon_44 := v_ret_32
   cond2 := notBool(anon_44)
   anon_4 := intToRef(1)
-  ret_35 := plusInts(anon_4, intToRef(2))
+  v_ret_35 := plusInts(anon_4, intToRef(2))
   goto lbl_ret_35
   label lbl_ret_35
-  l34_result := ret_35
-  ret_34 := boolToRef(intFromRef(l34_result) == 3)
+  l34_result := v_ret_35
+  v_ret_34 := boolToRef(intFromRef(l34_result) == 3)
   goto lbl_ret_34
   label lbl_ret_34
-  cond3 := ret_34
+  cond3 := v_ret_34
   anon_5 := intToRef(1)
-  ret_37 := anon_5
+  v_ret_37 := anon_5
   goto lbl_ret_37
   label lbl_ret_37
-  l36_result := ret_37
-  ret_36 := boolToRef(intFromRef(l36_result) == 3)
+  l36_result := v_ret_37
+  v_ret_36 := boolToRef(intFromRef(l36_result) == 3)
   goto lbl_ret_36
   label lbl_ret_36
-  anon := ret_36
-  cond4 := notBool(anon)
+  anon_45 := v_ret_36
+  cond4 := notBool(anon_45)
   anon_6 := intToRef(1)
-  ret_39 := plusInts(anon_6, intToRef(2))
+  v_ret_39 := plusInts(anon_6, intToRef(2))
   goto lbl_ret_39
   label lbl_ret_39
-  l38_result := ret_39
-  ret_38 := boolToRef(intFromRef(l38_result) == 3)
+  l38_result := v_ret_39
+  v_ret_38 := boolToRef(intFromRef(l38_result) == 3)
   goto lbl_ret_38
   label lbl_ret_38
-  cond5 := ret_38
+  cond5 := v_ret_38
   anon_7 := intToRef(1)
-  ret_41 := plusInts(anon_7, intToRef(2))
+  v_ret_41 := plusInts(anon_7, intToRef(2))
   goto lbl_ret_41
   label lbl_ret_41
-  l40_result := ret_41
-  ret_40 := boolToRef(intFromRef(l40_result) == 3)
+  l40_result := v_ret_41
+  v_ret_40 := boolToRef(intFromRef(l40_result) == 3)
   goto lbl_ret_40
   label lbl_ret_40
-  cond6 := ret_40
+  cond6 := v_ret_40
   anon_8 := intToRef(1)
-  ret_43 := plusInts(anon_8, intToRef(1))
+  v_ret_43 := plusInts(anon_8, intToRef(1))
   goto lbl_ret_43
   label lbl_ret_43
-  anon_9 := ret_43
-  ret := plusInts(anon_9, intToRef(1))
-  goto ret_44
-  label ret_44
-  l42_result := ret
-  ret_42 := boolToRef(intFromRef(l42_result) == 3)
+  anon_9 := v_ret_43
+  v_ret_44 := plusInts(anon_9, intToRef(1))
+  goto lbl_ret_44
+  label lbl_ret_44
+  l42_result := v_ret_44
+  v_ret_42 := boolToRef(intFromRef(l42_result) == 3)
   goto lbl_ret_42
   label lbl_ret_42
-  cond7 := ret_42
+  cond7 := v_ret_42
   assert boolFromRef(intResult)
   assert boolFromRef(genericResult)
   assert boolFromRef(stdlibResult)
@@ -352,114 +352,114 @@ method useRun() returns (ret_0: Ref)
   assert boolFromRef(doubleIntRunResult)
   assert boolFromRef(genericReceiverResult)
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /custom_run_functions.kt: info: Generated Viper text for complexScenario:
-method complexScenario(par_arg: Ref) returns (ret_0: Ref)
+method complexScenario(par_arg: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(par_arg), boolType())
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true ==> boolFromRef(par_arg)
-  ensures boolFromRef(ret_0) == false ==> !boolFromRef(par_arg)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true ==> boolFromRef(par_arg)
+  ensures boolFromRef(v_ret_0) == false ==> !boolFromRef(par_arg)
 {
   var anon_11: Ref
   var anon_12: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   if (boolFromRef(par_arg)) {
     var anon_13: Ref
-    var ret_2: Ref
+    var v_ret_2: Ref
     var anon_14: Ref
-    var ret_3: Ref
+    var v_ret_3: Ref
     var l5_result: Ref
-    var ret_4: Ref
+    var v_ret_4: Ref
     var anon_0: Ref
     var anon_15: Ref
-    var ret_5: Ref
+    var v_ret_5: Ref
     var anon_1: Ref
     var anon_16: Ref
-    var ret_6: Ref
+    var v_ret_6: Ref
     var anon_2: Ref
-    var ret_7: Ref
-    var ret_9: Ref
+    var v_ret_7: Ref
+    var v_ret_9: Ref
     var anon_3: Ref
-    var ret_8: Ref
+    var v_ret_8: Ref
     anon_0 := intToRef(1)
     inhale isSubtype(typeOf(anon_0), nullable(anyType()))
     anon_1 := anon_0
     inhale isSubtype(typeOf(anon_1), intType())
     anon_2 := anon_1
-    ret_8 := plusInts(anon_2, intToRef(1))
+    v_ret_8 := plusInts(anon_2, intToRef(1))
     goto lbl_ret_8
     label lbl_ret_8
-    anon_3 := ret_8
-    ret_9 := plusInts(anon_3, intToRef(1))
+    anon_3 := v_ret_8
+    v_ret_9 := plusInts(anon_3, intToRef(1))
     goto lbl_ret_9
     label lbl_ret_9
-    ret_7 := ret_9
+    v_ret_7 := v_ret_9
     goto lbl_ret_7
     label lbl_ret_7
-    ret_6 := ret_7
+    v_ret_6 := v_ret_7
     goto lbl_ret_6
     label lbl_ret_6
-    anon_16 := ret_6
-    ret_5 := anon_16
-    inhale isSubtype(typeOf(ret_5), nullable(anyType()))
+    anon_16 := v_ret_6
+    v_ret_5 := anon_16
+    inhale isSubtype(typeOf(v_ret_5), nullable(anyType()))
     goto lbl_ret_5
     label lbl_ret_5
-    anon_15 := ret_5
-    ret_4 := anon_15
-    inhale isSubtype(typeOf(ret_4), intType())
+    anon_15 := v_ret_5
+    v_ret_4 := anon_15
+    inhale isSubtype(typeOf(v_ret_4), intType())
     goto lbl_ret_4
     label lbl_ret_4
-    l5_result := ret_4
-    ret_3 := boolToRef(intFromRef(l5_result) == 3)
+    l5_result := v_ret_4
+    v_ret_3 := boolToRef(intFromRef(l5_result) == 3)
     goto lbl_ret_3
     label lbl_ret_3
-    anon_14 := ret_3
-    ret_2 := anon_14
+    anon_14 := v_ret_3
+    v_ret_2 := anon_14
     goto lbl_ret_2
     label lbl_ret_2
-    anon_13 := ret_2
-    ret_1 := anon_13
-    inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+    anon_13 := v_ret_2
+    v_ret_1 := anon_13
+    inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   } else {
     var anon_17: Ref
     anon_17 := nullValue()
-    ret_1 := anon_17
+    v_ret_1 := anon_17
   }
   goto lbl_ret_1
   label lbl_ret_1
-  anon_12 := ret_1
+  anon_12 := v_ret_1
   anon_11 := anon_12
   inhale isSubtype(typeOf(anon_11), nullable(boolType()))
   if (anon_11 != nullValue()) {
-    ret_0 := anon_11
+    v_ret_0 := anon_11
   } else {
     var anon_18: Ref
-    var ret_10: Ref
+    var v_ret_10: Ref
     var anon_19: Ref
-    var ret_11: Ref
-    var ret_12: Ref
+    var v_ret_11: Ref
+    var v_ret_12: Ref
     var l15_result: Ref
-    var ret_13: Ref
+    var v_ret_13: Ref
     var anon_4: Ref
     var anon_20: Ref
-    var ret_14: Ref
+    var v_ret_14: Ref
     var anon_5: Ref
     var anon_21: Ref
-    var ret_15: Ref
+    var v_ret_15: Ref
     var anon_6: Ref
     var anon_22: Ref
-    var ret_16: Ref
+    var v_ret_16: Ref
     var anon_7: Ref
     var anon_23: Ref
-    var ret_17: Ref
+    var v_ret_17: Ref
     var anon_8: Ref
     var anon_24: Ref
-    var ret_18: Ref
+    var v_ret_18: Ref
     var anon_9: Ref
-    var anon: Ref
-    var ret: Ref
+    var anon_25: Ref
+    var v_ret_19: Ref
     var anon_10: Ref
     anon_4 := intToRef(1)
     inhale isSubtype(typeOf(anon_4), nullable(anyType()))
@@ -474,54 +474,54 @@ method complexScenario(par_arg: Ref) returns (ret_0: Ref)
     inhale isSubtype(typeOf(anon_9), nullable(anyType()))
     inhale isSubtype(typeOf(anon_9), intType())
     anon_10 := anon_9
-    ret := plusInts(anon_10, intToRef(1))
-    goto ret_19
-    label ret_19
-    anon := ret
-    ret_18 := anon
-    inhale isSubtype(typeOf(ret_18), nullable(anyType()))
+    v_ret_19 := plusInts(anon_10, intToRef(1))
+    goto lbl_ret_19
+    label lbl_ret_19
+    anon_25 := v_ret_19
+    v_ret_18 := anon_25
+    inhale isSubtype(typeOf(v_ret_18), nullable(anyType()))
     goto lbl_ret_18
     label lbl_ret_18
-    anon_24 := ret_18
-    ret_17 := anon_24
-    inhale isSubtype(typeOf(ret_17), intType())
+    anon_24 := v_ret_18
+    v_ret_17 := anon_24
+    inhale isSubtype(typeOf(v_ret_17), intType())
     goto lbl_ret_17
     label lbl_ret_17
-    anon_23 := ret_17
-    ret_16 := anon_23
-    inhale isSubtype(typeOf(ret_16), nullable(anyType()))
+    anon_23 := v_ret_17
+    v_ret_16 := anon_23
+    inhale isSubtype(typeOf(v_ret_16), nullable(anyType()))
     goto lbl_ret_16
     label lbl_ret_16
-    anon_22 := ret_16
-    ret_15 := anon_22
-    inhale isSubtype(typeOf(ret_15), intType())
+    anon_22 := v_ret_16
+    v_ret_15 := anon_22
+    inhale isSubtype(typeOf(v_ret_15), intType())
     goto lbl_ret_15
     label lbl_ret_15
-    anon_21 := ret_15
-    ret_14 := anon_21
-    inhale isSubtype(typeOf(ret_14), nullable(anyType()))
+    anon_21 := v_ret_15
+    v_ret_14 := anon_21
+    inhale isSubtype(typeOf(v_ret_14), nullable(anyType()))
     goto lbl_ret_14
     label lbl_ret_14
-    anon_20 := ret_14
-    ret_13 := anon_20
-    inhale isSubtype(typeOf(ret_13), intType())
+    anon_20 := v_ret_14
+    v_ret_13 := anon_20
+    inhale isSubtype(typeOf(v_ret_13), intType())
     goto lbl_ret_13
     label lbl_ret_13
-    l15_result := ret_13
-    ret_12 := boolToRef(intFromRef(l15_result) == 3)
+    l15_result := v_ret_13
+    v_ret_12 := boolToRef(intFromRef(l15_result) == 3)
     goto lbl_ret_12
     label lbl_ret_12
-    ret_11 := ret_12
+    v_ret_11 := v_ret_12
     goto lbl_ret_11
     label lbl_ret_11
-    anon_19 := ret_11
-    ret_10 := anon_19
-    inhale isSubtype(typeOf(ret_10), nullable(anyType()))
+    anon_19 := v_ret_11
+    v_ret_10 := anon_19
+    inhale isSubtype(typeOf(v_ret_10), nullable(anyType()))
     goto lbl_ret_10
     label lbl_ret_10
-    anon_18 := ret_10
-    ret_0 := anon_18
-    inhale isSubtype(typeOf(ret_0), boolType())
+    anon_18 := v_ret_10
+    v_ret_0 := anon_18
+    inhale isSubtype(typeOf(v_ret_0), boolType())
   }
   goto lbl_ret_0
   label lbl_ret_0
@@ -533,53 +533,53 @@ field member: Ref
 field size: Ref
 
 method con() returns (v_ret: Ref)
-  ensures isSubtype(typeOf(v_ret), c_CustomClass())
-  ensures acc(_c_CustomClass_shared(v_ret), wildcard)
-  ensures acc(_c_CustomClass_unique(v_ret), write)
+  ensures isSubtype(typeOf(v_ret), CustomClass())
+  ensures acc(CustomClass_shared(v_ret), wildcard)
+  ensures acc(CustomClass_unique(v_ret), write)
 
 
-method testCustomClass() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method testCustomClass() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var custom: Ref
   var cond1: Ref
   var anon_0: Ref
   var anon_1: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_2: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var anon_3: Ref
   var anon_4: Ref
-  var ret_3: Ref
-  var anon: Ref
-  var ret: Ref
+  var v_ret_3: Ref
+  var anon_5: Ref
+  var v_ret_4: Ref
   custom := con()
-  unfold acc(_c_CustomClass_shared(custom), wildcard)
-  ret_2 := custom.member
+  unfold acc(CustomClass_shared(custom), wildcard)
+  v_ret_2 := custom.member
   goto lbl_ret_2
   label lbl_ret_2
-  anon_2 := ret_2
-  ret_1 := anon_2
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  anon_2 := v_ret_2
+  v_ret_1 := anon_2
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_1 := ret_1
+  anon_1 := v_ret_1
   anon_0 := anon_1
   inhale isSubtype(typeOf(anon_0), intType())
-  unfold acc(_c_CustomClass_shared(custom), wildcard)
-  ret := custom.member
-  goto ret_4
-  label ret_4
-  anon := ret
-  ret_3 := anon
-  inhale isSubtype(typeOf(ret_3), nullable(anyType()))
+  unfold acc(CustomClass_shared(custom), wildcard)
+  v_ret_4 := custom.member
+  goto lbl_ret_4
+  label lbl_ret_4
+  anon_5 := v_ret_4
+  v_ret_3 := anon_5
+  inhale isSubtype(typeOf(v_ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_4 := ret_3
+  anon_4 := v_ret_3
   anon_3 := anon_4
   inhale isSubtype(typeOf(anon_3), intType())
   cond1 := boolToRef(intFromRef(anon_0) == intFromRef(anon_3))
   assert boolFromRef(cond1)
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/inline_returns.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/inline_returns.fir.diag.txt
@@ -7,11 +7,11 @@ method simple_return() returns (ret_0: Ref)
   var cond1: Ref
   var ret_1: Ref
   var anon: Ref
-  var ret_2: Ref
-  ret_2 := boolToRef(false)
-  goto lbl_ret_2
-  label lbl_ret_2
-  anon := ret_2
+  var ret: Ref
+  ret := boolToRef(false)
+  goto ret_2
+  label ret_2
+  anon := ret
   ret_1 := notBool(anon)
   goto lbl_ret_1
   label lbl_ret_1

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/inline_returns.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/inline_returns.fir.diag.txt
@@ -1,158 +1,158 @@
 /inline_returns.kt: info: Generated Viper text for simple_return:
 field size: Ref
 
-method simple_return() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method simple_return() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon: Ref
-  var ret: Ref
-  ret := boolToRef(false)
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := notBool(anon)
+  var v_ret_2: Ref
+  v_ret_2 := boolToRef(false)
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon := v_ret_2
+  v_ret_1 := notBool(anon)
   goto lbl_ret_1
   label lbl_ret_1
-  cond1 := ret_1
+  cond1 := v_ret_1
   assert boolFromRef(cond1)
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /inline_returns.kt: info: Generated Viper text for unnamed_return:
-method unnamed_return() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method unnamed_return() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon: Ref
-  var ret: Ref
-  ret_0 := boolToRef(true)
+  var v_ret_2: Ref
+  v_ret_0 := boolToRef(true)
   goto lbl_ret_0
-  ret := boolToRef(true)
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := notBool(anon)
+  v_ret_2 := boolToRef(true)
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon := v_ret_2
+  v_ret_1 := notBool(anon)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /inline_returns.kt: info: Generated Viper text for named_local_return:
-method named_local_return() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method named_local_return() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon: Ref
-  var ret: Ref
-  ret := boolToRef(false)
-  goto ret_2
-  ret := boolToRef(true)
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := notBool(anon)
+  var v_ret_2: Ref
+  v_ret_2 := boolToRef(false)
+  goto lbl_ret_2
+  v_ret_2 := boolToRef(true)
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon := v_ret_2
+  v_ret_1 := notBool(anon)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /inline_returns.kt: info: Generated Viper text for named_nonlocal_return:
-method named_nonlocal_return() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method named_nonlocal_return() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon: Ref
-  var ret: Ref
-  ret_0 := boolToRef(true)
+  var v_ret_2: Ref
+  v_ret_0 := boolToRef(true)
   goto lbl_ret_0
-  ret := boolToRef(true)
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := notBool(anon)
+  v_ret_2 := boolToRef(true)
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon := v_ret_2
+  v_ret_1 := notBool(anon)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /inline_returns.kt: info: Generated Viper text for double_nonlocal_return:
-method double_nonlocal_return() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method double_nonlocal_return() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var x: Ref
-  var ret_3: Ref
-  var anon: Ref
-  var ret: Ref
-  ret_0 := boolToRef(true)
+  var v_ret_3: Ref
+  var anon_1: Ref
+  var v_ret_4: Ref
+  v_ret_0 := boolToRef(true)
   goto lbl_ret_0
-  ret := boolToRef(false)
-  goto ret_4
-  label ret_4
-  anon := ret
-  ret_3 := notBool(anon)
+  v_ret_4 := boolToRef(false)
+  goto lbl_ret_4
+  label lbl_ret_4
+  anon_1 := v_ret_4
+  v_ret_3 := notBool(anon_1)
   goto lbl_ret_3
   label lbl_ret_3
-  x := ret_3
-  ret_0 := boolToRef(false)
+  x := v_ret_3
+  v_ret_0 := boolToRef(false)
   goto lbl_ret_0
-  ret_2 := x
+  v_ret_2 := x
   goto lbl_ret_2
   label lbl_ret_2
-  anon_0 := ret_2
-  ret_1 := notBool(anon_0)
+  anon_0 := v_ret_2
+  v_ret_1 := notBool(anon_0)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /inline_returns.kt: info: Generated Viper text for named_double_nonlocal_return:
-method named_double_nonlocal_return() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method named_double_nonlocal_return() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon: Ref
-  var ret_2: Ref
-  var ret_3: Ref
-  var ret: Ref
-  ret_2 := boolToRef(false)
+  var v_ret_2: Ref
+  var v_ret_3: Ref
+  var v_ret_4: Ref
+  v_ret_2 := boolToRef(false)
   goto lbl_ret_2
-  ret_0 := boolToRef(false)
+  v_ret_0 := boolToRef(false)
   goto lbl_ret_0
-  label ret_4
-  inhale isSubtype(typeOf(ret), unitType())
-  ret_3 := ret
+  label lbl_ret_4
+  inhale isSubtype(typeOf(v_ret_4), unitType())
+  v_ret_3 := v_ret_4
   goto lbl_ret_3
   label lbl_ret_3
-  inhale isSubtype(typeOf(ret_3), unitType())
-  ret_0 := boolToRef(false)
+  inhale isSubtype(typeOf(v_ret_3), unitType())
+  v_ret_0 := boolToRef(false)
   goto lbl_ret_0
-  ret_2 := boolToRef(true)
+  v_ret_2 := boolToRef(true)
   goto lbl_ret_2
   label lbl_ret_2
-  anon := ret_2
-  ret_1 := notBool(anon)
+  anon := v_ret_2
+  v_ret_1 := notBool(anon)
   goto lbl_ret_1
   label lbl_ret_1
-  ret_0 := ret_1
+  v_ret_0 := v_ret_1
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
@@ -1,16 +1,8 @@
-/scoped_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/scoped_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /scoped_receivers.kt: info: Generated Viper text for with_run_extension_labeled:
 field size: Ref
 
-method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), nullable(intType()))
+method with_run_extension_labeled(v_this: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(v_this), nullable(intType()))
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var cond1: Ref
@@ -52,7 +44,7 @@ method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
   var anon_28: Ref
   var anon_29: Ref
   var ret_14: Ref
-  var anon: Ref
+  var anon_9: Ref
   var anon_30: Ref
   var ret_15: Ref
   var anon_10: Ref
@@ -60,10 +52,10 @@ method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
   var anon_32: Ref
   var ret_16: Ref
   var anon_11: Ref
-  var anon_33: Ref
-  var ret_17: Ref
+  var anon: Ref
+  var ret: Ref
   var anon_12: Ref
-  ret_1 := boolToRef([v$this] == nullValue())
+  ret_1 := boolToRef(v_this == nullValue())
   goto lbl_ret_1
   label lbl_ret_1
   anon_13 := ret_1
@@ -71,7 +63,7 @@ method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
     cond1 := boolToRef(true)
   } else {
     var ret_2: Ref
-    ret_2 := notBool(boolToRef([v$this] == nullValue()))
+    ret_2 := notBool(boolToRef(v_this == nullValue()))
     goto lbl_ret_2
     label lbl_ret_2
     cond1 := ret_2
@@ -125,7 +117,7 @@ method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
   assert !boolFromRef(anon_8)
   assert !boolFromRef(anon_8)
   assert boolFromRef(anon_1)
-  ret_12 := boolToRef([v$this] == nullValue())
+  ret_12 := boolToRef(v_this == nullValue())
   goto lbl_ret_12
   label lbl_ret_12
   anon_27 := ret_12
@@ -133,16 +125,16 @@ method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
     anon_26 := boolToRef(true)
   } else {
     var ret_13: Ref
-    ret_13 := notBool(boolToRef([v$this] == nullValue()))
+    ret_13 := notBool(boolToRef(v_this == nullValue()))
     goto lbl_ret_13
     label lbl_ret_13
     anon_26 := ret_13
   }
   assert boolFromRef(anon_26)
-  anon := boolToRef(false)
-  inhale isSubtype(typeOf(anon), nullable(anyType()))
-  inhale isSubtype(typeOf(anon), boolType())
-  anon_10 := anon
+  anon_9 := boolToRef(false)
+  inhale isSubtype(typeOf(anon_9), nullable(anyType()))
+  inhale isSubtype(typeOf(anon_9), boolType())
+  anon_10 := anon_9
   assert !boolFromRef(anon_10)
   assert !boolFromRef(anon_10)
   assert !boolFromRef(anon_8)
@@ -153,10 +145,10 @@ method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
   assert !boolFromRef(anon_10)
   assert boolFromRef(anon_12)
   assert boolFromRef(anon_12)
-  label lbl_ret_17
-  inhale isSubtype(typeOf(ret_17), unitType())
-  anon_33 := ret_17
-  ret_16 := anon_33
+  label ret_17
+  inhale isSubtype(typeOf(ret), unitType())
+  anon := ret
+  ret_16 := anon
   inhale isSubtype(typeOf(ret_16), nullable(anyType()))
   goto lbl_ret_16
   label lbl_ret_16
@@ -196,19 +188,3 @@ method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
-
-/scoped_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/scoped_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/scoped_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/scoped_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
@@ -1,8 +1,16 @@
+/scoped_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/scoped_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /scoped_receivers.kt: info: Generated Viper text for with_run_extension_labeled:
 field size: Ref
 
-method with_run_extension_labeled(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), nullable(intType()))
+method with_run_extension_labeled([v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), nullable(intType()))
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var cond1: Ref
@@ -44,7 +52,7 @@ method with_run_extension_labeled(this: Ref) returns (ret_0: Ref)
   var anon_28: Ref
   var anon_29: Ref
   var ret_14: Ref
-  var anon_9: Ref
+  var anon: Ref
   var anon_30: Ref
   var ret_15: Ref
   var anon_10: Ref
@@ -54,8 +62,8 @@ method with_run_extension_labeled(this: Ref) returns (ret_0: Ref)
   var anon_11: Ref
   var anon_33: Ref
   var ret_17: Ref
-  var anon: Ref
-  ret_1 := boolToRef(this == nullValue())
+  var anon_12: Ref
+  ret_1 := boolToRef([v$this] == nullValue())
   goto lbl_ret_1
   label lbl_ret_1
   anon_13 := ret_1
@@ -63,7 +71,7 @@ method with_run_extension_labeled(this: Ref) returns (ret_0: Ref)
     cond1 := boolToRef(true)
   } else {
     var ret_2: Ref
-    ret_2 := notBool(boolToRef(this == nullValue()))
+    ret_2 := notBool(boolToRef([v$this] == nullValue()))
     goto lbl_ret_2
     label lbl_ret_2
     cond1 := ret_2
@@ -117,7 +125,7 @@ method with_run_extension_labeled(this: Ref) returns (ret_0: Ref)
   assert !boolFromRef(anon_8)
   assert !boolFromRef(anon_8)
   assert boolFromRef(anon_1)
-  ret_12 := boolToRef(this == nullValue())
+  ret_12 := boolToRef([v$this] == nullValue())
   goto lbl_ret_12
   label lbl_ret_12
   anon_27 := ret_12
@@ -125,26 +133,26 @@ method with_run_extension_labeled(this: Ref) returns (ret_0: Ref)
     anon_26 := boolToRef(true)
   } else {
     var ret_13: Ref
-    ret_13 := notBool(boolToRef(this == nullValue()))
+    ret_13 := notBool(boolToRef([v$this] == nullValue()))
     goto lbl_ret_13
     label lbl_ret_13
     anon_26 := ret_13
   }
   assert boolFromRef(anon_26)
-  anon_9 := boolToRef(false)
-  inhale isSubtype(typeOf(anon_9), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_9), boolType())
-  anon_10 := anon_9
+  anon := boolToRef(false)
+  inhale isSubtype(typeOf(anon), nullable(anyType()))
+  inhale isSubtype(typeOf(anon), boolType())
+  anon_10 := anon
   assert !boolFromRef(anon_10)
   assert !boolFromRef(anon_10)
   assert !boolFromRef(anon_8)
   anon_11 := boolToRef(true)
   inhale isSubtype(typeOf(anon_11), nullable(anyType()))
   inhale isSubtype(typeOf(anon_11), boolType())
-  anon := anon_11
+  anon_12 := anon_11
   assert !boolFromRef(anon_10)
-  assert boolFromRef(anon)
-  assert boolFromRef(anon)
+  assert boolFromRef(anon_12)
+  assert boolFromRef(anon_12)
   label lbl_ret_17
   inhale isSubtype(typeOf(ret_17), unitType())
   anon_33 := ret_17
@@ -188,3 +196,19 @@ method with_run_extension_labeled(this: Ref) returns (ret_0: Ref)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
+
+/scoped_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/scoped_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/scoped_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/scoped_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
@@ -1,9 +1,9 @@
 /scoped_receivers.kt: info: Generated Viper text for with_run_extension_labeled:
 field size: Ref
 
-method with_run_extension_labeled(v_this_dispatch: Ref)
+method with_run_extension_labeled(v_this_extension: Ref)
   returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), nullable(intType()))
+  requires isSubtype(typeOf(v_this_extension), nullable(intType()))
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
@@ -56,7 +56,7 @@ method with_run_extension_labeled(v_this_dispatch: Ref)
   var anon_33: Ref
   var v_ret_17: Ref
   var anon_12: Ref
-  v_ret_1 := boolToRef(v_this_dispatch == nullValue())
+  v_ret_1 := boolToRef(v_this_extension == nullValue())
   goto lbl_ret_1
   label lbl_ret_1
   anon_13 := v_ret_1
@@ -64,7 +64,7 @@ method with_run_extension_labeled(v_this_dispatch: Ref)
     cond1 := boolToRef(true)
   } else {
     var v_ret_2: Ref
-    v_ret_2 := notBool(boolToRef(v_this_dispatch == nullValue()))
+    v_ret_2 := notBool(boolToRef(v_this_extension == nullValue()))
     goto lbl_ret_2
     label lbl_ret_2
     cond1 := v_ret_2
@@ -118,7 +118,7 @@ method with_run_extension_labeled(v_this_dispatch: Ref)
   assert !boolFromRef(anon_8)
   assert !boolFromRef(anon_8)
   assert boolFromRef(anon_1)
-  v_ret_12 := boolToRef(v_this_dispatch == nullValue())
+  v_ret_12 := boolToRef(v_this_extension == nullValue())
   goto lbl_ret_12
   label lbl_ret_12
   anon_27 := v_ret_12
@@ -126,7 +126,7 @@ method with_run_extension_labeled(v_this_dispatch: Ref)
     anon_26 := boolToRef(true)
   } else {
     var v_ret_13: Ref
-    v_ret_13 := notBool(boolToRef(v_this_dispatch == nullValue()))
+    v_ret_13 := notBool(boolToRef(v_this_extension == nullValue()))
     goto lbl_ret_13
     label lbl_ret_13
     anon_26 := v_ret_13

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/scoped_receivers.fir.diag.txt
@@ -1,72 +1,73 @@
 /scoped_receivers.kt: info: Generated Viper text for with_run_extension_labeled:
 field size: Ref
 
-method with_run_extension_labeled(v_this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(v_this), nullable(intType()))
-  ensures isSubtype(typeOf(ret_0), unitType())
+method with_run_extension_labeled(v_this_dispatch: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), nullable(intType()))
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
   var anon_13: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_14: Ref
   var anon_15: Ref
-  var ret_3: Ref
+  var v_ret_3: Ref
   var anon_0: Ref
   var anon_16: Ref
-  var ret_4: Ref
+  var v_ret_4: Ref
   var anon_1: Ref
   var anon_17: Ref
   var anon_18: Ref
-  var ret_5: Ref
+  var v_ret_5: Ref
   var anon_2: Ref
   var anon_19: Ref
-  var ret_6: Ref
+  var v_ret_6: Ref
   var anon_3: Ref
   var anon_20: Ref
-  var ret_7: Ref
+  var v_ret_7: Ref
   var anon_4: Ref
   var anon_21: Ref
-  var ret_8: Ref
+  var v_ret_8: Ref
   var anon_5: Ref
   var anon_22: Ref
-  var ret_9: Ref
+  var v_ret_9: Ref
   var anon_6: Ref
   var anon_23: Ref
   var anon_24: Ref
-  var ret_10: Ref
+  var v_ret_10: Ref
   var anon_7: Ref
   var anon_25: Ref
-  var ret_11: Ref
+  var v_ret_11: Ref
   var anon_8: Ref
   var anon_26: Ref
   var anon_27: Ref
-  var ret_12: Ref
+  var v_ret_12: Ref
   var anon_28: Ref
   var anon_29: Ref
-  var ret_14: Ref
+  var v_ret_14: Ref
   var anon_9: Ref
   var anon_30: Ref
-  var ret_15: Ref
+  var v_ret_15: Ref
   var anon_10: Ref
   var anon_31: Ref
   var anon_32: Ref
-  var ret_16: Ref
+  var v_ret_16: Ref
   var anon_11: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_33: Ref
+  var v_ret_17: Ref
   var anon_12: Ref
-  ret_1 := boolToRef(v_this == nullValue())
+  v_ret_1 := boolToRef(v_this_dispatch == nullValue())
   goto lbl_ret_1
   label lbl_ret_1
-  anon_13 := ret_1
+  anon_13 := v_ret_1
   if (boolFromRef(anon_13)) {
     cond1 := boolToRef(true)
   } else {
-    var ret_2: Ref
-    ret_2 := notBool(boolToRef(v_this == nullValue()))
+    var v_ret_2: Ref
+    v_ret_2 := notBool(boolToRef(v_this_dispatch == nullValue()))
     goto lbl_ret_2
     label lbl_ret_2
-    cond1 := ret_2
+    cond1 := v_ret_2
   }
   assert boolFromRef(cond1)
   anon_0 := boolToRef(true)
@@ -79,33 +80,33 @@ method with_run_extension_labeled(v_this: Ref) returns (ret_0: Ref)
   anon_3 := anon_2
   inhale isSubtype(typeOf(anon_3), nullable(intType()))
   anon_4 := anon_3
-  ret_7 := boolToRef(anon_4 == nullValue())
+  v_ret_7 := boolToRef(anon_4 == nullValue())
   goto lbl_ret_7
   label lbl_ret_7
-  anon_20 := ret_7
+  anon_20 := v_ret_7
   assert boolFromRef(anon_20)
   inhale isSubtype(typeOf(anon_3), nullable(intType()))
   anon_5 := anon_3
-  ret_8 := boolToRef(anon_5 == nullValue())
+  v_ret_8 := boolToRef(anon_5 == nullValue())
   goto lbl_ret_8
   label lbl_ret_8
-  anon_21 := ret_8
+  anon_21 := v_ret_8
   assert boolFromRef(anon_21)
   inhale isSubtype(typeOf(anon_3), nullable(intType()))
   anon_6 := anon_3
-  ret_9 := boolToRef(anon_6 == nullValue())
+  v_ret_9 := boolToRef(anon_6 == nullValue())
   goto lbl_ret_9
   label lbl_ret_9
-  anon_22 := ret_9
+  anon_22 := v_ret_9
   assert boolFromRef(anon_22)
   label lbl_ret_6
-  inhale isSubtype(typeOf(ret_6), unitType())
-  anon_19 := ret_6
-  ret_5 := anon_19
-  inhale isSubtype(typeOf(ret_5), nullable(anyType()))
+  inhale isSubtype(typeOf(v_ret_6), unitType())
+  anon_19 := v_ret_6
+  v_ret_5 := anon_19
+  inhale isSubtype(typeOf(v_ret_5), nullable(anyType()))
   goto lbl_ret_5
   label lbl_ret_5
-  anon_18 := ret_5
+  anon_18 := v_ret_5
   anon_17 := anon_18
   inhale isSubtype(typeOf(anon_17), unitType())
   assert boolFromRef(anon_1)
@@ -117,18 +118,18 @@ method with_run_extension_labeled(v_this: Ref) returns (ret_0: Ref)
   assert !boolFromRef(anon_8)
   assert !boolFromRef(anon_8)
   assert boolFromRef(anon_1)
-  ret_12 := boolToRef(v_this == nullValue())
+  v_ret_12 := boolToRef(v_this_dispatch == nullValue())
   goto lbl_ret_12
   label lbl_ret_12
-  anon_27 := ret_12
+  anon_27 := v_ret_12
   if (boolFromRef(anon_27)) {
     anon_26 := boolToRef(true)
   } else {
-    var ret_13: Ref
-    ret_13 := notBool(boolToRef(v_this == nullValue()))
+    var v_ret_13: Ref
+    v_ret_13 := notBool(boolToRef(v_this_dispatch == nullValue()))
     goto lbl_ret_13
     label lbl_ret_13
-    anon_26 := ret_13
+    anon_26 := v_ret_13
   }
   assert boolFromRef(anon_26)
   anon_9 := boolToRef(false)
@@ -145,46 +146,46 @@ method with_run_extension_labeled(v_this: Ref) returns (ret_0: Ref)
   assert !boolFromRef(anon_10)
   assert boolFromRef(anon_12)
   assert boolFromRef(anon_12)
-  label ret_17
-  inhale isSubtype(typeOf(ret), unitType())
-  anon := ret
-  ret_16 := anon
-  inhale isSubtype(typeOf(ret_16), nullable(anyType()))
+  label lbl_ret_17
+  inhale isSubtype(typeOf(v_ret_17), unitType())
+  anon_33 := v_ret_17
+  v_ret_16 := anon_33
+  inhale isSubtype(typeOf(v_ret_16), nullable(anyType()))
   goto lbl_ret_16
   label lbl_ret_16
-  anon_32 := ret_16
+  anon_32 := v_ret_16
   anon_31 := anon_32
   inhale isSubtype(typeOf(anon_31), unitType())
   label lbl_ret_15
-  inhale isSubtype(typeOf(ret_15), unitType())
-  anon_30 := ret_15
-  ret_14 := anon_30
-  inhale isSubtype(typeOf(ret_14), nullable(anyType()))
+  inhale isSubtype(typeOf(v_ret_15), unitType())
+  anon_30 := v_ret_15
+  v_ret_14 := anon_30
+  inhale isSubtype(typeOf(v_ret_14), nullable(anyType()))
   goto lbl_ret_14
   label lbl_ret_14
-  anon_29 := ret_14
+  anon_29 := v_ret_14
   anon_28 := anon_29
   inhale isSubtype(typeOf(anon_28), unitType())
   label lbl_ret_11
-  inhale isSubtype(typeOf(ret_11), unitType())
-  anon_25 := ret_11
-  ret_10 := anon_25
-  inhale isSubtype(typeOf(ret_10), nullable(anyType()))
+  inhale isSubtype(typeOf(v_ret_11), unitType())
+  anon_25 := v_ret_11
+  v_ret_10 := anon_25
+  inhale isSubtype(typeOf(v_ret_10), nullable(anyType()))
   goto lbl_ret_10
   label lbl_ret_10
-  anon_24 := ret_10
+  anon_24 := v_ret_10
   anon_23 := anon_24
   inhale isSubtype(typeOf(anon_23), unitType())
   label lbl_ret_4
-  inhale isSubtype(typeOf(ret_4), unitType())
-  anon_16 := ret_4
-  ret_3 := anon_16
-  inhale isSubtype(typeOf(ret_3), nullable(anyType()))
+  inhale isSubtype(typeOf(v_ret_4), unitType())
+  anon_16 := v_ret_4
+  v_ret_3 := anon_16
+  inhale isSubtype(typeOf(v_ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_15 := ret_3
+  anon_15 := v_ret_3
   anon_14 := anon_15
   inhale isSubtype(typeOf(anon_14), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -25,21 +25,21 @@ method checkMemberAccess() returns (ret_0: Ref)
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon_9: Ref
+  var anon: Ref
   var ret_3: Ref
   var anon_2: Ref
   var anon_10: Ref
   var ret_4: Ref
   var anon_3: Ref
-  var anon: Ref
+  var anon_11: Ref
   obj := con(intToRef(42))
   inhale isSubtype(typeOf(obj), nullable(anyType()))
   anon_0 := obj
   anon_7 := idFun(anon_0)
   anon_1 := anon_7
-  inhale isSubtype(typeOf(anon_1), _c_ClassWithMember())
-  inhale acc(c_ClassWithMember_shared(anon_1), wildcard)
-  unfold acc(c_ClassWithMember_shared(anon_1), wildcard)
+  inhale isSubtype(typeOf(anon_1), c_ClassWithMember())
+  inhale acc(_c_ClassWithMember_shared(anon_1), wildcard)
+  unfold acc(_c_ClassWithMember_shared(anon_1), wildcard)
   ret_2 := anon_1.bf_member
   goto lbl_ret_2
   label lbl_ret_2
@@ -53,12 +53,12 @@ method checkMemberAccess() returns (ret_0: Ref)
   inhale isSubtype(typeOf(anon_4), intType())
   inhale isSubtype(typeOf(obj), nullable(anyType()))
   anon_2 := obj
-  inhale isSubtype(typeOf(anon_2), _c_ClassWithMember())
-  inhale acc(c_ClassWithMember_shared(anon_2), wildcard)
+  inhale isSubtype(typeOf(anon_2), c_ClassWithMember())
+  inhale acc(_c_ClassWithMember_shared(anon_2), wildcard)
   anon_3 := anon_2
-  unfold acc(c_ClassWithMember_shared(obj), wildcard)
-  anon := obj.bf_member
-  ret_0 := boolToRef(intFromRef(anon) == 42)
+  unfold acc(_c_ClassWithMember_shared(obj), wildcard)
+  anon_11 := obj.bf_member
+  ret_0 := boolToRef(intFromRef(anon_11) == 42)
   goto lbl_ret_0
   label lbl_ret_4
   anon_10 := ret_4
@@ -66,18 +66,18 @@ method checkMemberAccess() returns (ret_0: Ref)
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_9 := ret_3
-  anon_8 := anon_9
+  anon := ret_3
+  anon_8 := anon
   inhale isSubtype(typeOf(anon_8), nothingType())
   label lbl_ret_0
 }
 
 method con(member: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(member), intType())
-  ensures isSubtype(typeOf(ret), _c_ClassWithMember())
-  ensures acc(c_ClassWithMember_shared(ret), wildcard)
-  ensures acc(c_ClassWithMember_unique(ret), write)
-  ensures intFromRef((unfolding acc(c_ClassWithMember_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_ClassWithMember())
+  ensures acc(_c_ClassWithMember_shared(ret), wildcard)
+  ensures acc(_c_ClassWithMember_unique(ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithMember_shared(ret), wildcard) in
       ret.bf_member)) ==
     intFromRef(member)
 
@@ -91,7 +91,7 @@ method idFun(par_arg: Ref) returns (ret: Ref)
 field bf_wrapped: Ref
 
 method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(box), _c_Box())
+  requires isSubtype(typeOf(box), c_Box())
   ensures isSubtype(typeOf(ret_0), boolType())
   ensures boolFromRef(ret_0) == true
 {
@@ -106,42 +106,42 @@ method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
   var anon_2: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon_9: Ref
+  var anon: Ref
   var ret_4: Ref
   var anon_3: Ref
   var anon_10: Ref
-  var anon: Ref
-  inhale acc(c_Box_shared(box), wildcard)
+  var anon_11: Ref
+  inhale acc(_c_Box_shared(box), wildcard)
   inhale isSubtype(typeOf(box), nullable(anyType()))
   anon_0 := box
   anon_4 := idFun(anon_0)
   anon_1 := anon_4
-  inhale isSubtype(typeOf(anon_1), _c_Box())
-  inhale acc(c_Box_shared(anon_1), wildcard)
-  unfold acc(c_Box_shared(anon_1), wildcard)
+  inhale isSubtype(typeOf(anon_1), c_Box())
+  inhale acc(_c_Box_shared(anon_1), wildcard)
+  unfold acc(_c_Box_shared(anon_1), wildcard)
   ret_2 := anon_1.bf_wrapped
   goto lbl_ret_2
   label lbl_ret_2
   ret_1 := ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  unfold acc(c_Box_shared(box), wildcard)
+  unfold acc(_c_Box_shared(box), wildcard)
   anon_8 := box.bf_wrapped
   anon_7 := con(anon_8)
   anon_2 := anon_7
   inhale isSubtype(typeOf(anon_2), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_2), _c_Box())
-  inhale acc(c_Box_shared(anon_2), wildcard)
+  inhale isSubtype(typeOf(anon_2), c_Box())
+  inhale acc(_c_Box_shared(anon_2), wildcard)
   anon_3 := anon_2
-  unfold acc(c_Box_shared(anon_3), wildcard)
+  unfold acc(_c_Box_shared(anon_3), wildcard)
   anon_10 := anon_3.bf_wrapped
-  unfold acc(c_Box_shared(box), wildcard)
-  anon := box.bf_wrapped
-  ret_0 := boolToRef(anon_10 == anon)
+  unfold acc(_c_Box_shared(box), wildcard)
+  anon_11 := box.bf_wrapped
+  ret_0 := boolToRef(anon_10 == anon_11)
   goto lbl_ret_0
   label lbl_ret_4
-  anon_9 := ret_4
-  ret_3 := anon_9
+  anon := ret_4
+  ret_3 := anon
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
@@ -153,10 +153,10 @@ method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
 
 method con(wrapped: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(wrapped), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), _c_Box())
-  ensures acc(c_Box_shared(ret), wildcard)
-  ensures acc(c_Box_unique(ret), write)
-  ensures (unfolding acc(c_Box_shared(ret), wildcard) in ret.bf_wrapped) ==
+  ensures isSubtype(typeOf(ret), c_Box())
+  ensures acc(_c_Box_shared(ret), wildcard)
+  ensures acc(_c_Box_unique(ret), write)
+  ensures (unfolding acc(_c_Box_shared(ret), wildcard) in ret.bf_wrapped) ==
     wrapped
 
 
@@ -169,7 +169,7 @@ method idFun(par_arg: Ref) returns (ret: Ref)
 field a: Ref
 
 method checkArgumentIsCopied(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), _c_ClassWithVar())
+  requires isSubtype(typeOf(x), c_ClassWithVar())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_2: Ref
@@ -177,20 +177,20 @@ method checkArgumentIsCopied(x: Ref) returns (ret_0: Ref)
   var ret_1: Ref
   var anon_0: Ref
   var anon_4: Ref
-  var anon_5: Ref
-  var ret_2: Ref
   var anon: Ref
+  var ret_2: Ref
+  var anon_1: Ref
   inhale acc(shared(x), wildcard)
   anon_4 := havoc()
   anon_0 := anon_4
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
-  anon := anon_0
-  ret_2 := anon
+  anon_1 := anon_0
+  ret_2 := anon_1
   goto lbl_ret_2
   label lbl_ret_2
-  anon_5 := ret_2
-  ret_1 := anon_5
+  anon := ret_2
+  ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
@@ -211,7 +211,7 @@ field c: Ref
 field i: Ref
 
 method accessManyMembers(m: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(m), _c_ManyMembers())
+  requires isSubtype(typeOf(m), c_ManyMembers())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_4: Ref
@@ -223,7 +223,7 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon_9: Ref
+  var anon: Ref
   var anon_10: Ref
   var anon_11: Ref
   var anon_12: Ref
@@ -240,23 +240,23 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   var anon_19: Ref
   var anon_20: Ref
   var anon_21: Ref
-  var anon: Ref
-  inhale acc(c_ManyMembers_shared(m), wildcard)
+  var anon_22: Ref
+  inhale acc(shared(m), wildcard)
   inhale isSubtype(typeOf(m), nullable(anyType()))
   anon_0 := m
-  inhale isSubtype(typeOf(anon_0), _c_ManyMembers())
-  inhale acc(c_ManyMembers_shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), c_ManyMembers())
+  inhale acc(shared(anon_0), wildcard)
   anon_1 := anon_0
-  unfold acc(c_ManyMembers_shared(anon_1), wildcard)
-  anon_9 := anon_1.i
-  anon_8 := idFun(anon_9)
+  unfold acc(shared(anon_1), wildcard)
+  anon := anon_1.i
+  anon_8 := idFun(anon)
   anon_7 := anon_8
   inhale isSubtype(typeOf(anon_7), intType())
   anon_12 := havoc_Boolean()
   anon_11 := idFun(anon_12)
   anon_10 := anon_11
   inhale isSubtype(typeOf(anon_10), boolType())
-  unfold acc(c_ManyMembers_shared(anon_1), wildcard)
+  unfold acc(shared(anon_1), wildcard)
   ret_2 := anon_1.c
   goto lbl_ret_2
   label lbl_ret_2
@@ -267,24 +267,24 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   label lbl_ret_1
   anon_5 := ret_1
   anon_4 := anon_5
-  inhale isSubtype(typeOf(anon_4), _c_ClassWithVar())
-  inhale acc(shared(anon_4), wildcard)
+  inhale isSubtype(typeOf(anon_4), c_ClassWithVar())
+  inhale acc(_c_ClassWithVar_shared(anon_4), wildcard)
   inhale isSubtype(typeOf(m), nullable(anyType()))
   anon_2 := m
   anon_16 := idFun(anon_2)
   anon_3 := anon_16
-  inhale isSubtype(typeOf(anon_3), _c_ManyMembers())
-  inhale acc(c_ManyMembers_shared(anon_3), wildcard)
-  unfold acc(c_ManyMembers_shared(anon_3), wildcard)
+  inhale isSubtype(typeOf(anon_3), c_ManyMembers())
+  inhale acc(shared(anon_3), wildcard)
+  unfold acc(shared(anon_3), wildcard)
   anon_19 := anon_3.i
   anon_18 := idFun(anon_19)
   anon_17 := anon_18
   inhale isSubtype(typeOf(anon_17), intType())
-  anon := havoc_Boolean()
-  anon_21 := idFun(anon)
+  anon_22 := havoc_Boolean()
+  anon_21 := idFun(anon_22)
   anon_20 := anon_21
   inhale isSubtype(typeOf(anon_20), boolType())
-  unfold acc(c_ManyMembers_shared(anon_3), wildcard)
+  unfold acc(shared(anon_3), wildcard)
   ret_4 := anon_3.c
   goto lbl_ret_4
   label lbl_ret_4
@@ -295,8 +295,8 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   label lbl_ret_3
   anon_14 := ret_3
   anon_13 := anon_14
-  inhale isSubtype(typeOf(anon_13), _c_ClassWithVar())
-  inhale acc(shared(anon_13), wildcard)
+  inhale isSubtype(typeOf(anon_13), c_ClassWithVar())
+  inhale acc(_c_ClassWithVar_shared(anon_13), wildcard)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
@@ -319,7 +319,7 @@ field size: Ref
 
 method checkEvaluatedOnce(i: Ref, mm: Ref) returns (ret_0: Ref)
   requires isSubtype(typeOf(i), intType())
-  requires isSubtype(typeOf(mm), _c_ManyMembers())
+  requires isSubtype(typeOf(mm), c_ManyMembers())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var anon_2: Ref
@@ -328,10 +328,10 @@ method checkEvaluatedOnce(i: Ref, mm: Ref) returns (ret_0: Ref)
   var anon_0: Ref
   var anon_4: Ref
   var anon_5: Ref
-  var anon_6: Ref
-  var ret_2: Ref
   var anon: Ref
-  inhale acc(c_ManyMembers_shared(mm), wildcard)
+  var ret_2: Ref
+  var anon_1: Ref
+  inhale acc(_c_ManyMembers_shared(mm), wildcard)
   anon_5 := havoc_Boolean()
   if (boolFromRef(anon_5)) {
     anon_4 := intToRef(1)
@@ -340,12 +340,12 @@ method checkEvaluatedOnce(i: Ref, mm: Ref) returns (ret_0: Ref)
   anon_0 := plusInts(i, anon_4)
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
-  anon := anon_0
-  assert intFromRef(anon) == intFromRef(anon)
+  anon_1 := anon_0
+  assert intFromRef(anon_1) == intFromRef(anon_1)
   label lbl_ret_2
   inhale isSubtype(typeOf(ret_2), unitType())
-  anon_6 := ret_2
-  ret_1 := anon_6
+  anon := ret_2
+  ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -9,7 +9,7 @@ method idFun(par_arg: Ref) returns (ret: Ref)
 }
 
 /viper_casts_while_inlining.kt: info: Generated Viper text for checkMemberAccess:
-field bf_member: Ref
+field member: Ref
 
 method checkMemberAccess() returns (ret_0: Ref)
   ensures isSubtype(typeOf(ret_0), boolType())
@@ -25,13 +25,13 @@ method checkMemberAccess() returns (ret_0: Ref)
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon: Ref
+  var anon_9: Ref
   var ret_3: Ref
   var anon_2: Ref
   var anon_10: Ref
-  var ret_4: Ref
+  var ret: Ref
   var anon_3: Ref
-  var anon_11: Ref
+  var anon: Ref
   obj := con(intToRef(42))
   inhale isSubtype(typeOf(obj), nullable(anyType()))
   anon_0 := obj
@@ -40,7 +40,7 @@ method checkMemberAccess() returns (ret_0: Ref)
   inhale isSubtype(typeOf(anon_1), c_ClassWithMember())
   inhale acc(_c_ClassWithMember_shared(anon_1), wildcard)
   unfold acc(_c_ClassWithMember_shared(anon_1), wildcard)
-  ret_2 := anon_1.bf_member
+  ret_2 := anon_1.member
   goto lbl_ret_2
   label lbl_ret_2
   anon_6 := ret_2
@@ -57,38 +57,38 @@ method checkMemberAccess() returns (ret_0: Ref)
   inhale acc(_c_ClassWithMember_shared(anon_2), wildcard)
   anon_3 := anon_2
   unfold acc(_c_ClassWithMember_shared(obj), wildcard)
-  anon_11 := obj.bf_member
-  ret_0 := boolToRef(intFromRef(anon_11) == 42)
+  anon := obj.member
+  ret_0 := boolToRef(intFromRef(anon) == 42)
   goto lbl_ret_0
-  label lbl_ret_4
-  anon_10 := ret_4
+  label ret_4
+  anon_10 := ret
   ret_3 := anon_10
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon := ret_3
-  anon_8 := anon
+  anon_9 := ret_3
+  anon_8 := anon_9
   inhale isSubtype(typeOf(anon_8), nothingType())
   label lbl_ret_0
 }
 
-method con(member: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(member), intType())
-  ensures isSubtype(typeOf(ret), c_ClassWithMember())
-  ensures acc(_c_ClassWithMember_shared(ret), wildcard)
-  ensures acc(_c_ClassWithMember_unique(ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithMember_shared(ret), wildcard) in
-      ret.bf_member)) ==
-    intFromRef(member)
+method con(par_member: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_member), intType())
+  ensures isSubtype(typeOf(v_ret), c_ClassWithMember())
+  ensures acc(_c_ClassWithMember_shared(v_ret), wildcard)
+  ensures acc(_c_ClassWithMember_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithMember_shared(v_ret), wildcard) in
+      v_ret.member)) ==
+    intFromRef(par_member)
 
 
-method idFun(par_arg: Ref) returns (ret: Ref)
+method idFun(par_arg: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_arg), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
 /viper_casts_while_inlining.kt: info: Generated Viper text for checkGenericMemberAccess:
-field bf_wrapped: Ref
+field wrapped: Ref
 
 method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
   requires isSubtype(typeOf(box), c_Box())
@@ -106,11 +106,11 @@ method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
   var anon_2: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon: Ref
-  var ret_4: Ref
+  var anon_9: Ref
+  var ret: Ref
   var anon_3: Ref
   var anon_10: Ref
-  var anon_11: Ref
+  var anon: Ref
   inhale acc(_c_Box_shared(box), wildcard)
   inhale isSubtype(typeOf(box), nullable(anyType()))
   anon_0 := box
@@ -119,14 +119,14 @@ method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
   inhale isSubtype(typeOf(anon_1), c_Box())
   inhale acc(_c_Box_shared(anon_1), wildcard)
   unfold acc(_c_Box_shared(anon_1), wildcard)
-  ret_2 := anon_1.bf_wrapped
+  ret_2 := anon_1.wrapped
   goto lbl_ret_2
   label lbl_ret_2
   ret_1 := ret_2
   goto lbl_ret_1
   label lbl_ret_1
   unfold acc(_c_Box_shared(box), wildcard)
-  anon_8 := box.bf_wrapped
+  anon_8 := box.wrapped
   anon_7 := con(anon_8)
   anon_2 := anon_7
   inhale isSubtype(typeOf(anon_2), nullable(anyType()))
@@ -134,14 +134,14 @@ method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
   inhale acc(_c_Box_shared(anon_2), wildcard)
   anon_3 := anon_2
   unfold acc(_c_Box_shared(anon_3), wildcard)
-  anon_10 := anon_3.bf_wrapped
+  anon_10 := anon_3.wrapped
   unfold acc(_c_Box_shared(box), wildcard)
-  anon_11 := box.bf_wrapped
-  ret_0 := boolToRef(anon_10 == anon_11)
+  anon := box.wrapped
+  ret_0 := boolToRef(anon_10 == anon)
   goto lbl_ret_0
-  label lbl_ret_4
-  anon := ret_4
-  ret_3 := anon
+  label ret_4
+  anon_9 := ret
+  ret_3 := anon_9
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
@@ -151,18 +151,18 @@ method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
   label lbl_ret_0
 }
 
-method con(wrapped: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(wrapped), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), c_Box())
-  ensures acc(_c_Box_shared(ret), wildcard)
-  ensures acc(_c_Box_unique(ret), write)
-  ensures (unfolding acc(_c_Box_shared(ret), wildcard) in ret.bf_wrapped) ==
-    wrapped
+method con(par_wrapped: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_wrapped), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), c_Box())
+  ensures acc(_c_Box_shared(v_ret), wildcard)
+  ensures acc(_c_Box_unique(v_ret), write)
+  ensures (unfolding acc(_c_Box_shared(v_ret), wildcard) in v_ret.wrapped) ==
+    par_wrapped
 
 
-method idFun(par_arg: Ref) returns (ret: Ref)
+method idFun(par_arg: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_arg), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
 /viper_casts_while_inlining.kt: info: Generated Viper text for checkArgumentIsCopied:
@@ -178,7 +178,7 @@ method checkArgumentIsCopied(x: Ref) returns (ret_0: Ref)
   var anon_0: Ref
   var anon_4: Ref
   var anon: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   inhale acc(shared(x), wildcard)
   anon_4 := havoc()
@@ -186,10 +186,10 @@ method checkArgumentIsCopied(x: Ref) returns (ret_0: Ref)
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
-  ret_2 := anon_1
-  goto lbl_ret_2
-  label lbl_ret_2
-  anon := ret_2
+  ret := anon_1
+  goto ret_2
+  label ret_2
+  anon := ret
   ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
@@ -223,7 +223,7 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon: Ref
+  var anon_9: Ref
   var anon_10: Ref
   var anon_11: Ref
   var anon_12: Ref
@@ -232,7 +232,7 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   var ret_3: Ref
   var anon_2: Ref
   var anon_15: Ref
-  var ret_4: Ref
+  var ret: Ref
   var anon_3: Ref
   var anon_16: Ref
   var anon_17: Ref
@@ -240,7 +240,7 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   var anon_19: Ref
   var anon_20: Ref
   var anon_21: Ref
-  var anon_22: Ref
+  var anon: Ref
   inhale acc(shared(m), wildcard)
   inhale isSubtype(typeOf(m), nullable(anyType()))
   anon_0 := m
@@ -248,8 +248,8 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   inhale acc(shared(anon_0), wildcard)
   anon_1 := anon_0
   unfold acc(shared(anon_1), wildcard)
-  anon := anon_1.i
-  anon_8 := idFun(anon)
+  anon_9 := anon_1.i
+  anon_8 := idFun(anon_9)
   anon_7 := anon_8
   inhale isSubtype(typeOf(anon_7), intType())
   anon_12 := havoc_Boolean()
@@ -280,15 +280,15 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   anon_18 := idFun(anon_19)
   anon_17 := anon_18
   inhale isSubtype(typeOf(anon_17), intType())
-  anon_22 := havoc_Boolean()
-  anon_21 := idFun(anon_22)
+  anon := havoc_Boolean()
+  anon_21 := idFun(anon)
   anon_20 := anon_21
   inhale isSubtype(typeOf(anon_20), boolType())
   unfold acc(shared(anon_3), wildcard)
-  ret_4 := anon_3.c
-  goto lbl_ret_4
-  label lbl_ret_4
-  anon_15 := ret_4
+  ret := anon_3.c
+  goto ret_4
+  label ret_4
+  anon_15 := ret
   ret_3 := anon_15
   inhale isSubtype(typeOf(ret_3), nullable(anyType()))
   goto lbl_ret_3
@@ -301,9 +301,9 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method idFun(par_arg: Ref) returns (ret: Ref)
+method idFun(par_arg: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_arg), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
 /viper_casts_while_inlining.kt: info: Generated Viper text for checkEvaluatedOnce:
@@ -329,7 +329,7 @@ method checkEvaluatedOnce(i: Ref, mm: Ref) returns (ret_0: Ref)
   var anon_4: Ref
   var anon_5: Ref
   var anon: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   inhale acc(_c_ManyMembers_shared(mm), wildcard)
   anon_5 := havoc_Boolean()
@@ -342,9 +342,9 @@ method checkEvaluatedOnce(i: Ref, mm: Ref) returns (ret_0: Ref)
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == intFromRef(anon_1)
-  label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
-  anon := ret_2
+  label ret_2
+  inhale isSubtype(typeOf(ret), unitType())
+  anon := ret
   ret_1 := anon
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -1,72 +1,72 @@
 /viper_casts_while_inlining.kt: info: Generated Viper text for idFun:
-method idFun(par_arg: Ref) returns (ret: Ref)
+method idFun(par_arg: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(par_arg), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(anyType()))
 {
-  ret := par_arg
-  goto ret_0
-  label ret_0
+  v_ret_0 := par_arg
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /viper_casts_while_inlining.kt: info: Generated Viper text for checkMemberAccess:
-field member: Ref
+field bf_member: Ref
 
-method checkMemberAccess() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method checkMemberAccess() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
   var obj: Ref
   var anon_4: Ref
   var anon_5: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
   var anon_6: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
   var anon_9: Ref
-  var ret_3: Ref
+  var v_ret_3: Ref
   var anon_2: Ref
   var anon_10: Ref
-  var ret: Ref
+  var v_ret_4: Ref
   var anon_3: Ref
-  var anon: Ref
+  var anon_11: Ref
   obj := con(intToRef(42))
   inhale isSubtype(typeOf(obj), nullable(anyType()))
   anon_0 := obj
   anon_7 := idFun(anon_0)
   anon_1 := anon_7
-  inhale isSubtype(typeOf(anon_1), c_ClassWithMember())
-  inhale acc(_c_ClassWithMember_shared(anon_1), wildcard)
-  unfold acc(_c_ClassWithMember_shared(anon_1), wildcard)
-  ret_2 := anon_1.member
+  inhale isSubtype(typeOf(anon_1), ClassWithMember())
+  inhale acc(ClassWithMember_shared(anon_1), wildcard)
+  unfold acc(ClassWithMember_shared(anon_1), wildcard)
+  v_ret_2 := anon_1.bf_member
   goto lbl_ret_2
   label lbl_ret_2
-  anon_6 := ret_2
-  ret_1 := anon_6
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  anon_6 := v_ret_2
+  v_ret_1 := anon_6
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_5 := ret_1
+  anon_5 := v_ret_1
   anon_4 := anon_5
   inhale isSubtype(typeOf(anon_4), intType())
   inhale isSubtype(typeOf(obj), nullable(anyType()))
   anon_2 := obj
-  inhale isSubtype(typeOf(anon_2), c_ClassWithMember())
-  inhale acc(_c_ClassWithMember_shared(anon_2), wildcard)
+  inhale isSubtype(typeOf(anon_2), ClassWithMember())
+  inhale acc(ClassWithMember_shared(anon_2), wildcard)
   anon_3 := anon_2
-  unfold acc(_c_ClassWithMember_shared(obj), wildcard)
-  anon := obj.member
-  ret_0 := boolToRef(intFromRef(anon) == 42)
+  unfold acc(ClassWithMember_shared(obj), wildcard)
+  anon_11 := obj.bf_member
+  v_ret_0 := boolToRef(intFromRef(anon_11) == 42)
   goto lbl_ret_0
-  label ret_4
-  anon_10 := ret
-  ret_3 := anon_10
-  inhale isSubtype(typeOf(ret_3), nullable(anyType()))
+  label lbl_ret_4
+  anon_10 := v_ret_4
+  v_ret_3 := anon_10
+  inhale isSubtype(typeOf(v_ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_9 := ret_3
+  anon_9 := v_ret_3
   anon_8 := anon_9
   inhale isSubtype(typeOf(anon_8), nothingType())
   label lbl_ret_0
@@ -74,11 +74,11 @@ method checkMemberAccess() returns (ret_0: Ref)
 
 method con(par_member: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_member), intType())
-  ensures isSubtype(typeOf(v_ret), c_ClassWithMember())
-  ensures acc(_c_ClassWithMember_shared(v_ret), wildcard)
-  ensures acc(_c_ClassWithMember_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithMember_shared(v_ret), wildcard) in
-      v_ret.member)) ==
+  ensures isSubtype(typeOf(v_ret), ClassWithMember())
+  ensures acc(ClassWithMember_shared(v_ret), wildcard)
+  ensures acc(ClassWithMember_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(ClassWithMember_shared(v_ret), wildcard) in
+      v_ret.bf_member)) ==
     intFromRef(par_member)
 
 
@@ -88,64 +88,64 @@ method idFun(par_arg: Ref) returns (v_ret: Ref)
 
 
 /viper_casts_while_inlining.kt: info: Generated Viper text for checkGenericMemberAccess:
-field wrapped: Ref
+field bf_wrapped: Ref
 
-method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(box), c_Box())
-  ensures isSubtype(typeOf(ret_0), boolType())
-  ensures boolFromRef(ret_0) == true
+method checkGenericMemberAccess(box: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(box), Box())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == true
 {
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   var anon_4: Ref
   var anon_5: Ref
   var anon_6: Ref
-  var ret_3: Ref
+  var v_ret_3: Ref
   var anon_2: Ref
   var anon_7: Ref
   var anon_8: Ref
   var anon_9: Ref
-  var ret: Ref
+  var v_ret_4: Ref
   var anon_3: Ref
   var anon_10: Ref
-  var anon: Ref
-  inhale acc(_c_Box_shared(box), wildcard)
+  var anon_11: Ref
+  inhale acc(Box_shared(box), wildcard)
   inhale isSubtype(typeOf(box), nullable(anyType()))
   anon_0 := box
   anon_4 := idFun(anon_0)
   anon_1 := anon_4
-  inhale isSubtype(typeOf(anon_1), c_Box())
-  inhale acc(_c_Box_shared(anon_1), wildcard)
-  unfold acc(_c_Box_shared(anon_1), wildcard)
-  ret_2 := anon_1.wrapped
+  inhale isSubtype(typeOf(anon_1), Box())
+  inhale acc(Box_shared(anon_1), wildcard)
+  unfold acc(Box_shared(anon_1), wildcard)
+  v_ret_2 := anon_1.bf_wrapped
   goto lbl_ret_2
   label lbl_ret_2
-  ret_1 := ret_2
+  v_ret_1 := v_ret_2
   goto lbl_ret_1
   label lbl_ret_1
-  unfold acc(_c_Box_shared(box), wildcard)
-  anon_8 := box.wrapped
+  unfold acc(Box_shared(box), wildcard)
+  anon_8 := box.bf_wrapped
   anon_7 := con(anon_8)
   anon_2 := anon_7
   inhale isSubtype(typeOf(anon_2), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_2), c_Box())
-  inhale acc(_c_Box_shared(anon_2), wildcard)
+  inhale isSubtype(typeOf(anon_2), Box())
+  inhale acc(Box_shared(anon_2), wildcard)
   anon_3 := anon_2
-  unfold acc(_c_Box_shared(anon_3), wildcard)
-  anon_10 := anon_3.wrapped
-  unfold acc(_c_Box_shared(box), wildcard)
-  anon := box.wrapped
-  ret_0 := boolToRef(anon_10 == anon)
+  unfold acc(Box_shared(anon_3), wildcard)
+  anon_10 := anon_3.bf_wrapped
+  unfold acc(Box_shared(box), wildcard)
+  anon_11 := box.bf_wrapped
+  v_ret_0 := boolToRef(anon_10 == anon_11)
   goto lbl_ret_0
-  label ret_4
-  anon_9 := ret
-  ret_3 := anon_9
-  inhale isSubtype(typeOf(ret_3), nullable(anyType()))
+  label lbl_ret_4
+  anon_9 := v_ret_4
+  v_ret_3 := anon_9
+  inhale isSubtype(typeOf(v_ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_6 := ret_3
+  anon_6 := v_ret_3
   anon_5 := anon_6
   inhale isSubtype(typeOf(anon_5), nothingType())
   label lbl_ret_0
@@ -153,10 +153,10 @@ method checkGenericMemberAccess(box: Ref) returns (ret_0: Ref)
 
 method con(par_wrapped: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_wrapped), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), c_Box())
-  ensures acc(_c_Box_shared(v_ret), wildcard)
-  ensures acc(_c_Box_unique(v_ret), write)
-  ensures (unfolding acc(_c_Box_shared(v_ret), wildcard) in v_ret.wrapped) ==
+  ensures isSubtype(typeOf(v_ret), Box())
+  ensures acc(Box_shared(v_ret), wildcard)
+  ensures acc(Box_unique(v_ret), write)
+  ensures (unfolding acc(Box_shared(v_ret), wildcard) in v_ret.bf_wrapped) ==
     par_wrapped
 
 
@@ -168,17 +168,17 @@ method idFun(par_arg: Ref) returns (v_ret: Ref)
 /viper_casts_while_inlining.kt: info: Generated Viper text for checkArgumentIsCopied:
 field a: Ref
 
-method checkArgumentIsCopied(x: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(x), c_ClassWithVar())
-  ensures isSubtype(typeOf(ret_0), unitType())
+method checkArgumentIsCopied(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), ClassWithVar())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_2: Ref
   var anon_3: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
   var anon_4: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_5: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   inhale acc(shared(x), wildcard)
   anon_4 := havoc()
@@ -186,19 +186,19 @@ method checkArgumentIsCopied(x: Ref) returns (ret_0: Ref)
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
-  ret := anon_1
-  goto ret_2
-  label ret_2
-  anon := ret
-  ret_1 := anon
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  v_ret_2 := anon_1
+  goto lbl_ret_2
+  label lbl_ret_2
+  anon_5 := v_ret_2
+  v_ret_1 := anon_5
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
+  anon_3 := v_ret_1
   anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), intType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /viper_casts_while_inlining.kt: info: Generated Viper text for accessManyMembers:
@@ -210,16 +210,16 @@ field c: Ref
 
 field i: Ref
 
-method accessManyMembers(m: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(m), c_ManyMembers())
-  ensures isSubtype(typeOf(ret_0), unitType())
+method accessManyMembers(m: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(m), ManyMembers())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_4: Ref
   var anon_5: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
   var anon_6: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
@@ -229,10 +229,10 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   var anon_12: Ref
   var anon_13: Ref
   var anon_14: Ref
-  var ret_3: Ref
+  var v_ret_3: Ref
   var anon_2: Ref
   var anon_15: Ref
-  var ret: Ref
+  var v_ret_4: Ref
   var anon_3: Ref
   var anon_16: Ref
   var anon_17: Ref
@@ -240,14 +240,14 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   var anon_19: Ref
   var anon_20: Ref
   var anon_21: Ref
-  var anon: Ref
-  inhale acc(shared(m), wildcard)
+  var anon_22: Ref
+  inhale acc(ManyMembers_shared(m), wildcard)
   inhale isSubtype(typeOf(m), nullable(anyType()))
   anon_0 := m
-  inhale isSubtype(typeOf(anon_0), c_ManyMembers())
-  inhale acc(shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), ManyMembers())
+  inhale acc(ManyMembers_shared(anon_0), wildcard)
   anon_1 := anon_0
-  unfold acc(shared(anon_1), wildcard)
+  unfold acc(ManyMembers_shared(anon_1), wildcard)
   anon_9 := anon_1.i
   anon_8 := idFun(anon_9)
   anon_7 := anon_8
@@ -256,49 +256,49 @@ method accessManyMembers(m: Ref) returns (ret_0: Ref)
   anon_11 := idFun(anon_12)
   anon_10 := anon_11
   inhale isSubtype(typeOf(anon_10), boolType())
-  unfold acc(shared(anon_1), wildcard)
-  ret_2 := anon_1.c
+  unfold acc(ManyMembers_shared(anon_1), wildcard)
+  v_ret_2 := anon_1.c
   goto lbl_ret_2
   label lbl_ret_2
-  anon_6 := ret_2
-  ret_1 := anon_6
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  anon_6 := v_ret_2
+  v_ret_1 := anon_6
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_5 := ret_1
+  anon_5 := v_ret_1
   anon_4 := anon_5
-  inhale isSubtype(typeOf(anon_4), c_ClassWithVar())
-  inhale acc(_c_ClassWithVar_shared(anon_4), wildcard)
+  inhale isSubtype(typeOf(anon_4), ClassWithVar())
+  inhale acc(ClassWithVar_shared(anon_4), wildcard)
   inhale isSubtype(typeOf(m), nullable(anyType()))
   anon_2 := m
   anon_16 := idFun(anon_2)
   anon_3 := anon_16
-  inhale isSubtype(typeOf(anon_3), c_ManyMembers())
-  inhale acc(shared(anon_3), wildcard)
-  unfold acc(shared(anon_3), wildcard)
+  inhale isSubtype(typeOf(anon_3), ManyMembers())
+  inhale acc(ManyMembers_shared(anon_3), wildcard)
+  unfold acc(ManyMembers_shared(anon_3), wildcard)
   anon_19 := anon_3.i
   anon_18 := idFun(anon_19)
   anon_17 := anon_18
   inhale isSubtype(typeOf(anon_17), intType())
-  anon := havoc_Boolean()
-  anon_21 := idFun(anon)
+  anon_22 := havoc_Boolean()
+  anon_21 := idFun(anon_22)
   anon_20 := anon_21
   inhale isSubtype(typeOf(anon_20), boolType())
-  unfold acc(shared(anon_3), wildcard)
-  ret := anon_3.c
-  goto ret_4
-  label ret_4
-  anon_15 := ret
-  ret_3 := anon_15
-  inhale isSubtype(typeOf(ret_3), nullable(anyType()))
+  unfold acc(ManyMembers_shared(anon_3), wildcard)
+  v_ret_4 := anon_3.c
+  goto lbl_ret_4
+  label lbl_ret_4
+  anon_15 := v_ret_4
+  v_ret_3 := anon_15
+  inhale isSubtype(typeOf(v_ret_3), nullable(anyType()))
   goto lbl_ret_3
   label lbl_ret_3
-  anon_14 := ret_3
+  anon_14 := v_ret_3
   anon_13 := anon_14
-  inhale isSubtype(typeOf(anon_13), c_ClassWithVar())
-  inhale acc(_c_ClassWithVar_shared(anon_13), wildcard)
+  inhale isSubtype(typeOf(anon_13), ClassWithVar())
+  inhale acc(ClassWithVar_shared(anon_13), wildcard)
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method idFun(par_arg: Ref) returns (v_ret: Ref)
@@ -317,41 +317,41 @@ field c: Ref
 
 field size: Ref
 
-method checkEvaluatedOnce(i: Ref, mm: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(i), intType())
-  requires isSubtype(typeOf(mm), c_ManyMembers())
-  ensures isSubtype(typeOf(ret_0), unitType())
+method checkEvaluatedOnce(par_i: Ref, mm: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_i), intType())
+  requires isSubtype(typeOf(mm), ManyMembers())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_2: Ref
   var anon_3: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
   var anon_4: Ref
   var anon_5: Ref
-  var anon: Ref
-  var ret: Ref
+  var anon_6: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
-  inhale acc(_c_ManyMembers_shared(mm), wildcard)
+  inhale acc(ManyMembers_shared(mm), wildcard)
   anon_5 := havoc_Boolean()
   if (boolFromRef(anon_5)) {
     anon_4 := intToRef(1)
   } else {
     anon_4 := intToRef(-1)}
-  anon_0 := plusInts(i, anon_4)
+  anon_0 := plusInts(par_i, anon_4)
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
   inhale isSubtype(typeOf(anon_0), intType())
   anon_1 := anon_0
   assert intFromRef(anon_1) == intFromRef(anon_1)
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
-  anon := ret
-  ret_1 := anon
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
+  anon_6 := v_ret_2
+  v_ret_1 := anon_6
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
+  anon_3 := v_ret_1
   anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -1,34 +1,50 @@
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /multiple_receivers.kt: info: Generated Viper text for applyDelta:
 field delta: Ref
 
 field size: Ref
 
-method applyDelta(v_this: Ref, this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(v_this), _c_ClassWithExtension())
-  requires isSubtype(typeOf(this), intType())
+method applyDelta(this: Ref, [v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(this), c_ClassWithExtension())
+  requires isSubtype(typeOf([v$this]), intType())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var withoutLabels: Ref
   var anon_0: Ref
   var withLabels: Ref
   var anon: Ref
-  inhale acc(c_ClassWithExtension_shared(v_this), wildcard)
-  unfold acc(c_ClassWithExtension_shared(v_this), wildcard)
-  anon_0 := v_this.delta
-  withoutLabels := plusInts(this, anon_0)
-  unfold acc(c_ClassWithExtension_shared(v_this), wildcard)
-  anon := v_this.delta
-  withLabels := plusInts(anon, this)
+  inhale acc(_c_ClassWithExtension_shared(this), wildcard)
+  unfold acc(_c_ClassWithExtension_shared(this), wildcard)
+  anon_0 := this.delta
+  withoutLabels := plusInts([v$this], anon_0)
+  unfold acc(_c_ClassWithExtension_shared(this), wildcard)
+  anon := this.delta
+  withLabels := plusInts(anon, [v$this])
   assert intFromRef(withoutLabels) == intFromRef(withLabels)
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /multiple_receivers.kt: info: Generated Viper text for returnDelta:
 field delta: Ref
 
 method returnDelta(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_ClassWithExtension())
+  requires isSubtype(typeOf(this), c_ClassWithExtension())
   ensures isSubtype(typeOf(ret_0), intType())
 {
   inhale acc(shared(this), wildcard)
@@ -37,29 +53,65 @@ method returnDelta(this: Ref) returns (ret_0: Ref)
   goto lbl_ret_0
   label lbl_ret_0
 }
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
 
 /multiple_receivers.kt: info: Generated Viper text for extensionReturnDelta:
 field delta: Ref
 
-method extensionReturnDelta(this: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(this), _c_ClassWithExtension())
+method extensionReturnDelta([v$this]: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf([v$this]), c_ClassWithExtension())
   ensures isSubtype(typeOf(ret_0), intType())
 {
-  inhale acc(shared(this), wildcard)
-  unfold acc(shared(this), wildcard)
-  ret_0 := this.delta
+  inhale acc(shared([v$this]), wildcard)
+  unfold acc(shared([v$this]), wildcard)
+  ret_0 := [v$this].delta
   goto lbl_ret_0
   label lbl_ret_0
 }
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/multiple_receivers.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
 
 /multiple_receivers.kt: info: Generated Viper text for checkClassWithExtension:
 field bf_delta: Ref
 
 field size: Ref
 
-method applyDelta(v_this: Ref, this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), _c_ClassWithExtension())
-  requires isSubtype(typeOf(this), intType())
+method applyDelta(this: Ref, [v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(this), c_ClassWithExtension())
+  requires isSubtype(typeOf([v$this]), intType())
   ensures isSubtype(typeOf(ret), unitType())
 
 
@@ -76,24 +128,24 @@ method checkClassWithExtension() returns (ret_0: Ref)
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon_9: Ref
+  var anon: Ref
   var anon_10: Ref
   var ret_3: Ref
   var anon_2: Ref
-  var anon: Ref
+  var anon_11: Ref
   anon_5 := con(intToRef(42))
   anon_0 := anon_5
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_0), _c_ClassWithExtension())
-  inhale acc(c_ClassWithExtension_shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), c_ClassWithExtension())
+  inhale acc(_c_ClassWithExtension_shared(anon_0), wildcard)
   anon_1 := anon_0
   anon_7 := applyDelta(anon_1, intToRef(42))
   anon_8 := returnDelta(anon_1)
-  anon_9 := extensionReturnDelta(anon_1)
+  anon := extensionReturnDelta(anon_1)
   anon_2 := intToRef(42)
-  unfold acc(c_ClassWithExtension_shared(anon_1), wildcard)
-  anon := anon_1.bf_delta
-  ret_3 := plusInts(anon_2, anon)
+  unfold acc(_c_ClassWithExtension_shared(anon_1), wildcard)
+  anon_11 := anon_1.bf_delta
+  ret_3 := plusInts(anon_2, anon_11)
   goto lbl_ret_3
   label lbl_ret_3
   anon_10 := ret_3
@@ -114,19 +166,19 @@ method checkClassWithExtension() returns (ret_0: Ref)
 
 method con(delta: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(delta), intType())
-  ensures isSubtype(typeOf(ret), _c_ClassWithExtension())
-  ensures acc(c_ClassWithExtension_shared(ret), wildcard)
-  ensures acc(c_ClassWithExtension_unique(ret), write)
-  ensures intFromRef((unfolding acc(c_ClassWithExtension_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_ClassWithExtension())
+  ensures acc(_c_ClassWithExtension_shared(ret), wildcard)
+  ensures acc(_c_ClassWithExtension_unique(ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithExtension_shared(ret), wildcard) in
       ret.bf_delta)) ==
     intFromRef(delta)
 
 
-method extensionReturnDelta(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_ClassWithExtension())
+method extensionReturnDelta([v$this]: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), c_ClassWithExtension())
   ensures isSubtype(typeOf(ret), intType())
 
 
-method returnDelta(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), _c_ClassWithExtension())
+method returnDelta(this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(this), c_ClassWithExtension())
   ensures isSubtype(typeOf(ret), intType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -1,20 +1,12 @@
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /multiple_receivers.kt: info: Generated Viper text for applyDelta:
 field delta: Ref
 
 field size: Ref
 
-method applyDelta(this: Ref, [v$this]: Ref) returns (ret_0: Ref)
+method applyDelta(this: Ref, v_this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_ClassWithExtension())
-  requires isSubtype(typeOf([v$this]), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  requires isSubtype(typeOf(v_this), intType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var withoutLabels: Ref
   var anon_0: Ref
@@ -23,96 +15,52 @@ method applyDelta(this: Ref, [v$this]: Ref) returns (ret_0: Ref)
   inhale acc(_c_ClassWithExtension_shared(this), wildcard)
   unfold acc(_c_ClassWithExtension_shared(this), wildcard)
   anon_0 := this.delta
-  withoutLabels := plusInts([v$this], anon_0)
+  withoutLabels := plusInts(v_this, anon_0)
   unfold acc(_c_ClassWithExtension_shared(this), wildcard)
   anon := this.delta
-  withLabels := plusInts(anon, [v$this])
+  withLabels := plusInts(anon, v_this)
   assert intFromRef(withoutLabels) == intFromRef(withLabels)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /multiple_receivers.kt: info: Generated Viper text for returnDelta:
 field delta: Ref
 
-method returnDelta(this: Ref) returns (ret_0: Ref)
+method returnDelta(this: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), c_ClassWithExtension())
-  ensures isSubtype(typeOf(ret_0), intType())
+  ensures isSubtype(typeOf(ret), intType())
 {
   inhale acc(shared(this), wildcard)
   unfold acc(shared(this), wildcard)
-  ret_0 := this.delta
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := this.delta
+  goto ret_0
+  label ret_0
 }
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
 
 /multiple_receivers.kt: info: Generated Viper text for extensionReturnDelta:
 field delta: Ref
 
-method extensionReturnDelta([v$this]: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf([v$this]), c_ClassWithExtension())
-  ensures isSubtype(typeOf(ret_0), intType())
+method extensionReturnDelta(v_this: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), c_ClassWithExtension())
+  ensures isSubtype(typeOf(ret), intType())
 {
-  inhale acc(shared([v$this]), wildcard)
-  unfold acc(shared([v$this]), wildcard)
-  ret_0 := [v$this].delta
-  goto lbl_ret_0
-  label lbl_ret_0
+  inhale acc(shared(v_this), wildcard)
+  unfold acc(shared(v_this), wildcard)
+  ret := v_this.delta
+  goto ret_0
+  label ret_0
 }
 
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/multiple_receivers.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /multiple_receivers.kt: info: Generated Viper text for checkClassWithExtension:
-field bf_delta: Ref
+field delta: Ref
 
 field size: Ref
 
-method applyDelta(this: Ref, [v$this]: Ref) returns (ret: Ref)
+method applyDelta(this: Ref, v_this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_ClassWithExtension())
-  requires isSubtype(typeOf([v$this]), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  requires isSubtype(typeOf(v_this), intType())
+  ensures isSubtype(typeOf(v_ret), unitType())
 
 
 method checkClassWithExtension() returns (ret_0: Ref)
@@ -128,11 +76,11 @@ method checkClassWithExtension() returns (ret_0: Ref)
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var anon: Ref
+  var anon_9: Ref
   var anon_10: Ref
-  var ret_3: Ref
+  var ret: Ref
   var anon_2: Ref
-  var anon_11: Ref
+  var anon: Ref
   anon_5 := con(intToRef(42))
   anon_0 := anon_5
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
@@ -141,14 +89,14 @@ method checkClassWithExtension() returns (ret_0: Ref)
   anon_1 := anon_0
   anon_7 := applyDelta(anon_1, intToRef(42))
   anon_8 := returnDelta(anon_1)
-  anon := extensionReturnDelta(anon_1)
+  anon_9 := extensionReturnDelta(anon_1)
   anon_2 := intToRef(42)
   unfold acc(_c_ClassWithExtension_shared(anon_1), wildcard)
-  anon_11 := anon_1.bf_delta
-  ret_3 := plusInts(anon_2, anon_11)
-  goto lbl_ret_3
-  label lbl_ret_3
-  anon_10 := ret_3
+  anon := anon_1.delta
+  ret := plusInts(anon_2, anon)
+  goto ret_3
+  label ret_3
+  anon_10 := ret
   assert intFromRef(anon_10) == 84
   label lbl_ret_2
   inhale isSubtype(typeOf(ret_2), unitType())
@@ -164,21 +112,21 @@ method checkClassWithExtension() returns (ret_0: Ref)
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method con(delta: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(delta), intType())
-  ensures isSubtype(typeOf(ret), c_ClassWithExtension())
-  ensures acc(_c_ClassWithExtension_shared(ret), wildcard)
-  ensures acc(_c_ClassWithExtension_unique(ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithExtension_shared(ret), wildcard) in
-      ret.bf_delta)) ==
-    intFromRef(delta)
+method con(par_delta: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_delta), intType())
+  ensures isSubtype(typeOf(v_ret), c_ClassWithExtension())
+  ensures acc(_c_ClassWithExtension_shared(v_ret), wildcard)
+  ensures acc(_c_ClassWithExtension_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithExtension_shared(v_ret), wildcard) in
+      v_ret.delta)) ==
+    intFromRef(par_delta)
 
 
-method extensionReturnDelta([v$this]: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), c_ClassWithExtension())
-  ensures isSubtype(typeOf(ret), intType())
+method extensionReturnDelta(v_this: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), c_ClassWithExtension())
+  ensures isSubtype(typeOf(v_ret), intType())
 
 
-method returnDelta(this: Ref) returns (ret: Ref)
+method returnDelta(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_ClassWithExtension())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret), intType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -3,9 +3,10 @@ field delta: Ref
 
 field size: Ref
 
-method applyDelta(v_this: Ref, v_this_dispatch: Ref) returns (v_ret_0: Ref)
+method applyDelta(v_this: Ref, v_this_extension: Ref)
+  returns (v_ret_0: Ref)
   requires isSubtype(typeOf(v_this), ClassWithExtension())
-  requires isSubtype(typeOf(v_this_dispatch), intType())
+  requires isSubtype(typeOf(v_this_extension), intType())
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var withoutLabels: Ref
@@ -15,10 +16,10 @@ method applyDelta(v_this: Ref, v_this_dispatch: Ref) returns (v_ret_0: Ref)
   inhale acc(ClassWithExtension_shared(v_this), wildcard)
   unfold acc(ClassWithExtension_shared(v_this), wildcard)
   anon_0 := v_this.delta
-  withoutLabels := plusInts(v_this_dispatch, anon_0)
+  withoutLabels := plusInts(v_this_extension, anon_0)
   unfold acc(ClassWithExtension_shared(v_this), wildcard)
   anon_1 := v_this.delta
-  withLabels := plusInts(anon_1, v_this_dispatch)
+  withLabels := plusInts(anon_1, v_this_extension)
   assert intFromRef(withoutLabels) == intFromRef(withLabels)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
@@ -41,13 +42,13 @@ method returnDelta(this: Ref) returns (v_ret_0: Ref)
 /multiple_receivers.kt: info: Generated Viper text for extensionReturnDelta:
 field delta: Ref
 
-method extensionReturnDelta(v_this_dispatch: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), ClassWithExtension())
+method extensionReturnDelta(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), ClassWithExtension())
   ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  inhale acc(shared(v_this_dispatch), wildcard)
-  unfold acc(shared(v_this_dispatch), wildcard)
-  v_ret_0 := v_this_dispatch.delta
+  inhale acc(shared(v_this_extension), wildcard)
+  unfold acc(shared(v_this_extension), wildcard)
+  v_ret_0 := v_this_extension.delta
   goto lbl_ret_0
   label lbl_ret_0
 }
@@ -57,9 +58,9 @@ field bf_delta: Ref
 
 field size: Ref
 
-method applyDelta(v_this: Ref, v_this_dispatch: Ref) returns (v_ret: Ref)
+method applyDelta(v_this: Ref, v_this_extension: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(v_this), ClassWithExtension())
-  requires isSubtype(typeOf(v_this_dispatch), intType())
+  requires isSubtype(typeOf(v_this_extension), intType())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
@@ -122,8 +123,8 @@ method con(par_delta: Ref) returns (v_ret: Ref)
     intFromRef(par_delta)
 
 
-method extensionReturnDelta(v_this_dispatch: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), ClassWithExtension())
+method extensionReturnDelta(v_this_extension: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this_extension), ClassWithExtension())
   ensures isSubtype(typeOf(v_ret), intType())
 
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -3,130 +3,130 @@ field delta: Ref
 
 field size: Ref
 
-method applyDelta(this: Ref, v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_ClassWithExtension())
-  requires isSubtype(typeOf(v_this), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+method applyDelta(v_this: Ref, v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this), ClassWithExtension())
+  requires isSubtype(typeOf(v_this_dispatch), intType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var withoutLabels: Ref
   var anon_0: Ref
   var withLabels: Ref
-  var anon: Ref
-  inhale acc(_c_ClassWithExtension_shared(this), wildcard)
-  unfold acc(_c_ClassWithExtension_shared(this), wildcard)
-  anon_0 := this.delta
-  withoutLabels := plusInts(v_this, anon_0)
-  unfold acc(_c_ClassWithExtension_shared(this), wildcard)
-  anon := this.delta
-  withLabels := plusInts(anon, v_this)
+  var anon_1: Ref
+  inhale acc(ClassWithExtension_shared(v_this), wildcard)
+  unfold acc(ClassWithExtension_shared(v_this), wildcard)
+  anon_0 := v_this.delta
+  withoutLabels := plusInts(v_this_dispatch, anon_0)
+  unfold acc(ClassWithExtension_shared(v_this), wildcard)
+  anon_1 := v_this.delta
+  withLabels := plusInts(anon_1, v_this_dispatch)
   assert intFromRef(withoutLabels) == intFromRef(withLabels)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /multiple_receivers.kt: info: Generated Viper text for returnDelta:
 field delta: Ref
 
-method returnDelta(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), c_ClassWithExtension())
-  ensures isSubtype(typeOf(ret), intType())
+method returnDelta(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), ClassWithExtension())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   inhale acc(shared(this), wildcard)
   unfold acc(shared(this), wildcard)
-  ret := this.delta
-  goto ret_0
-  label ret_0
+  v_ret_0 := this.delta
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /multiple_receivers.kt: info: Generated Viper text for extensionReturnDelta:
 field delta: Ref
 
-method extensionReturnDelta(v_this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), c_ClassWithExtension())
-  ensures isSubtype(typeOf(ret), intType())
+method extensionReturnDelta(v_this_dispatch: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), ClassWithExtension())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  inhale acc(shared(v_this), wildcard)
-  unfold acc(shared(v_this), wildcard)
-  ret := v_this.delta
-  goto ret_0
-  label ret_0
+  inhale acc(shared(v_this_dispatch), wildcard)
+  unfold acc(shared(v_this_dispatch), wildcard)
+  v_ret_0 := v_this_dispatch.delta
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /multiple_receivers.kt: info: Generated Viper text for checkClassWithExtension:
-field delta: Ref
+field bf_delta: Ref
 
 field size: Ref
 
-method applyDelta(this: Ref, v_this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_ClassWithExtension())
-  requires isSubtype(typeOf(v_this), intType())
+method applyDelta(v_this: Ref, v_this_dispatch: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), ClassWithExtension())
+  requires isSubtype(typeOf(v_this_dispatch), intType())
   ensures isSubtype(typeOf(v_ret), unitType())
 
 
-method checkClassWithExtension() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method checkClassWithExtension() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_3: Ref
   var anon_4: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
   var anon_5: Ref
   var anon_6: Ref
-  var ret_2: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   var anon_7: Ref
   var anon_8: Ref
   var anon_9: Ref
   var anon_10: Ref
-  var ret: Ref
+  var v_ret_3: Ref
   var anon_2: Ref
-  var anon: Ref
+  var anon_11: Ref
   anon_5 := con(intToRef(42))
   anon_0 := anon_5
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_0), c_ClassWithExtension())
-  inhale acc(_c_ClassWithExtension_shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), ClassWithExtension())
+  inhale acc(ClassWithExtension_shared(anon_0), wildcard)
   anon_1 := anon_0
   anon_7 := applyDelta(anon_1, intToRef(42))
   anon_8 := returnDelta(anon_1)
   anon_9 := extensionReturnDelta(anon_1)
   anon_2 := intToRef(42)
-  unfold acc(_c_ClassWithExtension_shared(anon_1), wildcard)
-  anon := anon_1.delta
-  ret := plusInts(anon_2, anon)
-  goto ret_3
-  label ret_3
-  anon_10 := ret
+  unfold acc(ClassWithExtension_shared(anon_1), wildcard)
+  anon_11 := anon_1.bf_delta
+  v_ret_3 := plusInts(anon_2, anon_11)
+  goto lbl_ret_3
+  label lbl_ret_3
+  anon_10 := v_ret_3
   assert intFromRef(anon_10) == 84
   label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
-  anon_6 := ret_2
-  ret_1 := anon_6
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  inhale isSubtype(typeOf(v_ret_2), unitType())
+  anon_6 := v_ret_2
+  v_ret_1 := anon_6
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_4 := ret_1
+  anon_4 := v_ret_1
   anon_3 := anon_4
   inhale isSubtype(typeOf(anon_3), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method con(par_delta: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_delta), intType())
-  ensures isSubtype(typeOf(v_ret), c_ClassWithExtension())
-  ensures acc(_c_ClassWithExtension_shared(v_ret), wildcard)
-  ensures acc(_c_ClassWithExtension_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithExtension_shared(v_ret), wildcard) in
-      v_ret.delta)) ==
+  ensures isSubtype(typeOf(v_ret), ClassWithExtension())
+  ensures acc(ClassWithExtension_shared(v_ret), wildcard)
+  ensures acc(ClassWithExtension_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(ClassWithExtension_shared(v_ret), wildcard) in
+      v_ret.bf_delta)) ==
     intFromRef(par_delta)
 
 
-method extensionReturnDelta(v_this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(v_this), c_ClassWithExtension())
+method extensionReturnDelta(v_this_dispatch: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), ClassWithExtension())
   ensures isSubtype(typeOf(v_ret), intType())
 
 
-method returnDelta(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_ClassWithExtension())
+method returnDelta(v_this: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(v_this), ClassWithExtension())
   ensures isSubtype(typeOf(v_ret), intType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/nullability.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/nullability.fir.diag.txt
@@ -1,8 +1,8 @@
 /nullability.kt: info: Generated Viper text for return_null:
-method return_null() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method return_null() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
-  ret := nullValue()
-  goto ret_0
-  label ret_0
+  v_ret_0 := nullValue()
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -5,7 +5,7 @@ field value: Ref
 
 function isAlternating(node: Ref, expectsPositive: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
+  requires isSubtype(typeOf(node), c_Node())
   requires isSubtype(typeOf(expectsPositive), boolType())
   ensures isSubtype(typeOf(result), boolType())
 {
@@ -53,19 +53,19 @@ field next: Ref
 field value: Ref
 
 function isStrictlyAscendingAndPositive(node: Ref): Ref
-  requires acc(c_Node_shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_Node())
-  requires intFromRef((unfolding acc(c_Node_shared(node), wildcard) in
+  requires acc(_c_Node_shared(node), wildcard)
+  requires isSubtype(typeOf(node), c_Node())
+  requires intFromRef((unfolding acc(_c_Node_shared(node), wildcard) in
       node.value)) >=
     0
   ensures isSubtype(typeOf(result), boolType())
 {
   (let l0_nextNode_0 ==
-    ((unfolding acc(c_Node_shared(node), wildcard) in node.next)) in
+    ((unfolding acc(_c_Node_shared(node), wildcard) in node.next)) in
     (let v_anon_2_0 ==
       ((!(l0_nextNode_0 == nullValue()) ?
-        (unfolding acc(c_Node_shared(node), wildcard) in
-          (unfolding acc(c_Node_shared(l0_nextNode_0), wildcard) in
+        (unfolding acc(_c_Node_shared(node), wildcard) in
+          (unfolding acc(_c_Node_shared(l0_nextNode_0), wildcard) in
             l0_nextNode_0.value)) :
         null)) in
       (let v_anon_3_0 ==
@@ -75,21 +75,21 @@ function isStrictlyAscendingAndPositive(node: Ref): Ref
         (let v_anon_5_0 ==
           ((!(intFromRef(v_anon_2_0) < 0) &&
           !(l0_nextNode_0 == nullValue()) ?
-            (unfolding acc(c_Node_shared(node), wildcard) in
-              (unfolding acc(c_Node_shared(l0_nextNode_0), wildcard) in
+            (unfolding acc(_c_Node_shared(node), wildcard) in
+              (unfolding acc(_c_Node_shared(l0_nextNode_0), wildcard) in
                 l0_nextNode_0.value)) :
             null)) in
           (let v_anon_6_0 ==
             ((!(intFromRef(v_anon_2_0) < 0) &&
             !(l0_nextNode_0 == nullValue()) ?
-              (unfolding acc(c_Node_shared(node), wildcard) in node.value) :
+              (unfolding acc(_c_Node_shared(node), wildcard) in node.value) :
               null)) in
             (let v_anon_4_0 ==
               ((!(intFromRef(v_anon_2_0) < 0) &&
               !(l0_nextNode_0 == nullValue()) ?
-                (unfolding acc(c_Node_shared(node), wildcard) in
-                  (unfolding acc(c_Node_shared(node), wildcard) in
-                    (unfolding acc(c_Node_shared(l0_nextNode_0), wildcard) in
+                (unfolding acc(_c_Node_shared(node), wildcard) in
+                  (unfolding acc(_c_Node_shared(node), wildcard) in
+                    (unfolding acc(_c_Node_shared(l0_nextNode_0), wildcard) in
                       andBools(gtInts(v_anon_5_0, v_anon_6_0), isStrictlyAscendingAndPositive(l0_nextNode_0))))) :
                 null)) in
               (let v_anon_1_0 ==
@@ -116,7 +116,7 @@ field value: Ref
 
 function isLocallyValidBST(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), _c_TreeNode())
+  requires isSubtype(typeOf(node), c_TreeNode())
   ensures isSubtype(typeOf(result), boolType())
 {
   (let l0_leftNode_0 ==

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -53,19 +53,18 @@ field next: Ref
 field value: Ref
 
 function isStrictlyAscendingAndPositive(node: Ref): Ref
-  requires acc(_c_Node_shared(node), wildcard)
+  requires acc(shared(node), wildcard)
   requires isSubtype(typeOf(node), c_Node())
-  requires intFromRef((unfolding acc(_c_Node_shared(node), wildcard) in
-      node.value)) >=
+  requires intFromRef((unfolding acc(shared(node), wildcard) in node.value)) >=
     0
   ensures isSubtype(typeOf(result), boolType())
 {
   (let l0_nextNode_0 ==
-    ((unfolding acc(_c_Node_shared(node), wildcard) in node.next)) in
+    ((unfolding acc(shared(node), wildcard) in node.next)) in
     (let v_anon_2_0 ==
       ((!(l0_nextNode_0 == nullValue()) ?
-        (unfolding acc(_c_Node_shared(node), wildcard) in
-          (unfolding acc(_c_Node_shared(l0_nextNode_0), wildcard) in
+        (unfolding acc(shared(node), wildcard) in
+          (unfolding acc(shared(l0_nextNode_0), wildcard) in
             l0_nextNode_0.value)) :
         null)) in
       (let v_anon_3_0 ==
@@ -75,21 +74,21 @@ function isStrictlyAscendingAndPositive(node: Ref): Ref
         (let v_anon_5_0 ==
           ((!(intFromRef(v_anon_2_0) < 0) &&
           !(l0_nextNode_0 == nullValue()) ?
-            (unfolding acc(_c_Node_shared(node), wildcard) in
-              (unfolding acc(_c_Node_shared(l0_nextNode_0), wildcard) in
+            (unfolding acc(shared(node), wildcard) in
+              (unfolding acc(shared(l0_nextNode_0), wildcard) in
                 l0_nextNode_0.value)) :
             null)) in
           (let v_anon_6_0 ==
             ((!(intFromRef(v_anon_2_0) < 0) &&
             !(l0_nextNode_0 == nullValue()) ?
-              (unfolding acc(_c_Node_shared(node), wildcard) in node.value) :
+              (unfolding acc(shared(node), wildcard) in node.value) :
               null)) in
             (let v_anon_4_0 ==
               ((!(intFromRef(v_anon_2_0) < 0) &&
               !(l0_nextNode_0 == nullValue()) ?
-                (unfolding acc(_c_Node_shared(node), wildcard) in
-                  (unfolding acc(_c_Node_shared(node), wildcard) in
-                    (unfolding acc(_c_Node_shared(l0_nextNode_0), wildcard) in
+                (unfolding acc(shared(node), wildcard) in
+                  (unfolding acc(shared(node), wildcard) in
+                    (unfolding acc(shared(l0_nextNode_0), wildcard) in
                       andBools(gtInts(v_anon_5_0, v_anon_6_0), isStrictlyAscendingAndPositive(l0_nextNode_0))))) :
                 null)) in
               (let v_anon_1_0 ==

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -5,46 +5,42 @@ field value: Ref
 
 function isAlternating(node: Ref, expectsPositive: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
+  requires isSubtype(typeOf(node), Node())
   requires isSubtype(typeOf(expectsPositive), boolType())
   ensures isSubtype(typeOf(result), boolType())
 {
-  (let v_anon_1_0 ==
+  (let anon_1_0 ==
     ((boolFromRef(expectsPositive) ?
       (unfolding acc(shared(node), wildcard) in node.value) :
       null)) in
-    (let v_anon_0_0 ==
+    (let anon_0_0 ==
       ((boolFromRef(expectsPositive) ?
         (unfolding acc(shared(node), wildcard) in
-          gtInts(v_anon_1_0, intToRef(0))) :
+          gtInts(anon_1_0, intToRef(0))) :
         null)) in
-      (let v_anon_3_0 ==
+      (let anon_3_0 ==
         ((!boolFromRef(expectsPositive) ?
           (unfolding acc(shared(node), wildcard) in node.value) :
           null)) in
-        (let v_anon_2_0 ==
+        (let anon_2_0 ==
           ((!boolFromRef(expectsPositive) ?
             (unfolding acc(shared(node), wildcard) in
-              ltInts(v_anon_3_0, intToRef(0))) :
+              ltInts(anon_3_0, intToRef(0))) :
             null)) in
-          (let l0_isCurrentValid_0 ==
-            ((boolFromRef(expectsPositive) ? v_anon_0_0 : v_anon_2_0)) in
-            (let l0_nextNode_0 ==
+          (let isCurrentValid_0 ==
+            ((boolFromRef(expectsPositive) ? anon_0_0 : anon_2_0)) in
+            (let nextNode_0 ==
               ((unfolding acc(shared(node), wildcard) in node.next)) in
-              (let v_anon_5_0 ==
-                ((!(l0_nextNode_0 == nullValue()) ?
+              (let anon_5_0 ==
+                ((!(nextNode_0 == nullValue()) ?
                   (unfolding acc(shared(node), wildcard) in
-                    isAlternating(l0_nextNode_0, notBool(expectsPositive))) :
+                    isAlternating(nextNode_0, notBool(expectsPositive))) :
                   null)) in
-                (let v_anon_6_0 ==
-                  ((!!(l0_nextNode_0 == nullValue()) ?
-                    boolToRef(true) :
-                    null)) in
-                  (let v_anon_4_0 ==
-                    ((!(l0_nextNode_0 == nullValue()) ?
-                      v_anon_5_0 :
-                      v_anon_6_0)) in
-                    andBools(l0_isCurrentValid_0, v_anon_4_0))))))))))
+                (let anon_6_0 ==
+                  ((!!(nextNode_0 == nullValue()) ? boolToRef(true) : null)) in
+                  (let anon_4_0 ==
+                    ((!(nextNode_0 == nullValue()) ? anon_5_0 : anon_6_0)) in
+                    andBools(isCurrentValid_0, anon_4_0))))))))))
 }
 
 /heap_dependent_specifications.kt: info: Generated Viper text for isStrictlyAscendingAndPositive:
@@ -53,57 +49,51 @@ field next: Ref
 field value: Ref
 
 function isStrictlyAscendingAndPositive(node: Ref): Ref
-  requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_Node())
-  requires intFromRef((unfolding acc(shared(node), wildcard) in node.value)) >=
+  requires acc(Node_shared(node), wildcard)
+  requires isSubtype(typeOf(node), Node())
+  requires intFromRef((unfolding acc(Node_shared(node), wildcard) in
+      node.value)) >=
     0
   ensures isSubtype(typeOf(result), boolType())
 {
-  (let l0_nextNode_0 ==
-    ((unfolding acc(shared(node), wildcard) in node.next)) in
-    (let v_anon_2_0 ==
-      ((!(l0_nextNode_0 == nullValue()) ?
-        (unfolding acc(shared(node), wildcard) in
-          (unfolding acc(shared(l0_nextNode_0), wildcard) in
-            l0_nextNode_0.value)) :
+  (let nextNode_0 ==
+    ((unfolding acc(Node_shared(node), wildcard) in node.next)) in
+    (let anon_2_0 ==
+      ((!(nextNode_0 == nullValue()) ?
+        (unfolding acc(Node_shared(node), wildcard) in
+          (unfolding acc(Node_shared(nextNode_0), wildcard) in
+            nextNode_0.value)) :
         null)) in
-      (let v_anon_3_0 ==
-        ((intFromRef(v_anon_2_0) < 0 && !(l0_nextNode_0 == nullValue()) ?
+      (let anon_3_0 ==
+        ((intFromRef(anon_2_0) < 0 && !(nextNode_0 == nullValue()) ?
           boolToRef(false) :
           null)) in
-        (let v_anon_5_0 ==
-          ((!(intFromRef(v_anon_2_0) < 0) &&
-          !(l0_nextNode_0 == nullValue()) ?
-            (unfolding acc(shared(node), wildcard) in
-              (unfolding acc(shared(l0_nextNode_0), wildcard) in
-                l0_nextNode_0.value)) :
+        (let anon_5_0 ==
+          ((!(intFromRef(anon_2_0) < 0) && !(nextNode_0 == nullValue()) ?
+            (unfolding acc(Node_shared(node), wildcard) in
+              (unfolding acc(Node_shared(nextNode_0), wildcard) in
+                nextNode_0.value)) :
             null)) in
-          (let v_anon_6_0 ==
-            ((!(intFromRef(v_anon_2_0) < 0) &&
-            !(l0_nextNode_0 == nullValue()) ?
-              (unfolding acc(shared(node), wildcard) in node.value) :
+          (let anon_6_0 ==
+            ((!(intFromRef(anon_2_0) < 0) && !(nextNode_0 == nullValue()) ?
+              (unfolding acc(Node_shared(node), wildcard) in node.value) :
               null)) in
-            (let v_anon_4_0 ==
-              ((!(intFromRef(v_anon_2_0) < 0) &&
-              !(l0_nextNode_0 == nullValue()) ?
-                (unfolding acc(shared(node), wildcard) in
-                  (unfolding acc(shared(node), wildcard) in
-                    (unfolding acc(shared(l0_nextNode_0), wildcard) in
-                      andBools(gtInts(v_anon_5_0, v_anon_6_0), isStrictlyAscendingAndPositive(l0_nextNode_0))))) :
+            (let anon_4_0 ==
+              ((!(intFromRef(anon_2_0) < 0) && !(nextNode_0 == nullValue()) ?
+                (unfolding acc(Node_shared(node), wildcard) in
+                  (unfolding acc(Node_shared(node), wildcard) in
+                    (unfolding acc(Node_shared(nextNode_0), wildcard) in
+                      andBools(gtInts(anon_5_0, anon_6_0), isStrictlyAscendingAndPositive(nextNode_0))))) :
                 null)) in
-              (let v_anon_1_0 ==
-                ((!(l0_nextNode_0 == nullValue()) ?
-                  (intFromRef(v_anon_2_0) < 0 ? v_anon_3_0 : v_anon_4_0) :
+              (let anon_1_0 ==
+                ((!(nextNode_0 == nullValue()) ?
+                  (intFromRef(anon_2_0) < 0 ? anon_3_0 : anon_4_0) :
                   null)) in
-                (let v_anon_7_0 ==
-                  ((!!(l0_nextNode_0 == nullValue()) ?
-                    boolToRef(true) :
-                    null)) in
-                  (let v_anon_0_0 ==
-                    ((!(l0_nextNode_0 == nullValue()) ?
-                      v_anon_1_0 :
-                      v_anon_7_0)) in
-                    v_anon_0_0)))))))))
+                (let anon_7_0 ==
+                  ((!!(nextNode_0 == nullValue()) ? boolToRef(true) : null)) in
+                  (let anon_0_0 ==
+                    ((!(nextNode_0 == nullValue()) ? anon_1_0 : anon_7_0)) in
+                    anon_0_0)))))))))
 }
 
 /heap_dependent_specifications.kt: info: Generated Viper text for isLocallyValidBST:
@@ -115,58 +105,57 @@ field value: Ref
 
 function isLocallyValidBST(node: Ref): Ref
   requires acc(shared(node), wildcard)
-  requires isSubtype(typeOf(node), c_TreeNode())
+  requires isSubtype(typeOf(node), TreeNode())
   ensures isSubtype(typeOf(result), boolType())
 {
-  (let l0_leftNode_0 ==
+  (let leftNode_0 ==
     ((unfolding acc(shared(node), wildcard) in node.left)) in
-    (let v_anon_1_0 ==
-      ((!(l0_leftNode_0 == nullValue()) ?
+    (let anon_1_0 ==
+      ((!(leftNode_0 == nullValue()) ?
         (unfolding acc(shared(node), wildcard) in
-          (unfolding acc(shared(l0_leftNode_0), wildcard) in
-            l0_leftNode_0.value)) :
+          (unfolding acc(shared(leftNode_0), wildcard) in leftNode_0.value)) :
         null)) in
-      (let v_anon_2_0 ==
-        ((!(l0_leftNode_0 == nullValue()) ?
+      (let anon_2_0 ==
+        ((!(leftNode_0 == nullValue()) ?
           (unfolding acc(shared(node), wildcard) in node.value) :
           null)) in
-        (let v_anon_0_0 ==
-          ((!(l0_leftNode_0 == nullValue()) ?
+        (let anon_0_0 ==
+          ((!(leftNode_0 == nullValue()) ?
             (unfolding acc(shared(node), wildcard) in
               (unfolding acc(shared(node), wildcard) in
-                (unfolding acc(shared(l0_leftNode_0), wildcard) in
-                  andBools(ltInts(v_anon_1_0, v_anon_2_0), isLocallyValidBST(l0_leftNode_0))))) :
+                (unfolding acc(shared(leftNode_0), wildcard) in
+                  andBools(ltInts(anon_1_0, anon_2_0), isLocallyValidBST(leftNode_0))))) :
             null)) in
-          (let v_anon_3_0 ==
-            ((!!(l0_leftNode_0 == nullValue()) ? boolToRef(true) : null)) in
-            (let l0_leftValid_0 ==
-              ((!(l0_leftNode_0 == nullValue()) ? v_anon_0_0 : v_anon_3_0)) in
-              (let l0_rightNode_0 ==
+          (let anon_3_0 ==
+            ((!!(leftNode_0 == nullValue()) ? boolToRef(true) : null)) in
+            (let leftValid_0 ==
+              ((!(leftNode_0 == nullValue()) ? anon_0_0 : anon_3_0)) in
+              (let rightNode_0 ==
                 ((unfolding acc(shared(node), wildcard) in node.right)) in
-                (let v_anon_5_0 ==
-                  ((!(l0_rightNode_0 == nullValue()) ?
+                (let anon_5_0 ==
+                  ((!(rightNode_0 == nullValue()) ?
                     (unfolding acc(shared(node), wildcard) in
-                      (unfolding acc(shared(l0_rightNode_0), wildcard) in
-                        l0_rightNode_0.value)) :
+                      (unfolding acc(shared(rightNode_0), wildcard) in
+                        rightNode_0.value)) :
                     null)) in
-                  (let v_anon_6_0 ==
-                    ((!(l0_rightNode_0 == nullValue()) ?
+                  (let anon_6_0 ==
+                    ((!(rightNode_0 == nullValue()) ?
                       (unfolding acc(shared(node), wildcard) in node.value) :
                       null)) in
-                    (let v_anon_4_0 ==
-                      ((!(l0_rightNode_0 == nullValue()) ?
+                    (let anon_4_0 ==
+                      ((!(rightNode_0 == nullValue()) ?
                         (unfolding acc(shared(node), wildcard) in
                           (unfolding acc(shared(node), wildcard) in
-                            (unfolding acc(shared(l0_rightNode_0), wildcard) in
-                              andBools(gtInts(v_anon_5_0, v_anon_6_0), isLocallyValidBST(l0_rightNode_0))))) :
+                            (unfolding acc(shared(rightNode_0), wildcard) in
+                              andBools(gtInts(anon_5_0, anon_6_0), isLocallyValidBST(rightNode_0))))) :
                         null)) in
-                      (let v_anon_7_0 ==
-                        ((!!(l0_rightNode_0 == nullValue()) ?
+                      (let anon_7_0 ==
+                        ((!!(rightNode_0 == nullValue()) ?
                           boolToRef(true) :
                           null)) in
-                        (let l0_rightValid_0 ==
-                          ((!(l0_rightNode_0 == nullValue()) ?
-                            v_anon_4_0 :
-                            v_anon_7_0)) in
-                          andBools(l0_leftValid_0, l0_rightValid_0)))))))))))))
+                        (let rightValid_0 ==
+                          ((!(rightNode_0 == nullValue()) ?
+                            anon_4_0 :
+                            anon_7_0)) in
+                          andBools(leftValid_0, rightValid_0)))))))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_rely_on_branch.fir.diag.txt
@@ -4,13 +4,13 @@ function safeDivide(x: Ref, y: Ref): Ref
   requires isSubtype(typeOf(y), intType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_res_0 ==
+  (let res_0 ==
     (intToRef(0)) in
-    (let l0_res_1 ==
+    (let res_1 ==
       ((!(intFromRef(y) == 0) ? divInts(x, y) : null)) in
-      (let l0_res_2 ==
-        ((!(intFromRef(y) == 0) ? l0_res_1 : l0_res_0)) in
-        l0_res_2)))
+      (let res_2 ==
+        ((!(intFromRef(y) == 0) ? res_1 : res_0)) in
+        res_2)))
 }
 
 /pure_function_rely_on_branch.kt: info: Generated Viper text for getStringLength:
@@ -18,13 +18,13 @@ function getStringLength(obj: Ref): Ref
   requires isSubtype(typeOf(obj), anyType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_len_0 ==
+  (let len_0 ==
     (intToRef(-1)) in
-    (let l0_len_1 ==
+    (let len_1 ==
       ((isSubtype(typeOf(obj), stringType()) ? stringLength(obj) : null)) in
-      (let l0_len_2 ==
-        ((isSubtype(typeOf(obj), stringType()) ? l0_len_1 : l0_len_0)) in
-        l0_len_2)))
+      (let len_2 ==
+        ((isSubtype(typeOf(obj), stringType()) ? len_1 : len_0)) in
+        len_2)))
 }
 
 /pure_function_rely_on_branch.kt: info: Generated Viper text for safeNestedDivide:
@@ -34,17 +34,17 @@ function safeNestedDivide(x: Ref, y: Ref, z: Ref): Ref
   requires isSubtype(typeOf(z), intType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_res_0 ==
+  (let res_0 ==
     (intToRef(0)) in
-    (let l0_res_1 ==
+    (let res_1 ==
       ((!(intFromRef(z) == 0) && !(intFromRef(y) == 0) ?
         divInts(divInts(x, y), z) :
         null)) in
-      (let l0_res_2 ==
-        ((!(intFromRef(z) == 0) ? l0_res_1 : l0_res_0)) in
-        (let l0_res_3 ==
-          ((!(intFromRef(y) == 0) ? l0_res_2 : l0_res_0)) in
-          l0_res_3))))
+      (let res_2 ==
+        ((!(intFromRef(z) == 0) ? res_1 : res_0)) in
+        (let res_3 ==
+          ((!(intFromRef(y) == 0) ? res_2 : res_0)) in
+          res_3))))
 }
 
 /pure_function_rely_on_branch.kt: info: Generated Viper text for safeInverseDifference:
@@ -53,13 +53,13 @@ function safeInverseDifference(x: Ref, y: Ref): Ref
   requires isSubtype(typeOf(y), intType())
   ensures isSubtype(typeOf(result), intType())
 {
-  (let l0_res_0 ==
+  (let res_0 ==
     (intToRef(0)) in
-    (let l0_res_1 ==
+    (let res_1 ==
       ((!(intFromRef(x) == intFromRef(y)) ?
         divInts(intToRef(100), minusInts(x, y)) :
         null)) in
-      (let l0_res_2 ==
-        ((!(intFromRef(x) == intFromRef(y)) ? l0_res_1 : l0_res_0)) in
-        l0_res_2)))
+      (let res_2 ==
+        ((!(intFromRef(x) == intFromRef(y)) ? res_1 : res_0)) in
+        res_2)))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
@@ -26,10 +26,10 @@ predicate shared(this: Ref) {
   isSubtype(typeOf(this.right), nullable(c_Node()))
 }
 
-method get_left_val(n: Ref) returns (ret_0: Ref)
+method get_left_val(n: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(n), c_Node())
   requires acc(_c_Node_unique(n), write)
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures isSubtype(typeOf(ret), nullable(intType()))
 {
   var anon_0: Ref
   inhale acc(shared(n), wildcard)
@@ -38,11 +38,11 @@ method get_left_val(n: Ref) returns (ret_0: Ref)
   if (anon_0 != nullValue()) {
     var anon: Ref
     anon := havoc_Int()
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }
 
 /binary_tree.kt: info: Generated Viper text for test:
@@ -50,7 +50,7 @@ field bf_data: Ref
 
 field bf_left: Ref
 
-field bf_right: Ref
+field right: Ref
 
 field size: Ref
 
@@ -59,10 +59,9 @@ predicate _c_Node_shared(this: Ref) {
   (this.bf_left != nullValue() ==>
   acc(_c_Node_shared(this.bf_left), wildcard)) &&
   isSubtype(typeOf(this.bf_left), nullable(c_Node())) &&
-  acc(this.bf_right, wildcard) &&
-  (this.bf_right != nullValue() ==>
-  acc(_c_Node_shared(this.bf_right), wildcard)) &&
-  isSubtype(typeOf(this.bf_right), nullable(c_Node()))
+  acc(this.right, wildcard) &&
+  (this.right != nullValue() ==> acc(_c_Node_shared(this.right), wildcard)) &&
+  isSubtype(typeOf(this.right), nullable(c_Node()))
 }
 
 predicate _c_Node_unique(this: Ref) {
@@ -72,12 +71,10 @@ predicate _c_Node_unique(this: Ref) {
   acc(_c_Node_shared(this.bf_left), wildcard)) &&
   (this.bf_left != nullValue() ==> acc(_c_Node_unique(this.bf_left), write)) &&
   isSubtype(typeOf(this.bf_left), nullable(c_Node())) &&
-  acc(this.bf_right, wildcard) &&
-  (this.bf_right != nullValue() ==>
-  acc(_c_Node_shared(this.bf_right), wildcard)) &&
-  (this.bf_right != nullValue() ==>
-  acc(_c_Node_unique(this.bf_right), write)) &&
-  isSubtype(typeOf(this.bf_right), nullable(c_Node()))
+  acc(this.right, wildcard) &&
+  (this.right != nullValue() ==> acc(_c_Node_shared(this.right), wildcard)) &&
+  (this.right != nullValue() ==> acc(_c_Node_unique(this.right), write)) &&
+  isSubtype(typeOf(this.right), nullable(c_Node()))
 }
 
 predicate io_c_Serializable_shared(this: Ref) {
@@ -88,16 +85,14 @@ predicate io_c_Serializable_unique(this: Ref) {
   true
 }
 
-predicate kotlin_c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
 predicate kotlin_c_BooleanArray_unique(this: Ref) {
   acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
   acc(kotlin_c_Cloneable_unique(this), write) &&
   acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_shared(this: Ref) {
+  true
 }
 
 predicate kotlin_c_Cloneable_unique(this: Ref) {
@@ -105,25 +100,29 @@ predicate kotlin_c_Cloneable_unique(this: Ref) {
 }
 
 predicate shared(this: Ref) {
-  true
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
 }
 
-method con(data: Ref, left: Ref, right: Ref) returns (ret: Ref)
+method con(data: Ref, left: Ref, par_right: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(data), intType())
   requires isSubtype(typeOf(left), nullable(c_Node()))
   requires left != nullValue() ==> acc(_c_Node_unique(left), write)
-  requires isSubtype(typeOf(right), nullable(c_Node()))
-  requires right != nullValue() ==> acc(_c_Node_unique(right), write)
-  ensures isSubtype(typeOf(ret), c_Node())
-  ensures acc(_c_Node_shared(ret), wildcard)
-  ensures acc(_c_Node_unique(ret), write)
-  ensures (unfolding acc(_c_Node_shared(ret), wildcard) in ret.bf_left) ==
+  requires isSubtype(typeOf(par_right), nullable(c_Node()))
+  requires par_right != nullValue() ==>
+    acc(_c_Node_unique(par_right), write)
+  ensures isSubtype(typeOf(v_ret), c_Node())
+  ensures acc(_c_Node_shared(v_ret), wildcard)
+  ensures acc(_c_Node_unique(v_ret), write)
+  ensures (unfolding acc(_c_Node_shared(v_ret), wildcard) in v_ret.bf_left) ==
     left &&
-    (unfolding acc(_c_Node_shared(ret), wildcard) in ret.bf_right) == right
+    (unfolding acc(_c_Node_shared(v_ret), wildcard) in v_ret.right) ==
+    par_right
 
 
-method test() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method test() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var n: Ref
   var anon_0: Ref
@@ -153,6 +152,6 @@ method test() returns (ret_0: Ref)
     anon_5 := nullValue()}
   expr2 := boolToRef(anon_5 == intToRef(4))
   assert boolFromRef(expr2)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
@@ -5,30 +5,30 @@ field left: Ref
 
 field right: Ref
 
-predicate c_Node_unique(this: Ref) {
+predicate _c_Node_unique(this: Ref) {
   acc(this.data, write) && isSubtype(typeOf(this.data), intType()) &&
   acc(this.left, wildcard) &&
   (this.left != nullValue() ==> acc(shared(this.left), wildcard)) &&
-  (this.left != nullValue() ==> acc(c_Node_unique(this.left), write)) &&
-  isSubtype(typeOf(this.left), nullable(_c_Node())) &&
+  (this.left != nullValue() ==> acc(_c_Node_unique(this.left), write)) &&
+  isSubtype(typeOf(this.left), nullable(c_Node())) &&
   acc(this.right, wildcard) &&
   (this.right != nullValue() ==> acc(shared(this.right), wildcard)) &&
-  (this.right != nullValue() ==> acc(c_Node_unique(this.right), write)) &&
-  isSubtype(typeOf(this.right), nullable(_c_Node()))
+  (this.right != nullValue() ==> acc(_c_Node_unique(this.right), write)) &&
+  isSubtype(typeOf(this.right), nullable(c_Node()))
 }
 
 predicate shared(this: Ref) {
   acc(this.left, wildcard) &&
   (this.left != nullValue() ==> acc(shared(this.left), wildcard)) &&
-  isSubtype(typeOf(this.left), nullable(_c_Node())) &&
+  isSubtype(typeOf(this.left), nullable(c_Node())) &&
   acc(this.right, wildcard) &&
   (this.right != nullValue() ==> acc(shared(this.right), wildcard)) &&
-  isSubtype(typeOf(this.right), nullable(_c_Node()))
+  isSubtype(typeOf(this.right), nullable(c_Node()))
 }
 
 method get_left_val(n: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(n), _c_Node())
-  requires acc(c_Node_unique(n), write)
+  requires isSubtype(typeOf(n), c_Node())
+  requires acc(_c_Node_unique(n), write)
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
 {
   var anon_0: Ref
@@ -54,53 +54,53 @@ field bf_right: Ref
 
 field size: Ref
 
-predicate c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_shared(this), wildcard) &&
-  acc(shared(this), wildcard)
-}
-
-predicate c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_unique(this), write) &&
-  acc(c_Serializable_unique(this), write)
-}
-
-predicate c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate c_Node_shared(this: Ref) {
+predicate _c_Node_shared(this: Ref) {
   acc(this.bf_left, wildcard) &&
   (this.bf_left != nullValue() ==>
-  acc(c_Node_shared(this.bf_left), wildcard)) &&
-  isSubtype(typeOf(this.bf_left), nullable(_c_Node())) &&
+  acc(_c_Node_shared(this.bf_left), wildcard)) &&
+  isSubtype(typeOf(this.bf_left), nullable(c_Node())) &&
   acc(this.bf_right, wildcard) &&
   (this.bf_right != nullValue() ==>
-  acc(c_Node_shared(this.bf_right), wildcard)) &&
-  isSubtype(typeOf(this.bf_right), nullable(_c_Node()))
+  acc(_c_Node_shared(this.bf_right), wildcard)) &&
+  isSubtype(typeOf(this.bf_right), nullable(c_Node()))
 }
 
-predicate c_Node_unique(this: Ref) {
+predicate _c_Node_unique(this: Ref) {
   acc(this.bf_data, write) && isSubtype(typeOf(this.bf_data), intType()) &&
   acc(this.bf_left, wildcard) &&
   (this.bf_left != nullValue() ==>
-  acc(c_Node_shared(this.bf_left), wildcard)) &&
-  (this.bf_left != nullValue() ==> acc(c_Node_unique(this.bf_left), write)) &&
-  isSubtype(typeOf(this.bf_left), nullable(_c_Node())) &&
+  acc(_c_Node_shared(this.bf_left), wildcard)) &&
+  (this.bf_left != nullValue() ==> acc(_c_Node_unique(this.bf_left), write)) &&
+  isSubtype(typeOf(this.bf_left), nullable(c_Node())) &&
   acc(this.bf_right, wildcard) &&
   (this.bf_right != nullValue() ==>
-  acc(c_Node_shared(this.bf_right), wildcard)) &&
+  acc(_c_Node_shared(this.bf_right), wildcard)) &&
   (this.bf_right != nullValue() ==>
-  acc(c_Node_unique(this.bf_right), write)) &&
-  isSubtype(typeOf(this.bf_right), nullable(_c_Node()))
+  acc(_c_Node_unique(this.bf_right), write)) &&
+  isSubtype(typeOf(this.bf_right), nullable(c_Node()))
 }
 
-predicate c_Serializable_unique(this: Ref) {
+predicate io_c_Serializable_shared(this: Ref) {
+  true
+}
+
+predicate io_c_Serializable_unique(this: Ref) {
+  true
+}
+
+predicate kotlin_c_BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
+}
+
+predicate kotlin_c_BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_unique(this), write) &&
+  acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_unique(this: Ref) {
   true
 }
 
@@ -110,16 +110,16 @@ predicate shared(this: Ref) {
 
 method con(data: Ref, left: Ref, right: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(data), intType())
-  requires isSubtype(typeOf(left), nullable(_c_Node()))
-  requires left != nullValue() ==> acc(c_Node_unique(left), write)
-  requires isSubtype(typeOf(right), nullable(_c_Node()))
-  requires right != nullValue() ==> acc(c_Node_unique(right), write)
-  ensures isSubtype(typeOf(ret), _c_Node())
-  ensures acc(c_Node_shared(ret), wildcard)
-  ensures acc(c_Node_unique(ret), write)
-  ensures (unfolding acc(c_Node_shared(ret), wildcard) in ret.bf_left) ==
+  requires isSubtype(typeOf(left), nullable(c_Node()))
+  requires left != nullValue() ==> acc(_c_Node_unique(left), write)
+  requires isSubtype(typeOf(right), nullable(c_Node()))
+  requires right != nullValue() ==> acc(_c_Node_unique(right), write)
+  ensures isSubtype(typeOf(ret), c_Node())
+  ensures acc(_c_Node_shared(ret), wildcard)
+  ensures acc(_c_Node_unique(ret), write)
+  ensures (unfolding acc(_c_Node_shared(ret), wildcard) in ret.bf_left) ==
     left &&
-    (unfolding acc(c_Node_shared(ret), wildcard) in ret.bf_right) == right
+    (unfolding acc(_c_Node_shared(ret), wildcard) in ret.bf_right) == right
 
 
 method test() returns (ret_0: Ref)
@@ -143,7 +143,7 @@ method test() returns (ret_0: Ref)
   anon_4 := havoc_Int()
   expr1 := boolToRef(intFromRef(anon_4) == 5)
   assert boolFromRef(expr1)
-  unfold acc(c_Node_shared(n), wildcard)
+  unfold acc(_c_Node_shared(n), wildcard)
   anon_6 := n.bf_left
   if (anon_6 != nullValue()) {
     var anon: Ref

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/binary_tree.fir.diag.txt
@@ -5,44 +5,44 @@ field left: Ref
 
 field right: Ref
 
-predicate _c_Node_unique(this: Ref) {
+predicate Node_unique(this: Ref) {
   acc(this.data, write) && isSubtype(typeOf(this.data), intType()) &&
   acc(this.left, wildcard) &&
   (this.left != nullValue() ==> acc(shared(this.left), wildcard)) &&
-  (this.left != nullValue() ==> acc(_c_Node_unique(this.left), write)) &&
-  isSubtype(typeOf(this.left), nullable(c_Node())) &&
+  (this.left != nullValue() ==> acc(Node_unique(this.left), write)) &&
+  isSubtype(typeOf(this.left), nullable(Node())) &&
   acc(this.right, wildcard) &&
   (this.right != nullValue() ==> acc(shared(this.right), wildcard)) &&
-  (this.right != nullValue() ==> acc(_c_Node_unique(this.right), write)) &&
-  isSubtype(typeOf(this.right), nullable(c_Node()))
+  (this.right != nullValue() ==> acc(Node_unique(this.right), write)) &&
+  isSubtype(typeOf(this.right), nullable(Node()))
 }
 
 predicate shared(this: Ref) {
   acc(this.left, wildcard) &&
   (this.left != nullValue() ==> acc(shared(this.left), wildcard)) &&
-  isSubtype(typeOf(this.left), nullable(c_Node())) &&
+  isSubtype(typeOf(this.left), nullable(Node())) &&
   acc(this.right, wildcard) &&
   (this.right != nullValue() ==> acc(shared(this.right), wildcard)) &&
-  isSubtype(typeOf(this.right), nullable(c_Node()))
+  isSubtype(typeOf(this.right), nullable(Node()))
 }
 
-method get_left_val(n: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(n), c_Node())
-  requires acc(_c_Node_unique(n), write)
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method get_left_val(n: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(n), Node())
+  requires acc(Node_unique(n), write)
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
   var anon_0: Ref
   inhale acc(shared(n), wildcard)
   unfold acc(shared(n), wildcard)
   anon_0 := n.left
   if (anon_0 != nullValue()) {
-    var anon: Ref
-    anon := havoc_Int()
-    ret := anon
+    var anon_1: Ref
+    anon_1 := havoc_Int()
+    v_ret_0 := anon_1
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /binary_tree.kt: info: Generated Viper text for test:
@@ -50,79 +50,79 @@ field bf_data: Ref
 
 field bf_left: Ref
 
-field right: Ref
+field bf_right: Ref
 
 field size: Ref
 
-predicate _c_Node_shared(this: Ref) {
-  acc(this.bf_left, wildcard) &&
-  (this.bf_left != nullValue() ==>
-  acc(_c_Node_shared(this.bf_left), wildcard)) &&
-  isSubtype(typeOf(this.bf_left), nullable(c_Node())) &&
-  acc(this.right, wildcard) &&
-  (this.right != nullValue() ==> acc(_c_Node_shared(this.right), wildcard)) &&
-  isSubtype(typeOf(this.right), nullable(c_Node()))
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
 }
 
-predicate _c_Node_unique(this: Ref) {
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Node_shared(this: Ref) {
+  acc(this.bf_left, wildcard) &&
+  (this.bf_left != nullValue() ==> acc(Node_shared(this.bf_left), wildcard)) &&
+  isSubtype(typeOf(this.bf_left), nullable(Node())) &&
+  acc(this.bf_right, wildcard) &&
+  (this.bf_right != nullValue() ==>
+  acc(Node_shared(this.bf_right), wildcard)) &&
+  isSubtype(typeOf(this.bf_right), nullable(Node()))
+}
+
+predicate Node_unique(this: Ref) {
   acc(this.bf_data, write) && isSubtype(typeOf(this.bf_data), intType()) &&
   acc(this.bf_left, wildcard) &&
-  (this.bf_left != nullValue() ==>
-  acc(_c_Node_shared(this.bf_left), wildcard)) &&
-  (this.bf_left != nullValue() ==> acc(_c_Node_unique(this.bf_left), write)) &&
-  isSubtype(typeOf(this.bf_left), nullable(c_Node())) &&
-  acc(this.right, wildcard) &&
-  (this.right != nullValue() ==> acc(_c_Node_shared(this.right), wildcard)) &&
-  (this.right != nullValue() ==> acc(_c_Node_unique(this.right), write)) &&
-  isSubtype(typeOf(this.right), nullable(c_Node()))
+  (this.bf_left != nullValue() ==> acc(Node_shared(this.bf_left), wildcard)) &&
+  (this.bf_left != nullValue() ==> acc(Node_unique(this.bf_left), write)) &&
+  isSubtype(typeOf(this.bf_left), nullable(Node())) &&
+  acc(this.bf_right, wildcard) &&
+  (this.bf_right != nullValue() ==>
+  acc(Node_shared(this.bf_right), wildcard)) &&
+  (this.bf_right != nullValue() ==> acc(Node_unique(this.bf_right), write)) &&
+  isSubtype(typeOf(this.bf_right), nullable(Node()))
 }
 
-predicate io_c_Serializable_shared(this: Ref) {
+predicate Serializable_shared(this: Ref) {
   true
 }
 
-predicate io_c_Serializable_unique(this: Ref) {
+predicate Serializable_unique(this: Ref) {
   true
 }
 
-predicate kotlin_c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_unique(this), write) &&
-  acc(io_c_Serializable_unique(this), write)
-}
-
-predicate kotlin_c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate kotlin_c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
-method con(data: Ref, left: Ref, par_right: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(data), intType())
-  requires isSubtype(typeOf(left), nullable(c_Node()))
-  requires left != nullValue() ==> acc(_c_Node_unique(left), write)
-  requires isSubtype(typeOf(par_right), nullable(c_Node()))
-  requires par_right != nullValue() ==>
-    acc(_c_Node_unique(par_right), write)
-  ensures isSubtype(typeOf(v_ret), c_Node())
-  ensures acc(_c_Node_shared(v_ret), wildcard)
-  ensures acc(_c_Node_unique(v_ret), write)
-  ensures (unfolding acc(_c_Node_shared(v_ret), wildcard) in v_ret.bf_left) ==
-    left &&
-    (unfolding acc(_c_Node_shared(v_ret), wildcard) in v_ret.right) ==
+method con(par_data: Ref, par_left: Ref, par_right: Ref)
+  returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_data), intType())
+  requires isSubtype(typeOf(par_left), nullable(Node()))
+  requires par_left != nullValue() ==> acc(Node_unique(par_left), write)
+  requires isSubtype(typeOf(par_right), nullable(Node()))
+  requires par_right != nullValue() ==> acc(Node_unique(par_right), write)
+  ensures isSubtype(typeOf(v_ret), Node())
+  ensures acc(Node_shared(v_ret), wildcard)
+  ensures acc(Node_unique(v_ret), write)
+  ensures (unfolding acc(Node_shared(v_ret), wildcard) in v_ret.bf_left) ==
+    par_left &&
+    (unfolding acc(Node_shared(v_ret), wildcard) in v_ret.bf_right) ==
     par_right
 
 
-method test() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method test() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var n: Ref
   var anon_0: Ref
@@ -142,16 +142,16 @@ method test() returns (ret: Ref)
   anon_4 := havoc_Int()
   expr1 := boolToRef(intFromRef(anon_4) == 5)
   assert boolFromRef(expr1)
-  unfold acc(_c_Node_shared(n), wildcard)
+  unfold acc(Node_shared(n), wildcard)
   anon_6 := n.bf_left
   if (anon_6 != nullValue()) {
-    var anon: Ref
-    anon := havoc_Int()
-    anon_5 := anon
+    var anon_7: Ref
+    anon_7 := havoc_Int()
+    anon_5 := anon_7
   } else {
     anon_5 := nullValue()}
   expr2 := boolToRef(anon_5 == intToRef(4))
   assert boolFromRef(expr2)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
@@ -17,10 +17,10 @@ predicate shared(this: Ref) {
   isSubtype(typeOf(this.next), nullable(c_Link()))
 }
 
-method getVal(l: Ref) returns (ret_0: Ref)
+method getVal(l: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(l), c_Link())
   requires acc(_c_Link_unique(l), write)
-  ensures isSubtype(typeOf(ret_0), nullable(intType()))
+  ensures isSubtype(typeOf(ret), nullable(intType()))
 {
   var anon_0: Ref
   inhale acc(shared(l), wildcard)
@@ -29,11 +29,11 @@ method getVal(l: Ref) returns (ret_0: Ref)
   if (anon_0 != nullValue()) {
     var anon: Ref
     anon := havoc_Int()
-    ret_0 := anon
+    ret := anon
   } else {
-    ret_0 := nullValue()}
-  goto lbl_ret_0
-  label lbl_ret_0
+    ret := nullValue()}
+  goto ret_0
+  label ret_0
 }
 
 /linked_list.kt: info: Generated Viper text for test:
@@ -67,16 +67,14 @@ predicate io_c_Serializable_unique(this: Ref) {
   true
 }
 
-predicate kotlin_c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
 predicate kotlin_c_BooleanArray_unique(this: Ref) {
   acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
   acc(kotlin_c_Cloneable_unique(this), write) &&
   acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_shared(this: Ref) {
+  true
 }
 
 predicate kotlin_c_Cloneable_unique(this: Ref) {
@@ -84,22 +82,24 @@ predicate kotlin_c_Cloneable_unique(this: Ref) {
 }
 
 predicate shared(this: Ref) {
-  true
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
 }
 
-method con(data: Ref, next: Ref) returns (ret: Ref)
+method con(data: Ref, next: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(data), intType())
   requires isSubtype(typeOf(next), nullable(c_Link()))
   requires next != nullValue() ==> acc(_c_Link_unique(next), write)
-  ensures isSubtype(typeOf(ret), c_Link())
-  ensures acc(_c_Link_shared(ret), wildcard)
-  ensures acc(_c_Link_unique(ret), write)
-  ensures (unfolding acc(_c_Link_shared(ret), wildcard) in ret.bf_next) ==
+  ensures isSubtype(typeOf(v_ret), c_Link())
+  ensures acc(_c_Link_shared(v_ret), wildcard)
+  ensures acc(_c_Link_unique(v_ret), write)
+  ensures (unfolding acc(_c_Link_shared(v_ret), wildcard) in v_ret.bf_next) ==
     next
 
 
-method test() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method test() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var l: Ref
   var anon_0: Ref
@@ -123,6 +123,6 @@ method test() returns (ret_0: Ref)
     anon_2 := nullValue()}
   expr2 := boolToRef(anon_2 == intToRef(3))
   assert boolFromRef(expr2)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
@@ -3,23 +3,23 @@ field data: Ref
 
 field next: Ref
 
-predicate c_Link_unique(this: Ref) {
+predicate _c_Link_unique(this: Ref) {
   acc(this.data, write) && isSubtype(typeOf(this.data), intType()) &&
   acc(this.next, wildcard) &&
   (this.next != nullValue() ==> acc(shared(this.next), wildcard)) &&
-  (this.next != nullValue() ==> acc(c_Link_unique(this.next), write)) &&
-  isSubtype(typeOf(this.next), nullable(_c_Link()))
+  (this.next != nullValue() ==> acc(_c_Link_unique(this.next), write)) &&
+  isSubtype(typeOf(this.next), nullable(c_Link()))
 }
 
 predicate shared(this: Ref) {
   acc(this.next, wildcard) &&
   (this.next != nullValue() ==> acc(shared(this.next), wildcard)) &&
-  isSubtype(typeOf(this.next), nullable(_c_Link()))
+  isSubtype(typeOf(this.next), nullable(c_Link()))
 }
 
 method getVal(l: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(l), _c_Link())
-  requires acc(c_Link_unique(l), write)
+  requires isSubtype(typeOf(l), c_Link())
+  requires acc(_c_Link_unique(l), write)
   ensures isSubtype(typeOf(ret_0), nullable(intType()))
 {
   var anon_0: Ref
@@ -43,43 +43,43 @@ field bf_next: Ref
 
 field size: Ref
 
-predicate c_BooleanArray_shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_shared(this), wildcard) &&
-  acc(shared(this), wildcard)
-}
-
-predicate c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(c_Cloneable_unique(this), write) &&
-  acc(c_Serializable_unique(this), write)
-}
-
-predicate c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate c_Link_shared(this: Ref) {
+predicate _c_Link_shared(this: Ref) {
   acc(this.bf_next, wildcard) &&
   (this.bf_next != nullValue() ==>
-  acc(c_Link_shared(this.bf_next), wildcard)) &&
-  isSubtype(typeOf(this.bf_next), nullable(_c_Link()))
+  acc(_c_Link_shared(this.bf_next), wildcard)) &&
+  isSubtype(typeOf(this.bf_next), nullable(c_Link()))
 }
 
-predicate c_Link_unique(this: Ref) {
+predicate _c_Link_unique(this: Ref) {
   acc(this.bf_data, write) && isSubtype(typeOf(this.bf_data), intType()) &&
   acc(this.bf_next, wildcard) &&
   (this.bf_next != nullValue() ==>
-  acc(c_Link_shared(this.bf_next), wildcard)) &&
-  (this.bf_next != nullValue() ==> acc(c_Link_unique(this.bf_next), write)) &&
-  isSubtype(typeOf(this.bf_next), nullable(_c_Link()))
+  acc(_c_Link_shared(this.bf_next), wildcard)) &&
+  (this.bf_next != nullValue() ==> acc(_c_Link_unique(this.bf_next), write)) &&
+  isSubtype(typeOf(this.bf_next), nullable(c_Link()))
 }
 
-predicate c_Serializable_unique(this: Ref) {
+predicate io_c_Serializable_shared(this: Ref) {
+  true
+}
+
+predicate io_c_Serializable_unique(this: Ref) {
+  true
+}
+
+predicate kotlin_c_BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(shared(this), wildcard) &&
+  acc(io_c_Serializable_shared(this), wildcard)
+}
+
+predicate kotlin_c_BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(kotlin_c_Cloneable_unique(this), write) &&
+  acc(io_c_Serializable_unique(this), write)
+}
+
+predicate kotlin_c_Cloneable_unique(this: Ref) {
   true
 }
 
@@ -89,12 +89,12 @@ predicate shared(this: Ref) {
 
 method con(data: Ref, next: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(data), intType())
-  requires isSubtype(typeOf(next), nullable(_c_Link()))
-  requires next != nullValue() ==> acc(c_Link_unique(next), write)
-  ensures isSubtype(typeOf(ret), _c_Link())
-  ensures acc(c_Link_shared(ret), wildcard)
-  ensures acc(c_Link_unique(ret), write)
-  ensures (unfolding acc(c_Link_shared(ret), wildcard) in ret.bf_next) ==
+  requires isSubtype(typeOf(next), nullable(c_Link()))
+  requires next != nullValue() ==> acc(_c_Link_unique(next), write)
+  ensures isSubtype(typeOf(ret), c_Link())
+  ensures acc(_c_Link_shared(ret), wildcard)
+  ensures acc(_c_Link_unique(ret), write)
+  ensures (unfolding acc(_c_Link_shared(ret), wildcard) in ret.bf_next) ==
     next
 
 
@@ -113,7 +113,7 @@ method test() returns (ret_0: Ref)
   anon_1 := havoc_Int()
   expr1 := boolToRef(intFromRef(anon_1) == 5)
   assert boolFromRef(expr1)
-  unfold acc(c_Link_shared(l), wildcard)
+  unfold acc(_c_Link_shared(l), wildcard)
   anon_3 := l.bf_next
   if (anon_3 != nullValue()) {
     var anon: Ref

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/failing-tests/linked_list.fir.diag.txt
@@ -3,37 +3,37 @@ field data: Ref
 
 field next: Ref
 
-predicate _c_Link_unique(this: Ref) {
+predicate Link_unique(this: Ref) {
   acc(this.data, write) && isSubtype(typeOf(this.data), intType()) &&
   acc(this.next, wildcard) &&
   (this.next != nullValue() ==> acc(shared(this.next), wildcard)) &&
-  (this.next != nullValue() ==> acc(_c_Link_unique(this.next), write)) &&
-  isSubtype(typeOf(this.next), nullable(c_Link()))
+  (this.next != nullValue() ==> acc(Link_unique(this.next), write)) &&
+  isSubtype(typeOf(this.next), nullable(Link()))
 }
 
 predicate shared(this: Ref) {
   acc(this.next, wildcard) &&
   (this.next != nullValue() ==> acc(shared(this.next), wildcard)) &&
-  isSubtype(typeOf(this.next), nullable(c_Link()))
+  isSubtype(typeOf(this.next), nullable(Link()))
 }
 
-method getVal(l: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(l), c_Link())
-  requires acc(_c_Link_unique(l), write)
-  ensures isSubtype(typeOf(ret), nullable(intType()))
+method getVal(l: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(l), Link())
+  requires acc(Link_unique(l), write)
+  ensures isSubtype(typeOf(v_ret_0), nullable(intType()))
 {
   var anon_0: Ref
   inhale acc(shared(l), wildcard)
   unfold acc(shared(l), wildcard)
   anon_0 := l.next
   if (anon_0 != nullValue()) {
-    var anon: Ref
-    anon := havoc_Int()
-    ret := anon
+    var anon_1: Ref
+    anon_1 := havoc_Int()
+    v_ret_0 := anon_1
   } else {
-    ret := nullValue()}
-  goto ret_0
-  label ret_0
+    v_ret_0 := nullValue()}
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /linked_list.kt: info: Generated Viper text for test:
@@ -43,63 +43,61 @@ field bf_next: Ref
 
 field size: Ref
 
-predicate _c_Link_shared(this: Ref) {
-  acc(this.bf_next, wildcard) &&
-  (this.bf_next != nullValue() ==>
-  acc(_c_Link_shared(this.bf_next), wildcard)) &&
-  isSubtype(typeOf(this.bf_next), nullable(c_Link()))
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
 }
 
-predicate _c_Link_unique(this: Ref) {
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Link_shared(this: Ref) {
+  acc(this.bf_next, wildcard) &&
+  (this.bf_next != nullValue() ==> acc(Link_shared(this.bf_next), wildcard)) &&
+  isSubtype(typeOf(this.bf_next), nullable(Link()))
+}
+
+predicate Link_unique(this: Ref) {
   acc(this.bf_data, write) && isSubtype(typeOf(this.bf_data), intType()) &&
   acc(this.bf_next, wildcard) &&
-  (this.bf_next != nullValue() ==>
-  acc(_c_Link_shared(this.bf_next), wildcard)) &&
-  (this.bf_next != nullValue() ==> acc(_c_Link_unique(this.bf_next), write)) &&
-  isSubtype(typeOf(this.bf_next), nullable(c_Link()))
+  (this.bf_next != nullValue() ==> acc(Link_shared(this.bf_next), wildcard)) &&
+  (this.bf_next != nullValue() ==> acc(Link_unique(this.bf_next), write)) &&
+  isSubtype(typeOf(this.bf_next), nullable(Link()))
 }
 
-predicate io_c_Serializable_shared(this: Ref) {
+predicate Serializable_shared(this: Ref) {
   true
 }
 
-predicate io_c_Serializable_unique(this: Ref) {
+predicate Serializable_unique(this: Ref) {
   true
 }
 
-predicate kotlin_c_BooleanArray_unique(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_unique(this), write) &&
-  acc(io_c_Serializable_unique(this), write)
-}
-
-predicate kotlin_c_Cloneable_shared(this: Ref) {
-  true
-}
-
-predicate kotlin_c_Cloneable_unique(this: Ref) {
-  true
-}
-
-predicate shared(this: Ref) {
-  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
-  acc(kotlin_c_Cloneable_shared(this), wildcard) &&
-  acc(io_c_Serializable_shared(this), wildcard)
-}
-
-method con(data: Ref, next: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(data), intType())
-  requires isSubtype(typeOf(next), nullable(c_Link()))
-  requires next != nullValue() ==> acc(_c_Link_unique(next), write)
-  ensures isSubtype(typeOf(v_ret), c_Link())
-  ensures acc(_c_Link_shared(v_ret), wildcard)
-  ensures acc(_c_Link_unique(v_ret), write)
-  ensures (unfolding acc(_c_Link_shared(v_ret), wildcard) in v_ret.bf_next) ==
-    next
+method con(par_data: Ref, par_next: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_data), intType())
+  requires isSubtype(typeOf(par_next), nullable(Link()))
+  requires par_next != nullValue() ==> acc(Link_unique(par_next), write)
+  ensures isSubtype(typeOf(v_ret), Link())
+  ensures acc(Link_shared(v_ret), wildcard)
+  ensures acc(Link_unique(v_ret), write)
+  ensures (unfolding acc(Link_shared(v_ret), wildcard) in v_ret.bf_next) ==
+    par_next
 
 
-method test() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method test() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l: Ref
   var anon_0: Ref
@@ -113,16 +111,16 @@ method test() returns (ret: Ref)
   anon_1 := havoc_Int()
   expr1 := boolToRef(intFromRef(anon_1) == 5)
   assert boolFromRef(expr1)
-  unfold acc(_c_Link_shared(l), wildcard)
+  unfold acc(Link_shared(l), wildcard)
   anon_3 := l.bf_next
   if (anon_3 != nullValue()) {
-    var anon: Ref
-    anon := havoc_Int()
-    anon_2 := anon
+    var anon_4: Ref
+    anon_4 := havoc_Int()
+    anon_2 := anon_4
   } else {
     anon_2 := nullValue()}
   expr2 := boolToRef(anon_2 == intToRef(3))
   assert boolFromRef(expr2)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
@@ -9,12 +9,12 @@ method idFun(par_t: Ref) returns (ret: Ref)
 }
 
 /unit_return_type.kt: info: Generated Viper text for directReturns:
-method directReturns(b: Ref) returns (ret_0: Ref)
+method directReturns(b: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   if (boolFromRef(b)) {
-    goto lbl_ret_0
+    goto ret_0
   } else {
     var anon_0: Ref
     var anon: Ref
@@ -22,24 +22,24 @@ method directReturns(b: Ref) returns (ret_0: Ref)
     anon_0 := anon
     inhale isSubtype(typeOf(anon_0), boolType())
     if (boolFromRef(anon_0)) {
-      goto lbl_ret_0
+      goto ret_0
     }
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
-method idFun(par_t: Ref) returns (ret: Ref)
+method idFun(par_t: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
 /unit_return_type.kt: info: Generated Viper text for useInlineUnit:
 field size: Ref
 
-method idFun(par_t: Ref) returns (ret: Ref)
+method idFun(par_t: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
 method useInlineUnit(b: Ref) returns (ret_0: Ref)
@@ -49,7 +49,7 @@ method useInlineUnit(b: Ref) returns (ret_0: Ref)
   var unitRes: Ref
   var ret_1: Ref
   var anon_0: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   inhale isSubtype(typeOf(b), nullable(anyType()))
   anon_0 := b
@@ -64,8 +64,8 @@ method useInlineUnit(b: Ref) returns (ret_0: Ref)
     anon_2 := anon
     inhale isSubtype(typeOf(anon_2), intType())
   }
-  label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
+  label ret_2
+  inhale isSubtype(typeOf(ret), unitType())
   label lbl_ret_1
   inhale isSubtype(typeOf(ret_1), unitType())
   unitRes := ret_1

--- a/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/unit_return_type.fir.diag.txt
@@ -1,32 +1,32 @@
 /unit_return_type.kt: info: Generated Viper text for idFun:
-method idFun(par_t: Ref) returns (ret: Ref)
+method idFun(par_t: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(par_t), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), nullable(anyType()))
+  ensures isSubtype(typeOf(v_ret_0), nullable(anyType()))
 {
-  ret := par_t
-  goto ret_0
-  label ret_0
+  v_ret_0 := par_t
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /unit_return_type.kt: info: Generated Viper text for directReturns:
-method directReturns(b: Ref) returns (ret: Ref)
+method directReturns(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   if (boolFromRef(b)) {
-    goto ret_0
+    goto lbl_ret_0
   } else {
     var anon_0: Ref
-    var anon: Ref
-    anon := idFun(b)
-    anon_0 := anon
+    var anon_1: Ref
+    anon_1 := idFun(b)
+    anon_0 := anon_1
     inhale isSubtype(typeOf(anon_0), boolType())
     if (boolFromRef(anon_0)) {
-      goto ret_0
+      goto lbl_ret_0
     }
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method idFun(par_t: Ref) returns (v_ret: Ref)
@@ -42,14 +42,14 @@ method idFun(par_t: Ref) returns (v_ret: Ref)
   ensures isSubtype(typeOf(v_ret), nullable(anyType()))
 
 
-method useInlineUnit(b: Ref) returns (ret_0: Ref)
+method useInlineUnit(b: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(b), boolType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var unitRes: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var ret: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   inhale isSubtype(typeOf(b), nullable(anyType()))
   anon_0 := b
@@ -58,18 +58,18 @@ method useInlineUnit(b: Ref) returns (ret_0: Ref)
   if (boolFromRef(anon_1)) {
     var tmp: Ref
     var anon_2: Ref
-    var anon: Ref
+    var anon_3: Ref
     tmp := intToRef(42)
-    anon := idFun(tmp)
-    anon_2 := anon
+    anon_3 := idFun(tmp)
+    anon_2 := anon_3
     inhale isSubtype(typeOf(anon_2), intType())
   }
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
   label lbl_ret_1
-  inhale isSubtype(typeOf(ret_1), unitType())
-  unitRes := ret_1
+  inhale isSubtype(typeOf(v_ret_1), unitType())
+  unitRes := v_ret_1
   assert unitRes == unitValue()
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/and_or_then.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/and_or_then.fir.diag.txt
@@ -1,43 +1,44 @@
 /and_or_then.kt: info: Generated Viper text for resultOrArg:
-method resultOrArg(par_arg: Ref) returns (ret: Ref)
+method resultOrArg(par_arg: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(par_arg), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) || boolFromRef(par_arg)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) || boolFromRef(par_arg)
 {
-  ret := notBool(par_arg)
-  goto ret_0
-  label ret_0
+  v_ret_0 := notBool(par_arg)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /and_or_then.kt: info: Generated Viper text for testImplies:
-method testImplies(par_arg: Ref) returns (ret: Ref)
+method testImplies(par_arg: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(par_arg), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(par_arg) ==> !boolFromRef(ret)
-  ensures boolFromRef(ret) ==> !boolFromRef(par_arg)
-  ensures !boolFromRef(par_arg) ==> boolFromRef(ret)
-  ensures !boolFromRef(ret) ==> boolFromRef(par_arg)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(par_arg) ==> !boolFromRef(v_ret_0)
+  ensures boolFromRef(v_ret_0) ==> !boolFromRef(par_arg)
+  ensures !boolFromRef(par_arg) ==> boolFromRef(v_ret_0)
+  ensures !boolFromRef(v_ret_0) ==> boolFromRef(par_arg)
 {
-  ret := notBool(par_arg)
-  goto ret_0
-  label ret_0
+  v_ret_0 := notBool(par_arg)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /and_or_then.kt: info: Generated Viper text for testAnd:
-method testAnd(arg1: Ref, arg2: Ref) returns (ret: Ref)
+method testAnd(arg1: Ref, arg2: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(arg1), boolType())
   requires isSubtype(typeOf(arg2), boolType())
-  ensures isSubtype(typeOf(ret), boolType())
-  ensures boolFromRef(ret) ==> boolFromRef(arg1) && boolFromRef(arg2)
-  ensures !boolFromRef(ret) ==> !boolFromRef(arg1) || !boolFromRef(arg2)
-  ensures boolFromRef(arg1) && boolFromRef(arg2) ==> boolFromRef(ret)
-  ensures !boolFromRef(arg1) ==> !boolFromRef(ret)
-  ensures !boolFromRef(arg2) ==> !boolFromRef(ret)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) ==> boolFromRef(arg1) && boolFromRef(arg2)
+  ensures !boolFromRef(v_ret_0) ==>
+    !boolFromRef(arg1) || !boolFromRef(arg2)
+  ensures boolFromRef(arg1) && boolFromRef(arg2) ==> boolFromRef(v_ret_0)
+  ensures !boolFromRef(arg1) ==> !boolFromRef(v_ret_0)
+  ensures !boolFromRef(arg2) ==> !boolFromRef(v_ret_0)
 {
   if (boolFromRef(arg1)) {
-    ret := arg2
+    v_ret_0 := arg2
   } else {
-    ret := boolToRef(false)}
-  goto ret_0
-  label ret_0
+    v_ret_0 := boolToRef(false)}
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
@@ -30,7 +30,7 @@ method forAllWithTriggersInLoop(str: Ref) returns (ret: Ref)
 {
   var res: Ref
   var i: Ref
-  var anon_1: Ref
+  var anon: Ref
   res := intToRef(0)
   i := intToRef(10)
   label cont
@@ -43,11 +43,11 @@ method forAllWithTriggersInLoop(str: Ref) returns (ret: Ref)
         (stringFromRef(str)[anon_builtin] - 97) *
         (stringFromRef(str)[anon_builtin] - 97) >=
         intFromRef(res))
-  anon_1 := gtInts(i, intToRef(0))
-  if (boolFromRef(anon_1)) {
-    var anon: Ref
-    anon := i
-    i := minusInts(anon, intToRef(1))
+  anon := gtInts(i, intToRef(0))
+  if (boolFromRef(anon)) {
+    var anon_0: Ref
+    anon_0 := i
+    i := minusInts(anon_0, intToRef(1))
     goto cont
   }
   label break

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.fir.diag.txt
@@ -1,36 +1,36 @@
 /forall_with_triggers.kt: info: Generated Viper text for forAllWithSimpleTrigger:
-method forAllWithSimpleTrigger() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method forAllWithSimpleTrigger() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
   ensures (forall anon: Int ::
       { anon * anon }
-      anon * anon >= 0 && anon * anon >= intFromRef(ret))
+      anon * anon >= 0 && anon * anon >= intFromRef(v_ret_0))
 {
-  ret := intToRef(0)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(0)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /forall_with_triggers.kt: info: Generated Viper text for forAllWithMultipleTriggers:
-method forAllWithMultipleTriggers() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method forAllWithMultipleTriggers() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
   ensures (forall anon: Int ::
       { anon * anon }
       { anon + 1 }
-      !(anon == 0) ==> anon * anon >= intFromRef(ret))
+      !(anon == 0) ==> anon * anon >= intFromRef(v_ret_0))
 {
-  ret := intToRef(1)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(1)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /forall_with_triggers.kt: info: Generated Viper text for forAllWithTriggersInLoop:
-method forAllWithTriggersInLoop(str: Ref) returns (ret: Ref)
+method forAllWithTriggersInLoop(str: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var res: Ref
   var i: Ref
-  var anon: Ref
+  var anon_1: Ref
   res := intToRef(0)
   i := intToRef(10)
   label cont
@@ -43,8 +43,8 @@ method forAllWithTriggersInLoop(str: Ref) returns (ret: Ref)
         (stringFromRef(str)[anon_builtin] - 97) *
         (stringFromRef(str)[anon_builtin] - 97) >=
         intFromRef(res))
-  anon := gtInts(i, intToRef(0))
-  if (boolFromRef(anon)) {
+  anon_1 := gtInts(i, intToRef(0))
+  if (boolFromRef(anon_1)) {
     var anon_0: Ref
     anon_0 := i
     i := minusInts(anon_0, intToRef(1))
@@ -60,17 +60,17 @@ method forAllWithTriggersInLoop(str: Ref) returns (ret: Ref)
       (stringFromRef(str)[anon_builtin] - 97) *
       (stringFromRef(str)[anon_builtin] - 97) >=
       intFromRef(res))
-  ret := res
-  goto ret_0
-  label ret_0
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /forall_with_triggers.kt: info: Generated Viper text for forAllWithoutTriggers:
-method forAllWithoutTriggers() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method forAllWithoutTriggers() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
   ensures (forall anon: Int ::anon * anon >= 0)
 {
-  ret := intToRef(0)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(0)
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
@@ -28,7 +28,7 @@ method anyIntegerSquaredIsAtLeastZeroStringVersion(str: Ref)
 {
   var res: Ref
   var i: Ref
-  var anon_1: Ref
+  var anon: Ref
   res := intToRef(0)
   i := intToRef(10)
   label cont
@@ -40,11 +40,11 @@ method anyIntegerSquaredIsAtLeastZeroStringVersion(str: Ref)
         (stringFromRef(str)[anon_builtin] - 97) *
         (stringFromRef(str)[anon_builtin] - 97) >=
         intFromRef(res))
-  anon_1 := gtInts(i, intToRef(0))
-  if (boolFromRef(anon_1)) {
-    var anon: Ref
-    anon := i
-    i := minusInts(anon, intToRef(1))
+  anon := gtInts(i, intToRef(0))
+  if (boolFromRef(anon)) {
+    var anon_0: Ref
+    anon_0 := i
+    i := minusInts(anon_0, intToRef(1))
     goto cont
   }
   label break

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.fir.diag.txt
@@ -1,34 +1,34 @@
 /simple_forall.kt: info: Generated Viper text for anyIntegerSquaredAtLeastZero:
-method anyIntegerSquaredAtLeastZero() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method anyIntegerSquaredAtLeastZero() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
   ensures (forall anon: Int ::anon * anon >= 0 &&
-      anon * anon >= intFromRef(ret))
+      anon * anon >= intFromRef(v_ret_0))
 {
-  ret := intToRef(0)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(0)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /simple_forall.kt: info: Generated Viper text for anyIntegerSquaredIsAtLeastOneExceptZero:
-method anyIntegerSquaredIsAtLeastOneExceptZero() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method anyIntegerSquaredIsAtLeastOneExceptZero() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
   ensures (forall anon: Int ::!(anon == 0) ==>
-      anon * anon >= intFromRef(ret))
+      anon * anon >= intFromRef(v_ret_0))
 {
-  ret := intToRef(1)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(1)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /simple_forall.kt: info: Generated Viper text for anyIntegerSquaredIsAtLeastZeroStringVersion:
 method anyIntegerSquaredIsAtLeastZeroStringVersion(str: Ref)
-  returns (ret: Ref)
+  returns (v_ret_0: Ref)
   requires isSubtype(typeOf(str), stringType())
-  ensures isSubtype(typeOf(ret), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var res: Ref
   var i: Ref
-  var anon: Ref
+  var anon_1: Ref
   res := intToRef(0)
   i := intToRef(10)
   label cont
@@ -40,8 +40,8 @@ method anyIntegerSquaredIsAtLeastZeroStringVersion(str: Ref)
         (stringFromRef(str)[anon_builtin] - 97) *
         (stringFromRef(str)[anon_builtin] - 97) >=
         intFromRef(res))
-  anon := gtInts(i, intToRef(0))
-  if (boolFromRef(anon)) {
+  anon_1 := gtInts(i, intToRef(0))
+  if (boolFromRef(anon_1)) {
     var anon_0: Ref
     anon_0 := i
     i := minusInts(anon_0, intToRef(1))
@@ -56,7 +56,7 @@ method anyIntegerSquaredIsAtLeastZeroStringVersion(str: Ref)
       (stringFromRef(str)[anon_builtin] - 97) *
       (stringFromRef(str)[anon_builtin] - 97) >=
       intFromRef(res))
-  ret := res
-  goto ret_0
-  label ret_0
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
@@ -1,9 +1,9 @@
 /simple_loop.kt: info: Generated Viper text for test:
 field size: Ref
 
-method test(n: Ref) returns (ret_0: Ref)
+method test(n: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(n), intType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var it: Ref
   var holds: Ref
@@ -49,8 +49,8 @@ method test(n: Ref) returns (ret_0: Ref)
     assert boolFromRef(holds)
     assert intFromRef(it) == intFromRef(n)
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /simple_loop.kt: info: Generated Viper text for loopInsideLoop:
@@ -96,8 +96,8 @@ method loopInsideLoop() returns (ret: Ref)
 /simple_loop.kt: info: Generated Viper text for withBreak:
 field size: Ref
 
-method withBreak() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method withBreak() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var i: Ref
   var anon: Ref
@@ -116,8 +116,8 @@ method withBreak() returns (ret_0: Ref)
   assert isSubtype(typeOf(i), intType())
   assert intFromRef(i) <= 10
   assert intFromRef(i) == 10
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /simple_loop.kt: info: Generated Viper text for test_boolean_postcondition:
@@ -125,20 +125,20 @@ field bf_e: Ref
 
 field size: Ref
 
-method con(e: Ref) returns (ret: Ref)
+method con(e: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(e), intType())
-  ensures isSubtype(typeOf(ret), c_WithVar())
-  ensures acc(_c_WithVar_shared(ret), wildcard)
-  ensures acc(_c_WithVar_unique(ret), write)
+  ensures isSubtype(typeOf(v_ret), c_WithVar())
+  ensures acc(_c_WithVar_shared(v_ret), wildcard)
+  ensures acc(_c_WithVar_unique(v_ret), write)
 
 
-method doSomething(this: Ref) returns (ret: Ref)
+method doSomething(this: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), c_WithVar())
-  ensures isSubtype(typeOf(ret), boolType())
+  ensures isSubtype(typeOf(v_ret), boolType())
 
 
-method test_boolean_postcondition() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method test_boolean_postcondition() returns (ret: Ref)
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var withVar: Ref
   var boolean: Ref
@@ -159,6 +159,6 @@ method test_boolean_postcondition() returns (ret_0: Ref)
   assert isSubtype(typeOf(withVar), c_WithVar())
   assert isSubtype(typeOf(boolean), boolType())
   assert !boolFromRef(boolean)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
@@ -127,13 +127,13 @@ field size: Ref
 
 method con(e: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(e), intType())
-  ensures isSubtype(typeOf(ret), _c_WithVar())
-  ensures acc(c_WithVar_shared(ret), wildcard)
-  ensures acc(c_WithVar_unique(ret), write)
+  ensures isSubtype(typeOf(ret), c_WithVar())
+  ensures acc(_c_WithVar_shared(ret), wildcard)
+  ensures acc(_c_WithVar_unique(ret), write)
 
 
 method doSomething(this: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), _c_WithVar())
+  requires isSubtype(typeOf(this), c_WithVar())
   ensures isSubtype(typeOf(ret), boolType())
 
 
@@ -146,8 +146,8 @@ method test_boolean_postcondition() returns (ret_0: Ref)
   withVar := con(intToRef(42))
   boolean := boolToRef(true)
   label cont
-    invariant acc(c_WithVar_shared(withVar), wildcard)
-    invariant isSubtype(typeOf(withVar), _c_WithVar())
+    invariant acc(_c_WithVar_shared(withVar), wildcard)
+    invariant isSubtype(typeOf(withVar), c_WithVar())
     invariant isSubtype(typeOf(boolean), boolType())
   anon := boolean
   if (boolFromRef(anon)) {
@@ -155,8 +155,8 @@ method test_boolean_postcondition() returns (ret_0: Ref)
     goto cont
   }
   label break
-  assert acc(c_WithVar_shared(withVar), wildcard)
-  assert isSubtype(typeOf(withVar), _c_WithVar())
+  assert acc(_c_WithVar_shared(withVar), wildcard)
+  assert isSubtype(typeOf(withVar), c_WithVar())
   assert isSubtype(typeOf(boolean), boolType())
   assert !boolFromRef(boolean)
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_loop.fir.diag.txt
@@ -1,9 +1,9 @@
 /simple_loop.kt: info: Generated Viper text for test:
 field size: Ref
 
-method test(n: Ref) returns (ret: Ref)
+method test(n: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(n), intType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var it: Ref
   var holds: Ref
@@ -29,19 +29,19 @@ method test(n: Ref) returns (ret: Ref)
   assert boolFromRef(holds)
   assert intFromRef(it) == 10
   if (intFromRef(it) <= intFromRef(n)) {
-    var anon: Ref
-    label cont
+    var anon_1: Ref
+    label cont_1
       invariant isSubtype(typeOf(it), intType())
       invariant isSubtype(typeOf(holds), boolType())
       invariant isSubtype(typeOf(n), intType())
       invariant intFromRef(it) <= intFromRef(n)
       invariant boolFromRef(holds)
-    anon := ltInts(it, n)
-    if (boolFromRef(anon)) {
+    anon_1 := ltInts(it, n)
+    if (boolFromRef(anon_1)) {
       it := plusInts(it, intToRef(1))
-      goto cont
+      goto cont_1
     }
-    label break
+    label break_1
     assert isSubtype(typeOf(it), intType())
     assert isSubtype(typeOf(holds), boolType())
     assert isSubtype(typeOf(n), intType())
@@ -49,13 +49,13 @@ method test(n: Ref) returns (ret: Ref)
     assert boolFromRef(holds)
     assert intFromRef(it) == intFromRef(n)
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /simple_loop.kt: info: Generated Viper text for loopInsideLoop:
-method loopInsideLoop() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method loopInsideLoop() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var i: Ref
   var anon_0: Ref
@@ -66,19 +66,19 @@ method loopInsideLoop() returns (ret: Ref)
   anon_0 := ltInts(i, intToRef(10))
   if (boolFromRef(anon_0)) {
     var j: Ref
-    var anon: Ref
+    var anon_1: Ref
     j := plusInts(i, intToRef(1))
-    label cont
+    label cont_1
       invariant isSubtype(typeOf(j), intType())
       invariant isSubtype(typeOf(i), intType())
       invariant intFromRef(i) < intFromRef(j)
       invariant intFromRef(j) <= 10
-    anon := ltInts(j, intToRef(10))
-    if (boolFromRef(anon)) {
+    anon_1 := ltInts(j, intToRef(10))
+    if (boolFromRef(anon_1)) {
       j := plusInts(j, intToRef(1))
-      goto cont
+      goto cont_1
     }
-    label break
+    label break_1
     assert isSubtype(typeOf(j), intType())
     assert isSubtype(typeOf(i), intType())
     assert intFromRef(i) < intFromRef(j)
@@ -89,15 +89,15 @@ method loopInsideLoop() returns (ret: Ref)
   label break_0
   assert isSubtype(typeOf(i), intType())
   assert intFromRef(i) <= 10
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /simple_loop.kt: info: Generated Viper text for withBreak:
 field size: Ref
 
-method withBreak() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method withBreak() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var i: Ref
   var anon: Ref
@@ -116,8 +116,8 @@ method withBreak() returns (ret: Ref)
   assert isSubtype(typeOf(i), intType())
   assert intFromRef(i) <= 10
   assert intFromRef(i) == 10
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /simple_loop.kt: info: Generated Viper text for test_boolean_postcondition:
@@ -125,20 +125,20 @@ field bf_e: Ref
 
 field size: Ref
 
-method con(e: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(e), intType())
-  ensures isSubtype(typeOf(v_ret), c_WithVar())
-  ensures acc(_c_WithVar_shared(v_ret), wildcard)
-  ensures acc(_c_WithVar_unique(v_ret), write)
+method con(par_e: Ref) returns (v_ret: Ref)
+  requires isSubtype(typeOf(par_e), intType())
+  ensures isSubtype(typeOf(v_ret), WithVar())
+  ensures acc(WithVar_shared(v_ret), wildcard)
+  ensures acc(WithVar_unique(v_ret), write)
 
 
 method doSomething(this: Ref) returns (v_ret: Ref)
-  requires isSubtype(typeOf(this), c_WithVar())
+  requires isSubtype(typeOf(this), WithVar())
   ensures isSubtype(typeOf(v_ret), boolType())
 
 
-method test_boolean_postcondition() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), unitType())
+method test_boolean_postcondition() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var withVar: Ref
   var boolean: Ref
@@ -146,8 +146,8 @@ method test_boolean_postcondition() returns (ret: Ref)
   withVar := con(intToRef(42))
   boolean := boolToRef(true)
   label cont
-    invariant acc(_c_WithVar_shared(withVar), wildcard)
-    invariant isSubtype(typeOf(withVar), c_WithVar())
+    invariant acc(WithVar_shared(withVar), wildcard)
+    invariant isSubtype(typeOf(withVar), WithVar())
     invariant isSubtype(typeOf(boolean), boolType())
   anon := boolean
   if (boolFromRef(anon)) {
@@ -155,10 +155,10 @@ method test_boolean_postcondition() returns (ret: Ref)
     goto cont
   }
   label break
-  assert acc(_c_WithVar_shared(withVar), wildcard)
-  assert isSubtype(typeOf(withVar), c_WithVar())
+  assert acc(WithVar_shared(withVar), wildcard)
+  assert isSubtype(typeOf(withVar), WithVar())
   assert isSubtype(typeOf(boolean), boolType())
   assert !boolFromRef(boolean)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
@@ -42,23 +42,23 @@ method returnGreater13() returns (ret: Ref)
 }
 
 /simple_postcondition.kt: info: Generated Viper text for testPostconditionIsUsedByPrecondition:
-method returnGreater13() returns (ret: Ref)
+method returnGreater13() returns (v_ret: Ref)
+  ensures isSubtype(typeOf(v_ret), intType())
+  ensures intFromRef(v_ret) > 13
+
+
+method testPostconditionIsUsedByPrecondition() returns (ret: Ref)
   ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(ret) > 13
-
-
-method testPostconditionIsUsedByPrecondition() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), intType())
 {
   var anon: Ref
   anon := returnGreater13()
-  ret_0 := testWithPrecondition(anon)
-  goto lbl_ret_0
-  label lbl_ret_0
+  ret := testWithPrecondition(anon)
+  goto ret_0
+  label ret_0
 }
 
-method testWithPrecondition(int: Ref) returns (ret: Ref)
+method testWithPrecondition(int: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(int), intType())
   requires intFromRef(int) > 10
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(ret) > 0
+  ensures isSubtype(typeOf(v_ret), intType())
+  ensures intFromRef(v_ret) > 0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_postcondition.fir.diag.txt
@@ -1,44 +1,44 @@
 /simple_postcondition.kt: info: Generated Viper text for testGreater:
-method testGreater(init: Ref) returns (ret: Ref)
+method testGreater(init: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(init), intType())
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(ret) > intFromRef(init)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) > intFromRef(init)
 {
-  ret := plusInts(init, intToRef(5))
-  goto ret_0
-  label ret_0
+  v_ret_0 := plusInts(init, intToRef(5))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /simple_postcondition.kt: info: Generated Viper text for testString:
-method testString() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), charType())
-  ensures charFromRef(ret) == 97
+method testString() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), charType())
+  ensures charFromRef(v_ret_0) == 97
 {
-  ret := stringGet(stringToRef(Seq(98, 97, 98)), intToRef(1))
-  goto ret_0
-  label ret_0
+  v_ret_0 := stringGet(stringToRef(Seq(98, 97, 98)), intToRef(1))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /simple_postcondition.kt: info: Generated Viper text for testWithPrecondition:
-method testWithPrecondition(int: Ref) returns (ret: Ref)
+method testWithPrecondition(int: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(int), intType())
   requires intFromRef(int) > 10
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(ret) > 0
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) > 0
 {
-  ret := minusInts(int, intToRef(10))
-  goto ret_0
-  label ret_0
+  v_ret_0 := minusInts(int, intToRef(10))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /simple_postcondition.kt: info: Generated Viper text for returnGreater13:
-method returnGreater13() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(ret) > 13
+method returnGreater13() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) > 13
 {
-  ret := intToRef(16)
-  goto ret_0
-  label ret_0
+  v_ret_0 := intToRef(16)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /simple_postcondition.kt: info: Generated Viper text for testPostconditionIsUsedByPrecondition:
@@ -47,14 +47,14 @@ method returnGreater13() returns (v_ret: Ref)
   ensures intFromRef(v_ret) > 13
 
 
-method testPostconditionIsUsedByPrecondition() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), intType())
+method testPostconditionIsUsedByPrecondition() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var anon: Ref
   anon := returnGreater13()
-  ret := testWithPrecondition(anon)
-  goto ret_0
-  label ret_0
+  v_ret_0 := testWithPrecondition(anon)
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method testWithPrecondition(int: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
@@ -1,18 +1,18 @@
 /simple_precondition.kt: info: Generated Viper text for test:
 field size: Ref
 
-method test(idx: Ref) returns (ret_0: Ref)
+method test(idx: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(idx), intType())
   requires 0 <= intFromRef(idx)
   requires intFromRef(idx) < 3
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   assert 0 <= intFromRef(idx)
   assert intFromRef(idx) < 3
   assert !(intFromRef(idx) == 100)
   assert Seq(97, 97, 97)[intFromRef(idx)] == 97
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /simple_precondition.kt: info: Generated Viper text for inlineWithSpecification:
@@ -33,21 +33,21 @@ method good_call() returns (ret_0: Ref)
   var anon: Ref
   var ret_1: Ref
   var anon_0: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   anon := test(intToRef(2))
   anon_0 := boolToRef(true)
   label lbl_ret_1
   inhale isSubtype(typeOf(ret_1), unitType())
   anon_1 := boolToRef(false)
-  label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
+  label ret_2
+  inhale isSubtype(typeOf(ret), unitType())
   label lbl_ret_0
   inhale isSubtype(typeOf(ret_0), unitType())
 }
 
-method test(idx: Ref) returns (ret: Ref)
+method test(idx: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(idx), intType())
   requires 0 <= intFromRef(idx)
   requires intFromRef(idx) < 3
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
@@ -30,16 +30,16 @@ method inlineWithSpecification(bool: Ref) returns (ret: Ref)
 method good_call() returns (ret_0: Ref)
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  var anon_2: Ref
+  var anon: Ref
   var ret_1: Ref
   var anon_0: Ref
   var ret_2: Ref
-  var anon: Ref
-  anon_2 := test(intToRef(2))
+  var anon_1: Ref
+  anon := test(intToRef(2))
   anon_0 := boolToRef(true)
   label lbl_ret_1
   inhale isSubtype(typeOf(ret_1), unitType())
-  anon := boolToRef(false)
+  anon_1 := boolToRef(false)
   label lbl_ret_2
   inhale isSubtype(typeOf(ret_2), unitType())
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_precondition.fir.diag.txt
@@ -1,49 +1,49 @@
 /simple_precondition.kt: info: Generated Viper text for test:
 field size: Ref
 
-method test(idx: Ref) returns (ret: Ref)
+method test(idx: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(idx), intType())
   requires 0 <= intFromRef(idx)
   requires intFromRef(idx) < 3
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   assert 0 <= intFromRef(idx)
   assert intFromRef(idx) < 3
   assert !(intFromRef(idx) == 100)
   assert Seq(97, 97, 97)[intFromRef(idx)] == 97
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /simple_precondition.kt: info: Generated Viper text for inlineWithSpecification:
-method inlineWithSpecification(bool: Ref) returns (ret: Ref)
+method inlineWithSpecification(bool: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(bool), boolType())
   requires true
   requires boolFromRef(bool)
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /simple_precondition.kt: info: Generated Viper text for good_call:
-method good_call() returns (ret_0: Ref)
-  ensures isSubtype(typeOf(ret_0), unitType())
+method good_call() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var anon: Ref
-  var ret_1: Ref
+  var anon_2: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
-  var ret: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
-  anon := test(intToRef(2))
+  anon_2 := test(intToRef(2))
   anon_0 := boolToRef(true)
   label lbl_ret_1
-  inhale isSubtype(typeOf(ret_1), unitType())
+  inhale isSubtype(typeOf(v_ret_1), unitType())
   anon_1 := boolToRef(false)
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 method test(idx: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,38 +1,29 @@
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /string_iterations.kt: info: Generated Viper text for firstAtLeast:
-method firstAtLeast([v$this]: Ref, c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
+method firstAtLeast(v_this: Ref, c: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(ret), intType())
   ensures 0 <= intFromRef(ret) &&
-    intFromRef(ret) <= |stringFromRef([v$this])|
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < intFromRef(ret) ==>
-      stringFromRef([v$this])[anon_builtin] < charFromRef(c))
-  ensures !(intFromRef(ret) == |stringFromRef([v$this])|) ==>
-    stringFromRef([v$this])[intFromRef(ret)] >= charFromRef(c)
+    intFromRef(ret) <= |stringFromRef(v_this)|
+  ensures (forall anon: Int ::0 <= anon && anon < intFromRef(ret) ==>
+      stringFromRef(v_this)[anon] < charFromRef(c))
+  ensures !(intFromRef(ret) == |stringFromRef(v_this)|) ==>
+    stringFromRef(v_this)[intFromRef(ret)] >= charFromRef(c)
 {
   var i: Ref
-  var anon: Ref
+  var anon_0: Ref
   i := intToRef(0)
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef([v$this])|
-    invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-        anon_builtin_1 < intFromRef(i) ==>
-        stringFromRef([v$this])[anon_builtin_1] < charFromRef(c))
-  anon := ltInts(i, stringLength([v$this]))
-  if (boolFromRef(anon)) {
-    if (stringFromRef([v$this])[intFromRef(i)] >= charFromRef(c)) {
+      intFromRef(i) <= |stringFromRef(v_this)|
+    invariant (forall anon_builtin: Int ::0 <= anon_builtin &&
+        anon_builtin < intFromRef(i) ==>
+        stringFromRef(v_this)[anon_builtin] < charFromRef(c))
+  anon_0 := ltInts(i, stringLength(v_this))
+  if (boolFromRef(anon_0)) {
+    if (stringFromRef(v_this)[intFromRef(i)] >= charFromRef(c)) {
       goto break
     }
     i := plusInts(i, intToRef(1))
@@ -41,98 +32,42 @@ method firstAtLeast([v$this]: Ref, c: Ref) returns (ret: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
-  assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-      anon_builtin_1 < intFromRef(i) ==>
-      stringFromRef([v$this])[anon_builtin_1] < charFromRef(c))
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
+  assert (forall anon_builtin: Int ::0 <= anon_builtin &&
+      anon_builtin < intFromRef(i) ==>
+      stringFromRef(v_this)[anon_builtin] < charFromRef(c))
   ret := i
   goto ret_0
   label ret_0
 }
 
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
-Please report this at https://github.com/jesyspa/kotlin
-
 /string_iterations.kt: info: Generated Viper text for lastLess:
-method lastLess([v$this]: Ref, c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf([v$this]), stringType())
+method lastLess(v_this: Ref, c: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(ret), intType())
   ensures -1 <= intFromRef(ret) &&
-    intFromRef(ret) <= |stringFromRef([v$this])| - 1
-  ensures (forall anon_builtin: Int ::intFromRef(ret) < anon_builtin &&
-      anon_builtin < |stringFromRef([v$this])| ==>
-      stringFromRef([v$this])[anon_builtin] >= charFromRef(c))
+    intFromRef(ret) <= |stringFromRef(v_this)| - 1
+  ensures (forall anon: Int ::intFromRef(ret) < anon &&
+      anon < |stringFromRef(v_this)| ==>
+      stringFromRef(v_this)[anon] >= charFromRef(c))
   ensures !(intFromRef(ret) == -1) ==>
-    stringFromRef([v$this])[intFromRef(ret)] < charFromRef(c)
+    stringFromRef(v_this)[intFromRef(ret)] < charFromRef(c)
 {
   var i: Ref
-  var anon: Ref
-  i := minusInts(stringLength([v$this]), intToRef(1))
+  var anon_0: Ref
+  i := minusInts(stringLength(v_this), intToRef(1))
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
     invariant -1 <= intFromRef(i) &&
-      intFromRef(i) < |stringFromRef([v$this])|
-    invariant (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-        anon_builtin_1 < |stringFromRef([v$this])| ==>
-        stringFromRef([v$this])[anon_builtin_1] >= charFromRef(c))
-  anon := gtInts(i, intToRef(-1))
-  if (boolFromRef(anon)) {
-    if (stringFromRef([v$this])[intFromRef(i)] < charFromRef(c)) {
+      intFromRef(i) < |stringFromRef(v_this)|
+    invariant (forall anon_builtin: Int ::intFromRef(i) < anon_builtin &&
+        anon_builtin < |stringFromRef(v_this)| ==>
+        stringFromRef(v_this)[anon_builtin] >= charFromRef(c))
+  anon_0 := gtInts(i, intToRef(-1))
+  if (boolFromRef(anon_0)) {
+    if (stringFromRef(v_this)[intFromRef(i)] < charFromRef(c)) {
       goto break
     }
     i := minusInts(i, intToRef(1))
@@ -141,71 +76,11 @@ method lastLess([v$this]: Ref, c: Ref) returns (ret: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef([v$this])|
-  assert (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef([v$this])| ==>
-      stringFromRef([v$this])[anon_builtin_1] >= charFromRef(c))
+  assert -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(v_this)|
+  assert (forall anon_builtin: Int ::intFromRef(i) < anon_builtin &&
+      anon_builtin < |stringFromRef(v_this)| ==>
+      stringFromRef(v_this)[anon_builtin] >= charFromRef(c))
   ret := i
   goto ret_0
   label ret_0
 }
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin
-
-/string_iterations.kt: error: An internal error has occurred.
-Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,27 +1,38 @@
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /string_iterations.kt: info: Generated Viper text for firstAtLeast:
-method firstAtLeast(this: Ref, c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method firstAtLeast([v$this]: Ref, c: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(ret), intType())
-  ensures 0 <= intFromRef(ret) && intFromRef(ret) <= |stringFromRef(this)|
+  ensures 0 <= intFromRef(ret) &&
+    intFromRef(ret) <= |stringFromRef([v$this])|
   ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
       anon_builtin < intFromRef(ret) ==>
-      stringFromRef(this)[anon_builtin] < charFromRef(c))
-  ensures !(intFromRef(ret) == |stringFromRef(this)|) ==>
-    stringFromRef(this)[intFromRef(ret)] >= charFromRef(c)
+      stringFromRef([v$this])[anon_builtin] < charFromRef(c))
+  ensures !(intFromRef(ret) == |stringFromRef([v$this])|) ==>
+    stringFromRef([v$this])[intFromRef(ret)] >= charFromRef(c)
 {
   var i: Ref
-  var anon_0: Ref
+  var anon: Ref
   i := intToRef(0)
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
-    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
-    invariant (forall anon: Int ::0 <= anon && anon < intFromRef(i) ==>
-        stringFromRef(this)[anon] < charFromRef(c))
-  anon_0 := ltInts(i, stringLength(this))
-  if (boolFromRef(anon_0)) {
-    if (stringFromRef(this)[intFromRef(i)] >= charFromRef(c)) {
+    invariant 0 <= intFromRef(i) &&
+      intFromRef(i) <= |stringFromRef([v$this])|
+    invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+        anon_builtin_1 < intFromRef(i) ==>
+        stringFromRef([v$this])[anon_builtin_1] < charFromRef(c))
+  anon := ltInts(i, stringLength([v$this]))
+  if (boolFromRef(anon)) {
+    if (stringFromRef([v$this])[intFromRef(i)] >= charFromRef(c)) {
       goto break
     }
     i := plusInts(i, intToRef(1))
@@ -30,40 +41,98 @@ method firstAtLeast(this: Ref, c: Ref) returns (ret: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
-  assert (forall anon: Int ::0 <= anon && anon < intFromRef(i) ==>
-      stringFromRef(this)[anon] < charFromRef(c))
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef([v$this])|
+  assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+      anon_builtin_1 < intFromRef(i) ==>
+      stringFromRef([v$this])[anon_builtin_1] < charFromRef(c))
   ret := i
   goto ret_0
   label ret_0
 }
 
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: [v$this] is not a valid identifier. (<no position>)
+Please report this at https://github.com/jesyspa/kotlin
+
 /string_iterations.kt: info: Generated Viper text for lastLess:
-method lastLess(this: Ref, c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method lastLess([v$this]: Ref, c: Ref) returns (ret: Ref)
+  requires isSubtype(typeOf([v$this]), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(ret), intType())
   ensures -1 <= intFromRef(ret) &&
-    intFromRef(ret) <= |stringFromRef(this)| - 1
+    intFromRef(ret) <= |stringFromRef([v$this])| - 1
   ensures (forall anon_builtin: Int ::intFromRef(ret) < anon_builtin &&
-      anon_builtin < |stringFromRef(this)| ==>
-      stringFromRef(this)[anon_builtin] >= charFromRef(c))
+      anon_builtin < |stringFromRef([v$this])| ==>
+      stringFromRef([v$this])[anon_builtin] >= charFromRef(c))
   ensures !(intFromRef(ret) == -1) ==>
-    stringFromRef(this)[intFromRef(ret)] < charFromRef(c)
+    stringFromRef([v$this])[intFromRef(ret)] < charFromRef(c)
 {
   var i: Ref
-  var anon_0: Ref
-  i := minusInts(stringLength(this), intToRef(1))
+  var anon: Ref
+  i := minusInts(stringLength([v$this]), intToRef(1))
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
-    invariant -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(this)|
-    invariant (forall anon: Int ::intFromRef(i) < anon &&
-        anon < |stringFromRef(this)| ==>
-        stringFromRef(this)[anon] >= charFromRef(c))
-  anon_0 := gtInts(i, intToRef(-1))
-  if (boolFromRef(anon_0)) {
-    if (stringFromRef(this)[intFromRef(i)] < charFromRef(c)) {
+    invariant -1 <= intFromRef(i) &&
+      intFromRef(i) < |stringFromRef([v$this])|
+    invariant (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
+        anon_builtin_1 < |stringFromRef([v$this])| ==>
+        stringFromRef([v$this])[anon_builtin_1] >= charFromRef(c))
+  anon := gtInts(i, intToRef(-1))
+  if (boolFromRef(anon)) {
+    if (stringFromRef([v$this])[intFromRef(i)] < charFromRef(c)) {
       goto break
     }
     i := minusInts(i, intToRef(1))
@@ -72,11 +141,71 @@ method lastLess(this: Ref, c: Ref) returns (ret: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(this)|
-  assert (forall anon: Int ::intFromRef(i) < anon &&
-      anon < |stringFromRef(this)| ==>
-      stringFromRef(this)[anon] >= charFromRef(c))
+  assert -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef([v$this])|
+  assert (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
+      anon_builtin_1 < |stringFromRef([v$this])| ==>
+      stringFromRef([v$this])[anon_builtin_1] >= charFromRef(c))
   ret := i
   goto ret_0
   label ret_0
 }
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin
+
+/string_iterations.kt: error: An internal error has occurred.
+Details: Consistency error: Local var name must be valid identifier. (<wrapped value>)
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,14 +1,15 @@
 /string_iterations.kt: info: Generated Viper text for firstAtLeast:
-method firstAtLeast(v_this: Ref, c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method firstAtLeast(v_this_dispatch: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(c), charType())
-  ensures isSubtype(typeOf(ret), intType())
-  ensures 0 <= intFromRef(ret) &&
-    intFromRef(ret) <= |stringFromRef(v_this)|
-  ensures (forall anon: Int ::0 <= anon && anon < intFromRef(ret) ==>
-      stringFromRef(v_this)[anon] < charFromRef(c))
-  ensures !(intFromRef(ret) == |stringFromRef(v_this)|) ==>
-    stringFromRef(v_this)[intFromRef(ret)] >= charFromRef(c)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures 0 <= intFromRef(v_ret_0) &&
+    intFromRef(v_ret_0) <= |stringFromRef(v_this_dispatch)|
+  ensures (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
+      anon_builtin_2 < intFromRef(v_ret_0) ==>
+      stringFromRef(v_this_dispatch)[anon_builtin_2] < charFromRef(c))
+  ensures !(intFromRef(v_ret_0) == |stringFromRef(v_this_dispatch)|) ==>
+    stringFromRef(v_this_dispatch)[intFromRef(v_ret_0)] >= charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
@@ -17,13 +18,13 @@ method firstAtLeast(v_this: Ref, c: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this)|
-    invariant (forall anon_builtin: Int ::0 <= anon_builtin &&
-        anon_builtin < intFromRef(i) ==>
-        stringFromRef(v_this)[anon_builtin] < charFromRef(c))
-  anon_0 := ltInts(i, stringLength(v_this))
+      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+    invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+        anon_builtin_1 < intFromRef(i) ==>
+        stringFromRef(v_this_dispatch)[anon_builtin_1] < charFromRef(c))
+  anon_0 := ltInts(i, stringLength(v_this_dispatch))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(v_this)[intFromRef(i)] >= charFromRef(c)) {
+    if (stringFromRef(v_this_dispatch)[intFromRef(i)] >= charFromRef(c)) {
       goto break
     }
     i := plusInts(i, intToRef(1))
@@ -32,42 +33,44 @@ method firstAtLeast(v_this: Ref, c: Ref) returns (ret: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(v_this)|
-  assert (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin < intFromRef(i) ==>
-      stringFromRef(v_this)[anon_builtin] < charFromRef(c))
-  ret := i
-  goto ret_0
-  label ret_0
+  assert 0 <= intFromRef(i) &&
+    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+  assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+      anon_builtin_1 < intFromRef(i) ==>
+      stringFromRef(v_this_dispatch)[anon_builtin_1] < charFromRef(c))
+  v_ret_0 := i
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /string_iterations.kt: info: Generated Viper text for lastLess:
-method lastLess(v_this: Ref, c: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(v_this), stringType())
+method lastLess(v_this_dispatch: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_dispatch), stringType())
   requires isSubtype(typeOf(c), charType())
-  ensures isSubtype(typeOf(ret), intType())
-  ensures -1 <= intFromRef(ret) &&
-    intFromRef(ret) <= |stringFromRef(v_this)| - 1
-  ensures (forall anon: Int ::intFromRef(ret) < anon &&
-      anon < |stringFromRef(v_this)| ==>
-      stringFromRef(v_this)[anon] >= charFromRef(c))
-  ensures !(intFromRef(ret) == -1) ==>
-    stringFromRef(v_this)[intFromRef(ret)] < charFromRef(c)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures -1 <= intFromRef(v_ret_0) &&
+    intFromRef(v_ret_0) <= |stringFromRef(v_this_dispatch)| - 1
+  ensures (forall anon_builtin_2: Int ::intFromRef(v_ret_0) <
+      anon_builtin_2 &&
+      anon_builtin_2 < |stringFromRef(v_this_dispatch)| ==>
+      stringFromRef(v_this_dispatch)[anon_builtin_2] >= charFromRef(c))
+  ensures !(intFromRef(v_ret_0) == -1) ==>
+    stringFromRef(v_this_dispatch)[intFromRef(v_ret_0)] < charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
-  i := minusInts(stringLength(v_this), intToRef(1))
+  i := minusInts(stringLength(v_this_dispatch), intToRef(1))
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
     invariant -1 <= intFromRef(i) &&
-      intFromRef(i) < |stringFromRef(v_this)|
-    invariant (forall anon_builtin: Int ::intFromRef(i) < anon_builtin &&
-        anon_builtin < |stringFromRef(v_this)| ==>
-        stringFromRef(v_this)[anon_builtin] >= charFromRef(c))
+      intFromRef(i) < |stringFromRef(v_this_dispatch)|
+    invariant (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
+        anon_builtin_1 < |stringFromRef(v_this_dispatch)| ==>
+        stringFromRef(v_this_dispatch)[anon_builtin_1] >= charFromRef(c))
   anon_0 := gtInts(i, intToRef(-1))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(v_this)[intFromRef(i)] < charFromRef(c)) {
+    if (stringFromRef(v_this_dispatch)[intFromRef(i)] < charFromRef(c)) {
       goto break
     }
     i := minusInts(i, intToRef(1))
@@ -76,11 +79,12 @@ method lastLess(v_this: Ref, c: Ref) returns (ret: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(v_this)|
-  assert (forall anon_builtin: Int ::intFromRef(i) < anon_builtin &&
-      anon_builtin < |stringFromRef(v_this)| ==>
-      stringFromRef(v_this)[anon_builtin] >= charFromRef(c))
-  ret := i
-  goto ret_0
-  label ret_0
+  assert -1 <= intFromRef(i) &&
+    intFromRef(i) < |stringFromRef(v_this_dispatch)|
+  assert (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
+      anon_builtin_1 < |stringFromRef(v_this_dispatch)| ==>
+      stringFromRef(v_this_dispatch)[anon_builtin_1] >= charFromRef(c))
+  v_ret_0 := i
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,15 +1,15 @@
 /string_iterations.kt: info: Generated Viper text for firstAtLeast:
-method firstAtLeast(v_this_dispatch: Ref, c: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method firstAtLeast(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures 0 <= intFromRef(v_ret_0) &&
-    intFromRef(v_ret_0) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(v_ret_0) <= |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(v_ret_0) ==>
-      stringFromRef(v_this_dispatch)[anon_builtin_2] < charFromRef(c))
-  ensures !(intFromRef(v_ret_0) == |stringFromRef(v_this_dispatch)|) ==>
-    stringFromRef(v_this_dispatch)[intFromRef(v_ret_0)] >= charFromRef(c)
+      stringFromRef(v_this_extension)[anon_builtin_2] < charFromRef(c))
+  ensures !(intFromRef(v_ret_0) == |stringFromRef(v_this_extension)|) ==>
+    stringFromRef(v_this_extension)[intFromRef(v_ret_0)] >= charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
@@ -18,13 +18,13 @@ method firstAtLeast(v_this_dispatch: Ref, c: Ref) returns (v_ret_0: Ref)
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
     invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+      intFromRef(i) <= |stringFromRef(v_this_extension)|
     invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
         anon_builtin_1 < intFromRef(i) ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_1] < charFromRef(c))
-  anon_0 := ltInts(i, stringLength(v_this_dispatch))
+        stringFromRef(v_this_extension)[anon_builtin_1] < charFromRef(c))
+  anon_0 := ltInts(i, stringLength(v_this_extension))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(v_this_dispatch)[intFromRef(i)] >= charFromRef(c)) {
+    if (stringFromRef(v_this_extension)[intFromRef(i)] >= charFromRef(c)) {
       goto break
     }
     i := plusInts(i, intToRef(1))
@@ -34,43 +34,43 @@ method firstAtLeast(v_this_dispatch: Ref, c: Ref) returns (v_ret_0: Ref)
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
   assert 0 <= intFromRef(i) &&
-    intFromRef(i) <= |stringFromRef(v_this_dispatch)|
+    intFromRef(i) <= |stringFromRef(v_this_extension)|
   assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
       anon_builtin_1 < intFromRef(i) ==>
-      stringFromRef(v_this_dispatch)[anon_builtin_1] < charFromRef(c))
+      stringFromRef(v_this_extension)[anon_builtin_1] < charFromRef(c))
   v_ret_0 := i
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /string_iterations.kt: info: Generated Viper text for lastLess:
-method lastLess(v_this_dispatch: Ref, c: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_dispatch), stringType())
+method lastLess(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures -1 <= intFromRef(v_ret_0) &&
-    intFromRef(v_ret_0) <= |stringFromRef(v_this_dispatch)| - 1
+    intFromRef(v_ret_0) <= |stringFromRef(v_this_extension)| - 1
   ensures (forall anon_builtin_2: Int ::intFromRef(v_ret_0) <
       anon_builtin_2 &&
-      anon_builtin_2 < |stringFromRef(v_this_dispatch)| ==>
-      stringFromRef(v_this_dispatch)[anon_builtin_2] >= charFromRef(c))
+      anon_builtin_2 < |stringFromRef(v_this_extension)| ==>
+      stringFromRef(v_this_extension)[anon_builtin_2] >= charFromRef(c))
   ensures !(intFromRef(v_ret_0) == -1) ==>
-    stringFromRef(v_this_dispatch)[intFromRef(v_ret_0)] < charFromRef(c)
+    stringFromRef(v_this_extension)[intFromRef(v_ret_0)] < charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
-  i := minusInts(stringLength(v_this_dispatch), intToRef(1))
+  i := minusInts(stringLength(v_this_extension), intToRef(1))
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
     invariant -1 <= intFromRef(i) &&
-      intFromRef(i) < |stringFromRef(v_this_dispatch)|
+      intFromRef(i) < |stringFromRef(v_this_extension)|
     invariant (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-        anon_builtin_1 < |stringFromRef(v_this_dispatch)| ==>
-        stringFromRef(v_this_dispatch)[anon_builtin_1] >= charFromRef(c))
+        anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
+        stringFromRef(v_this_extension)[anon_builtin_1] >= charFromRef(c))
   anon_0 := gtInts(i, intToRef(-1))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(v_this_dispatch)[intFromRef(i)] < charFromRef(c)) {
+    if (stringFromRef(v_this_extension)[intFromRef(i)] < charFromRef(c)) {
       goto break
     }
     i := minusInts(i, intToRef(1))
@@ -80,10 +80,10 @@ method lastLess(v_this_dispatch: Ref, c: Ref) returns (v_ret_0: Ref)
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
   assert -1 <= intFromRef(i) &&
-    intFromRef(i) < |stringFromRef(v_this_dispatch)|
+    intFromRef(i) < |stringFromRef(v_this_extension)|
   assert (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(v_this_dispatch)| ==>
-      stringFromRef(v_this_dispatch)[anon_builtin_1] >= charFromRef(c))
+      anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
+      stringFromRef(v_this_extension)[anon_builtin_1] >= charFromRef(c))
   v_ret_0 := i
   goto lbl_ret_0
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
@@ -12,27 +12,31 @@ method firstNotSortedIndex(s: Ref) returns (ret: Ref)
     goto ret_0
   } else {
     var i: Ref
-    var anon_0: Ref
+    var anon: Ref
     i := intToRef(1)
     label cont
       invariant isSubtype(typeOf(i), intType())
       invariant isSubtype(typeOf(s), stringType())
-      invariant (forall anon: Int ::0 <= anon && anon + 1 < intFromRef(i) ==>
-          stringFromRef(s)[anon] <= stringFromRef(s)[anon + 1])
+      invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+          anon_builtin_1 + 1 < intFromRef(i) ==>
+          stringFromRef(s)[anon_builtin_1] <=
+          stringFromRef(s)[anon_builtin_1 + 1])
     if (intFromRef(i) < |stringFromRef(s)|) {
-      anon_0 := leChars(stringGet(s, minusInts(i, intToRef(1))), stringGet(s,
+      anon := leChars(stringGet(s, minusInts(i, intToRef(1))), stringGet(s,
         i))
     } else {
-      anon_0 := boolToRef(false)}
-    if (boolFromRef(anon_0)) {
+      anon := boolToRef(false)}
+    if (boolFromRef(anon)) {
       i := plusInts(i, intToRef(1))
       goto cont
     }
     label break
     assert isSubtype(typeOf(i), intType())
     assert isSubtype(typeOf(s), stringType())
-    assert (forall anon: Int ::0 <= anon && anon + 1 < intFromRef(i) ==>
-        stringFromRef(s)[anon] <= stringFromRef(s)[anon + 1])
+    assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+        anon_builtin_1 + 1 < intFromRef(i) ==>
+        stringFromRef(s)[anon_builtin_1] <=
+        stringFromRef(s)[anon_builtin_1 + 1])
     ret := i
     goto ret_0
   }
@@ -49,20 +53,20 @@ method returnNewString() returns (ret: Ref)
 }
 
 /strings_in_conditions.kt: info: Generated Viper text for addCharacterTimes:
-method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret: Ref)
+method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
   requires isSubtype(typeOf(c), charType())
   requires isSubtype(typeOf(n), intType())
   requires intFromRef(n) >= 0
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(s)| + intFromRef(n)
+  ensures isSubtype(typeOf(ret_0), stringType())
+  ensures |stringFromRef(ret_0)| == |stringFromRef(s)| + intFromRef(n)
   ensures (forall anon_builtin: Int ::|stringFromRef(s)| <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon_builtin] == charFromRef(c))
+      anon_builtin < |stringFromRef(ret_0)| ==>
+      stringFromRef(ret_0)[anon_builtin] == charFromRef(c))
 {
   var i: Ref
   var res: Ref
-  var anon_0: Ref
+  var anon: Ref
   i := intToRef(0)
   res := s
   label cont
@@ -73,11 +77,12 @@ method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(n), intType())
     invariant 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(n)
     invariant |stringFromRef(res)| == |stringFromRef(s)| + intFromRef(i)
-    invariant (forall anon: Int ::|stringFromRef(s)| <= anon &&
-        anon < |stringFromRef(res)| ==>
-        stringFromRef(res)[anon] == charFromRef(c))
-  anon_0 := ltInts(i, n)
-  if (boolFromRef(anon_0)) {
+    invariant (forall anon_builtin_1: Int ::|stringFromRef(s)| <=
+        anon_builtin_1 &&
+        anon_builtin_1 < |stringFromRef(res)| ==>
+        stringFromRef(res)[anon_builtin_1] == charFromRef(c))
+  anon := ltInts(i, n)
+  if (boolFromRef(anon)) {
     res := addStringChar(res, c)
     goto cont
   }
@@ -89,15 +94,15 @@ method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(n), intType())
   assert 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(n)
   assert |stringFromRef(res)| == |stringFromRef(s)| + intFromRef(i)
-  assert (forall anon: Int ::|stringFromRef(s)| <= anon &&
-      anon < |stringFromRef(res)| ==>
-      stringFromRef(res)[anon] == charFromRef(c))
-  ret := res
-  goto ret_0
-  label ret_0
+  assert (forall anon_builtin_1: Int ::|stringFromRef(s)| <= anon_builtin_1 &&
+      anon_builtin_1 < |stringFromRef(res)| ==>
+      stringFromRef(res)[anon_builtin_1] == charFromRef(c))
+  ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
-method plus(this: Ref, other: Ref) returns (v_ret: Ref)
+method plus(this: Ref, other: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(v_ret), stringType())
+  ensures isSubtype(typeOf(ret), stringType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
@@ -3,40 +3,39 @@ method firstNotSortedIndex(s: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(s), stringType())
   ensures isSubtype(typeOf(ret), intType())
   ensures 0 <= intFromRef(ret) && intFromRef(ret) <= |stringFromRef(s)|
-  ensures (forall anon_builtin: Int ::0 <= anon_builtin &&
-      anon_builtin + 1 < intFromRef(ret) ==>
-      stringFromRef(s)[anon_builtin] <= stringFromRef(s)[anon_builtin + 1])
+  ensures (forall anon: Int ::0 <= anon && anon + 1 < intFromRef(ret) ==>
+      stringFromRef(s)[anon] <= stringFromRef(s)[anon + 1])
 {
   if (|stringFromRef(s)| == 0) {
     ret := intToRef(0)
     goto ret_0
   } else {
     var i: Ref
-    var anon: Ref
+    var anon_0: Ref
     i := intToRef(1)
     label cont
       invariant isSubtype(typeOf(i), intType())
       invariant isSubtype(typeOf(s), stringType())
-      invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-          anon_builtin_1 + 1 < intFromRef(i) ==>
-          stringFromRef(s)[anon_builtin_1] <=
-          stringFromRef(s)[anon_builtin_1 + 1])
+      invariant (forall anon_builtin: Int ::0 <= anon_builtin &&
+          anon_builtin + 1 < intFromRef(i) ==>
+          stringFromRef(s)[anon_builtin] <=
+          stringFromRef(s)[anon_builtin + 1])
     if (intFromRef(i) < |stringFromRef(s)|) {
-      anon := leChars(stringGet(s, minusInts(i, intToRef(1))), stringGet(s,
+      anon_0 := leChars(stringGet(s, minusInts(i, intToRef(1))), stringGet(s,
         i))
     } else {
-      anon := boolToRef(false)}
-    if (boolFromRef(anon)) {
+      anon_0 := boolToRef(false)}
+    if (boolFromRef(anon_0)) {
       i := plusInts(i, intToRef(1))
       goto cont
     }
     label break
     assert isSubtype(typeOf(i), intType())
     assert isSubtype(typeOf(s), stringType())
-    assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-        anon_builtin_1 + 1 < intFromRef(i) ==>
-        stringFromRef(s)[anon_builtin_1] <=
-        stringFromRef(s)[anon_builtin_1 + 1])
+    assert (forall anon_builtin: Int ::0 <= anon_builtin &&
+        anon_builtin + 1 < intFromRef(i) ==>
+        stringFromRef(s)[anon_builtin] <=
+        stringFromRef(s)[anon_builtin + 1])
     ret := i
     goto ret_0
   }
@@ -53,20 +52,20 @@ method returnNewString() returns (ret: Ref)
 }
 
 /strings_in_conditions.kt: info: Generated Viper text for addCharacterTimes:
-method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret_0: Ref)
+method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(s), stringType())
   requires isSubtype(typeOf(c), charType())
   requires isSubtype(typeOf(n), intType())
   requires intFromRef(n) >= 0
-  ensures isSubtype(typeOf(ret_0), stringType())
-  ensures |stringFromRef(ret_0)| == |stringFromRef(s)| + intFromRef(n)
-  ensures (forall anon_builtin: Int ::|stringFromRef(s)| <= anon_builtin &&
-      anon_builtin < |stringFromRef(ret_0)| ==>
-      stringFromRef(ret_0)[anon_builtin] == charFromRef(c))
+  ensures isSubtype(typeOf(ret), stringType())
+  ensures |stringFromRef(ret)| == |stringFromRef(s)| + intFromRef(n)
+  ensures (forall anon: Int ::|stringFromRef(s)| <= anon &&
+      anon < |stringFromRef(ret)| ==>
+      stringFromRef(ret)[anon] == charFromRef(c))
 {
   var i: Ref
   var res: Ref
-  var anon: Ref
+  var anon_0: Ref
   i := intToRef(0)
   res := s
   label cont
@@ -77,12 +76,12 @@ method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret_0: Ref)
     invariant isSubtype(typeOf(n), intType())
     invariant 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(n)
     invariant |stringFromRef(res)| == |stringFromRef(s)| + intFromRef(i)
-    invariant (forall anon_builtin_1: Int ::|stringFromRef(s)| <=
-        anon_builtin_1 &&
-        anon_builtin_1 < |stringFromRef(res)| ==>
-        stringFromRef(res)[anon_builtin_1] == charFromRef(c))
-  anon := ltInts(i, n)
-  if (boolFromRef(anon)) {
+    invariant (forall anon_builtin: Int ::|stringFromRef(s)| <=
+        anon_builtin &&
+        anon_builtin < |stringFromRef(res)| ==>
+        stringFromRef(res)[anon_builtin] == charFromRef(c))
+  anon_0 := ltInts(i, n)
+  if (boolFromRef(anon_0)) {
     res := addStringChar(res, c)
     goto cont
   }
@@ -94,15 +93,15 @@ method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret_0: Ref)
   assert isSubtype(typeOf(n), intType())
   assert 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(n)
   assert |stringFromRef(res)| == |stringFromRef(s)| + intFromRef(i)
-  assert (forall anon_builtin_1: Int ::|stringFromRef(s)| <= anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(res)| ==>
-      stringFromRef(res)[anon_builtin_1] == charFromRef(c))
-  ret_0 := res
-  goto lbl_ret_0
-  label lbl_ret_0
+  assert (forall anon_builtin: Int ::|stringFromRef(s)| <= anon_builtin &&
+      anon_builtin < |stringFromRef(res)| ==>
+      stringFromRef(res)[anon_builtin] == charFromRef(c))
+  ret := res
+  goto ret_0
+  label ret_0
 }
 
-method plus(this: Ref, other: Ref) returns (ret: Ref)
+method plus(this: Ref, other: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret), stringType())
+  ensures isSubtype(typeOf(v_ret), stringType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
@@ -1,14 +1,17 @@
 /strings_in_conditions.kt: info: Generated Viper text for firstNotSortedIndex:
-method firstNotSortedIndex(s: Ref) returns (ret: Ref)
+method firstNotSortedIndex(s: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
-  ensures isSubtype(typeOf(ret), intType())
-  ensures 0 <= intFromRef(ret) && intFromRef(ret) <= |stringFromRef(s)|
-  ensures (forall anon: Int ::0 <= anon && anon + 1 < intFromRef(ret) ==>
-      stringFromRef(s)[anon] <= stringFromRef(s)[anon + 1])
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures 0 <= intFromRef(v_ret_0) &&
+    intFromRef(v_ret_0) <= |stringFromRef(s)|
+  ensures (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
+      anon_builtin_2 + 1 < intFromRef(v_ret_0) ==>
+      stringFromRef(s)[anon_builtin_2] <=
+      stringFromRef(s)[anon_builtin_2 + 1])
 {
   if (|stringFromRef(s)| == 0) {
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
   } else {
     var i: Ref
     var anon_0: Ref
@@ -16,10 +19,10 @@ method firstNotSortedIndex(s: Ref) returns (ret: Ref)
     label cont
       invariant isSubtype(typeOf(i), intType())
       invariant isSubtype(typeOf(s), stringType())
-      invariant (forall anon_builtin: Int ::0 <= anon_builtin &&
-          anon_builtin + 1 < intFromRef(i) ==>
-          stringFromRef(s)[anon_builtin] <=
-          stringFromRef(s)[anon_builtin + 1])
+      invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+          anon_builtin_1 + 1 < intFromRef(i) ==>
+          stringFromRef(s)[anon_builtin_1] <=
+          stringFromRef(s)[anon_builtin_1 + 1])
     if (intFromRef(i) < |stringFromRef(s)|) {
       anon_0 := leChars(stringGet(s, minusInts(i, intToRef(1))), stringGet(s,
         i))
@@ -32,36 +35,37 @@ method firstNotSortedIndex(s: Ref) returns (ret: Ref)
     label break
     assert isSubtype(typeOf(i), intType())
     assert isSubtype(typeOf(s), stringType())
-    assert (forall anon_builtin: Int ::0 <= anon_builtin &&
-        anon_builtin + 1 < intFromRef(i) ==>
-        stringFromRef(s)[anon_builtin] <=
-        stringFromRef(s)[anon_builtin + 1])
-    ret := i
-    goto ret_0
+    assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
+        anon_builtin_1 + 1 < intFromRef(i) ==>
+        stringFromRef(s)[anon_builtin_1] <=
+        stringFromRef(s)[anon_builtin_1 + 1])
+    v_ret_0 := i
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /strings_in_conditions.kt: info: Generated Viper text for returnNewString:
-method returnNewString() returns (ret: Ref)
-  ensures isSubtype(typeOf(ret), stringType())
+method returnNewString() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), stringType())
 {
-  ret := stringToRef(Seq(52, 50))
-  goto ret_0
-  label ret_0
+  v_ret_0 := stringToRef(Seq(52, 50))
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 /strings_in_conditions.kt: info: Generated Viper text for addCharacterTimes:
-method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret: Ref)
+method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(s), stringType())
   requires isSubtype(typeOf(c), charType())
   requires isSubtype(typeOf(n), intType())
   requires intFromRef(n) >= 0
-  ensures isSubtype(typeOf(ret), stringType())
-  ensures |stringFromRef(ret)| == |stringFromRef(s)| + intFromRef(n)
-  ensures (forall anon: Int ::|stringFromRef(s)| <= anon &&
-      anon < |stringFromRef(ret)| ==>
-      stringFromRef(ret)[anon] == charFromRef(c))
+  ensures isSubtype(typeOf(v_ret_0), stringType())
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(s)| + intFromRef(n)
+  ensures (forall anon_builtin_2: Int ::|stringFromRef(s)| <=
+      anon_builtin_2 &&
+      anon_builtin_2 < |stringFromRef(v_ret_0)| ==>
+      stringFromRef(v_ret_0)[anon_builtin_2] == charFromRef(c))
 {
   var i: Ref
   var res: Ref
@@ -76,10 +80,10 @@ method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret: Ref)
     invariant isSubtype(typeOf(n), intType())
     invariant 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(n)
     invariant |stringFromRef(res)| == |stringFromRef(s)| + intFromRef(i)
-    invariant (forall anon_builtin: Int ::|stringFromRef(s)| <=
-        anon_builtin &&
-        anon_builtin < |stringFromRef(res)| ==>
-        stringFromRef(res)[anon_builtin] == charFromRef(c))
+    invariant (forall anon_builtin_1: Int ::|stringFromRef(s)| <=
+        anon_builtin_1 &&
+        anon_builtin_1 < |stringFromRef(res)| ==>
+        stringFromRef(res)[anon_builtin_1] == charFromRef(c))
   anon_0 := ltInts(i, n)
   if (boolFromRef(anon_0)) {
     res := addStringChar(res, c)
@@ -93,12 +97,12 @@ method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(n), intType())
   assert 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(n)
   assert |stringFromRef(res)| == |stringFromRef(s)| + intFromRef(i)
-  assert (forall anon_builtin: Int ::|stringFromRef(s)| <= anon_builtin &&
-      anon_builtin < |stringFromRef(res)| ==>
-      stringFromRef(res)[anon_builtin] == charFromRef(c))
-  ret := res
-  goto ret_0
-  label ret_0
+  assert (forall anon_builtin_1: Int ::|stringFromRef(s)| <= anon_builtin_1 &&
+      anon_builtin_1 < |stringFromRef(res)| ==>
+      stringFromRef(res)[anon_builtin_1] == charFromRef(c))
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
 }
 
 method plus(this: Ref, other: Ref) returns (v_ret: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/sum_of_1_to_n.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/sum_of_1_to_n.fir.diag.txt
@@ -1,28 +1,28 @@
 /sum_of_1_to_n.kt: info: Generated Viper text for recursiveSumOfIntegersUpToN:
-method recursiveSumOfIntegersUpToN(n: Ref) returns (ret: Ref)
+method recursiveSumOfIntegersUpToN(n: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(n), intType())
   requires intFromRef(n) >= 0
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(ret) == intFromRef(n) * (intFromRef(n) + 1) \ 2
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) == intFromRef(n) * (intFromRef(n) + 1) \ 2
 {
   if (intFromRef(n) == 0) {
-    ret := intToRef(0)
-    goto ret_0
+    v_ret_0 := intToRef(0)
+    goto lbl_ret_0
   } else {
     var anon: Ref
     anon := recursiveSumOfIntegersUpToN(minusInts(n, intToRef(1)))
-    ret := plusInts(n, anon)
-    goto ret_0
+    v_ret_0 := plusInts(n, anon)
+    goto lbl_ret_0
   }
-  label ret_0
+  label lbl_ret_0
 }
 
 /sum_of_1_to_n.kt: info: Generated Viper text for sumOfIntegersUpToN:
-method sumOfIntegersUpToN(n: Ref) returns (ret: Ref)
+method sumOfIntegersUpToN(n: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(n), intType())
   requires intFromRef(n) >= 0
-  ensures isSubtype(typeOf(ret), intType())
-  ensures intFromRef(ret) == intFromRef(n) * (intFromRef(n) + 1) \ 2
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) == intFromRef(n) * (intFromRef(n) + 1) \ 2
 {
   var sum: Ref
   var i: Ref
@@ -47,7 +47,7 @@ method sumOfIntegersUpToN(n: Ref) returns (ret: Ref)
   assert isSubtype(typeOf(n), intType())
   assert intFromRef(i) <= intFromRef(n)
   assert intFromRef(sum) == intFromRef(i) * (intFromRef(i) + 1) \ 2
-  ret := sum
-  goto ret_0
-  label ret_0
+  v_ret_0 := sum
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
@@ -5,16 +5,16 @@ field size: Ref
 
 method con(par_field: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(par_field), intType())
-  ensures isSubtype(typeOf(ret), _c_ClassWithField())
-  ensures acc(c_ClassWithField_shared(ret), wildcard)
-  ensures acc(c_ClassWithField_unique(ret), write)
-  ensures intFromRef((unfolding acc(c_ClassWithField_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_ClassWithField())
+  ensures acc(_c_ClassWithField_shared(ret), wildcard)
+  ensures acc(_c_ClassWithField_unique(ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(ret), wildcard) in
       ret.bf_field)) ==
     intFromRef(par_field)
 
 
 method test_while(param: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(param), _c_ClassWithField())
+  requires isSubtype(typeOf(param), c_ClassWithField())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var c: Ref
@@ -25,9 +25,9 @@ method test_while(param: Ref) returns (ret_0: Ref)
   var anon_1: Ref
   var cond2: Ref
   var anon: Ref
-  inhale acc(c_ClassWithField_shared(param), wildcard)
+  inhale acc(_c_ClassWithField_shared(param), wildcard)
   c := con(intToRef(13))
-  unfold acc(c_ClassWithField_shared(param), wildcard)
+  unfold acc(_c_ClassWithField_shared(param), wildcard)
   initParamField := param.bf_field
   if (intFromRef(initParamField) > 0) {
     iteration := intToRef(0)
@@ -37,34 +37,34 @@ method test_while(param: Ref) returns (ret_0: Ref)
     iteration := timesInts(intermediate, intermediate)
   }
   label cont
-    invariant acc(c_ClassWithField_shared(c), wildcard)
-    invariant isSubtype(typeOf(c), _c_ClassWithField())
+    invariant acc(_c_ClassWithField_shared(c), wildcard)
+    invariant isSubtype(typeOf(c), c_ClassWithField())
     invariant isSubtype(typeOf(initParamField), intType())
     invariant isSubtype(typeOf(iteration), intType())
-    invariant acc(c_ClassWithField_shared(param), wildcard)
-    invariant isSubtype(typeOf(param), _c_ClassWithField())
+    invariant acc(_c_ClassWithField_shared(param), wildcard)
+    invariant isSubtype(typeOf(param), c_ClassWithField())
   anon_0 := ltInts(iteration, intToRef(10))
   if (boolFromRef(anon_0)) {
     var l4_field: Ref
     var paramField: Ref
-    unfold acc(c_ClassWithField_shared(c), wildcard)
+    unfold acc(_c_ClassWithField_shared(c), wildcard)
     l4_field := c.bf_field
-    unfold acc(c_ClassWithField_shared(param), wildcard)
+    unfold acc(_c_ClassWithField_shared(param), wildcard)
     paramField := param.bf_field
     iteration := plusInts(iteration, intToRef(1))
     goto cont
   }
   label break
-  assert acc(c_ClassWithField_shared(c), wildcard)
-  assert isSubtype(typeOf(c), _c_ClassWithField())
+  assert acc(_c_ClassWithField_shared(c), wildcard)
+  assert isSubtype(typeOf(c), c_ClassWithField())
   assert isSubtype(typeOf(initParamField), intType())
   assert isSubtype(typeOf(iteration), intType())
-  assert acc(c_ClassWithField_shared(param), wildcard)
-  assert isSubtype(typeOf(param), _c_ClassWithField())
-  unfold acc(c_ClassWithField_shared(c), wildcard)
+  assert acc(_c_ClassWithField_shared(param), wildcard)
+  assert isSubtype(typeOf(param), c_ClassWithField())
+  unfold acc(_c_ClassWithField_shared(c), wildcard)
   anon_1 := c.bf_field
   cond1 := boolToRef(intFromRef(anon_1) == 13)
-  unfold acc(c_ClassWithField_shared(param), wildcard)
+  unfold acc(_c_ClassWithField_shared(param), wildcard)
   anon := param.bf_field
   cond2 := boolToRef(intFromRef(initParamField) == intFromRef(anon))
   assert boolFromRef(cond1)
@@ -80,16 +80,16 @@ field size: Ref
 
 method con(par_field: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(par_field), intType())
-  ensures isSubtype(typeOf(ret), _c_ClassWithField())
-  ensures acc(c_ClassWithField_shared(ret), wildcard)
-  ensures acc(c_ClassWithField_unique(ret), write)
-  ensures intFromRef((unfolding acc(c_ClassWithField_shared(ret), wildcard) in
+  ensures isSubtype(typeOf(ret), c_ClassWithField())
+  ensures acc(_c_ClassWithField_shared(ret), wildcard)
+  ensures acc(_c_ClassWithField_unique(ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(ret), wildcard) in
       ret.bf_field)) ==
     intFromRef(par_field)
 
 
 method test_while_with_inlining(param: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(param), _c_ClassWithField())
+  requires isSubtype(typeOf(param), c_ClassWithField())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
   var local: Ref
@@ -105,49 +105,49 @@ method test_while_with_inlining(param: Ref) returns (ret_0: Ref)
   var anon_6: Ref
   var anon_7: Ref
   var anon: Ref
-  inhale acc(c_ClassWithField_shared(param), wildcard)
+  inhale acc(_c_ClassWithField_shared(param), wildcard)
   local := con(intToRef(13))
   anon_4 := con(intToRef(42))
   anon_0 := anon_4
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_0), _c_ClassWithField())
-  inhale acc(c_ClassWithField_shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), c_ClassWithField())
+  inhale acc(_c_ClassWithField_shared(anon_0), wildcard)
   anon_1 := anon_0
   iteration := intToRef(0)
   label cont
     invariant isSubtype(typeOf(iteration), intType())
-    invariant acc(c_ClassWithField_shared(anon_1), wildcard)
-    invariant isSubtype(typeOf(anon_1), _c_ClassWithField())
-    invariant acc(c_ClassWithField_shared(local), wildcard)
-    invariant isSubtype(typeOf(local), _c_ClassWithField())
-    invariant acc(c_ClassWithField_shared(param), wildcard)
-    invariant isSubtype(typeOf(param), _c_ClassWithField())
+    invariant acc(_c_ClassWithField_shared(anon_1), wildcard)
+    invariant isSubtype(typeOf(anon_1), c_ClassWithField())
+    invariant acc(_c_ClassWithField_shared(local), wildcard)
+    invariant isSubtype(typeOf(local), c_ClassWithField())
+    invariant acc(_c_ClassWithField_shared(param), wildcard)
+    invariant isSubtype(typeOf(param), c_ClassWithField())
   anon_6 := ltInts(iteration, intToRef(10))
   if (boolFromRef(anon_6)) {
     var paramField: Ref
     var localField: Ref
     var thisField: Ref
-    unfold acc(c_ClassWithField_shared(param), wildcard)
+    unfold acc(_c_ClassWithField_shared(param), wildcard)
     paramField := param.bf_field
-    unfold acc(c_ClassWithField_shared(local), wildcard)
+    unfold acc(_c_ClassWithField_shared(local), wildcard)
     localField := local.bf_field
-    unfold acc(c_ClassWithField_shared(anon_1), wildcard)
+    unfold acc(_c_ClassWithField_shared(anon_1), wildcard)
     thisField := anon_1.bf_field
     iteration := plusInts(iteration, intToRef(1))
     goto cont
   }
   label break
   assert isSubtype(typeOf(iteration), intType())
-  assert acc(c_ClassWithField_shared(anon_1), wildcard)
-  assert isSubtype(typeOf(anon_1), _c_ClassWithField())
-  assert acc(c_ClassWithField_shared(local), wildcard)
-  assert isSubtype(typeOf(local), _c_ClassWithField())
-  assert acc(c_ClassWithField_shared(param), wildcard)
-  assert isSubtype(typeOf(param), _c_ClassWithField())
-  unfold acc(c_ClassWithField_shared(anon_1), wildcard)
+  assert acc(_c_ClassWithField_shared(anon_1), wildcard)
+  assert isSubtype(typeOf(anon_1), c_ClassWithField())
+  assert acc(_c_ClassWithField_shared(local), wildcard)
+  assert isSubtype(typeOf(local), c_ClassWithField())
+  assert acc(_c_ClassWithField_shared(param), wildcard)
+  assert isSubtype(typeOf(param), c_ClassWithField())
+  unfold acc(_c_ClassWithField_shared(anon_1), wildcard)
   anon_7 := anon_1.bf_field
   assert intFromRef(anon_7) == 42
-  unfold acc(c_ClassWithField_shared(local), wildcard)
+  unfold acc(_c_ClassWithField_shared(local), wildcard)
   anon := local.bf_field
   assert intFromRef(anon) == 13
   label lbl_ret_2
@@ -173,7 +173,7 @@ method test_while_with_smartcast(param: Ref, innerParam: Ref)
   requires isSubtype(typeOf(innerParam), anyType())
   ensures isSubtype(typeOf(ret_0), unitType())
 {
-  if (isSubtype(typeOf(param), _c_ClassWithField())) {
+  if (isSubtype(typeOf(param), c_ClassWithField())) {
     var iteration: Ref
     var anon: Ref
     iteration := intToRef(0)
@@ -187,7 +187,7 @@ method test_while_with_smartcast(param: Ref, innerParam: Ref)
       inhale acc(shared(param), wildcard)
       unfold acc(shared(param), wildcard)
       paramField := param.bf_field
-      if (isSubtype(typeOf(innerParam), _c_ClassWithField())) {
+      if (isSubtype(typeOf(innerParam), c_ClassWithField())) {
         var innerParamField: Ref
         inhale acc(shared(innerParam), wildcard)
         unfold acc(shared(innerParam), wildcard)

--- a/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
@@ -3,19 +3,19 @@ field bf_field: Ref
 
 field size: Ref
 
-method con(par_field: Ref) returns (ret: Ref)
+method con(par_field: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_field), intType())
-  ensures isSubtype(typeOf(ret), c_ClassWithField())
-  ensures acc(_c_ClassWithField_shared(ret), wildcard)
-  ensures acc(_c_ClassWithField_unique(ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(ret), wildcard) in
-      ret.bf_field)) ==
+  ensures isSubtype(typeOf(v_ret), c_ClassWithField())
+  ensures acc(_c_ClassWithField_shared(v_ret), wildcard)
+  ensures acc(_c_ClassWithField_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(v_ret), wildcard) in
+      v_ret.bf_field)) ==
     intFromRef(par_field)
 
 
-method test_while(param: Ref) returns (ret_0: Ref)
+method test_while(param: Ref) returns (ret: Ref)
   requires isSubtype(typeOf(param), c_ClassWithField())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   var c: Ref
   var initParamField: Ref
@@ -69,8 +69,8 @@ method test_while(param: Ref) returns (ret_0: Ref)
   cond2 := boolToRef(intFromRef(initParamField) == intFromRef(anon))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }
 
 /while.kt: info: Generated Viper text for test_while_with_inlining:
@@ -78,13 +78,13 @@ field bf_field: Ref
 
 field size: Ref
 
-method con(par_field: Ref) returns (ret: Ref)
+method con(par_field: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_field), intType())
-  ensures isSubtype(typeOf(ret), c_ClassWithField())
-  ensures acc(_c_ClassWithField_shared(ret), wildcard)
-  ensures acc(_c_ClassWithField_unique(ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(ret), wildcard) in
-      ret.bf_field)) ==
+  ensures isSubtype(typeOf(v_ret), c_ClassWithField())
+  ensures acc(_c_ClassWithField_shared(v_ret), wildcard)
+  ensures acc(_c_ClassWithField_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(v_ret), wildcard) in
+      v_ret.bf_field)) ==
     intFromRef(par_field)
 
 
@@ -99,7 +99,7 @@ method test_while_with_inlining(param: Ref) returns (ret_0: Ref)
   var anon_0: Ref
   var anon_4: Ref
   var anon_5: Ref
-  var ret_2: Ref
+  var ret: Ref
   var anon_1: Ref
   var iteration: Ref
   var anon_6: Ref
@@ -150,9 +150,9 @@ method test_while_with_inlining(param: Ref) returns (ret_0: Ref)
   unfold acc(_c_ClassWithField_shared(local), wildcard)
   anon := local.bf_field
   assert intFromRef(anon) == 13
-  label lbl_ret_2
-  inhale isSubtype(typeOf(ret_2), unitType())
-  anon_5 := ret_2
+  label ret_2
+  inhale isSubtype(typeOf(ret), unitType())
+  anon_5 := ret
   ret_1 := anon_5
   inhale isSubtype(typeOf(ret_1), nullable(anyType()))
   goto lbl_ret_1
@@ -168,10 +168,10 @@ method test_while_with_inlining(param: Ref) returns (ret_0: Ref)
 field bf_field: Ref
 
 method test_while_with_smartcast(param: Ref, innerParam: Ref)
-  returns (ret_0: Ref)
+  returns (ret: Ref)
   requires isSubtype(typeOf(param), anyType())
   requires isSubtype(typeOf(innerParam), anyType())
-  ensures isSubtype(typeOf(ret_0), unitType())
+  ensures isSubtype(typeOf(ret), unitType())
 {
   if (isSubtype(typeOf(param), c_ClassWithField())) {
     var iteration: Ref
@@ -201,6 +201,6 @@ method test_while_with_smartcast(param: Ref, innerParam: Ref)
     assert isSubtype(typeOf(param), anyType())
     assert isSubtype(typeOf(innerParam), anyType())
   }
-  label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  label ret_0
+  inhale isSubtype(typeOf(ret), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/while.fir.diag.txt
@@ -5,17 +5,17 @@ field size: Ref
 
 method con(par_field: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_field), intType())
-  ensures isSubtype(typeOf(v_ret), c_ClassWithField())
-  ensures acc(_c_ClassWithField_shared(v_ret), wildcard)
-  ensures acc(_c_ClassWithField_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(v_ret), wildcard) in
+  ensures isSubtype(typeOf(v_ret), ClassWithField())
+  ensures acc(ClassWithField_shared(v_ret), wildcard)
+  ensures acc(ClassWithField_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(ClassWithField_shared(v_ret), wildcard) in
       v_ret.bf_field)) ==
     intFromRef(par_field)
 
 
-method test_while(param: Ref) returns (ret: Ref)
-  requires isSubtype(typeOf(param), c_ClassWithField())
-  ensures isSubtype(typeOf(ret), unitType())
+method test_while(param: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(param), ClassWithField())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var c: Ref
   var initParamField: Ref
@@ -24,10 +24,10 @@ method test_while(param: Ref) returns (ret: Ref)
   var cond1: Ref
   var anon_1: Ref
   var cond2: Ref
-  var anon: Ref
-  inhale acc(_c_ClassWithField_shared(param), wildcard)
+  var anon_2: Ref
+  inhale acc(ClassWithField_shared(param), wildcard)
   c := con(intToRef(13))
-  unfold acc(_c_ClassWithField_shared(param), wildcard)
+  unfold acc(ClassWithField_shared(param), wildcard)
   initParamField := param.bf_field
   if (intFromRef(initParamField) > 0) {
     iteration := intToRef(0)
@@ -37,40 +37,40 @@ method test_while(param: Ref) returns (ret: Ref)
     iteration := timesInts(intermediate, intermediate)
   }
   label cont
-    invariant acc(_c_ClassWithField_shared(c), wildcard)
-    invariant isSubtype(typeOf(c), c_ClassWithField())
+    invariant acc(ClassWithField_shared(c), wildcard)
+    invariant isSubtype(typeOf(c), ClassWithField())
     invariant isSubtype(typeOf(initParamField), intType())
     invariant isSubtype(typeOf(iteration), intType())
-    invariant acc(_c_ClassWithField_shared(param), wildcard)
-    invariant isSubtype(typeOf(param), c_ClassWithField())
+    invariant acc(ClassWithField_shared(param), wildcard)
+    invariant isSubtype(typeOf(param), ClassWithField())
   anon_0 := ltInts(iteration, intToRef(10))
   if (boolFromRef(anon_0)) {
     var l4_field: Ref
     var paramField: Ref
-    unfold acc(_c_ClassWithField_shared(c), wildcard)
+    unfold acc(ClassWithField_shared(c), wildcard)
     l4_field := c.bf_field
-    unfold acc(_c_ClassWithField_shared(param), wildcard)
+    unfold acc(ClassWithField_shared(param), wildcard)
     paramField := param.bf_field
     iteration := plusInts(iteration, intToRef(1))
     goto cont
   }
   label break
-  assert acc(_c_ClassWithField_shared(c), wildcard)
-  assert isSubtype(typeOf(c), c_ClassWithField())
+  assert acc(ClassWithField_shared(c), wildcard)
+  assert isSubtype(typeOf(c), ClassWithField())
   assert isSubtype(typeOf(initParamField), intType())
   assert isSubtype(typeOf(iteration), intType())
-  assert acc(_c_ClassWithField_shared(param), wildcard)
-  assert isSubtype(typeOf(param), c_ClassWithField())
-  unfold acc(_c_ClassWithField_shared(c), wildcard)
+  assert acc(ClassWithField_shared(param), wildcard)
+  assert isSubtype(typeOf(param), ClassWithField())
+  unfold acc(ClassWithField_shared(c), wildcard)
   anon_1 := c.bf_field
   cond1 := boolToRef(intFromRef(anon_1) == 13)
-  unfold acc(_c_ClassWithField_shared(param), wildcard)
-  anon := param.bf_field
-  cond2 := boolToRef(intFromRef(initParamField) == intFromRef(anon))
+  unfold acc(ClassWithField_shared(param), wildcard)
+  anon_2 := param.bf_field
+  cond2 := boolToRef(intFromRef(initParamField) == intFromRef(anon_2))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /while.kt: info: Generated Viper text for test_while_with_inlining:
@@ -80,100 +80,100 @@ field size: Ref
 
 method con(par_field: Ref) returns (v_ret: Ref)
   requires isSubtype(typeOf(par_field), intType())
-  ensures isSubtype(typeOf(v_ret), c_ClassWithField())
-  ensures acc(_c_ClassWithField_shared(v_ret), wildcard)
-  ensures acc(_c_ClassWithField_unique(v_ret), write)
-  ensures intFromRef((unfolding acc(_c_ClassWithField_shared(v_ret), wildcard) in
+  ensures isSubtype(typeOf(v_ret), ClassWithField())
+  ensures acc(ClassWithField_shared(v_ret), wildcard)
+  ensures acc(ClassWithField_unique(v_ret), write)
+  ensures intFromRef((unfolding acc(ClassWithField_shared(v_ret), wildcard) in
       v_ret.bf_field)) ==
     intFromRef(par_field)
 
 
-method test_while_with_inlining(param: Ref) returns (ret_0: Ref)
-  requires isSubtype(typeOf(param), c_ClassWithField())
-  ensures isSubtype(typeOf(ret_0), unitType())
+method test_while_with_inlining(param: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(param), ClassWithField())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var local: Ref
   var anon_2: Ref
   var anon_3: Ref
-  var ret_1: Ref
+  var v_ret_1: Ref
   var anon_0: Ref
   var anon_4: Ref
   var anon_5: Ref
-  var ret: Ref
+  var v_ret_2: Ref
   var anon_1: Ref
   var iteration: Ref
   var anon_6: Ref
   var anon_7: Ref
-  var anon: Ref
-  inhale acc(_c_ClassWithField_shared(param), wildcard)
+  var anon_8: Ref
+  inhale acc(ClassWithField_shared(param), wildcard)
   local := con(intToRef(13))
   anon_4 := con(intToRef(42))
   anon_0 := anon_4
   inhale isSubtype(typeOf(anon_0), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_0), c_ClassWithField())
-  inhale acc(_c_ClassWithField_shared(anon_0), wildcard)
+  inhale isSubtype(typeOf(anon_0), ClassWithField())
+  inhale acc(ClassWithField_shared(anon_0), wildcard)
   anon_1 := anon_0
   iteration := intToRef(0)
   label cont
     invariant isSubtype(typeOf(iteration), intType())
-    invariant acc(_c_ClassWithField_shared(anon_1), wildcard)
-    invariant isSubtype(typeOf(anon_1), c_ClassWithField())
-    invariant acc(_c_ClassWithField_shared(local), wildcard)
-    invariant isSubtype(typeOf(local), c_ClassWithField())
-    invariant acc(_c_ClassWithField_shared(param), wildcard)
-    invariant isSubtype(typeOf(param), c_ClassWithField())
+    invariant acc(ClassWithField_shared(anon_1), wildcard)
+    invariant isSubtype(typeOf(anon_1), ClassWithField())
+    invariant acc(ClassWithField_shared(local), wildcard)
+    invariant isSubtype(typeOf(local), ClassWithField())
+    invariant acc(ClassWithField_shared(param), wildcard)
+    invariant isSubtype(typeOf(param), ClassWithField())
   anon_6 := ltInts(iteration, intToRef(10))
   if (boolFromRef(anon_6)) {
     var paramField: Ref
     var localField: Ref
     var thisField: Ref
-    unfold acc(_c_ClassWithField_shared(param), wildcard)
+    unfold acc(ClassWithField_shared(param), wildcard)
     paramField := param.bf_field
-    unfold acc(_c_ClassWithField_shared(local), wildcard)
+    unfold acc(ClassWithField_shared(local), wildcard)
     localField := local.bf_field
-    unfold acc(_c_ClassWithField_shared(anon_1), wildcard)
+    unfold acc(ClassWithField_shared(anon_1), wildcard)
     thisField := anon_1.bf_field
     iteration := plusInts(iteration, intToRef(1))
     goto cont
   }
   label break
   assert isSubtype(typeOf(iteration), intType())
-  assert acc(_c_ClassWithField_shared(anon_1), wildcard)
-  assert isSubtype(typeOf(anon_1), c_ClassWithField())
-  assert acc(_c_ClassWithField_shared(local), wildcard)
-  assert isSubtype(typeOf(local), c_ClassWithField())
-  assert acc(_c_ClassWithField_shared(param), wildcard)
-  assert isSubtype(typeOf(param), c_ClassWithField())
-  unfold acc(_c_ClassWithField_shared(anon_1), wildcard)
+  assert acc(ClassWithField_shared(anon_1), wildcard)
+  assert isSubtype(typeOf(anon_1), ClassWithField())
+  assert acc(ClassWithField_shared(local), wildcard)
+  assert isSubtype(typeOf(local), ClassWithField())
+  assert acc(ClassWithField_shared(param), wildcard)
+  assert isSubtype(typeOf(param), ClassWithField())
+  unfold acc(ClassWithField_shared(anon_1), wildcard)
   anon_7 := anon_1.bf_field
   assert intFromRef(anon_7) == 42
-  unfold acc(_c_ClassWithField_shared(local), wildcard)
-  anon := local.bf_field
-  assert intFromRef(anon) == 13
-  label ret_2
-  inhale isSubtype(typeOf(ret), unitType())
-  anon_5 := ret
-  ret_1 := anon_5
-  inhale isSubtype(typeOf(ret_1), nullable(anyType()))
+  unfold acc(ClassWithField_shared(local), wildcard)
+  anon_8 := local.bf_field
+  assert intFromRef(anon_8) == 13
+  label lbl_ret_2
+  inhale isSubtype(typeOf(v_ret_2), unitType())
+  anon_5 := v_ret_2
+  v_ret_1 := anon_5
+  inhale isSubtype(typeOf(v_ret_1), nullable(anyType()))
   goto lbl_ret_1
   label lbl_ret_1
-  anon_3 := ret_1
+  anon_3 := v_ret_1
   anon_2 := anon_3
   inhale isSubtype(typeOf(anon_2), unitType())
   label lbl_ret_0
-  inhale isSubtype(typeOf(ret_0), unitType())
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
 /while.kt: info: Generated Viper text for test_while_with_smartcast:
 field bf_field: Ref
 
 method test_while_with_smartcast(param: Ref, innerParam: Ref)
-  returns (ret: Ref)
+  returns (v_ret_0: Ref)
   requires isSubtype(typeOf(param), anyType())
   requires isSubtype(typeOf(innerParam), anyType())
-  ensures isSubtype(typeOf(ret), unitType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  if (isSubtype(typeOf(param), c_ClassWithField())) {
+  if (isSubtype(typeOf(param), ClassWithField())) {
     var iteration: Ref
     var anon: Ref
     iteration := intToRef(0)
@@ -187,7 +187,7 @@ method test_while_with_smartcast(param: Ref, innerParam: Ref)
       inhale acc(shared(param), wildcard)
       unfold acc(shared(param), wildcard)
       paramField := param.bf_field
-      if (isSubtype(typeOf(innerParam), c_ClassWithField())) {
+      if (isSubtype(typeOf(innerParam), ClassWithField())) {
         var innerParamField: Ref
         inhale acc(shared(innerParam), wildcard)
         unfold acc(shared(innerParam), wildcard)
@@ -201,6 +201,6 @@ method test_while_with_smartcast(param: Ref, innerParam: Ref)
     assert isSubtype(typeOf(param), anyType())
     assert isSubtype(typeOf(innerParam), anyType())
   }
-  label ret_0
-  inhale isSubtype(typeOf(ret), unitType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
 }


### PR DESCRIPTION
With the new short name resolver, there are sometimes annoying changes. The short name resolver performs an iterative process to make names unique. Basically one collision is resolved after the other. The order of resolving the collision can have an effect on the final result. This leads to the following problems:

If a developer changes e.g. the order in which classes are embedded. Even though the list of embedded classes contain the same elements, it can still change the expected result.

This was not tested, but probably also the order of method definitions in kotlin files can lead to the same effect.