### PR TITLE
Special Properties Unification

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -245,15 +245,18 @@ class ProgramConverter(
 
     override fun embedProperty(symbol: FirPropertySymbol): PropertyEmbedding {
 
-        SpecialProperties.byCallableId[symbol.callableId]?.let {
-            return it
-        }
-
         if (symbol.receiverParameterSymbol != null) {
             return embedCustomProperty(symbol)
         } else {
+
             val name = symbol.embedMemberPropertyName()
             return typeResolver.getOrPutProperty(name) {
+                with(typeResolver) {
+                    with(session) {
+                        SpecialProperties.lookup(symbol)?.let { return@getOrPutProperty it }
+                    }
+                }
+
                 embedBackingField(symbol)?.let {
                     return@getOrPutProperty PropertyEmbedding(
                         BackingFieldGetter(it), BackingFieldSetter(it)
@@ -456,7 +459,7 @@ class ProgramConverter(
             Visibilities.isPrivate(symbol.visibility)
         )
         val fieldIsAllowed = symbol.hasBackingField && !symbol.isCustom && (symbol.isFinal || classSymbol.isFinal)
-        val backingField = scopedName.specialEmbedding(embedding, typeResolver) ?: fieldIsAllowed.ifTrue {
+        val backingField = fieldIsAllowed.ifTrue {
             UserFieldEmbedding(
                 scopedName,
                 embedType(symbol.resolvedReturnType),

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -214,7 +214,7 @@ class ProgramConverter(
      */
     private fun embedClass(symbol: FirRegularClassSymbol): ClassTypeEmbedding {
         val className = symbol.classId.embedName()
-        typeResolver.lookupEmbedding(className)?.let { return it }
+        typeResolver.lookupClassTypeEmbedding(className)?.let { return it }
 
         val embedding = typeResolver.getEmbeddingOrExecute(className) {
             val classEmbedding = buildClassPretype {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -80,7 +80,7 @@ class ProgramConverter(
             domains = listOf(RuntimeTypeDomain(typeResolver)),
             // We need to deduplicate fields since public fields with the same name are represented differently
             // at `FieldEmbedding` level but map to the same Viper.
-            fields = SpecialFields.all.map { it.toViper() } + typeResolver.backingFields().distinctBy { it.name }
+            fields = typeResolver.backingFields().distinctBy { it.name }
                 .map { it.toViper() },
             functions = SpecialFunctions.all + functions.values.mapNotNull { it.viperFunction(typeResolver) }
                 .distinctBy { it.name },
@@ -251,18 +251,21 @@ class ProgramConverter(
 
             val name = symbol.embedMemberPropertyName()
             return typeResolver.getOrPutProperty(name) {
+
+                // Check if the symbol should receive a special treatment
                 with(typeResolver) {
                     with(session) {
                         SpecialProperties.lookup(symbol)?.let { return@getOrPutProperty it }
                     }
                 }
 
+                // Check if the symbol can be represented using a backing field
                 embedBackingField(symbol)?.let {
                     return@getOrPutProperty PropertyEmbedding(
                         BackingFieldGetter(it), BackingFieldSetter(it)
                     )
                 }
-                embedType(symbol.dispatchReceiverType!!)
+                // Create a custom getter+setter
                 embedCustomProperty(symbol)
             }
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -248,17 +248,14 @@ class ProgramConverter(
         if (symbol.receiverParameterSymbol != null) {
             return embedCustomProperty(symbol)
         } else {
-
             val name = symbol.embedMemberPropertyName()
             return typeResolver.getOrPutProperty(name) {
-
                 // Check if the symbol should receive a special treatment
                 with(typeResolver) {
                     with(session) {
                         SpecialProperties.lookup(symbol)?.let { return@getOrPutProperty it }
                     }
                 }
-
                 // Check if the symbol can be represented using a backing field
                 embedBackingField(symbol)?.let {
                     return@getOrPutProperty PropertyEmbedding(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SpecialFields.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SpecialFields.kt
@@ -5,18 +5,39 @@
 
 package org.jetbrains.kotlin.formver.core.conversion
 
+
+import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.FieldAccess
+import org.jetbrains.kotlin.formver.core.embeddings.expression.IntLit
+import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeInvariantEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.core.names.SpecialFieldName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
-class SpecialField(baseName: String, override val type: TypeEmbedding, override val viperType: Type) : FieldEmbedding {
+class SpecialField(
+    baseName: String,
+    override val type: TypeEmbedding,
+    override val viperType: Type,
+    override val includeInShortDump: Boolean = false,
+    private val extraInvariantsBuilder: (FieldEmbedding) -> List<TypeInvariantEmbedding> = { listOf() },
+) : FieldEmbedding {
     override val name: SymbolicName = SpecialFieldName(baseName)
     override val accessPolicy: AccessPolicy = AccessPolicy.ALWAYS_WRITEABLE
-    override val includeInShortDump: Boolean = false
+    override fun extraAccessInvariantsForParameter(): List<TypeInvariantEmbedding> = extraInvariantsBuilder(this)
 }
 
-object SpecialFields {
-    val all: List<SpecialField> = listOf()
+val CollectionSizeFieldEmbedding: FieldEmbedding = SpecialField(
+    baseName = "size",
+    type = buildType { int() },
+    viperType = Type.Ref,
+    includeInShortDump = true,
+) { field ->
+    listOf(object : TypeInvariantEmbedding {
+        override fun fillHole(exp: ExpEmbedding): ExpEmbedding =
+            OperatorExpEmbeddings.GeIntInt(FieldAccess(exp, field), IntLit(0))
+    })
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
@@ -14,16 +14,15 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.LeIntInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.Not
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubIntInt
-import org.jetbrains.kotlin.formver.core.embeddings.properties.ListSizeFieldEmbedding
 import org.jetbrains.kotlin.formver.core.names.NameMatcher
 
 private fun VariableEmbedding.sameSize(): ExpEmbedding =
-    EqCmp(FieldAccess(this, ListSizeFieldEmbedding), Old(FieldAccess(this, ListSizeFieldEmbedding)))
+    EqCmp(FieldAccess(this, CollectionSizeFieldEmbedding), Old(FieldAccess(this, CollectionSizeFieldEmbedding)))
 
 private fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding =
     EqCmp(
-        FieldAccess(this, ListSizeFieldEmbedding),
-        OperatorExpEmbeddings.AddIntInt(Old(FieldAccess(this, ListSizeFieldEmbedding)), IntLit(amount)),
+        FieldAccess(this, CollectionSizeFieldEmbedding),
+        OperatorExpEmbeddings.AddIntInt(Old(FieldAccess(this, CollectionSizeFieldEmbedding)), IntLit(amount)),
     )
 
 sealed interface StdLibReceiverInterface {
@@ -113,7 +112,7 @@ data object GetPrecondition : StdLibPrecondition {
                 SourceRole.ListElementAccessCheck(SourceRole.ListElementAccessCheck.AccessCheckType.LESS_THAN_ZERO)
             ),
             GtIntInt(
-                FieldAccess(receiver, ListSizeFieldEmbedding),
+                FieldAccess(receiver, CollectionSizeFieldEmbedding),
                 indexArg,
                 SourceRole.ListElementAccessCheck(SourceRole.ListElementAccessCheck.AccessCheckType.GREATER_THAN_LIST_SIZE)
             ),
@@ -132,7 +131,7 @@ data object SubListPrecondition : StdLibPrecondition {
         return listOf(
             LeIntInt(fromIndexArg, toIndexArg, SourceRole.SubListCreation.CheckInSize),
             GeIntInt(fromIndexArg, IntLit(0), SourceRole.SubListCreation.CheckNegativeIndices),
-            LeIntInt(toIndexArg, FieldAccess(receiver, ListSizeFieldEmbedding), SourceRole.SubListCreation.CheckInSize)
+            LeIntInt(toIndexArg, FieldAccess(receiver, CollectionSizeFieldEmbedding), SourceRole.SubListCreation.CheckInSize)
         )
     }
 
@@ -146,7 +145,7 @@ data object EmptyListPostcondition : StdLibPostcondition {
         function: NamedFunctionSignature
     ): List<ExpEmbedding> {
         return listOf(
-            EqCmp(FieldAccess(returnVariable, ListSizeFieldEmbedding), IntLit(0))
+            EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), IntLit(0))
         )
     }
 
@@ -162,8 +161,8 @@ data object IsEmptyPostcondition : StdLibPostcondition {
         val receiver = function.dispatchReceiver!!
         return listOf(
             receiver.sameSize(),
-            Implies(returnVariable, EqCmp(FieldAccess(receiver, ListSizeFieldEmbedding), IntLit(0))),
-            Implies(Not(returnVariable), GtIntInt(FieldAccess(receiver, ListSizeFieldEmbedding), IntLit(0)))
+            Implies(returnVariable, EqCmp(FieldAccess(receiver, CollectionSizeFieldEmbedding), IntLit(0))),
+            Implies(Not(returnVariable), GtIntInt(FieldAccess(receiver, CollectionSizeFieldEmbedding), IntLit(0)))
         )
     }
 
@@ -192,7 +191,7 @@ data object SubListPostcondition : StdLibPostcondition {
         val toIndexArg = function.formalArgs[2]
         return listOf(
             function.dispatchReceiver!!.sameSize(),
-            EqCmp(FieldAccess(returnVariable, ListSizeFieldEmbedding), SubIntInt(toIndexArg, fromIndexArg))
+            EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), SubIntInt(toIndexArg, fromIndexArg))
         )
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
@@ -53,7 +53,7 @@ class TypeResolver {
 
     fun getEmbeddingOrExecute(name: ScopedName, action: () -> ClassTypeEmbedding) = classEmbedding[name] ?: action()
 
-    fun lookupEmbedding(name: SymbolicName) = classEmbedding[name] ?: interfaceEmbedding[name]
+    fun lookupClassTypeEmbedding(name: SymbolicName) = classEmbedding[name] ?: interfaceEmbedding[name]
 
     /**
      * Extends the subtype relation with [subtype] <: [supertype]
@@ -68,7 +68,7 @@ class TypeResolver {
      * These are only the direct super types, transitive closure is not included.
      */
     fun lookupSuperTypes(name: SymbolicName) =
-        superTypes.getOrDefault(name, emptySet()).mapNotNull { lookupEmbedding(it) }
+        superTypes.getOrDefault(name, emptySet()).mapNotNull { lookupClassTypeEmbedding(it) }
 
     /**
      * Get or Put a property to the class.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
@@ -95,11 +95,11 @@ object ListSizeFieldEmbedding : FieldEmbedding {
     }
 }
 
-fun ScopedName.specialEmbedding(embedding: ClassTypeEmbedding, ctx: TypeResolver): FieldEmbedding? =
+fun ScopedName.specialEmbedding(embedding: ClassTypeEmbedding, ctx: TypeResolver): PropertyEmbedding? =
     NameMatcher.Companion.matchClassScope(this) {
         ifBackingFieldName("size") {
             return ctx.isCollectionInheritor(embedding).ifTrue {
-                ListSizeFieldEmbedding
+                PropertyEmbedding(BackingFieldGetter(ListSizeFieldEmbedding), null)
             }
         }
         return null

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
@@ -78,29 +78,3 @@ class UserFieldEmbedding(
         get() = accessPolicy == AccessPolicy.ALWAYS_READABLE || accessPolicy == AccessPolicy.BY_RECEIVER_UNIQUENESS
     override val includeInShortDump: Boolean = true
 }
-
-
-object ListSizeFieldEmbedding : FieldEmbedding {
-    override val name = SpecialFieldName("size")
-    override val type = buildType { int() }
-    override val viperType = Type.Ref
-    override val accessPolicy = AccessPolicy.ALWAYS_WRITEABLE
-    override val includeInShortDump: Boolean = true
-    override fun extraAccessInvariantsForParameter(): List<TypeInvariantEmbedding> =
-        listOf(NonNegativeSizeTypeInvariantEmbedding)
-
-    object NonNegativeSizeTypeInvariantEmbedding : TypeInvariantEmbedding {
-        override fun fillHole(exp: ExpEmbedding): ExpEmbedding =
-            OperatorExpEmbeddings.GeIntInt(FieldAccess(exp, ListSizeFieldEmbedding), IntLit(0))
-    }
-}
-
-fun ScopedName.specialEmbedding(embedding: ClassTypeEmbedding, ctx: TypeResolver): PropertyEmbedding? =
-    NameMatcher.Companion.matchClassScope(this) {
-        ifBackingFieldName("size") {
-            return ctx.isCollectionInheritor(embedding).ifTrue {
-                PropertyEmbedding(BackingFieldGetter(ListSizeFieldEmbedding), null)
-            }
-        }
-        return null
-    }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
@@ -5,14 +5,58 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.properties
 
+
+import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.utils.visibility
+import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.kotlinCallableId
-import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.formver.core.names.NameMatcher
+import org.jetbrains.kotlin.formver.core.names.embedMemberBackingFieldName
+import org.jetbrains.kotlin.formver.core.names.embedName
+
+abstract class SpecialProperty(val property: PropertyEmbedding) {
+    context(typeResolver: TypeResolver, session: FirSession)
+    abstract fun match(symbol: FirPropertySymbol) : Boolean
+}
+
+
+val StringSizeProperty = object: SpecialProperty(PropertyEmbedding(LengthFieldGetter, setter = null)) {
+    context(typeResolver: TypeResolver, session: FirSession)
+    override fun match(symbol: FirPropertySymbol) : Boolean {
+        return symbol.callableId == kotlinCallableId("String", "length")
+    }
+}
+
+val CollectionSizeProperty = object: SpecialProperty(PropertyEmbedding(BackingFieldGetter(ListSizeFieldEmbedding), setter = null)) {
+    context(typeResolver: TypeResolver, session: FirSession)
+    override fun match(symbol: FirPropertySymbol) : Boolean {
+        val classSymbol = symbol.dispatchReceiverType?.toClassSymbol(session) as? FirRegularClassSymbol ?: return false
+
+        val embedding = typeResolver.lookupClassTypeEmbedding(classSymbol.classId.embedName()) ?: return false
+        val scopedName = symbol.callableId!!.embedMemberBackingFieldName(
+            Visibilities.isPrivate(symbol.visibility)
+        )
+        NameMatcher.Companion.matchClassScope(scopedName) {
+            ifBackingFieldName("size") {
+                val result = typeResolver.isCollectionInheritor(embedding)
+                return result
+            }
+            return false
+        }
+    }
+}
+
+
 
 object SpecialProperties {
-    val byCallableId: Map<CallableId, PropertyEmbedding> = mapOf(
-        kotlinCallableId("String", "length") to PropertyEmbedding(LengthFieldGetter, setter = null)
-    )
 
-    fun isSpecial(symbol: FirPropertySymbol) = symbol.callableId in byCallableId.keys
+    val all: List<SpecialProperty> = listOf(StringSizeProperty, CollectionSizeProperty)
+
+    context(typeResolver: TypeResolver, session: FirSession)
+    fun lookup(symbol: FirPropertySymbol) : PropertyEmbedding? = all.firstOrNull { it.match(symbol) }?.property
+
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.formver.core.conversion.CollectionSizeFieldEmbedding
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.kotlinCallableId
 import org.jetbrains.kotlin.formver.core.names.NameMatcher
@@ -31,7 +32,7 @@ val StringSizeProperty = object: SpecialProperty(PropertyEmbedding(LengthFieldGe
     }
 }
 
-val CollectionSizeProperty = object: SpecialProperty(PropertyEmbedding(BackingFieldGetter(ListSizeFieldEmbedding), setter = null)) {
+val CollectionSizeProperty = object: SpecialProperty(PropertyEmbedding(BackingFieldGetter(CollectionSizeFieldEmbedding), setter = null)) {
     context(typeResolver: TypeResolver, session: FirSession)
     override fun match(symbol: FirPropertySymbol) : Boolean {
         val classSymbol = symbol.dispatchReceiverType?.toClassSymbol(session) as? FirRegularClassSymbol ?: return false

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
@@ -21,20 +21,19 @@ import org.jetbrains.kotlin.formver.core.names.embedName
 
 abstract class SpecialProperty(val property: PropertyEmbedding) {
     context(typeResolver: TypeResolver, session: FirSession)
-    abstract fun match(symbol: FirPropertySymbol) : Boolean
+    abstract fun match(symbol: FirPropertySymbol): Boolean
 }
 
 
-val StringSizeProperty = object: SpecialProperty(PropertyEmbedding(LengthFieldGetter, setter = null)) {
+object StringSizeProperty : SpecialProperty(PropertyEmbedding(LengthFieldGetter, setter = null)) {
     context(typeResolver: TypeResolver, session: FirSession)
-    override fun match(symbol: FirPropertySymbol) : Boolean {
-        return symbol.callableId == kotlinCallableId("String", "length")
-    }
+    override fun match(symbol: FirPropertySymbol): Boolean = symbol.callableId == kotlinCallableId("String", "length")
 }
 
-val CollectionSizeProperty = object: SpecialProperty(PropertyEmbedding(BackingFieldGetter(CollectionSizeFieldEmbedding), setter = null)) {
+object CollectionSizeProperty :
+    SpecialProperty(PropertyEmbedding(BackingFieldGetter(CollectionSizeFieldEmbedding), setter = null)) {
     context(typeResolver: TypeResolver, session: FirSession)
-    override fun match(symbol: FirPropertySymbol) : Boolean {
+    override fun match(symbol: FirPropertySymbol): Boolean {
         val classSymbol = symbol.dispatchReceiverType?.toClassSymbol(session) as? FirRegularClassSymbol ?: return false
 
         val embedding = typeResolver.lookupClassTypeEmbedding(classSymbol.classId.embedName()) ?: return false
@@ -52,12 +51,11 @@ val CollectionSizeProperty = object: SpecialProperty(PropertyEmbedding(BackingFi
 }
 
 
-
 object SpecialProperties {
 
     val all: List<SpecialProperty> = listOf(StringSizeProperty, CollectionSizeProperty)
 
     context(typeResolver: TypeResolver, session: FirSession)
-    fun lookup(symbol: FirPropertySymbol) : PropertyEmbedding? = all.firstOrNull { it.match(symbol) }?.property
+    fun lookup(symbol: FirPropertySymbol): PropertyEmbedding? = all.firstOrNull { it.match(symbol) }?.property
 
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassPredicateBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassPredicateBuilder.kt
@@ -32,7 +32,7 @@ internal class ClassPredicateBuilder private constructor(
             predicateName: SymbolicName,
             action: ClassPredicateBuilder.() -> Unit,
         ): Predicate {
-            val typeEmbedding = ctx.lookupEmbedding(name)!!
+            val typeEmbedding = ctx.lookupClassTypeEmbedding(name)!!
             val builder = ClassPredicateBuilder(
                 TypeEmbedding(typeEmbedding, TypeEmbeddingFlags(nullable = false)),
                 ctx.lookupClassFields(name),


### PR DESCRIPTION
## Changes

- in #122 I did not find all the unclear names of functions. Therefore `lookupEmbedding()`  was renamed to `lookupClassTypeEmbedding()`
- Before the lookup process of special properties was a bit all over the place. This PR tries to unify this. 
  - The distinction between special properties and special fields was removed. Special fields can be represented as special properties using the `BackingFieldGetter/Setter` classes.
  - Every Special Property must be defined together with a `match` function. This function given the fir property symbol decided if its property should be used or not.
- All those special properties are collected in the object `SpecialProperties`. This object has a lookup method. Which is used by the `ProgramConverter`