### PR TITLE
Drop havoc on field accesses through unique receivers

### DIFF
--- a/formver.compiler-plugin/core/build.gradle.kts
+++ b/formver.compiler-plugin/core/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     compileOnly(project(":formver.common"))
     compileOnly(project(":formver.compiler-plugin:viper"))
+    compileOnly(project(":formver.compiler-plugin:uniqueness"))
     compileOnly(kotlin("compiler"))
 
     // TODO: figure out how to avoid this dependency

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConversionContext.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.names.FunctionResultVariableName
 import org.jetbrains.kotlin.formver.core.names.ReturnLabelName
 import org.jetbrains.kotlin.formver.core.names.ReturnVariableName
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessFacts
 
 
 class ReturnTarget private constructor(val variable: VariableEmbedding, val label: LabelEmbedding?) {
@@ -44,6 +45,13 @@ interface MethodConversionContext : ProgramConversionContext {
     val signature: FunctionSignature
     val defaultResolvedReturnTarget: ReturnTarget
     val isValidForForAllBlock: Boolean
+
+    /**
+     * Per-function uniqueness analysis result. Null when uniqueness checking is disabled,
+     * the function has no CFG, or the analyzer could not complete. Consumers must treat
+     * `null` as "no uniqueness information available" and fall back accordingly.
+     */
+    val uniquenessFacts: UniquenessFacts?
 
     fun resolveParameter(symbol: FirValueParameterSymbol): ExpEmbedding
     fun resolveLocal(symbol: FirVariableSymbol<*>): VariableEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConverter.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.VariableEmbedding
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessFacts
 
 /**
  * The symbol resolution data for a single method.
@@ -29,7 +30,10 @@ class MethodConverter(
     private val paramResolver: ParameterResolver,
     scopeDepth: ScopeIndex,
     private val parent: MethodConversionContext? = null,
+    private val ownFacts: UniquenessFacts? = null,
 ) : MethodConversionContext, ProgramConversionContext by programCtx {
+    override val uniquenessFacts: UniquenessFacts?
+        get() = ownFacts ?: parent?.uniquenessFacts
     private var propertyResolver = PropertyResolver(scopeDepth)
 
     override val isValidForForAllBlock: Boolean

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.*
+import org.jetbrains.kotlin.fir.resolve.dfa.controlFlowGraph
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -29,6 +30,7 @@ import org.jetbrains.kotlin.formver.core.isAdt
 import org.jetbrains.kotlin.formver.core.purity.checkValidity
 import org.jetbrains.kotlin.formver.core.purity.isPure
 import org.jetbrains.kotlin.formver.core.names.*
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessFacts
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Program
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
@@ -122,7 +124,7 @@ class ProgramConverter(
      */
     fun convertAll() {
         for ((declaration, signature, returnTarget) in registered) {
-            val stmtCtx = createBodyConversionContext(signature, returnTarget)
+            val stmtCtx = createBodyConversionContext(signature, declaration, returnTarget)
             if (signature.isPure) {
                 convertedBodyResolver.storePure(signature.name, stmtCtx.convertPureBody(declaration))
             } else {
@@ -205,7 +207,7 @@ class ProgramConverter(
             symbol.source, "Expected FirSimpleFunction, got unexpected type ${symbol.fir.javaClass.simpleName}"
         )
         if (declaration.body != null) {
-            val stmtCtx = createBodyConversionContext(signature, returnTarget)
+            val stmtCtx = createBodyConversionContext(signature, declaration, returnTarget)
             convertedBodyResolver.storePure(signature.name, stmtCtx.convertPureBody(declaration))
         }
         return new
@@ -213,9 +215,9 @@ class ProgramConverter(
 
     private fun createBodyConversionContext(
         signature: NamedFunctionSignature,
-        target: ReturnTarget
+        declaration: FirSimpleFunction,
+        target: ReturnTarget,
     ): StmtConversionContext {
-
         val paramResolver = RootParameterResolver(
             this@ProgramConverter,
             signature,
@@ -223,11 +225,17 @@ class ProgramConverter(
             signature.labelName,
             target
         )
+        val facts = if (config.checkUniqueness) {
+            declaration.controlFlowGraphReference?.controlFlowGraph?.let {
+                UniquenessFacts.analyze(session, it)
+            }
+        } else null
         val stmtCtx = MethodConverter(
             this@ProgramConverter,
             signature,
             paramResolver,
             scopeIndexProducer.getFresh(),
+            ownFacts = facts,
         ).statementCtxt()
         return stmtCtx
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -126,17 +126,18 @@ fun StmtConversionContext.embedPropertyAccess(accessExpression: FirPropertyAcces
         is FirValueParameterSymbol -> embedParameter(calleeSymbol).asPropertyAccess()
         is FirPropertySymbol -> {
             val type = embedType(calleeSymbol.resolvedReturnType)
+            val receiverIsUnique = uniquenessFacts?.isReceiverUniqueAt(accessExpression) ?: false
             when {
                 accessExpression.dispatchReceiver != null -> {
                     val property = calleeSymbol.findFinalParentProperty()?.let {
                         embedProperty(it)
                     } ?: embedProperty(calleeSymbol)
-                    ClassPropertyAccess(convert(accessExpression.dispatchReceiver!!), property, type)
+                    ClassPropertyAccess(convert(accessExpression.dispatchReceiver!!), property, type, receiverIsUnique)
                 }
 
                 accessExpression.extensionReceiver != null -> {
                     val property = embedProperty(calleeSymbol)
-                    ClassPropertyAccess(convert(accessExpression.extensionReceiver!!), property, type)
+                    ClassPropertyAccess(convert(accessExpression.extensionReceiver!!), property, type, receiverIsUnique)
                 }
 
                 else -> embedLocalProperty(calleeSymbol)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -58,7 +58,11 @@ data class PrimitiveFieldAccess(val inner: ExpEmbedding, val field: FieldEmbeddi
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
-data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : ExpEmbedding {
+data class FieldAccess(
+    val receiver: ExpEmbedding,
+    val field: FieldEmbedding,
+    val receiverIsUnique: Boolean = false,
+) : ExpEmbedding {
     override val type: TypeEmbedding = field.type
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFieldAccess(this)
@@ -68,8 +72,12 @@ data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : 
 /**
  * Represents a combination of `Assign` + `FieldAccess`.
  */
-data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbedding, val newValue: ExpEmbedding) :
-    ExpEmbedding {
+data class FieldModification(
+    val receiver: ExpEmbedding,
+    val field: FieldEmbedding,
+    val newValue: ExpEmbedding,
+    val receiverIsUnique: Boolean = false,
+) : ExpEmbedding {
     override val type: TypeEmbedding = buildType { unit() }
 
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(receiver, newValue)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
@@ -7,20 +7,34 @@ package org.jetbrains.kotlin.formver.core.embeddings.properties
 
 import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.FieldAccess
+import org.jetbrains.kotlin.formver.core.embeddings.expression.FieldModification
 import org.jetbrains.kotlin.formver.core.embeddings.expression.withNewTypeInvariants
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 
 // We assume that thanks to the checks done by the Kotlin compiler, a property with a
 // missing getter or setter will never be accessed.
-class ClassPropertyAccess(val receiver: ExpEmbedding, val property: PropertyEmbedding, val type: TypeEmbedding) :
-    PropertyAccessEmbedding {
-    override fun getValue(ctx: StmtConversionContext): ExpEmbedding =
-        property.getter!!.getValue(receiver, ctx).withNewTypeInvariants(type, ctx.typeResolver) {
+class ClassPropertyAccess(
+    val receiver: ExpEmbedding,
+    val property: PropertyEmbedding,
+    val type: TypeEmbedding,
+    val receiverIsUnique: Boolean = false,
+) : PropertyAccessEmbedding {
+    override fun getValue(ctx: StmtConversionContext): ExpEmbedding {
+        val raw = property.getter!!.getValue(receiver, ctx)
+        // For backing fields we can tag the FieldAccess with receiver-uniqueness so the linearizer
+        // knows it can drop the conservative havoc on read. Custom getters return non-FieldAccess
+        // expressions; the flag doesn't apply there.
+        val tagged = if (receiverIsUnique && raw is FieldAccess) raw.copy(receiverIsUnique = true) else raw
+        return tagged.withNewTypeInvariants(type, ctx.typeResolver) {
             proven = true
             access = true
         }
+    }
 
     // set value must already have correct type so no need to worry
-    override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding =
-        property.setter!!.setValue(receiver, value, ctx)
+    override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {
+        val raw = property.setter!!.setValue(receiver, value, ctx)
+        return if (receiverIsUnique && raw is FieldModification) raw.copy(receiverIsUnique = true) else raw
+    }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
@@ -88,3 +88,12 @@ fun ClassTypeEmbedding.predicateAccess(
         ?: error("Translating shared predicate of ${name.debugMangled} yielded no predicate access."))
     return access
 }
+
+fun ClassTypeEmbedding.uniquePredicateAccessOrNull(
+    receiver: ExpEmbedding,
+    ctx: TypeResolver,
+    source: KtSourceElement?,
+): Exp.PredicateAccess? {
+    val invariant = uniquePredicateAccessInvariant(ctx) ?: return null
+    return invariant.fillHole(receiver).pureToViper(toBuiltin = true, ctx, source) as? Exp.PredicateAccess
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
@@ -56,13 +56,53 @@ interface LinearizationContext {
         result: VariableEmbedding?
     )
 
-    fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp
+    fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        receiverIsUnique: Boolean = false,
+    ): Exp
 
-    fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding)
+    fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        result: VariableEmbedding,
+        receiverIsUnique: Boolean = false,
+    )
 
     fun addModifier(mod: StmtModifier)
 
     fun resolveVariableName(name: SymbolicName): SymbolicName
+
+    /**
+     * Register that [receiverName] is an `@Unique` parameter eligible for function-scope
+     * unfolding. The actual `Stmt.Unfold` is *not* emitted here; it's deferred until the
+     * first access via [tryUseFunctionScopedReceiver], so functions that never touch the
+     * parameter don't emit a no-op unfold/fold pair.
+     *
+     * Default: no-op (only the main body Linearizer uses this; pure-expression linearizers
+     * don't need it since they never emit unfold/fold).
+     */
+    fun registerEligibleReceiver(receiverName: SymbolicName, predAcc: Exp.PredicateAccess) {}
+
+    /**
+     * If [receiverName] is registered (and the receiver is therefore at function-scope
+     * unfolded by convention), return true and emit the deferred `Stmt.Unfold` if this is
+     * the first access. The caller then emits the field op directly without its own
+     * unfold/fold pair. Returns false for receivers that aren't eligible — the caller
+     * falls back to the per-access cycle (or the conservative havoc).
+     *
+     * Default: false.
+     */
+    fun tryUseFunctionScopedReceiver(receiverName: SymbolicName): Boolean = false
+
+    /**
+     * Emit a `fold` for every receiver that was actually unfolded by
+     * [tryUseFunctionScopedReceiver]. Used at function exit (epilogue and each early-return
+     * goto). Receivers registered but never accessed are skipped. Default: no-op.
+     */
+    fun foldUsedFunctionScopedReceivers() {}
 }
 
 fun LinearizationContext.freshAnonVar(init: TypeBuilder.() -> PretypeBuilder): AnonymousVariableEmbedding =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -14,9 +14,11 @@ import org.jetbrains.kotlin.formver.core.embeddings.*
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toFuncApp
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toMethodCall
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
+import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
 import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
+import org.jetbrains.kotlin.formver.core.embeddings.types.uniquePredicateAccessOrNull
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 import org.jetbrains.kotlin.formver.viper.ast.viperLiteral
@@ -145,7 +147,23 @@ data class LinearizationVisitor(
                     ctx.addStatement { Stmt.Inhale(invariant.linearize().toViperBuiltinType(ctx), ctx.source.asPosition) }
                 }
             }
+            // Register `@Unique` parameters whose type carries a unique predicate as eligible
+            // for function-scope unfolding. The actual `Stmt.Unfold` is deferred until first
+            // access (see Linearizer.tryUseFunctionScopedReceiver), so functions that never
+            // touch the parameter don't emit a useless unfold/fold pair. The first access
+            // emits the unfold; the function epilogue (and each early return) emits a
+            // matching fold only for receivers that were actually unfolded.
+            e.signature?.formalArgs?.forEach { arg ->
+                if (!arg.isUnique) return@forEach
+                val classType = arg.type.pretype as? ClassTypeEmbedding ?: return@forEach
+                val predAcc = classType.uniquePredicateAccessOrNull(arg, ctx.typeResolver, ctx.source)
+                    ?: return@forEach
+                ctx.registerEligibleReceiver(ctx.resolveVariableName(arg.name), predAcc)
+            }
             e.body.linearize().toViperMaybeStoringIn(result, ctx)
+            // Fold matching the entry-time unfolds before falling through to the return label.
+            // Early returns emit their own folds via Linearizer.addReturn.
+            ctx.foldUsedFunctionScopedReceivers()
             ctx.addLabel(e.returnLabel.toViper(ctx))
         }
     }
@@ -410,11 +428,11 @@ data class LinearizationVisitor(
             if (e.field.accessPolicy == AccessPolicy.ALWAYS_WRITEABLE) {
                 return PrimitiveFieldAccess(e.receiver, e.field).linearize().toViper(ctx)
             }
-            return ctx.addFieldAccess(receiverLinearizable, e.receiver.type, e.field)
+            return ctx.addFieldAccess(receiverLinearizable, e.receiver.type, e.field, e.receiverIsUnique)
         }
 
         override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
-            ctx.addFieldAccessStoringIn(receiverLinearizable, e.receiver.type, e.field, result)
+            ctx.addFieldAccessStoringIn(receiverLinearizable, e.receiver.type, e.field, result, e.receiverIsUnique)
         }
 
         override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {
@@ -434,6 +452,11 @@ data class LinearizationVisitor(
         override fun toViperUnusedResult(ctx: LinearizationContext) {
             when (e.field.accessPolicy) {
                 AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+                    if (e.receiverIsUnique && emitUniqueReceiverFieldWrite(e, ctx)) return
+                    // The conservative path for shared receivers: a write to a `var` field
+                    // whose receiver might be aliased can't be represented in a way the read
+                    // side can frame, so we drop the write entirely (the read will havoc).
+                    // TODO: see Linearizer's matching TODO on the read side.
                     e.receiver.linearize().toViperUnusedResult(ctx)
                     e.newValue.linearize().toViperUnusedResult(ctx)
                 }
@@ -457,6 +480,49 @@ data class LinearizationVisitor(
                     }
                 }
             }
+        }
+
+        /**
+         * Mirror of `Linearizer.emitUniqueReceiverFieldRead` for writes. Unfolds the unique
+         * class predicate, emits a real `Stmt.FieldAssign`, and folds back so subsequent
+         * reads / writes on this receiver still hold the predicate. Returns false on
+         * multi-step hierarchies (see comment on the read-side helper).
+         */
+        private fun emitUniqueReceiverFieldWrite(e: FieldModification, ctx: LinearizationContext): Boolean {
+            val classType = e.receiver.type.pretype as? ClassTypeEmbedding ?: return false
+            val hierarchyPath = ctx.typeResolver.hierarchyPathTo(e.receiver.type.pretype, e.field).toList()
+            if (hierarchyPath.size != 1 || hierarchyPath.single() !== classType) return false
+
+            val receiverViper = e.receiver.linearize().toViper(ctx)
+            val functionScoped = receiverViper is Exp.LocalVar &&
+                    ctx.tryUseFunctionScopedReceiver(receiverViper.name)
+
+            if (functionScoped) {
+                // Function-scope unfold is in place (or was just emitted by the lazy hook on
+                // this access); just emit the assign.
+                val newValueViper = e.newValue.linearize().toViper(ctx)
+                ctx.addStatement {
+                    Stmt.FieldAssign(
+                        Exp.FieldAccess(receiverViper, e.field.toViper()),
+                        newValueViper,
+                        ctx.source.asPosition
+                    )
+                }
+            } else {
+                val receiverWrapper = ExpWrapper(receiverViper, e.receiver.type)
+                val uniquePredAcc = classType.uniquePredicateAccessOrNull(receiverWrapper, ctx.typeResolver, ctx.source) ?: return false
+                ctx.addStatement { Stmt.Unfold(uniquePredAcc, ctx.source.asPosition) }
+                val newValueViper = e.newValue.linearize().toViper(ctx)
+                ctx.addStatement {
+                    Stmt.FieldAssign(
+                        Exp.FieldAccess(receiverViper, e.field.toViper()),
+                        newValueViper,
+                        ctx.source.asPosition
+                    )
+                }
+                ctx.addStatement { Stmt.Fold(uniquePredAcc, ctx.source.asPosition) }
+            }
+            return true
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -21,6 +21,8 @@ import org.jetbrains.kotlin.formver.core.embeddings.toViperGoto
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
+import org.jetbrains.kotlin.formver.core.embeddings.types.uniquePredicateAccessOrNull
+import org.jetbrains.kotlin.formver.core.names.debugMangled
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -82,7 +84,31 @@ data class Linearizer(
     override fun addReturn(returnExp: Linearizable, target: ReturnTarget) {
         returnExp.toViperStoringIn(target.variable, this)
         val returnLabel = target.label ?: throw SnaktInternalException(null, "Return target without label")
+        // Fold any function-scope unfolded predicates before the goto so the predicate
+        // postcondition holds at the return target. The fold itself doesn't disturb the
+        // returnExp evaluation: it ran above and stored its result already.
+        foldUsedFunctionScopedReceivers()
         addStatement { returnLabel.toLink().toViperGoto(this) }
+    }
+
+    override fun registerEligibleReceiver(receiverName: SymbolicName, predAcc: Exp.PredicateAccess) {
+        state.preUnfoldedReceivers.add(PreUnfoldedReceiver(receiverName, predAcc))
+    }
+
+    override fun tryUseFunctionScopedReceiver(receiverName: SymbolicName): Boolean {
+        val entry = state.preUnfoldedReceivers.firstOrNull { it.receiverName == receiverName } ?: return false
+        if (!entry.unfolded) {
+            addStatement { Stmt.Unfold(entry.predicateAccess, source.asPosition) }
+            entry.unfolded = true
+        }
+        return true
+    }
+
+    override fun foldUsedFunctionScopedReceivers() {
+        for (entry in state.preUnfoldedReceivers) {
+            if (!entry.unfolded) continue
+            addStatement { Stmt.Fold(entry.predicateAccess, source.asPosition) }
+        }
     }
 
     override fun addBranch(
@@ -98,9 +124,14 @@ data class Linearizer(
             Stmt.If(condViper, thenViper, elseViper, source.asPosition)
         }
 
-    override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
+    override fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        receiverIsUnique: Boolean,
+    ): Exp {
         val result = freshAnonVar(field.type)
-        addFieldAccessStoringIn(receiver, receiverType, field, result)
+        addFieldAccessStoringIn(receiver, receiverType, field, result, receiverIsUnique)
         return result.toViperExp(this)
     }
 
@@ -108,11 +139,22 @@ data class Linearizer(
         stmtModifierTracker?.add(mod) ?: error("Not in a statement")
     }
 
-    override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
+    override fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        result: VariableEmbedding,
+        receiverIsUnique: Boolean,
+    ) {
+        if (field.accessPolicy == AccessPolicy.BY_RECEIVER_UNIQUENESS && receiverIsUnique) {
+            if (emitUniqueReceiverFieldRead(receiver, receiverType, field, result)) return
+            // fall through to the conservative havoc on the rare cases where we don't have a
+            // unique-predicate handle (e.g. multi-step hierarchy not yet plumbed).
+        }
         addStatement {
             when (field.accessPolicy) {
-                // TODO: Handling a unique field on a shared receiver must be added here.
                 AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+                    // TODO: Handling a unique field on a shared receiver must be added here.
                     receiver.toViperUnusedResult(this)
                     field.type.havocMethod(typeResolver).toMethodCall(emptyList(), listOf(result.toLocalVarUse()))
                 }
@@ -132,6 +174,55 @@ data class Linearizer(
                 }
             }
         }
+    }
+
+    /**
+     * Read a `var` field through a unique receiver without dropping the value to havoc.
+     * The unique predicate carries `acc(receiver.field, write)`, so we unfold it, perform a
+     * direct field-read, and fold it back so subsequent code (and other unique reads) still
+     * holds the predicate. Returns false if we can't resolve a unique-predicate handle for
+     * this field's containing class — in that case the caller falls back to havoc.
+     *
+     * Limited to single-step hierarchy: when the field lives in a strict supertype, we punt
+     * to the conservative path. Deeper hierarchies want the same fold/unfold chain that the
+     * shared-predicate path already does, just with full perm and an inverse-order refold.
+     */
+    private fun emitUniqueReceiverFieldRead(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        result: VariableEmbedding,
+    ): Boolean {
+        val classType = receiverType.pretype as? ClassTypeEmbedding ?: return false
+        val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field).toList()
+        if (hierarchyPath.size != 1 || hierarchyPath.single() !== classType) return false
+
+        addStatement {
+            val receiverViper = receiver.toViper(this)
+            val functionScoped = receiverViper is Exp.LocalVar &&
+                    tryUseFunctionScopedReceiver(receiverViper.name)
+            if (functionScoped) {
+                // Function-scope unfold is in place (or was just emitted by the lazy hook
+                // on this very access); just emit the read.
+                Stmt.assign(
+                    result.toLocalVarUse(),
+                    Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
+                )
+            } else {
+                val receiverWrapper = ExpWrapper(receiverViper, receiverType)
+                val uniquePredAcc = classType.uniquePredicateAccessOrNull(receiverWrapper, typeResolver, source)
+                    ?: error("ClassTypeEmbedding ${classType.name.debugMangled} has no unique-predicate access")
+                addStatement { Stmt.Unfold(uniquePredAcc, source.asPosition) }
+                addStatement {
+                    Stmt.assign(
+                        result.toLocalVarUse(),
+                        Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
+                    )
+                }
+                Stmt.Fold(uniquePredAcc, source.asPosition)
+            }
+        }
+        return true
     }
 
     private fun Sequence<ClassTypeEmbedding>?.unfoldHierarchyPath(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
@@ -77,11 +77,22 @@ data class PureExpLinearizer(
         throw PureExpLinearizerMisuseException("addBranch")
     }
 
-    override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
+    override fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        result: VariableEmbedding,
+        receiverIsUnique: Boolean,
+    ) {
         throw PureExpLinearizerMisuseException("addFieldAccessWithResult")
     }
 
-    override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
+    override fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        receiverIsUnique: Boolean,
+    ): Exp {
         val receiverViper = receiver.toViper(this)
         val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field)
         val primitiveAccess: Exp = Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
@@ -99,7 +99,13 @@ data class PureFunBodyLinearizer(
         }
     }
 
-    override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
+    override fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        result: VariableEmbedding,
+        receiverIsUnique: Boolean,
+    ) {
         val viperReceiver = receiver.toViper(this)
         if (viperReceiver !is Exp.LocalVar) throw SnaktInternalException(
             source,
@@ -113,9 +119,14 @@ data class PureFunBodyLinearizer(
         ssaConverter.addAssignment(result.name, primitiveAccess, accessInvariants)
     }
 
-    override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
+    override fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        field: FieldEmbedding,
+        receiverIsUnique: Boolean,
+    ): Exp {
         val result = freshAnonVar(field.type)
-        addFieldAccessStoringIn(receiver, receiverType, field, result)
+        addFieldAccessStoringIn(receiver, receiverType, field, result, receiverIsUnique)
         return result.toViperExp(this)
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SharedLinearizationState.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SharedLinearizationState.kt
@@ -8,7 +8,31 @@ package org.jetbrains.kotlin.formver.core.linearization
 import org.jetbrains.kotlin.formver.core.conversion.FreshEntityProducer
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.viper.SymbolicName
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+
+/**
+ * One entry in the function-scope unfolded-predicate list. We track the receiver's Viper
+ * variable name (so per-access emit helpers can recognise it) and the matching predicate
+ * access (so we can emit a `fold` at every exit point — function epilogue and each early
+ * return). Populated by `visitFunctionExp` for `@Unique` parameters; promoted from
+ * "registered, not yet unfolded" to "unfolded" on first access.
+ */
+data class PreUnfoldedReceiver(
+    val receiverName: SymbolicName,
+    val predicateAccess: Exp.PredicateAccess,
+    var unfolded: Boolean = false,
+)
 
 class SharedLinearizationState(private val producer: FreshEntityProducer<AnonymousVariableEmbedding, TypeEmbedding>) {
+    /**
+     * `@Unique` parameters that *could* be unfolded once at function scope. Per-access
+     * read/write helpers consult this list; the first access to such a receiver emits the
+     * unfold lazily and flips `unfolded`. Function-exit / early-return paths emit a `fold`
+     * only for receivers that were actually unfolded (i.e. accessed). Receivers that the
+     * function never touches stay un-unfolded — no `unfold pred; fold pred` no-op pair.
+     */
+    val preUnfoldedReceivers: MutableList<PreUnfoldedReceiver> = mutableListOf()
+
     fun freshAnonVar(type: TypeEmbedding) = producer.getFresh(type)
 }

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.NEVER_VALI
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.RENDER_PREDICATES
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.REPLACE_STDLIB_EXTENSIONS
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.UNIQUE_CHECK_ONLY
+import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.CHECK_UNIQUENESS
 import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.directives.model.SimpleDirectivesContainer
@@ -60,7 +61,7 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
             uniquenessOnly || localityOnly -> TargetsSelection.NO_TARGETS
             else -> TargetsSelection.ALL_TARGETS
         }
-        val checkUniqueness = uniquenessOnly
+        val checkUniqueness = uniquenessOnly || CHECK_UNIQUENESS in module.directives
         // TODO: Eventually turn on locality checking together with uniqueness checking once the latter will be able to
         //  leverage locality information.
         val checkLocality = localityOnly // || checkUniqueness
@@ -96,6 +97,10 @@ object FormVerDirectives : SimpleDirectivesContainer() {
 
     val UNIQUE_CHECK_ONLY by directive(
         description = "Do uniqueness checking"
+    )
+
+    val CHECK_UNIQUENESS by directive(
+        description = "Run the uniqueness checker alongside verification (without forcing NO_TARGETS for selection)"
     )
 
     val LOCALITY_CHECK_ONLY by directive(

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -881,6 +881,28 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/uniqueness")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Uniqueness {
+      @Test
+      public void testAllFilesPresentInUniqueness() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/verification/uniqueness"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("unique_field_read.kt")
+      public void testUnique_field_read() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_read.kt");
+      }
+
+      @Test
+      @TestMetadata("unique_field_write.kt")
+      public void testUnique_field_write() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_write.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/user_invariants")
     @TestDataPath("$PROJECT_ROOT")
     public class User_invariants {

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_read.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_read.fir.diag.txt
@@ -1,0 +1,123 @@
+/unique_field_read.kt: info: Generated Viper text for readMemberUnique:
+field bf_v: Ref
+
+field size: Ref
+
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate X_shared(this: Ref) {
+  true
+}
+
+predicate X_unique(this: Ref) {
+  acc(this.bf_v, write) && isSubtype(typeOf(this.bf_v), intType())
+}
+
+method readMemberUnique(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), X())
+  requires acc(X_unique(x), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var k: Ref
+  var anon: Ref
+  inhale acc(X_shared(x), wildcard)
+  unfold acc(X_unique(x), write)
+  k := x.bf_v
+  anon := x.bf_v
+  assert intFromRef(k) == intFromRef(anon)
+  fold acc(X_unique(x), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/unique_field_read.kt: info: Generated Viper text for constructAndRead:
+field bf_v: Ref
+
+field size: Ref
+
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate X_shared(this: Ref) {
+  true
+}
+
+predicate X_unique(this: Ref) {
+  acc(this.bf_v, write) && isSubtype(typeOf(this.bf_v), intType())
+}
+
+method con(par_v: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_v), intType())
+  ensures isSubtype(typeOf(ret_1), X())
+  ensures acc(X_shared(ret_1), wildcard)
+  ensures acc(X_unique(ret_1), write)
+
+
+method constructAndRead() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var x: Ref
+  var k: Ref
+  var anon: Ref
+  x := con(intToRef(42))
+  unfold acc(X_unique(x), write)
+  k := x.bf_v
+  fold acc(X_unique(x), write)
+  unfold acc(X_unique(x), write)
+  anon := x.bf_v
+  fold acc(X_unique(x), write)
+  assert intFromRef(k) == intFromRef(anon)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_read.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_read.kt
@@ -1,0 +1,26 @@
+// CHECK_UNIQUENESS
+// RENDER_PREDICATES
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.verify
+
+class X(var v: Int)
+
+// Two reads of `x.v` separated by a local-val assignment should agree when `x` is unique:
+// uniqueness rules out aliasing, so the linearizer can drop the conservative havoc on the
+// second read.
+@AlwaysVerify
+fun <!VIPER_TEXT!>readMemberUnique<!>(@Unique x: X) {
+    val k = x.v
+    verify(k == x.v)
+}
+
+// A freshly-constructed unique local should also have stable reads of its var fields.
+@AlwaysVerify
+fun <!VIPER_TEXT!>constructAndRead<!>() {
+    @Unique val x = X(42)
+    val k = x.v
+    verify(k == x.v)
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_write.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_write.fir.diag.txt
@@ -1,0 +1,241 @@
+/unique_field_write.kt: info: Generated Viper text for writeThenRead:
+field bf_v: Ref
+
+field size: Ref
+
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate X_shared(this: Ref) {
+  true
+}
+
+predicate X_unique(this: Ref) {
+  acc(this.bf_v, write) && isSubtype(typeOf(this.bf_v), intType())
+}
+
+method writeThenRead(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), X())
+  requires acc(X_unique(x), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var k: Ref
+  inhale acc(X_shared(x), wildcard)
+  unfold acc(X_unique(x), write)
+  x.bf_v := intToRef(7)
+  k := x.bf_v
+  assert intFromRef(k) == 7
+  fold acc(X_unique(x), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/unique_field_write.kt: info: Generated Viper text for writeTwiceReadOnce:
+field bf_v: Ref
+
+field size: Ref
+
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate X_shared(this: Ref) {
+  true
+}
+
+predicate X_unique(this: Ref) {
+  acc(this.bf_v, write) && isSubtype(typeOf(this.bf_v), intType())
+}
+
+method writeTwiceReadOnce(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), X())
+  requires acc(X_unique(x), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var k: Ref
+  inhale acc(X_shared(x), wildcard)
+  unfold acc(X_unique(x), write)
+  x.bf_v := intToRef(1)
+  x.bf_v := intToRef(9)
+  k := x.bf_v
+  assert intFromRef(k) == 9
+  fold acc(X_unique(x), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/unique_field_write.kt: info: Generated Viper text for readWriteRead:
+field bf_v: Ref
+
+field size: Ref
+
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate X_shared(this: Ref) {
+  true
+}
+
+predicate X_unique(this: Ref) {
+  acc(this.bf_v, write) && isSubtype(typeOf(this.bf_v), intType())
+}
+
+method readWriteRead(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), X())
+  requires acc(X_unique(x), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var k1: Ref
+  var k2: Ref
+  inhale acc(X_shared(x), wildcard)
+  unfold acc(X_unique(x), write)
+  x.bf_v := intToRef(3)
+  k1 := x.bf_v
+  x.bf_v := intToRef(11)
+  k2 := x.bf_v
+  assert intFromRef(k1) == 3
+  assert intFromRef(k2) == 11
+  fold acc(X_unique(x), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/unique_field_write.kt: info: Generated Viper text for writeOneReadAnother:
+field bf_v: Ref
+
+field size: Ref
+
+predicate BooleanArray_shared(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_shared(this), wildcard) &&
+  acc(Serializable_shared(this), wildcard)
+}
+
+predicate BooleanArray_unique(this: Ref) {
+  acc(this.size, wildcard) && isSubtype(typeOf(this.size), intType()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_shared(this: Ref) {
+  true
+}
+
+predicate Cloneable_unique(this: Ref) {
+  true
+}
+
+predicate Serializable_shared(this: Ref) {
+  true
+}
+
+predicate Serializable_unique(this: Ref) {
+  true
+}
+
+predicate X_shared(this: Ref) {
+  true
+}
+
+predicate X_unique(this: Ref) {
+  acc(this.bf_v, write) && isSubtype(typeOf(this.bf_v), intType())
+}
+
+method writeOneReadAnother(x: Ref, y: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), X())
+  requires acc(X_unique(x), write)
+  requires isSubtype(typeOf(y), X())
+  requires acc(X_unique(y), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale acc(X_shared(x), wildcard)
+  inhale acc(X_shared(y), wildcard)
+  unfold acc(X_unique(x), write)
+  x.bf_v := intToRef(5)
+  unfold acc(X_unique(y), write)
+  y.bf_v := intToRef(8)
+  anon_0 := x.bf_v
+  assert intFromRef(anon_0) == 5
+  anon_1 := y.bf_v
+  assert intFromRef(anon_1) == 8
+  fold acc(X_unique(x), write)
+  fold acc(X_unique(y), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_write.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/unique_field_write.kt
@@ -1,0 +1,47 @@
+// CHECK_UNIQUENESS
+// RENDER_PREDICATES
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.Unique
+import org.jetbrains.kotlin.formver.plugin.verify
+
+class X(var v: Int)
+
+// A write through a unique receiver should propagate to a subsequent read of the same field.
+@AlwaysVerify
+fun <!VIPER_TEXT!>writeThenRead<!>(@Unique x: X) {
+    x.v = 7
+    val k = x.v
+    verify(k == 7)
+}
+
+// Last-write-wins: the most recent write should be visible on read.
+@AlwaysVerify
+fun <!VIPER_TEXT!>writeTwiceReadOnce<!>(@Unique x: X) {
+    x.v = 1
+    x.v = 9
+    val k = x.v
+    verify(k == 9)
+}
+
+// A read interleaved between two writes should reflect the prior write, and the post-write
+// read should reflect the new write.
+@AlwaysVerify
+fun <!VIPER_TEXT!>readWriteRead<!>(@Unique x: X) {
+    x.v = 3
+    val k1 = x.v
+    x.v = 11
+    val k2 = x.v
+    verify(k1 == 3)
+    verify(k2 == 11)
+}
+
+// Two unique receivers: a write to one must not affect a read of another.
+@AlwaysVerify
+fun <!VIPER_TEXT!>writeOneReadAnother<!>(@Unique x: X, @Unique y: X) {
+    x.v = 5
+    y.v = 8
+    verify(x.v == 5)
+    verify(y.v == 8)
+}

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessFacts.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/UniquenessFacts.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.uniqueness
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraph
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.VariableAssignmentNode
+
+/**
+ * Per-FIR-expression view of the uniqueness analysis result.
+ *
+ * Adapter exposed to the Viper conversion so it can ask "is the receiver of this property
+ * access unique at the point where we read it?" without depending on the trie internals.
+ */
+class UniquenessFacts private constructor(
+    private val receiverUniqueAt: Map<FirElement, Boolean>,
+) {
+    /**
+     * Returns true if the dispatch (or extension) receiver of [access] holds a value with
+     * uniqueness `Active(Unique, _)` immediately before the access executes. Returns false
+     * for anything we don't know about — the conversion is expected to fall back to the
+     * conservative aliasing-allowed translation in that case.
+     */
+    fun isReceiverUniqueAt(access: FirPropertyAccessExpression): Boolean =
+        receiverUniqueAt[access] ?: false
+
+    companion object {
+        /**
+         * Runs the uniqueness analyzer over [graph] and collects per-access receiver-uniqueness
+         * snapshots. Returns null if the analyzer cannot complete (e.g. throws on a violating
+         * function); the plugin-side `UniquenessDeclarationChecker` still reports the diagnostic,
+         * we just skip the optimization for this function body.
+         */
+        fun analyze(session: FirSession, graph: ControlFlowGraph): UniquenessFacts? {
+            return try {
+                val resolver = UniquenessResolver(session)
+                val initial = UniquenessTrie(resolver)
+                val facts = UniquenessGraphAnalyzer(resolver, initial).analyze(graph)
+
+                val receiverUniqueAt = mutableMapOf<FirElement, Boolean>()
+                for (node in graph.nodes) {
+                    when (val fir = node.fir) {
+                        is FirPropertyAccessExpression ->
+                            recordIfApplicable(receiverUniqueAt, fir, node, facts)
+                        else -> {
+                            // For assignment nodes, the lValue is the property access we care
+                            // about (e.g. `x.v = 7` puts the receiver-uniqueness query on the
+                            // lValue, not on a standalone access node).
+                            if (node is VariableAssignmentNode) {
+                                val lValue = node.fir.lValue as? FirPropertyAccessExpression ?: continue
+                                recordIfApplicable(receiverUniqueAt, lValue, node, facts)
+                            }
+                        }
+                    }
+                }
+                UniquenessFacts(receiverUniqueAt)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun recordIfApplicable(
+            into: MutableMap<FirElement, Boolean>,
+            access: FirPropertyAccessExpression,
+            node: CFGNode<*>,
+            facts: FlowFacts<UniquenessTrie>,
+        ) {
+            val receiverPath = access.explicitReceiver?.receiverPath ?: return
+            val trie = facts.flowBefore(node)
+            val nodeData = trie.ensure(receiverPath)
+            val receiverType = nodeData.parentsJoin
+            into[access] = receiverType is UniquenessType.Active &&
+                    receiverType.uniqueLevel == UniqueLevel.Unique
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Wires the uniqueness analyzer's per-CFG-node results into Viper conversion for the first time. Two reads of `x.v` separated by a local-val (and writes through a unique receiver) now agree instead of bottoming out in a fresh havoc per access.
- Builds in three commits: read-side fix + plumbing, write-side mirror, and a function-scope unfold/fold hoist that keeps the emitted Viper compact enough for Silicon's evaluator at default JVM stack size.

## Background

The CLI plugin's linearizer was emitting `havocMethod.toMethodCall(...)` for every `var`-field read through a unique receiver (`AccessPolicy.BY_RECEIVER_UNIQUENESS` branch in `Linearizer.addFieldAccessStoringIn`), with the matching write branch dropping the assignment entirely. The TODO at `Linearizer.kt:107` ("Handling a unique field on a shared receiver must be added here") was the load-bearing comment. The uniqueness checker had the data needed to refine this — a per-CFG-node `UniquenessTrie` — but its output was thrown away when `UniquenessDeclarationChecker.check` returned, and `core` had no dep on `uniqueness`.

## What changes

**Architectural plumbing** (commit 1): new `UniquenessFacts` adapter in the `uniqueness` module exposes a per-`FirPropertyAccessExpression` query (`isReceiverUniqueAt`). `core` gains a `compileOnly` dep on `uniqueness`; `ProgramConverter.createBodyConversionContext` runs `UniquenessGraphAnalyzer` once per function body when `config.checkUniqueness` is on and stashes the facts on `MethodConversionContext`. `embedPropertyAccess` queries the facts and tags `ClassPropertyAccess` (and downstream `FieldAccess` / `FieldModification`) with `receiverIsUnique`. New `Linearizer.emitUniqueReceiverFieldRead` (commit 1) and `visitFieldModification.emitUniqueReceiverFieldWrite` (commit 2) emit unfold-of-unique-predicate / direct field op / fold instead of havoc / no-op.

**Function-scope hoist** (commit 3): the per-access unfold/fold cycles compounded into a deep evaluator tree on Silicon's side — `twoWritesOneRead` overflowed a default JVM thread stack on the Gradle compile path (the test fork uses `-Xss30M` and masked it). `SharedLinearizationState` now tracks `@Unique` parameters that have been registered for function-scope unfolding; `LinearizationVisitor.visitFunctionExp` registers them at body entry but defers the actual `Stmt.Unfold` until first access via `Linearizer.tryUseFunctionScopedReceiver`. The function epilogue and `Linearizer.addReturn` emit `Stmt.Fold` only for receivers that were actually unfolded — so functions that never touch the parameter emit no unfold/fold pair, keeping existing baselines quiet. Output for the pinned test cases collapses (e.g. `writeTwiceReadOnce` from nine statements to five in the unfold/op/fold band).

## Test surface

- New `// CHECK_UNIQUENESS` test directive enables the uniqueness checker alongside verification (without forcing the `NO_TARGETS` selection that `// UNIQUE_CHECK_ONLY` does).
- New `verification/uniqueness/unique_field_read.kt` covers `readMemberUnique(@Unique x: X)` and `constructAndRead` (`@Unique val x = X(42)`).
- New `verification/uniqueness/unique_field_write.kt` covers `writeThenRead`, `writeTwiceReadOnce`, `readWriteRead`, and `writeOneReadAnother` (no cross-talk between two unique receivers).
- Verified manually in a sandbox Gradle project at *default* JVM args — the multi-write cases pass without a `-Xss` override.
- Full `:formver.compiler-plugin:test` is green.

## Out of scope (flagged in commit bodies for whoever picks up next)

- Function calls within the body that consume a unique receiver (`@Unique` argument elsewhere) — needs facts-at-call-site to fold-before-call and drop the receiver from the unfolded set.
- `@Unique val` locals (non-parameter) — still on the per-access unfold/fold path; works for ≤2 accesses.
- Multi-step hierarchy in the unique-receiver predicate path — `emitUniqueReceiverFieldRead/Write` punt to havoc when the field's containing class isn't the receiver type itself.
- Constructor postcondition that establishes `bf$v == par$v` for primary-constructor field initializers — orthogonal to read-stability.
- Throw-on-first-violation in `UniquenessGraphChecker` — orthogonal smell.
- Promoting the existing `failing-tests/{binary_tree,linked_list}.kt` to positive tests — needs the `@Unique val`-local case (gap 2 above) plus a `// CHECK_UNIQUENESS` directive.

## Test plan

- [ ] `./gradlew :formver.compiler-plugin:test` passes
- [ ] `./gradlew publishToMavenLocal` succeeds
- [ ] `./gradlew compileKotlin` from a downstream Gradle project that sets `formver { checkUniqueness(true) }` and exercises a `@Unique` parameter with a `var` field passes verification at default JVM stack size
- [ ] Functions with `@Unique` parameters that *don't* access fields produce byte-identical Viper output to the previous baseline