### PR TITLE
Clean up the names package

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/DomainName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/DomainName.kt
@@ -72,7 +72,7 @@ data class FromRefFuncName(val baseName: SymbolicName) : SymbolicName {
 data class NamedDomainAxiomLabel(val domainName: SymbolicName, val baseName: String) : SymbolicName {
     override val inViper: Boolean = true
 
-    override val candidates: List<CandidateName> = nameWithDependentPrefixCandidates(baseName, domainName)
+    override val candidates: List<CandidateName> = nameWithPrefixCandidates(baseName, domainName)
 
     override val children: List<AnyName> = listOf(domainName)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
@@ -129,31 +129,21 @@ data class SpecialFieldName(val name: String) : FreshName {
     override val children: List<AnyName> = listOf(nameType)
 }
 
-sealed class LabelName(override val n: Int) : NumberedName {
+sealed class LabelName(val labelString: String) : NumberedName {
     override val nameType: NameType = NameType.Base.Label
     override val inViper: Boolean = true
 
     override val candidates: List<CandidateName>
-        get() {
-            val name = when (this) {
-                is BreakLabelName -> "break"
-                is CatchLabelName -> "catch"
-                is ContinueLabelName -> "cont"
-                is ReturnLabelName -> "ret"
-                is TryExitLabelName -> "tryExit"
-            }
-            return nameWithPrefixAndSuffixCandidates(name, nameType, n.toString())
-        }
+        get() = nameWithPrefixAndSuffixCandidates(labelString, nameType, n.toString())
 
-    override val children: List<AnyName>
-        get() = listOf(nameType)
+    override val children: List<AnyName> = listOf(nameType)
 }
 
-data class ReturnLabelName(override val n: Int) : LabelName(n)
-data class BreakLabelName(override val n: Int) : LabelName(n)
-data class ContinueLabelName(override val n: Int) : LabelName(n)
-data class CatchLabelName(override val n: Int) : LabelName(n)
-data class TryExitLabelName(override val n: Int) : LabelName(n)
+data class ReturnLabelName(override val n: Int) : LabelName("ret")
+data class BreakLabelName(override val n: Int) : LabelName("break")
+data class ContinueLabelName(override val n: Int) : LabelName("cont")
+data class CatchLabelName(override val n: Int) : LabelName("catch")
+data class TryExitLabelName(override val n: Int) : LabelName("tryExit")
 
 
 data class DomainAssociatedFuncName(val name: String) : FreshName {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameCandidate.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameCandidate.kt
@@ -23,20 +23,11 @@ fun nameWithPrefixAndSuffixCandidates(name: String, nameType: AnyName, suffix: S
         }
     }
 
-fun nameWithPrefixCandidates(name: String, nameType: AnyName): List<CandidateName> =
+fun nameWithPrefixCandidates(name: String, prefix: AnyName): List<CandidateName> =
     buildCandidates {
         candidate {
             +name
         }
-        candidate {
-            +nameType
-            +name
-        }
-    }
-
-fun nameWithDependentPrefixCandidates(name: String, prefix: AnyName): List<CandidateName> =
-    buildCandidates {
-        candidate { +name }
         candidate {
             +prefix
             +name
@@ -51,5 +42,3 @@ fun nameWithDependentPrefixCandidates(name: AnyName, prefix: AnyName): List<Cand
             +name
         }
     }
-
-fun AnyName.candidates(): List<CandidateName> = candidates

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/NameScope.kt
@@ -65,7 +65,7 @@ data object PublicScope : NameScope {
 }
 
 data class PrivateScope(override val parent: NameScope) : NameScope {
-    override val candidates: List<CandidateName> = nameWithDependentPrefixCandidates("private", parent)
+    override val candidates: List<CandidateName> = nameWithPrefixCandidates("private", parent)
     override val children: List<AnyName> = listOf(parent)
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedNameBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ScopedNameBuilder.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlin.formver.core.names
 
 import org.jetbrains.kotlin.name.FqName
 
-class ScopeBuilder {
+open class ScopeBuilder {
     private var scope: NameScope? = null
 
     fun complete(): NameScope {
@@ -62,31 +62,8 @@ class ScopeBuilder {
 }
 
 
-class ScopedNameBuilder {
-    private val scopeBuilder = ScopeBuilder()
-
-    fun complete(name: KotlinName): ScopedName {
-        val scope = scopeBuilder.complete()
-        return ScopedName(scope, name)
-    }
-
-    fun packageScope(packageName: FqName) = scopeBuilder.packageScope(packageName)
-
-    fun packageScope(packageName: List<String>) = scopeBuilder.packageScope(packageName)
-    fun classScope(className: ClassKotlinName) = scopeBuilder.classScope(className)
-
-    fun publicScope() = scopeBuilder.publicScope()
-
-    fun privateScope() = scopeBuilder.privateScope()
-
-
-    fun parameterScope() = scopeBuilder.parameterScope()
-
-    fun localScope(level: Int) = scopeBuilder.localScope(level)
-
-    fun badScope() = scopeBuilder.badScope()
-
-    fun fakeScope() = scopeBuilder.fakeScope()
+class ScopedNameBuilder : ScopeBuilder() {
+    fun complete(name: KotlinName): ScopedName = ScopedName(complete(), name)
 }
 
 // TODO: generalise this to work for all names.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ShortNameResolver.kt
@@ -41,7 +41,7 @@ private fun NamePart.longName(): String = when (this) {
 
 private fun CandidateName.longName(): String = parts.joinToString("") { it.longName() }
 
-fun AnyName.longName(): String = candidates().last().longName()
+fun AnyName.longName(): String = candidates.last().longName()
 
 
 /**
@@ -63,7 +63,7 @@ private fun CandidateName.debugId(): String = if (parts.size > 1) {
     parts.joinToString("") { it.debugId() }
 }
 
-fun AnyName.debugId(): String = candidates().last().debugId()
+fun AnyName.debugId(): String = candidates.last().debugId()
 
 
 // END UTILITY SECTION
@@ -123,17 +123,17 @@ class ShortNameResolver : NameResolver {
 
     private fun currentCandidate(name: AnyName): CandidateName {
         val index = currentCandidate.getOrPut(name) { 0 }
-        return name.candidates()[index]
+        return name.candidates[index]
     }
 
     private fun nextCandidate(name: AnyName): CandidateName {
         val index = currentCandidate.getOrPut(name) { 0 }
-        return name.candidates()[index + 1]
+        return name.candidates[index + 1]
     }
 
     private fun hasNextCandidate(name: AnyName): Boolean {
         val currentIndex = currentCandidate[name] ?: 0
-        return currentIndex + 1 < name.candidates().size
+        return currentIndex + 1 < name.candidates.size
     }
     // END RESOLVE NAMES
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/debug/NameGraphRenderer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/debug/NameGraphRenderer.kt
@@ -106,7 +106,7 @@ class NameGraphRenderer(val shortNameResolver: ShortNameResolver) {
             }
         }
 
-        fun candidates(entity: AnyName): String = entity.candidates().joinToString(nl) { candidateNameTemplate(it) }
+        fun candidates(entity: AnyName): String = entity.candidates.joinToString(nl) { candidateNameTemplate(it) }
 
         fun id(entity: AnyName): String {
             val hashCode = entity.hashCode() + entity::class.qualifiedName.hashCode()


### PR DESCRIPTION
## Summary
A handful of small dedupe/dead-code passes in the names package. None of them
change Viper output (no test fixtures regenerate):

- Delete the `AnyName.candidates()` wrapper, which only returned the
  `candidates` property. Switch the five call sites in `ShortNameResolver`
  and `NameGraphRenderer` to the property directly.
- Drop `nameWithDependentPrefixCandidates(String, AnyName)` — its body
  was byte-identical to `nameWithPrefixCandidates(String, AnyName)`. Move
  its two call sites (`PrivateScope`, `NamedDomainAxiomLabel`) over and
  rename the surviving helper's second parameter from `nameType` to
  `prefix`, since it now spans both `NameType` and `NameScope` prefixes.
- Make `ScopedNameBuilder` extend `ScopeBuilder` instead of wrapping it.
  Removes 8 forwarder methods.
- Replace the `when (this)` block in `LabelName` with a `labelString`
  constructor parameter. The five subclasses stay so that
  `SimpleFreshEntityProducer<CatchLabelName>` and the `::CatchLabelName`
  constructor references continue to typecheck.

Net: −44 lines.

## Test plan
- [x] `./gradlew :formver.compiler-plugin:core:compileKotlin` — green
- [x] `./gradlew :formver.compiler-plugin:test` — green (no fixture diffs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)