### PR TITLE
Support reference equality (=== and !==)

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -194,6 +194,8 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         return when (equalityOperatorCall.operation) {
             FirOperation.EQ -> convertEqCmp(left, right)
             FirOperation.NOT_EQ -> Not(convertEqCmp(left, right))
+            FirOperation.IDENTITY -> IdentityCmp(left, right)
+            FirOperation.NOT_IDENTITY -> Not(IdentityCmp(left, right))
             else -> handleUnimplementedElement(
                 equalityOperatorCall.source,
                 "Equality comparison operation ${equalityOperatorCall.operation} not yet implemented.",

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
@@ -34,6 +34,7 @@ interface ExpVisitor<R> {
     fun visitDeclare(e: Declare): R
     fun visitEqCmp(e: EqCmp): R
     fun visitNeCmp(e: NeCmp): R
+    fun visitIdentityCmp(e: IdentityCmp): R
     fun visitBinaryOperatorExpEmbedding(e: BinaryOperatorExpEmbedding): R
     fun visitSequentialAnd(e: SequentialAnd): R
     fun visitSequentialOr(e: SequentialOr): R
@@ -94,6 +95,7 @@ interface DefaultingExpVisitor<R> : ExpVisitor<R> {
     override fun visitDeclare(e: Declare): R = visitDefault(e)
     override fun visitEqCmp(e: EqCmp): R = visitDefault(e)
     override fun visitNeCmp(e: NeCmp): R = visitDefault(e)
+    override fun visitIdentityCmp(e: IdentityCmp): R = visitDefault(e)
     override fun visitBinaryOperatorExpEmbedding(e: BinaryOperatorExpEmbedding): R = visitDefault(e)
     override fun visitSequentialAnd(e: SequentialAnd): R = visitDefault(e)
     override fun visitSequentialOr(e: SequentialOr): R = visitDefault(e)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
@@ -43,4 +43,24 @@ data class NeCmp(
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitNeCmp(this)
 }
 
+/**
+ * Reference equality (Kotlin `===`).
+ *
+ * Unlike [EqCmp], this never unwraps to a builtin type — operands are compared
+ * as Viper `Ref`s, so two distinct boxed values are not identified even when
+ * their unwrapped representations match.
+ */
+data class IdentityCmp(
+    val left: ExpEmbedding,
+    val right: ExpEmbedding,
+    override val sourceRole: SourceRole? = null,
+) : ExpEmbedding {
+    override val type
+        get() = buildType { boolean() }
+
+    override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
+
+    override fun <R> accept(v: ExpVisitor<R>): R = v.visitIdentityCmp(this)
+}
+
 fun ExpEmbedding.notNullCmp(): ExpEmbedding = NeCmp(this, NullLit)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
@@ -21,6 +21,10 @@ sealed interface AnyComparisonExpression : ExpEmbedding {
 
     val comparisonOperation: Operator
 
+    /** Whether to compare the operands at their builtin type; they are compared as `Ref`s otherwise. */
+    val comparesUnwrapped: Boolean
+        get() = left.type == right.type
+
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
 }
 
@@ -43,23 +47,14 @@ data class NeCmp(
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitNeCmp(this)
 }
 
-/**
- * Reference equality (Kotlin `===`).
- *
- * Unlike [EqCmp], this never unwraps to a builtin type — operands are compared
- * as Viper `Ref`s, so two distinct boxed values are not identified even when
- * their unwrapped representations match.
- */
+/** Kotlin reference equality (`===`). */
 data class IdentityCmp(
-    val left: ExpEmbedding,
-    val right: ExpEmbedding,
+    override val left: ExpEmbedding,
+    override val right: ExpEmbedding,
     override val sourceRole: SourceRole? = null,
-) : ExpEmbedding {
-    override val type
-        get() = buildType { boolean() }
-
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
-
+) : AnyComparisonExpression {
+    override val comparisonOperation = EqAny
+    override val comparesUnwrapped = false
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitIdentityCmp(this)
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
-import org.jetbrains.kotlin.formver.viper.ast.EqAny
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toConjunction
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
@@ -347,22 +346,7 @@ data class LinearizationVisitor(
     override fun visitEqCmp(e: EqCmp): Linearizable = comparisonLinearizable(e)
     override fun visitNeCmp(e: NeCmp): Linearizable = comparisonLinearizable(e)
 
-    override fun visitIdentityCmp(e: IdentityCmp): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
-        override fun toViper(ctx: LinearizationContext): Exp =
-            RuntimeTypeDomain.boolInjection.toRef(
-                toViperBuiltinType(ctx),
-                pos = ctx.source.asPosition,
-                info = e.sourceRole.asInfo
-            )
-
-        override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
-            EqAny(
-                e.left.linearize().toViper(ctx),
-                e.right.linearize().toViper(ctx),
-                pos = ctx.source.asPosition,
-                info = e.sourceRole.asInfo
-            )
-    }
+    override fun visitIdentityCmp(e: IdentityCmp): Linearizable = comparisonLinearizable(e)
 
     private fun comparisonLinearizable(e: AnyComparisonExpression): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
         override fun toViper(ctx: LinearizationContext): Exp =
@@ -372,20 +356,16 @@ data class LinearizationVisitor(
                 info = e.sourceRole.asInfo
             )
 
-        override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
-            if (e.left.type == e.right.type)
-                e.comparisonOperation(
-                    e.left.linearize().toViperBuiltinType(ctx),
-                    e.right.linearize().toViperBuiltinType(ctx),
-                    pos = ctx.source.asPosition,
-                    info = e.sourceRole.asInfo
-                )
-            else e.comparisonOperation(
-                e.left.linearize().toViper(ctx),
-                e.right.linearize().toViper(ctx),
+        override fun toViperBuiltinType(ctx: LinearizationContext): Exp {
+            fun ExpEmbedding.operand(): Exp =
+                if (e.comparesUnwrapped) linearize().toViperBuiltinType(ctx) else linearize().toViper(ctx)
+            return e.comparisonOperation(
+                e.left.operand(),
+                e.right.operand(),
                 pos = ctx.source.asPosition,
                 info = e.sourceRole.asInfo
             )
+        }
     }
 
     // endregion

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
+import org.jetbrains.kotlin.formver.viper.ast.EqAny
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toConjunction
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
@@ -345,6 +346,23 @@ data class LinearizationVisitor(
 
     override fun visitEqCmp(e: EqCmp): Linearizable = comparisonLinearizable(e)
     override fun visitNeCmp(e: NeCmp): Linearizable = comparisonLinearizable(e)
+
+    override fun visitIdentityCmp(e: IdentityCmp): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
+        override fun toViper(ctx: LinearizationContext): Exp =
+            RuntimeTypeDomain.boolInjection.toRef(
+                toViperBuiltinType(ctx),
+                pos = ctx.source.asPosition,
+                info = e.sourceRole.asInfo
+            )
+
+        override fun toViperBuiltinType(ctx: LinearizationContext): Exp =
+            EqAny(
+                e.left.linearize().toViper(ctx),
+                e.right.linearize().toViper(ctx),
+                pos = ctx.source.asPosition,
+                info = e.sourceRole.asInfo
+            )
+    }
 
     private fun comparisonLinearizable(e: AnyComparisonExpression): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
         override fun toViper(ctx: LinearizationContext): Exp =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
@@ -34,6 +34,7 @@ internal class ExprPurityVisitor(val declaredVariables: MutableSet<VariableEmbed
     override fun visitSequentialOr(e: SequentialOr) = e.allChildrenPure(this)
     override fun visitEqCmp(e: EqCmp) = e.allChildrenPure(this)
     override fun visitNeCmp(e: NeCmp) = e.allChildrenPure(this)
+    override fun visitIdentityCmp(e: IdentityCmp) = e.allChildrenPure(this)
     override fun visitUnaryOperatorExpEmbedding(e: UnaryOperatorExpEmbedding) = e.allChildrenPure(this)
     override fun visitWithPosition(e: WithPosition) = e.allChildrenPure(this)
     override fun visitInjectionBasedExpEmbedding(e: InjectionBasedExpEmbedding) = e.allChildrenPure(this)

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -710,6 +710,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("identity_equality.kt")
+      public void testIdentity_equality() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/operators/identity_equality.kt");
+      }
+
+      @Test
       @TestMetadata("safe_call.kt")
       public void testSafe_call() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/operators/safe_call.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/operators/identity_equality.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/operators/identity_equality.fir.diag.txt
@@ -1,0 +1,41 @@
+/identity_equality.kt: info: Generated Viper text for identity:
+method identity(x: Ref, y: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), C())
+  requires isSubtype(typeOf(y), C())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+{
+  v_ret_0 := boolToRef(x == y)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/identity_equality.kt: info: Generated Viper text for nonIdentity:
+method nonIdentity(x: Ref, y: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), C())
+  requires isSubtype(typeOf(y), C())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+{
+  v_ret_0 := notBool(boolToRef(x == y))
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/identity_equality.kt: info: Generated Viper text for identityWithNull:
+method identityWithNull(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), nullable(C()))
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+{
+  v_ret_0 := boolToRef(x == nullValue())
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/identity_equality.kt: info: Generated Viper text for nonIdentityWithNull:
+method nonIdentityWithNull(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), nullable(C()))
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+{
+  v_ret_0 := notBool(boolToRef(x == nullValue()))
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/operators/identity_equality.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/operators/identity_equality.kt
@@ -1,0 +1,20 @@
+// FULL_JDK
+// NEVER_VALIDATE
+
+class C
+
+fun <!VIPER_TEXT!>identity<!>(x: C, y: C): Boolean {
+    return x === y
+}
+
+fun <!VIPER_TEXT!>nonIdentity<!>(x: C, y: C): Boolean {
+    return x !== y
+}
+
+fun <!VIPER_TEXT!>identityWithNull<!>(x: C?): Boolean {
+    return x === null
+}
+
+fun <!VIPER_TEXT!>nonIdentityWithNull<!>(x: C?): Boolean {
+    return x !== null
+}


### PR DESCRIPTION
## Summary
- Adds an `IdentityCmp` expression embedding that linearizes to Viper `Ref` equality without unwrapping operands to their builtin type.
- Wires `FirOperation.IDENTITY` and `NOT_IDENTITY` in `StmtConversionVisitor`, alongside the existing `EQ` / `NOT_EQ` cases.
- New conversion-only test `operators/identity_equality.kt` covering object/object and object/null forms.

## Why a separate embedding rather than reusing `EqCmp`
`EqCmp` linearizes to a comparison on the *builtin* type when both operands match — fine for `==`, wrong for `===`. Even where they happen to coincide today, `convertEqCmp` carries a TODO to dispatch through `.equals()`; once that lands, `===` must remain raw `Ref` equality. Keeping the two embeddings distinct preserves that.

## Test plan
- [x] `./gradlew :formver.compiler-plugin:test` — full suite green
- [x] New goldens for `identity_equality.kt` show `boolToRef(x == y)` for `===` and `notBool(...)` for `!==`, with `nullValue()` on the null side