### PR TITLE
Reduce SimpleNameResolver to rendering the last candidate

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -26,32 +26,44 @@ fun CandidateName.name(): String = parts.joinToString("") { it.name() }
 
 
 /**
- * Gives the most specific name.
+ * The fully-disambiguated form of a name, rendered as a valid Viper
+ * identifier. Distinct from [debugId], which adds readability decorations
+ * that aren't valid in Viper identifiers.
+ *
+ * Use this when a resolver needs a guaranteed-unique name without doing
+ * collision resolution (see [SimpleNameResolver]).
  */
-fun NamePart.fullName(): String = when (this) {
-    is NamePart.Dependent -> fullName()
-    is NamePart.Basic -> this.name
+private fun NamePart.longName(): String = when (this) {
+    is NamePart.Dependent -> name.longName()
+    is NamePart.Basic -> name
     NamePart.Separator -> SEPARATOR
 }
 
-/**
- * Gives the most specific name.
- */
-fun NamePart.Dependent.fullName(): String = name.candidates().last().fullName()
+private fun CandidateName.longName(): String = parts.joinToString("") { it.longName() }
+
+fun AnyName.longName(): String = candidates().last().longName()
+
 
 /**
- * Gives the most specific name.
+ * Debug rendering of a name. Same structure as [longName] but wraps
+ * multi-part dependent candidates in `[…]` for readability.
+ *
+ * The result is not a valid Viper identifier and is intended for
+ * debug/dump output only.
  */
-fun CandidateName.fullName(): String = if (parts.size > 1) {
-    "[" + parts.joinToString("") { it.fullName() } + "]"
-} else {
-    parts.joinToString("") { it.fullName() }
+private fun NamePart.debugId(): String = when (this) {
+    is NamePart.Dependent -> name.debugId()
+    is NamePart.Basic -> name
+    NamePart.Separator -> SEPARATOR
 }
 
-/**
- * Gives the most specific name.
- */
-fun AnyName.fullName(): String = candidates().last().fullName()
+private fun CandidateName.debugId(): String = if (parts.size > 1) {
+    "[" + parts.joinToString("") { it.debugId() } + "]"
+} else {
+    parts.joinToString("") { it.debugId() }
+}
+
+fun AnyName.debugId(): String = candidates().last().debugId()
 
 
 // END UTILITY SECTION
@@ -100,9 +112,9 @@ class ShortNameResolver : NameResolver {
 
     // START RESOLVE NAMES
     override fun lookup(name: SymbolicName): String = mangledNames.getOrElse(name) {
-        // The name.fullName() contains characters which are not allowed in viper. This should only happen when we dump the ExpEmbedding, which can contain
+        // The name.debugId() contains characters which are not allowed in viper. This should only happen when we dump the ExpEmbedding, which can contain
         // entities that the final program does not.
-        name.fullName()
+        name.debugId()
     }
 
     internal fun current(entity: AnyName): String {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/SimpleNameResolver.kt
@@ -1,226 +1,28 @@
 package org.jetbrains.kotlin.formver.names
 
-import org.jetbrains.kotlin.formver.common.SnaktInternalException
-import org.jetbrains.kotlin.formver.core.embeddings.types.FunctionTypeEmbedding
-import org.jetbrains.kotlin.formver.core.names.*
-import org.jetbrains.kotlin.formver.viper.*
+import org.jetbrains.kotlin.formver.core.names.longName
+import org.jetbrains.kotlin.formver.viper.AnyName
+import org.jetbrains.kotlin.formver.viper.NameResolver
+import org.jetbrains.kotlin.formver.viper.SymbolicName
 
 /**
- * Resolves mangled names into Viper identifiers while maintaining uniqueness.
+ * Resolver that gives every name its fully-disambiguated form, without
+ * any collision tracking.
  *
- * Current strategy (simplified, will be extended later):
- *  1. Concatenate all non-null components (type, scope, baseName) with SEPARATOR.
- *
- * Future strategy:
- *  1. Try to use a short name: <type>_<baseName>.
- *  2. If the short name is reserved or conflicts with an existing name of the same type, fall back to a long name:
- *     <type>_<scope>_<baseName>.
- *  3. Track used names to detect conflicts for future resolutions.
+ * Used as a fallback / debug resolver. See
+ * [org.jetbrains.kotlin.formver.core.names.ShortNameResolver] for the
+ * collision-aware version.
  */
 class SimpleNameResolver : NameResolver {
 
     val cache = mutableMapOf<AnyName, String>()
 
-    enum class NameTypeAction {
-        SHOW,
-        SKIP;
-
-        fun show() = this == SHOW
-    }
-    companion object {
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveParts(
-            name: AnyName
-        ): List<String> = when (name) {
-            is NameScope -> resolveNameScope(name)
-            is SymbolicName -> resolveSymbolicName(name)
-            is NameType -> if (nameTypeAction.show()) listOf(resolveNameType(name)) else emptyList()
-
-            else -> throw SnaktInternalException(null, "Unexpected name type: ${name::class.simpleName}")
-        }
-
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveOptionalNameScope(name: NameScope?): List<String> =
-            if (name == null) emptyList() else resolveNameScope(name)
-
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveNameScope(
-            name: NameScope
-        ): List<String> {
-
-            // Since every public field with the same name should be matched to the same string, we should not add the
-            // parent scope (which is the class, making it non-unique)
-            val parentScopes = if (name !is PublicScope) {
-                resolveOptionalNameScope(name.parent)
-            } else {
-                emptyList()
-            }
-            val scope = when (name) {
-                is BadScope -> throw SnaktInternalException(null, "BadScope should never be resolved")
-                is ClassScope -> resolveParts(name.className)
-                is FakeScope -> emptyList()
-                is LocalScope -> listOf("l${name.level}")
-                is PackageScope -> {
-                    if (name.packageName.isRoot) {
-                        emptyList()
-                    } else {
-                        listOf($$"pkg$$${name.packageName.asViperString()}")
-                    }
-                }
-
-                is ParameterScope -> listOf("par")
-                is PrivateScope -> listOf("private")
-                is PublicScope -> listOf("public")
-            }
-            return parentScopes + scope
-        }
-
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveSymbolicName(
-            name: SymbolicName
-        ): List<String> = when (name) {
-            is FreshName -> resolveFreshName(name)
-            is KotlinName -> resolveKotlinName(name)
-            is ScopedName -> listOfNotNull(resolveOptionalNameType(name.nameType)) + resolveParts(
-                name.scope
-            ) + with(if (name.nameType == name.name.nameType) NameTypeAction.SKIP else nameTypeAction) {
-                resolveParts(
-                    name.name
-                )
-            }
-
-            is DomainName -> resolveParts(name.nameType) + listOf(name.baseName)
-            is NamedDomainAxiomLabel -> with(NameTypeAction.SKIP) { resolveParts(name.domainName) } + listOf(name.baseName)
-            is QualifiedDomainFuncName -> resolveParts(name.nameType) + with(NameTypeAction.SKIP) {
-                resolveParts(
-                    name.domainName
-                )
-            } + resolveParts(name.funcName)
-
-            is UnqualifiedDomainFuncName -> listOf(name.baseName)
-            is ListOfNames<*> -> name.names.flatMap { resolveParts(it) }
-            is FunctionTypeName -> with(NameTypeAction.SHOW) {
-                resolveParts(
-                    name.args
-                ) + resolveParts(
-                    name.returns
-                )
-            }
-
-            is PretypeName -> listOf(name.name)
-            is AdtName -> resolveParts(name.nameType) + resolveParts(name.className)
-            is ToRefFuncName -> resolveParts(name.baseName) + listOf("ToRef")
-            is FromRefFuncName -> resolveParts(name.baseName) + listOf("FromRef")
-            is AdtConstructorName -> resolveParts(name.nameType) +
-                    with(NameTypeAction.SKIP) { resolveParts(name.adtName) } +
-                    resolveParts(name.className)
-            is TypeName -> resolveParts(name.nameType) + listOfNotNull(buildString {
-                if (name.nullable) append("N")
-                if (name.pretype is FunctionTypeEmbedding) append("F")
-            }.ifEmpty { null }) + with(NameTypeAction.SKIP) { resolveParts(name.pretype.name) }
-
-            else -> throw SnaktInternalException(null, "Unexpected name type: ${name::class.simpleName}")
-        }
-
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveFreshName(name: FreshName): List<String> {
-            val typeParts =
-                name.nameType.takeIf { it != NameType.Base.Variable }.let { resolveOptionalNameType(it) }
-            val nameParts = when (name) {
-                is NumberedName -> resolveNumberedName(name)
-                is PredicateName -> listOf(name.name)
-                DispatchReceiverName -> listOf("this", "dispatch")
-                is DomainAssociatedFuncName -> listOf(name.name)
-                is DomainFuncParameterName -> listOf(name.name)
-                ExtensionReceiverName -> listOf("this", "extension")
-                is HavocName -> resolveParts(name.type.name)
-                PlaceholderReturnVariableName -> listOf("ret")
-                is SpecialFieldName -> listOf(name.name)
-            }
-            return listOfNotNull(typeParts) + nameParts
-        }
-
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveNumberedName(name: NumberedName): List<String> = when (name) {
-            is AnonymousBuiltinName -> listOf("anon", "builtin")
-            is AnonymousName -> listOf("anon")
-            is LabelName -> when (name) {
-                is BreakLabelName -> listOf("break")
-                is CatchLabelName -> listOf("catch")
-                is ContinueLabelName -> listOf("cont")
-                is ReturnLabelName -> listOf("ret")
-                is TryExitLabelName -> listOf("tryExit")
-            }
-
-            is PlaceholderArgumentName -> listOf("arg")
-            is ReturnVariableName -> listOf("ret")
-            is SsaVariableName -> resolveParts(name.baseName)
-        } + listOf(name.n.toString())
-
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveKotlinName(name: KotlinName): List<String> = when (name) {
-            is ClassKotlinName -> resolveParts(name.nameType) + listOf(name.name.asViperString())
-            is ConstructorKotlinName -> resolveParts(name.nameType) + resolveParts(name.type.name)
-            is SimpleKotlinName -> listOf(name.name.asStringStripSpecialMarkers())
-            is TypedKotlinName -> resolveParts(
-                name.nameType
-            ) + listOf(name.name.asStringStripSpecialMarkers())
-
-            is TypedKotlinNameWithType -> resolveParts(
-                name.nameType
-            ) + listOf(name.name.asStringStripSpecialMarkers()) + resolveParts(name.type.name)
-        }
-
-        context(nameTypeAction: NameTypeAction)
-        private fun resolveOptionalNameType(name: NameTypeBase?): String? =
-            if (name == null || !nameTypeAction.show()) null else {
-                resolveNameType(name)
-            }
-
-        private fun resolveNameType(name: NameTypeBase): String = when (name) {
-            NameType.Member.Property -> "p"
-            NameType.Member.BackingField -> "bf"
-            NameType.Member.Getter -> "g"
-            NameType.Member.Setter -> "s"
-            NameType.Member.ExtensionSetter -> "es"
-            NameType.Member.ExtensionGetter -> "eg"
-            NameType.TypeCategory.GeneralType -> "t"
-            NameType.TypeCategory.Class -> "c"
-            NameType.Base.Constructor -> "con"
-            NameType.Base.Function -> "f"
-            NameType.Base.Predicate -> "pred"
-            NameType.Base.Havoc -> "havoc"
-            NameType.Base.Label -> "lbl"
-            NameType.Base.Variable -> "v"
-            NameType.Base.Domain -> "d"
-            NameType.Base.DomainFunction -> "df"
-            NameType.Base.Adt -> "adt"
-            NameType.Base.AdtCons -> "constr"
-            is NameTypeBase -> throw SnaktInternalException(
-                null, "NameTypeBase should never been inherited by something else than NameType"
-            )
-        }
-
-        fun debugResolve(name: SymbolicName): String = with(NameTypeAction.SHOW) {
-            resolveParts(name).joinToString(SEPARATOR)
-        }
-    }
-
-    override fun lookup(name: SymbolicName): String = cache.getOrPut(
-        name
-    ) {
-        with(NameTypeAction.SHOW) {
-            resolveParts(name).joinToString(SEPARATOR)
-        }
-    }
+    override fun lookup(name: SymbolicName): String = cache.getOrPut(name) { name.longName() }
 
     override fun resolve() {}
 
     override fun register(name: AnyName) {}
 }
 
-
 val SymbolicName.debugMangled: String
-    get() {
-        return SimpleNameResolver.debugResolve(this)
-    }
+    get() = longName()

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/debug/NameGraphRenderer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/debug/NameGraphRenderer.kt
@@ -137,8 +137,9 @@ class NameGraphRenderer(val shortNameResolver: ShortNameResolver) {
             is NameScope -> "Scope: "
             is NameType -> "Type: "
             is SymbolicName -> {
-                if (entity.nameType != null) {
-                    entity.nameType!!.fullName() + ": "
+                val nameType = entity.nameType
+                if (nameType != null) {
+                    nameType.debugId() + ": "
                 } else {
                     when (entity) {
                         is FreshName -> "Fresh: "
@@ -160,7 +161,7 @@ class NameGraphRenderer(val shortNameResolver: ShortNameResolver) {
 
             is ViperKeyword -> "Viper Keyword: "
             else -> throw SnaktInternalException(null, "Unsupported entity type: ${entity.javaClass.name}")
-        } + entity.fullName() + nl + nodeLabel(entity)
+        } + entity.debugId() + nl + nodeLabel(entity)
 
 
         fun relationLabel(relation: Relation) = when (relation) {


### PR DESCRIPTION
## Summary
- `SimpleNameResolver` reimplemented all of name decomposition (scope walking, `FreshName` cases, `KotlinName` cases, `NameTypeAction` context, etc.) just to produce a single string. Since every `AnyName` exposes a `candidates` list ordered shortest-to-fullest, rendering the last one already gives a fully-disambiguated name. That is all `SimpleNameResolver` was reconstructing by hand.
- Split the existing helper in `ShortNameResolver.kt`:
  - `fullName()` is renamed to `debugId()`. Behaviour unchanged: wraps multi-part dependent candidates in `[…]`, which is not a valid Viper identifier. Used by `NameGraphRenderer` and by `ShortNameResolver`'s unresolved-name fallback.
  - `longName()` is new. Same recursive descent without the bracketing, so the result is a valid Viper identifier.
- `SimpleNameResolver.lookup` and `SymbolicName.debugMangled` now call `longName()` directly. The 200-line companion object goes away.

## Test plan
- [x] `./gradlew :formver.compiler-plugin:test` passes
- [x] `./gradlew :formver.compiler-plugin:update` produces no fixture deltas, which confirms that `SimpleNameResolver` only feeds debug paths (`ToViperBuiltinOnlyError`, `PureExpLinearizer.catchNameResolver`, `debugMangled`) and that `ShortNameResolver` continues to own the real output.