### PR TITLE
Split function-body conversion into convert and linearize phases

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
@@ -12,8 +12,12 @@ import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
 /**
- * The output of converting an impure (method-style) function body: the `FunctionExp` wrap built
- * during conversion, together with the `ReturnTarget` it was converted against.
+ * The output of converting an impure (method-style) function body.
+ *
+ * The [returnTarget] is preserved alongside [bodyExp] because linearization needs to attach a
+ * Unit invariant to the return variable when the function returns Unit and the body has no
+ * explicit `return`. The body alone does not expose that variable, so conversion has to hand
+ * it off explicitly.
  */
 data class ConvertedMethodBody(
     val bodyExp: FunctionExp,

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
@@ -5,11 +5,11 @@
 
 package org.jetbrains.kotlin.formver.core.conversion
 
-import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.FunctionExp
 import org.jetbrains.kotlin.formver.viper.SymbolicName
-import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Function
+import org.jetbrains.kotlin.formver.viper.ast.Method
 
 /**
  * The output of converting an impure (method-style) function body.
@@ -55,22 +55,24 @@ class ConvertedBodyResolver {
 }
 
 /**
- * Stores per-function Viper outputs from the linearization phase, keyed by symbolic name.
+ * Stores the finalized Viper [Method] / [Function] for each user-defined or partially-special callable,
+ * keyed by symbolic name. Populated by `linearizeAll` so that `buildProgram` reduces to concatenation.
  *
- * Each entry is written at most once; storing under a name that already has an entry is an error.
+ * Iteration order over [methods] / [functions] reflects insertion order, which is the order the
+ * `ProgramConverter` emits.
  */
 class LinearizedBodyResolver {
-    private val impure: MutableMap<SymbolicName, FunctionBodyEmbedding> = mutableMapOf()
-    private val pure: MutableMap<SymbolicName, Exp> = mutableMapOf()
+    private val methodsByName: MutableMap<SymbolicName, Method> = mutableMapOf()
+    private val functionsByName: MutableMap<SymbolicName, Function> = mutableMapOf()
 
-    fun storeImpure(name: SymbolicName, body: FunctionBodyEmbedding) {
-        check(impure.put(name, body) == null) { "Linearized method body for $name was already stored" }
+    fun storeMethod(name: SymbolicName, method: Method) {
+        check(methodsByName.put(name, method) == null) { "Linearized method for $name was already stored" }
     }
 
-    fun storePure(name: SymbolicName, body: Exp) {
-        check(pure.put(name, body) == null) { "Linearized function body for $name was already stored" }
+    fun storeFunction(name: SymbolicName, function: Function) {
+        check(functionsByName.put(name, function) == null) { "Linearized function for $name was already stored" }
     }
 
-    fun lookupImpure(name: SymbolicName): FunctionBodyEmbedding? = impure[name]
-    fun lookupPure(name: SymbolicName): Exp? = pure[name]
+    val methods: Collection<Method> get() = methodsByName.values
+    val functions: Collection<Function> get() = functionsByName.values
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.conversion
+
+import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.viper.SymbolicName
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+
+/**
+ * The output of converting an impure function body: the fully-built `ExpEmbedding` (typically a
+ * `FunctionExp` wrapping the body) together with the `ReturnTarget` it was converted against.
+ */
+data class ImpureConvertedBody(
+    val bodyExp: ExpEmbedding,
+    val returnTarget: ReturnTarget,
+)
+
+/**
+ * Stores per-function `ExpEmbedding` outputs from the conversion phase, keyed by symbolic name.
+ * Pure and impure functions live in separate maps so the value type can stay precise.
+ */
+class ConvertedBodyResolver {
+    private val impure: MutableMap<SymbolicName, ImpureConvertedBody> = mutableMapOf()
+    private val pure: MutableMap<SymbolicName, ExpEmbedding> = mutableMapOf()
+
+    fun storeImpure(name: SymbolicName, body: ImpureConvertedBody) {
+        impure[name] = body
+    }
+
+    fun storePure(name: SymbolicName, body: ExpEmbedding) {
+        pure[name] = body
+    }
+
+    fun lookupImpure(name: SymbolicName): ImpureConvertedBody? = impure[name]
+    fun lookupPure(name: SymbolicName): ExpEmbedding? = pure[name]
+
+    fun forEachImpure(action: (SymbolicName, ImpureConvertedBody) -> Unit) {
+        impure.forEach { (name, body) -> action(name, body) }
+    }
+
+    fun forEachPure(action: (SymbolicName, ExpEmbedding) -> Unit) {
+        pure.forEach { (name, body) -> action(name, body) }
+    }
+}
+
+/**
+ * Stores per-function Viper outputs from the linearization phase, keyed by symbolic name.
+ * Bodies that fail validity checks have no entry here.
+ */
+class LinearizedBodyResolver {
+    private val impure: MutableMap<SymbolicName, FunctionBodyEmbedding> = mutableMapOf()
+    private val pure: MutableMap<SymbolicName, Exp> = mutableMapOf()
+
+    fun storeImpure(name: SymbolicName, body: FunctionBodyEmbedding) {
+        impure[name] = body
+    }
+
+    fun storePure(name: SymbolicName, body: Exp) {
+        pure[name] = body
+    }
+
+    fun lookupImpure(name: SymbolicName): FunctionBodyEmbedding? = impure[name]
+    fun lookupPure(name: SymbolicName): Exp? = pure[name]
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/BodyResolvers.kt
@@ -7,38 +7,41 @@ package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.expression.FunctionExp
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 
 /**
- * The output of converting an impure function body: the fully-built `ExpEmbedding` (typically a
- * `FunctionExp` wrapping the body) together with the `ReturnTarget` it was converted against.
+ * The output of converting an impure (method-style) function body: the `FunctionExp` wrap built
+ * during conversion, together with the `ReturnTarget` it was converted against.
  */
-data class ImpureConvertedBody(
-    val bodyExp: ExpEmbedding,
+data class ConvertedMethodBody(
+    val bodyExp: FunctionExp,
     val returnTarget: ReturnTarget,
 )
 
 /**
  * Stores per-function `ExpEmbedding` outputs from the conversion phase, keyed by symbolic name.
  * Pure and impure functions live in separate maps so the value type can stay precise.
+ *
+ * Each entry is written at most once; storing under a name that already has an entry is an error.
  */
 class ConvertedBodyResolver {
-    private val impure: MutableMap<SymbolicName, ImpureConvertedBody> = mutableMapOf()
+    private val impure: MutableMap<SymbolicName, ConvertedMethodBody> = mutableMapOf()
     private val pure: MutableMap<SymbolicName, ExpEmbedding> = mutableMapOf()
 
-    fun storeImpure(name: SymbolicName, body: ImpureConvertedBody) {
-        impure[name] = body
+    fun storeImpure(name: SymbolicName, body: ConvertedMethodBody) {
+        check(impure.put(name, body) == null) { "Converted method body for $name was already stored" }
     }
 
     fun storePure(name: SymbolicName, body: ExpEmbedding) {
-        pure[name] = body
+        check(pure.put(name, body) == null) { "Converted function body for $name was already stored" }
     }
 
-    fun lookupImpure(name: SymbolicName): ImpureConvertedBody? = impure[name]
+    fun lookupImpure(name: SymbolicName): ConvertedMethodBody? = impure[name]
     fun lookupPure(name: SymbolicName): ExpEmbedding? = pure[name]
 
-    fun forEachImpure(action: (SymbolicName, ImpureConvertedBody) -> Unit) {
+    fun forEachImpure(action: (SymbolicName, ConvertedMethodBody) -> Unit) {
         impure.forEach { (name, body) -> action(name, body) }
     }
 
@@ -49,18 +52,19 @@ class ConvertedBodyResolver {
 
 /**
  * Stores per-function Viper outputs from the linearization phase, keyed by symbolic name.
- * Bodies that fail validity checks have no entry here.
+ *
+ * Each entry is written at most once; storing under a name that already has an entry is an error.
  */
 class LinearizedBodyResolver {
     private val impure: MutableMap<SymbolicName, FunctionBodyEmbedding> = mutableMapOf()
     private val pure: MutableMap<SymbolicName, Exp> = mutableMapOf()
 
     fun storeImpure(name: SymbolicName, body: FunctionBodyEmbedding) {
-        impure[name] = body
+        check(impure.put(name, body) == null) { "Linearized method body for $name was already stored" }
     }
 
     fun storePure(name: SymbolicName, body: Exp) {
-        pure[name] = body
+        check(pure.put(name, body) == null) { "Linearized function body for $name was already stored" }
     }
 
     fun lookupImpure(name: SymbolicName): FunctionBodyEmbedding? = impure[name]

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.common.ErrorCollector
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.core.embeddings.callables.PureUserFunctionEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousBuiltinVariableEmbedding
@@ -43,7 +42,7 @@ interface ProgramConversionContext {
     val convertedBodyResolver: ConvertedBodyResolver
     val linearizedBodyResolver: LinearizedBodyResolver
 
-    fun embedFunction(symbol: FirFunctionSymbol<*>): FunctionEmbedding
+    fun embedFunction(symbol: FirFunctionSymbol<*>): CallableEmbedding
     fun embedPureFunction(symbol: FirFunctionSymbol<*>): PureUserFunctionEmbedding
     fun embedAnyFunction(symbol: FirFunctionSymbol<*>): CallableEmbedding
     fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): Pair<ReturnTarget,FunctionSignature>

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionSignature
-import org.jetbrains.kotlin.formver.core.embeddings.callables.PureFunctionEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.callables.PureUserFunctionEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousBuiltinVariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.VariableEmbedding
@@ -44,7 +44,7 @@ interface ProgramConversionContext {
     val linearizedBodyResolver: LinearizedBodyResolver
 
     fun embedFunction(symbol: FirFunctionSymbol<*>): FunctionEmbedding
-    fun embedPureFunction(symbol: FirFunctionSymbol<*>): PureFunctionEmbedding
+    fun embedPureFunction(symbol: FirFunctionSymbol<*>): PureUserFunctionEmbedding
     fun embedAnyFunction(symbol: FirFunctionSymbol<*>): CallableEmbedding
     fun embedFunctionSignature(symbol: FirFunctionSymbol<*>): Pair<ReturnTarget,FunctionSignature>
     fun embedType(type: ConeKotlinType): TypeEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
@@ -40,6 +40,8 @@ interface ProgramConversionContext {
     val returnTargetProducer: FreshEntityProducer<ReturnTarget, TypeEmbedding>
     val nameResolver: NameResolver
     val typeResolver: TypeResolver
+    val convertedBodyResolver: ConvertedBodyResolver
+    val linearizedBodyResolver: LinearizedBodyResolver
 
     fun embedFunction(symbol: FirFunctionSymbol<*>): FunctionEmbedding
     fun embedPureFunction(symbol: FirFunctionSymbol<*>): PureFunctionEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -50,12 +50,10 @@ class ProgramConverter(
 
     override val typeResolver: TypeResolver = TypeResolver()
 
-    // Cast is valid since we check that values are not null. We specify the type for `filterValues` explicitly to ensure there's no
-    // loss of type information earlier.
-    @Suppress("UNCHECKED_CAST")
     val debugExpEmbeddings: Map<SymbolicName, ExpEmbedding>
-        get() = methods.mapValues { (it.value as? UserFunctionEmbedding)?.body?.debugExpEmbedding() }
-            .filterValues { value: ExpEmbedding? -> value != null } as Map<SymbolicName, ExpEmbedding>
+        get() = buildMap {
+            convertedBodyResolver.forEachImpure { name, body -> put(name, body.bodyExp) }
+        }
 
 
     override val whileIndexProducer = indexProducer()
@@ -68,6 +66,8 @@ class ProgramConverter(
     override val anonBuiltinVarProducer = FreshEntityProducer(::AnonymousBuiltinVariableEmbedding)
     override val returnTargetProducer = FreshEntityProducer(ReturnTarget::createForDepth)
     override val nameResolver = ShortNameResolver()
+    override val convertedBodyResolver = ConvertedBodyResolver()
+    override val linearizedBodyResolver = LinearizedBodyResolver()
 
 
     val program: Program
@@ -76,10 +76,20 @@ class ProgramConverter(
             // We need to deduplicate fields since public fields with the same name are represented differently
             // at `FieldEmbedding` level but map to the same Viper.
             fields = typeResolver.backingFields().distinctBy { it.name }.map { it.toViper() },
-            functions = SpecialFunctions.all + functions.values.mapNotNull { it.viperFunction(typeResolver) }
-                .distinctBy { it.name },
-            methods = SpecialMethods.all + methods.values.mapNotNull { it.viperMethod(typeResolver) }
-                .distinctBy { it.name } + typeResolver.backingFields().map { it.type.havocMethod(typeResolver) }
+            functions = SpecialFunctions.all + functions.entries.mapNotNull { (name, embedding) ->
+                val linearized = linearizedBodyResolver.lookupPure(name)
+                check(linearized != null || convertedBodyResolver.lookupPure(name) == null) {
+                    "Internal error: pure function $name was converted but not linearized"
+                }
+                embedding.viperFunction(typeResolver, linearized)
+            }.distinctBy { it.name },
+            methods = SpecialMethods.all + methods.entries.mapNotNull { (name, embedding) ->
+                val linearized = linearizedBodyResolver.lookupImpure(name)
+                check(linearized != null || convertedBodyResolver.lookupImpure(name) == null) {
+                    "Internal error: impure function $name was converted but not linearized"
+                }
+                embedding.viperMethod(typeResolver, linearized)
+            }.distinctBy { it.name } + typeResolver.backingFields().map { it.type.havocMethod(typeResolver) }
                 .distinctBy { it.name },
             predicates = typeResolver.classTypeEmbeddings().flatMap {
                 with(typeResolver) {
@@ -93,12 +103,16 @@ class ProgramConverter(
 
 
     fun registerForVerification(declaration: FirSimpleFunction) {
-        // Note: it is important that `body` is only set after embedding is complete, as we need to
-        // place the embedding in the map before processing the body.
+        val (returnTarget, fullSignature) = embedFullSignature(declaration.symbol)
+        // Note: it is important that the body is only converted after the embedding is in place,
+        // as we need to place the embedding in the map before processing the body.
         if (declaration.symbol.isPure(session)) {
-            embedPureFunction(declaration.symbol)
+            embedPureUserFunction(declaration.symbol, fullSignature, returnTarget)
         } else {
-            embedUserFunction(declaration)
+            val stmtCtx = createBodyConversionContext(fullSignature, returnTarget)
+            embedUserFunction(declaration.symbol, fullSignature)
+            stmtCtx.convertImpureBody(declaration, fullSignature, returnTarget)
+            stmtCtx.linearizeImpureBody(declaration, fullSignature.name)
         }
         if (errorCollector.collectedAdtError()) {
             errorCollector.addAdtError(
@@ -121,7 +135,8 @@ class ProgramConverter(
         )
         if (declaration.body != null) {
             val stmtCtx = createBodyConversionContext(signature, returnTarget)
-            new.body = stmtCtx.convertFunctionWithBody(declaration)
+            stmtCtx.convertPureBody(declaration, signature.name)
+            stmtCtx.linearizePureBody(declaration, signature.name)
         }
         return new
     }
@@ -185,15 +200,13 @@ class ProgramConverter(
         return Pair(preconditionContext, postconditionContext)
     }
 
-    fun embedUserFunction(declaration: FirSimpleFunction): UserFunctionEmbedding {
-        val symbol = declaration.symbol
+    fun embedUserFunction(
+        symbol: FirFunctionSymbol<*>,
+        signature: FullNamedFunctionSignature,
+    ): UserFunctionEmbedding {
         val name = symbol.embedName(this)
         (methods[name] as? UserFunctionEmbedding)?.also { return it }
-        val (returnTarget, fullSignature) = embedFullSignature(symbol)
-        val new = UserFunctionEmbedding(embedCallable(symbol, fullSignature)).apply {
-            val stmtCtx = createBodyConversionContext(fullSignature, returnTarget)
-            body = stmtCtx.convertMethodWithBody(declaration, fullSignature)
-        }
+        val new = UserFunctionEmbedding(embedCallable(symbol, signature))
         methods[name] = new
         return new
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -75,42 +75,59 @@ class ProgramConverter(
     override val linearizedBodyResolver = LinearizedBodyResolver()
 
 
-    fun program(): Program = Program(
-        domains = listOf(RuntimeTypeDomain(typeResolver)),
-        // We need to deduplicate fields since public fields with the same name are represented differently
-        // at `FieldEmbedding` level but map to the same Viper.
-        fields = typeResolver.backingFields().distinctBy { it.name }
-            .map { it.toViper() },
-        functions = SpecialFunctions.all + functions.entries.mapNotNull { (name, embedding) ->
-            val linearized = linearizedBodyResolver.lookupPure(name)
-            check(linearized != null || convertedBodyResolver.lookupPure(name) == null) {
-                "Internal error: pure function $name was converted but not linearized"
+    fun buildProgram(): Program {
+        val backingFields = typeResolver.backingFields()
+
+        val viperFunctions = buildList {
+            addAll(SpecialFunctions.all)
+            functions.forEach { (name, embedding) ->
+                val linearized = linearizedBodyResolver.lookupPure(name)
+                check(linearized != null || convertedBodyResolver.lookupPure(name) == null) {
+                    "Internal error: pure function $name was converted but not linearized"
+                }
+                add(embedding.viperFunction(typeResolver, linearized))
             }
-            embedding.viperFunction(typeResolver, linearized)
-        }.distinctBy { it.name },
-        methods = SpecialMethods.all + methods.entries.mapNotNull { (name, embedding) ->
-            val linearized = linearizedBodyResolver.lookupImpure(name)
-            check(linearized != null || convertedBodyResolver.lookupImpure(name) == null) {
-                "Internal error: impure function $name was converted but not linearized"
+        }
+
+        val viperMethods = buildList {
+            addAll(SpecialMethods.all)
+            methods.forEach { (name, embedding) ->
+                val linearized = linearizedBodyResolver.lookupImpure(name)
+                check(linearized != null || convertedBodyResolver.lookupImpure(name) == null) {
+                    "Internal error: impure function $name was converted but not linearized"
+                }
+                val callable = embedding.userCallable() ?: return@forEach
+                val method = linearized?.toViperMethod(callable, typeResolver) ?: callable.toViperMethodHeader(typeResolver)
+                if (method != null) add(method)
             }
-            val callable = when (embedding) {
-                is UserFunctionEmbedding -> embedding.callable
-                is FullySpecialKotlinFunction -> null
-                is PartiallySpecialKotlinFunction -> embedding.baseEmbedding?.callable
-                else -> error("Unexpected embedding in methods map for $name: $embedding")
-            } ?: return@mapNotNull null
-            linearized?.toViperMethod(callable, typeResolver) ?: callable.toViperMethodHeader(typeResolver)
-        }.distinctBy { it.name } + typeResolver.backingFields().map { it.type.havocMethod(typeResolver) }
-            .distinctBy { it.name },
-        predicates = typeResolver.classTypeEmbeddings().flatMap {
-            with(typeResolver) {
-                listOf(
-                    it.sharedPredicate(), it.uniquePredicate()
-                )
-            }
-        },
-        adts = typeResolver.adtTypeEmbeddings().map { it.toViper() },
-    )
+            // Multiple backing fields can share a type, so havoc methods collide on name.
+            backingFields.map { it.type.havocMethod(typeResolver) }
+                .distinctBy { it.name }
+                .forEach(::add)
+        }
+
+        return Program(
+            domains = listOf(RuntimeTypeDomain(typeResolver)),
+            // Public fields with the same name are represented differently at `FieldEmbedding` level
+            // but map to the same Viper field, so we deduplicate before emitting.
+            fields = backingFields.distinctBy { it.name }.map { it.toViper() },
+            functions = viperFunctions,
+            methods = viperMethods,
+            predicates = typeResolver.classTypeEmbeddings().flatMap {
+                with(typeResolver) {
+                    listOf(it.sharedPredicate(), it.uniquePredicate())
+                }
+            },
+            adts = typeResolver.adtTypeEmbeddings().map { it.toViper() },
+        )
+    }
+
+    private fun CallableEmbedding.userCallable(): RichCallableEmbedding? = when (this) {
+        is UserFunctionEmbedding -> callable
+        is FullySpecialKotlinFunction -> null
+        is PartiallySpecialKotlinFunction -> baseEmbedding?.callable
+        else -> error("Unexpected embedding in methods map: $this")
+    }
 
     /**
      * Embed the declaration's signature and queue its body for later processing by [convertAll].
@@ -127,13 +144,11 @@ class ProgramConverter(
 
     /**
      * Convert each registered declaration's body to an `ExpEmbedding`, populating [convertedBodyResolver].
-     * Pure callees reached transitively are converted via [embedPureFunction]; their entries land in the
-     * same resolver.
      */
     fun convertAll() {
         for ((declaration, signature, returnTarget) in registered) {
             val stmtCtx = createBodyConversionContext(signature, returnTarget)
-            if (declaration.symbol.isPure(session)) {
+            if (signature.isPure) {
                 convertedBodyResolver.storePure(signature.name, stmtCtx.convertPureBody(declaration))
             } else {
                 stmtCtx.convertImpureBody(declaration, signature, returnTarget)?.let {
@@ -184,11 +199,8 @@ class ProgramConverter(
 
     private fun ensurePureUserFunctionEmbedding(
         symbol: FirFunctionSymbol<*>, signature: FullNamedFunctionSignature
-    ): PureUserFunctionEmbedding {
-        (functions[signature.name] as? PureUserFunctionEmbedding)?.also { return it }
-        val new = PureUserFunctionEmbedding(embedCallable(symbol, signature))
-        functions[signature.name] = new
-        return new
+    ): PureUserFunctionEmbedding = functions.getOrPut(signature.name) {
+        PureUserFunctionEmbedding(embedCallable(symbol, signature))
     }
 
     @OptIn(SymbolInternals::class)
@@ -271,10 +283,10 @@ class ProgramConverter(
         signature: FullNamedFunctionSignature,
     ): UserFunctionEmbedding {
         val name = symbol.embedName(this)
-        (methods[name] as? UserFunctionEmbedding)?.also { return it }
-        val new = UserFunctionEmbedding(embedCallable(symbol, signature))
-        methods[name] = new
-        return new
+        (methods[name] as? UserFunctionEmbedding)?.let { return it }
+        return UserFunctionEmbedding(embedCallable(symbol, signature)).also {
+            methods[name] = it
+        }
     }
 
     private fun embedGetterFunction(symbol: FirPropertySymbol): CallableEmbedding {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -46,7 +46,7 @@ class ProgramConverter(
         putAll(SpecialKotlinFunctions.byName)
         putAll(PartiallySpecialKotlinFunctions.generateAllByName())
     }.toMutableMap()
-    private val functions: MutableMap<SymbolicName, PureFunctionEmbedding> = mutableMapOf()
+    private val functions: MutableMap<SymbolicName, PureUserFunctionEmbedding> = mutableMapOf()
 
     override val typeResolver: TypeResolver = TypeResolver()
 
@@ -88,7 +88,8 @@ class ProgramConverter(
                 check(linearized != null || convertedBodyResolver.lookupImpure(name) == null) {
                     "Internal error: impure function $name was converted but not linearized"
                 }
-                embedding.viperMethod(typeResolver, linearized)
+                val callable = embedding.userCallable() ?: return@mapNotNull null
+                linearized?.toViperMethod(callable, typeResolver) ?: callable.toViperMethodHeader(typeResolver)
             }.distinctBy { it.name } + typeResolver.backingFields().map { it.type.havocMethod(typeResolver) }
                 .distinctBy { it.name },
             predicates = typeResolver.classTypeEmbeddings().flatMap {
@@ -254,7 +255,7 @@ class ProgramConverter(
         }
     }
 
-    override fun embedPureFunction(symbol: FirFunctionSymbol<*>): PureFunctionEmbedding {
+    override fun embedPureFunction(symbol: FirFunctionSymbol<*>): PureUserFunctionEmbedding {
         val (returnTarget, signature) = embedFullSignature(symbol)
         return embedPureUserFunction(symbol, signature, returnTarget)
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -25,6 +25,9 @@ import org.jetbrains.kotlin.formver.core.embeddings.callables.*
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 import org.jetbrains.kotlin.formver.core.embeddings.properties.*
 import org.jetbrains.kotlin.formver.core.embeddings.types.*
+import org.jetbrains.kotlin.formver.core.isAdt
+import org.jetbrains.kotlin.formver.core.purity.checkValidity
+import org.jetbrains.kotlin.formver.core.purity.isPure
 import org.jetbrains.kotlin.formver.core.names.*
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Program
@@ -42,11 +45,13 @@ class ProgramConverter(
     override val config: PluginConfiguration,
     override val errorCollector: ErrorCollector
 ) : ProgramConversionContext {
-    private val methods: MutableMap<SymbolicName, FunctionEmbedding> = buildMap {
+    private val methods: MutableMap<SymbolicName, CallableEmbedding> = buildMap {
         putAll(SpecialKotlinFunctions.byName)
         putAll(PartiallySpecialKotlinFunctions.generateAllByName())
     }.toMutableMap()
     private val functions: MutableMap<SymbolicName, PureUserFunctionEmbedding> = mutableMapOf()
+
+    private val registered: MutableList<Triple<FirSimpleFunction, FullNamedFunctionSignature, ReturnTarget>> = mutableListOf()
 
     override val typeResolver: TypeResolver = TypeResolver()
 
@@ -70,57 +75,120 @@ class ProgramConverter(
     override val linearizedBodyResolver = LinearizedBodyResolver()
 
 
-    val program: Program
-        get() = Program(
-            domains = listOf(RuntimeTypeDomain(typeResolver)),
-            // We need to deduplicate fields since public fields with the same name are represented differently
-            // at `FieldEmbedding` level but map to the same Viper.
-            fields = typeResolver.backingFields().distinctBy { it.name }.map { it.toViper() },
-            functions = SpecialFunctions.all + functions.entries.mapNotNull { (name, embedding) ->
-                val linearized = linearizedBodyResolver.lookupPure(name)
-                check(linearized != null || convertedBodyResolver.lookupPure(name) == null) {
-                    "Internal error: pure function $name was converted but not linearized"
-                }
-                embedding.viperFunction(typeResolver, linearized)
-            }.distinctBy { it.name },
-            methods = SpecialMethods.all + methods.entries.mapNotNull { (name, embedding) ->
-                val linearized = linearizedBodyResolver.lookupImpure(name)
-                check(linearized != null || convertedBodyResolver.lookupImpure(name) == null) {
-                    "Internal error: impure function $name was converted but not linearized"
-                }
-                val callable = embedding.userCallable() ?: return@mapNotNull null
-                linearized?.toViperMethod(callable, typeResolver) ?: callable.toViperMethodHeader(typeResolver)
-            }.distinctBy { it.name } + typeResolver.backingFields().map { it.type.havocMethod(typeResolver) }
-                .distinctBy { it.name },
-            predicates = typeResolver.classTypeEmbeddings().flatMap {
-                with(typeResolver) {
-                    listOf(
-                        it.sharedPredicate(), it.uniquePredicate()
-                    )
-                }
-            },
-            adts = typeResolver.adtTypeEmbeddings().map { it.toViper() },
-        )
+    fun program(): Program = Program(
+        domains = listOf(RuntimeTypeDomain(typeResolver)),
+        // We need to deduplicate fields since public fields with the same name are represented differently
+        // at `FieldEmbedding` level but map to the same Viper.
+        fields = typeResolver.backingFields().distinctBy { it.name }
+            .map { it.toViper() },
+        functions = SpecialFunctions.all + functions.entries.mapNotNull { (name, embedding) ->
+            val linearized = linearizedBodyResolver.lookupPure(name)
+            check(linearized != null || convertedBodyResolver.lookupPure(name) == null) {
+                "Internal error: pure function $name was converted but not linearized"
+            }
+            embedding.viperFunction(typeResolver, linearized)
+        }.distinctBy { it.name },
+        methods = SpecialMethods.all + methods.entries.mapNotNull { (name, embedding) ->
+            val linearized = linearizedBodyResolver.lookupImpure(name)
+            check(linearized != null || convertedBodyResolver.lookupImpure(name) == null) {
+                "Internal error: impure function $name was converted but not linearized"
+            }
+            val callable = when (embedding) {
+                is UserFunctionEmbedding -> embedding.callable
+                is FullySpecialKotlinFunction -> null
+                is PartiallySpecialKotlinFunction -> embedding.baseEmbedding?.callable
+                else -> error("Unexpected embedding in methods map for $name: $embedding")
+            } ?: return@mapNotNull null
+            linearized?.toViperMethod(callable, typeResolver) ?: callable.toViperMethodHeader(typeResolver)
+        }.distinctBy { it.name } + typeResolver.backingFields().map { it.type.havocMethod(typeResolver) }
+            .distinctBy { it.name },
+        predicates = typeResolver.classTypeEmbeddings().flatMap {
+            with(typeResolver) {
+                listOf(
+                    it.sharedPredicate(), it.uniquePredicate()
+                )
+            }
+        },
+        adts = typeResolver.adtTypeEmbeddings().map { it.toViper() },
+    )
 
-
-    fun registerForVerification(declaration: FirSimpleFunction) {
-        val (returnTarget, fullSignature) = embedFullSignature(declaration.symbol)
-        // Note: it is important that the body is only converted after the embedding is in place,
-        // as we need to place the embedding in the map before processing the body.
+    /**
+     * Embed the declaration's signature and queue its body for later processing by [convertAll].
+     */
+    fun register(declaration: FirSimpleFunction) {
+        val (returnTarget, signature) = embedFullSignature(declaration.symbol)
         if (declaration.symbol.isPure(session)) {
-            embedPureUserFunction(declaration.symbol, fullSignature, returnTarget)
+            ensurePureUserFunctionEmbedding(declaration.symbol, signature)
         } else {
-            val stmtCtx = createBodyConversionContext(fullSignature, returnTarget)
-            embedUserFunction(declaration.symbol, fullSignature)
-            stmtCtx.convertImpureBody(declaration, fullSignature, returnTarget)
-            stmtCtx.linearizeImpureBody(declaration, fullSignature.name)
+            embedUserFunction(declaration.symbol, signature)
         }
-        if (errorCollector.collectedAdtError()) {
-            errorCollector.addAdtError(
-                declaration.source,
-                "Function '${declaration.name.asString()}' references an invalid ADT",
-            )
+        registered += Triple(declaration, signature, returnTarget)
+    }
+
+    /**
+     * Convert each registered declaration's body to an `ExpEmbedding`, populating [convertedBodyResolver].
+     * Pure callees reached transitively are converted via [embedPureFunction]; their entries land in the
+     * same resolver.
+     */
+    fun convertAll() {
+        for ((declaration, signature, returnTarget) in registered) {
+            val stmtCtx = createBodyConversionContext(signature, returnTarget)
+            if (declaration.symbol.isPure(session)) {
+                convertedBodyResolver.storePure(signature.name, stmtCtx.convertPureBody(declaration))
+            } else {
+                stmtCtx.convertImpureBody(declaration, signature, returnTarget)?.let {
+                    convertedBodyResolver.storeImpure(signature.name, it)
+                }
+            }
+            if (errorCollector.collectedAdtError()) {
+                errorCollector.addAdtError(
+                    declaration.source,
+                    "Function '${declaration.name.asString()}' references an invalid ADT",
+                )
+            }
         }
+    }
+
+    /**
+     * Walk converted bodies to surface validity / purity errors via [errorCollector].
+     * Bodies that fail are still present in [convertedBodyResolver]; callers are expected to inspect
+     * [errorCollector] after this returns and bail before invoking [linearizeAll].
+     */
+    fun validateAll() {
+        convertedBodyResolver.forEachImpure { name, body ->
+            val source = (methods[name] as? UserFunctionEmbedding)?.callable?.declarationSource
+            body.bodyExp.checkValidity(source, errorCollector)
+        }
+        convertedBodyResolver.forEachPure { name, body ->
+            if (!body.isPure()) {
+                val source = functions[name]?.callable?.declarationSource
+                errorCollector.addPurityError(source, "Impure function body detected in pure function")
+            }
+        }
+    }
+
+    /**
+     * Linearize each converted body to its Viper form, populating [linearizedBodyResolver].
+     * Should only be invoked when [errorCollector] is clean.
+     */
+    fun linearizeAll() {
+        convertedBodyResolver.forEachImpure { name, converted ->
+            val source = (methods[name] as? UserFunctionEmbedding)?.callable?.declarationSource
+            linearizedBodyResolver.storeImpure(name, linearizeImpureBody(source, converted))
+        }
+        convertedBodyResolver.forEachPure { name, body ->
+            val source = functions[name]?.callable?.declarationSource
+            linearizedBodyResolver.storePure(name, linearizePureBody(source, body))
+        }
+    }
+
+    private fun ensurePureUserFunctionEmbedding(
+        symbol: FirFunctionSymbol<*>, signature: FullNamedFunctionSignature
+    ): PureUserFunctionEmbedding {
+        (functions[signature.name] as? PureUserFunctionEmbedding)?.also { return it }
+        val new = PureUserFunctionEmbedding(embedCallable(symbol, signature))
+        functions[signature.name] = new
+        return new
     }
 
     @OptIn(SymbolInternals::class)
@@ -128,16 +196,13 @@ class ProgramConverter(
         symbol: FirFunctionSymbol<*>, signature: FullNamedFunctionSignature, returnTarget: ReturnTarget
     ): PureUserFunctionEmbedding {
         (functions[signature.name] as? PureUserFunctionEmbedding)?.also { return it }
-        val new = PureUserFunctionEmbedding(embedCallable(symbol, signature))
-        // Insert into the map before processing the body, so recursive calls can find the embedding.
-        functions[signature.name] = new
+        val new = ensurePureUserFunctionEmbedding(symbol, signature)
         val declaration = symbol.fir as? FirSimpleFunction ?: throw SnaktInternalException(
             symbol.source, "Expected FirSimpleFunction, got unexpected type ${symbol.fir.javaClass.simpleName}"
         )
         if (declaration.body != null) {
             val stmtCtx = createBodyConversionContext(signature, returnTarget)
-            stmtCtx.convertPureBody(declaration, signature.name)
-            stmtCtx.linearizePureBody(declaration, signature.name)
+            convertedBodyResolver.storePure(signature.name, stmtCtx.convertPureBody(declaration))
         }
         return new
     }
@@ -212,7 +277,7 @@ class ProgramConverter(
         return new
     }
 
-    private fun embedGetterFunction(symbol: FirPropertySymbol): FunctionEmbedding {
+    private fun embedGetterFunction(symbol: FirPropertySymbol): CallableEmbedding {
         val name = symbol.embedGetterName(this)
         return methods.getOrPut(name) {
             val signature = GetterFunctionSignature(name, symbol)
@@ -222,7 +287,7 @@ class ProgramConverter(
         }
     }
 
-    private fun embedSetterFunction(symbol: FirPropertySymbol): FunctionEmbedding {
+    private fun embedSetterFunction(symbol: FirPropertySymbol): CallableEmbedding {
         val name = symbol.embedSetterName(this)
         return methods.getOrPut(name) {
             val signature = SetterFunctionSignature(name, symbol)
@@ -232,7 +297,7 @@ class ProgramConverter(
         }
     }
 
-    override fun embedFunction(symbol: FirFunctionSymbol<*>): FunctionEmbedding {
+    override fun embedFunction(symbol: FirFunctionSymbol<*>): CallableEmbedding {
         val lookupName = symbol.embedName(this)
         return when (val existing = methods[lookupName]) {
             null -> {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -45,11 +45,12 @@ class ProgramConverter(
     override val config: PluginConfiguration,
     override val errorCollector: ErrorCollector
 ) : ProgramConversionContext {
-    private val methods: MutableMap<SymbolicName, CallableEmbedding> = buildMap {
+    private val specialFunctions: Map<SymbolicName, SpecialKotlinFunction> = buildMap {
         putAll(SpecialKotlinFunctions.byName)
         putAll(PartiallySpecialKotlinFunctions.generateAllByName())
-    }.toMutableMap()
-    private val functions: MutableMap<SymbolicName, PureUserFunctionEmbedding> = mutableMapOf()
+    }
+    private val impureFunctions: MutableMap<SymbolicName, UserFunctionEmbedding> = mutableMapOf()
+    private val pureFunctions: MutableMap<SymbolicName, PureUserFunctionEmbedding> = mutableMapOf()
 
     private val registered: MutableList<Triple<FirSimpleFunction, FullNamedFunctionSignature, ReturnTarget>> = mutableListOf()
 
@@ -78,28 +79,9 @@ class ProgramConverter(
     fun buildProgram(): Program {
         val backingFields = typeResolver.backingFields()
 
-        val viperFunctions = buildList {
-            addAll(SpecialFunctions.all)
-            functions.forEach { (name, embedding) ->
-                val linearized = linearizedBodyResolver.lookupPure(name)
-                check(linearized != null || convertedBodyResolver.lookupPure(name) == null) {
-                    "Internal error: pure function $name was converted but not linearized"
-                }
-                add(embedding.viperFunction(typeResolver, linearized))
-            }
-        }
-
         val viperMethods = buildList {
             addAll(SpecialMethods.all)
-            methods.forEach { (name, embedding) ->
-                val linearized = linearizedBodyResolver.lookupImpure(name)
-                check(linearized != null || convertedBodyResolver.lookupImpure(name) == null) {
-                    "Internal error: impure function $name was converted but not linearized"
-                }
-                val callable = embedding.userCallable() ?: return@forEach
-                val method = linearized?.toViperMethod(callable, typeResolver) ?: callable.toViperMethodHeader(typeResolver)
-                if (method != null) add(method)
-            }
+            addAll(linearizedBodyResolver.methods)
             // Multiple backing fields can share a type, so havoc methods collide on name.
             backingFields.map { it.type.havocMethod(typeResolver) }
                 .distinctBy { it.name }
@@ -111,7 +93,7 @@ class ProgramConverter(
             // Public fields with the same name are represented differently at `FieldEmbedding` level
             // but map to the same Viper field, so we deduplicate before emitting.
             fields = backingFields.distinctBy { it.name }.map { it.toViper() },
-            functions = viperFunctions,
+            functions = SpecialFunctions.all + linearizedBodyResolver.functions,
             methods = viperMethods,
             predicates = typeResolver.classTypeEmbeddings().flatMap {
                 with(typeResolver) {
@@ -120,13 +102,6 @@ class ProgramConverter(
             },
             adts = typeResolver.adtTypeEmbeddings().map { it.toViper() },
         )
-    }
-
-    private fun CallableEmbedding.userCallable(): RichCallableEmbedding? = when (this) {
-        is UserFunctionEmbedding -> callable
-        is FullySpecialKotlinFunction -> null
-        is PartiallySpecialKotlinFunction -> baseEmbedding?.callable
-        else -> error("Unexpected embedding in methods map: $this")
     }
 
     /**
@@ -171,35 +146,52 @@ class ProgramConverter(
      */
     fun validateAll() {
         convertedBodyResolver.forEachImpure { name, body ->
-            val source = (methods[name] as? UserFunctionEmbedding)?.callable?.declarationSource
+            val source = impureFunctions[name]?.callable?.declarationSource
             body.bodyExp.checkValidity(source, errorCollector)
         }
         convertedBodyResolver.forEachPure { name, body ->
             if (!body.isPure()) {
-                val source = functions[name]?.callable?.declarationSource
+                val source = pureFunctions[name]?.callable?.declarationSource
                 errorCollector.addPurityError(source, "Impure function body detected in pure function")
             }
         }
     }
 
     /**
-     * Linearize each converted body to its Viper form, populating [linearizedBodyResolver].
-     * Should only be invoked when [errorCollector] is clean.
+     * Build the finalized Viper `Method` / `Function` for every embedded callable, storing each in
+     * [linearizedBodyResolver]. Should only be invoked when [errorCollector] is clean.
+     *
+     * Iterates the embedding maps directly (rather than the converted-body map) so that callables
+     * without a body still get a Viper header.
      */
     fun linearizeAll() {
-        convertedBodyResolver.forEachImpure { name, converted ->
-            val source = (methods[name] as? UserFunctionEmbedding)?.callable?.declarationSource
-            linearizedBodyResolver.storeImpure(name, linearizeImpureBody(source, converted))
+        for ((name, special) in specialFunctions) {
+            // Fully-special functions never produce a Viper method; partially-special ones produce a
+            // header only when their base embedding has been initialised.
+            val callable = (special as? PartiallySpecialKotlinFunction)?.baseEmbedding?.callable ?: continue
+            callable.toViperMethodHeader(typeResolver)?.let { linearizedBodyResolver.storeMethod(name, it) }
         }
-        convertedBodyResolver.forEachPure { name, body ->
-            val source = functions[name]?.callable?.declarationSource
-            linearizedBodyResolver.storePure(name, linearizePureBody(source, body))
+        for ((name, embedding) in impureFunctions) {
+            val callable = embedding.callable
+            val source = callable.declarationSource
+            val converted = convertedBodyResolver.lookupImpure(name)
+            val method = if (converted != null) {
+                linearizeImpureBody(source, converted).toViperMethod(callable, typeResolver)
+            } else {
+                callable.toViperMethodHeader(typeResolver)
+            }
+            if (method != null) linearizedBodyResolver.storeMethod(name, method)
+        }
+        for ((name, embedding) in pureFunctions) {
+            val converted = convertedBodyResolver.lookupPure(name)
+            val linearized = converted?.let { linearizePureBody(embedding.callable.declarationSource, it) }
+            linearizedBodyResolver.storeFunction(name, embedding.viperFunction(typeResolver, linearized))
         }
     }
 
     private fun ensurePureUserFunctionEmbedding(
         symbol: FirFunctionSymbol<*>, signature: FullNamedFunctionSignature
-    ): PureUserFunctionEmbedding = functions.getOrPut(signature.name) {
+    ): PureUserFunctionEmbedding = pureFunctions.getOrPut(signature.name) {
         PureUserFunctionEmbedding(embedCallable(symbol, signature))
     }
 
@@ -207,7 +199,7 @@ class ProgramConverter(
     private fun embedPureUserFunction(
         symbol: FirFunctionSymbol<*>, signature: FullNamedFunctionSignature, returnTarget: ReturnTarget
     ): PureUserFunctionEmbedding {
-        (functions[signature.name] as? PureUserFunctionEmbedding)?.also { return it }
+        pureFunctions[signature.name]?.also { return it }
         val new = ensurePureUserFunctionEmbedding(symbol, signature)
         val declaration = symbol.fir as? FirSimpleFunction ?: throw SnaktInternalException(
             symbol.source, "Expected FirSimpleFunction, got unexpected type ${symbol.fir.javaClass.simpleName}"
@@ -283,15 +275,15 @@ class ProgramConverter(
         signature: FullNamedFunctionSignature,
     ): UserFunctionEmbedding {
         val name = symbol.embedName(this)
-        (methods[name] as? UserFunctionEmbedding)?.let { return it }
+        impureFunctions[name]?.let { return it }
         return UserFunctionEmbedding(embedCallable(symbol, signature)).also {
-            methods[name] = it
+            impureFunctions[name] = it
         }
     }
 
     private fun embedGetterFunction(symbol: FirPropertySymbol): CallableEmbedding {
         val name = symbol.embedGetterName(this)
-        return methods.getOrPut(name) {
+        return impureFunctions.getOrPut(name) {
             val signature = GetterFunctionSignature(name, symbol)
             UserFunctionEmbedding(
                 NonInlineNamedFunction(signature)
@@ -301,7 +293,7 @@ class ProgramConverter(
 
     private fun embedSetterFunction(symbol: FirPropertySymbol): CallableEmbedding {
         val name = symbol.embedSetterName(this)
-        return methods.getOrPut(name) {
+        return impureFunctions.getOrPut(name) {
             val signature = SetterFunctionSignature(name, symbol)
             UserFunctionEmbedding(
                 NonInlineNamedFunction(signature)
@@ -311,24 +303,17 @@ class ProgramConverter(
 
     override fun embedFunction(symbol: FirFunctionSymbol<*>): CallableEmbedding {
         val lookupName = symbol.embedName(this)
-        return when (val existing = methods[lookupName]) {
-            null -> {
-                val callable = embedCallable(symbol)
-                UserFunctionEmbedding(callable).also {
-                    methods[lookupName] = it
-                }
-            }
-
-            is PartiallySpecialKotlinFunction -> {
-                if (existing.baseEmbedding != null) return existing
-                val callable = embedCallable(symbol)
-                val userFunction = UserFunctionEmbedding(callable)
-                existing.also {
-                    it.initBaseEmbedding(userFunction)
-                }
-            }
-
-            else -> existing
+        specialFunctions[lookupName]?.let { existing ->
+            if (existing !is PartiallySpecialKotlinFunction) return existing
+            if (existing.baseEmbedding != null) return existing
+            val callable = embedCallable(symbol)
+            existing.initBaseEmbedding(UserFunctionEmbedding(callable))
+            return existing
+        }
+        impureFunctions[lookupName]?.let { return it }
+        val callable = embedCallable(symbol)
+        return UserFunctionEmbedding(callable).also {
+            impureFunctions[lookupName] = it
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.core.conversion
 
+import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.FirLabel
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.isFinal
@@ -26,8 +27,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.isCustom
 import org.jetbrains.kotlin.formver.core.isInvariantBuilderFunctionNamed
 import org.jetbrains.kotlin.formver.core.linearization.*
-import org.jetbrains.kotlin.formver.core.purity.checkValidity
-import org.jetbrains.kotlin.formver.core.purity.isPure
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.utils.addIfNotNull
@@ -247,66 +246,51 @@ fun StmtConversionContext.convertImpureBody(
     declaration: FirSimpleFunction,
     signature: FullNamedFunctionSignature,
     returnTarget: ReturnTarget,
-) {
-    val firBody = declaration.body ?: return
+): ConvertedMethodBody? {
+    val firBody = declaration.body ?: return null
     val body = convert(firBody)
     val returnLabel = returnTarget.label ?: throw SnaktInternalException(
         declaration.source, "Return target label not found for method ${declaration.name}"
     )
     val bodyExp = FunctionExp(signature, body, returnLabel)
-    convertedBodyResolver.storeImpure(signature.name, ImpureConvertedBody(bodyExp, returnTarget))
+    return ConvertedMethodBody(bodyExp, returnTarget)
 }
 
-fun StmtConversionContext.linearizeImpureBody(
-    declaration: FirSimpleFunction,
-    name: SymbolicName,
-) {
-    val converted = convertedBodyResolver.lookupImpure(name) ?: return
-    val seqnBuilder = SeqnBuilder(declaration.source)
-    val linearizer =
-        Linearizer(SharedLinearizationState(anonVarProducer), seqnBuilder, declaration.source, typeResolver)
-    converted.bodyExp.toLinearizable(declaration.source).toViperUnusedResult(linearizer)
-    // note: we must guarantee somewhere that returned value is Unit
-    // as we may not encounter any `return` statement in the body
-    converted.returnTarget.variable.withIsUnitInvariantIfUnit(typeResolver)
-        .toLinearizable(declaration.source).toViperUnusedResult(linearizer)
-    val isValid = converted.bodyExp.checkValidity(declaration.source, errorCollector)
-    if (isValid) {
-        linearizedBodyResolver.storeImpure(
-            name,
-            FunctionBodyEmbedding(seqnBuilder.block),
-        )
-    }
-}
-
-fun StmtConversionContext.convertPureBody(
-    declaration: FirSimpleFunction,
-    name: SymbolicName,
-) {
+fun StmtConversionContext.convertPureBody(declaration: FirSimpleFunction): ExpEmbedding {
     val firBody = declaration.body ?: throw SnaktInternalException(
         declaration.source,
         "Pure functions expect a function body to exist"
     )
-    convertedBodyResolver.storePure(name, convert(firBody))
+    return convert(firBody)
 }
 
-fun StmtConversionContext.linearizePureBody(
-    declaration: FirSimpleFunction,
-    name: SymbolicName,
-) {
-    val body = convertedBodyResolver.lookupPure(name) ?: return
-    if (!body.isPure()) {
-        errorCollector.addPurityError(declaration.source, "Impure function body detected in pure function")
-        return
-    }
+fun ProgramConversionContext.linearizeImpureBody(
+    source: KtSourceElement?,
+    converted: ConvertedMethodBody,
+): FunctionBodyEmbedding {
+    val seqnBuilder = SeqnBuilder(source)
+    val linearizer =
+        Linearizer(SharedLinearizationState(anonVarProducer), seqnBuilder, source, typeResolver)
+    converted.bodyExp.toLinearizable(source).toViperUnusedResult(linearizer)
+    // note: we must guarantee somewhere that returned value is Unit
+    // as we may not encounter any `return` statement in the body
+    converted.returnTarget.variable.withIsUnitInvariantIfUnit(typeResolver)
+        .toLinearizable(source).toViperUnusedResult(linearizer)
+    return FunctionBodyEmbedding(seqnBuilder.block)
+}
+
+fun ProgramConversionContext.linearizePureBody(
+    source: KtSourceElement?,
+    body: ExpEmbedding,
+): Exp {
     val pureFunBodyLinearizer = PureFunBodyLinearizer(
-        declaration.source,
+        source,
         SharedLinearizationState(anonVarProducer),
-        SsaConverter(declaration.source),
+        SsaConverter(source),
         typeResolver
     )
-    body.toLinearizable(declaration.source).toViperUnusedResult(pureFunBodyLinearizer)
-    linearizedBodyResolver.storePure(name, pureFunBodyLinearizer.constructExpression())
+    body.toLinearizable(source).toViperUnusedResult(pureFunBodyLinearizer)
+    return pureFunBodyLinearizer.constructExpression()
 }
 
 private const val INVALID_STATEMENT_MSG =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -14,9 +14,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.fir.types.isBoolean
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
-import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyConversionResult
 import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.InvalidFunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.LabelEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FullNamedFunctionSignature
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionSignature
@@ -245,41 +243,61 @@ fun StmtConversionContext.insertForAllFunctionCall(
     }
 }
 
-fun StmtConversionContext.convertMethodWithBody(
+fun StmtConversionContext.convertImpureBody(
     declaration: FirSimpleFunction,
     signature: FullNamedFunctionSignature,
-): FunctionBodyConversionResult? {
-    val firBody = declaration.body ?: return null
+    returnTarget: ReturnTarget,
+) {
+    val firBody = declaration.body ?: return
     val body = convert(firBody)
-    val returnLabel = defaultResolvedReturnTarget.label ?: throw SnaktInternalException(declaration.source, "Return target label not found for method ${declaration.name}")
+    val returnLabel = returnTarget.label ?: throw SnaktInternalException(
+        declaration.source, "Return target label not found for method ${declaration.name}"
+    )
     val bodyExp = FunctionExp(signature, body, returnLabel)
+    convertedBodyResolver.storeImpure(signature.name, ImpureConvertedBody(bodyExp, returnTarget))
+}
+
+fun StmtConversionContext.linearizeImpureBody(
+    declaration: FirSimpleFunction,
+    name: SymbolicName,
+) {
+    val converted = convertedBodyResolver.lookupImpure(name) ?: return
     val seqnBuilder = SeqnBuilder(declaration.source)
     val linearizer =
         Linearizer(SharedLinearizationState(anonVarProducer), seqnBuilder, declaration.source, typeResolver)
-    bodyExp.toLinearizable(declaration.source).toViperUnusedResult(linearizer)
+    converted.bodyExp.toLinearizable(declaration.source).toViperUnusedResult(linearizer)
     // note: we must guarantee somewhere that returned value is Unit
     // as we may not encounter any `return` statement in the body
-    signature.returns.withIsUnitInvariantIfUnit(typeResolver).toLinearizable(declaration.source)
-        .toViperUnusedResult(linearizer)
-    val isValid = body.checkValidity(declaration.source, errorCollector)
-    return if (isValid) {
-        FunctionBodyEmbedding(seqnBuilder.block, bodyExp)
-    } else {
-        InvalidFunctionBodyEmbedding(declaration.source, bodyExp)
+    converted.returnTarget.variable.withIsUnitInvariantIfUnit(typeResolver)
+        .toLinearizable(declaration.source).toViperUnusedResult(linearizer)
+    val isValid = converted.bodyExp.checkValidity(declaration.source, errorCollector)
+    if (isValid) {
+        linearizedBodyResolver.storeImpure(
+            name,
+            FunctionBodyEmbedding(seqnBuilder.block),
+        )
     }
 }
 
-fun StmtConversionContext.convertFunctionWithBody(
-    declaration: FirSimpleFunction
-): Exp? {
+fun StmtConversionContext.convertPureBody(
+    declaration: FirSimpleFunction,
+    name: SymbolicName,
+) {
     val firBody = declaration.body ?: throw SnaktInternalException(
         declaration.source,
         "Pure functions expect a function body to exist"
     )
-    val body = convert(firBody)
+    convertedBodyResolver.storePure(name, convert(firBody))
+}
+
+fun StmtConversionContext.linearizePureBody(
+    declaration: FirSimpleFunction,
+    name: SymbolicName,
+) {
+    val body = convertedBodyResolver.lookupPure(name) ?: return
     if (!body.isPure()) {
         errorCollector.addPurityError(declaration.source, "Impure function body detected in pure function")
-        return null
+        return
     }
     val pureFunBodyLinearizer = PureFunBodyLinearizer(
         declaration.source,
@@ -288,7 +306,7 @@ fun StmtConversionContext.convertFunctionWithBody(
         typeResolver
     )
     body.toLinearizable(declaration.source).toViperUnusedResult(pureFunBodyLinearizer)
-    return pureFunBodyLinearizer.constructExpression()
+    linearizedBodyResolver.storePure(name, pureFunBodyLinearizer.constructExpression())
 }
 
 private const val INVALID_STATEMENT_MSG =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.common.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.formver.core.embeddings.LabelLink
 import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.insertCall
 import org.jetbrains.kotlin.formver.core.embeddings.callables.isVerifyFunction
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
@@ -291,8 +290,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         flatMap { arg ->
             when (arg) {
                 is FirVarargArgumentsExpression -> {
-                    // Short circuit as isVerifyFunction property only exists on embedding of type FunctionEmbedding
-                    if (function == null || function is FunctionEmbedding && !function.isVerifyFunction) {
+                    if (function == null || !function.isVerifyFunction) {
                         throw SnaktInternalException(
                             arg.source, "Vararg arguments are currently supported for `verify` function only."
                         )

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/FunctionBodyEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/FunctionBodyEmbedding.kt
@@ -6,31 +6,21 @@
 package org.jetbrains.kotlin.formver.core.embeddings
 
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.formver.core.conversion.ReturnTarget
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FullNamedFunctionSignature
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toViperMethod
-import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Method
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
-sealed interface FunctionBodyConversionResult {
-    fun debugExpEmbedding(): ExpEmbedding?
-}
+sealed interface FunctionBodyConversionResult
 
 data class FunctionBodyEmbedding(
     val viperBody: Stmt.Seqn,
-    val debugExpEmbedding: ExpEmbedding? = null
 ) : FunctionBodyConversionResult {
     fun toViperMethod(signature: FullNamedFunctionSignature, ctx: TypeResolver): Method =
         signature.toViperMethod(viperBody, ctx)
-
-    override fun debugExpEmbedding(): ExpEmbedding? = debugExpEmbedding
 }
 
 data class InvalidFunctionBodyEmbedding(
     val source: KtSourceElement? = null,
-    val debugExpEmbedding: ExpEmbedding? = null
-) : FunctionBodyConversionResult {
-    override fun debugExpEmbedding(): ExpEmbedding? = debugExpEmbedding
-}
+) : FunctionBodyConversionResult

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -54,7 +54,7 @@ object SpecialKotlinFunctions {
         ClassKotlinName(listOf("InvariantBuilder"))
     }
 
-    val byName: Map<SymbolicName, FunctionEmbedding> = buildFullySpecialFunctions {
+    val byName: Map<SymbolicName, CallableEmbedding> = buildFullySpecialFunctions {
         val intIntToIntType = buildFunctionPretype {
             withDispatchReceiver { int() }
             withParam { int() }
@@ -218,10 +218,10 @@ object SpecialKotlinFunctions {
     }
 }
 
-val FunctionEmbedding.isVerifyFunction: Boolean
+val CallableEmbedding.isVerifyFunction: Boolean
     get() = isFormverPluginFunctionNamed(name = "verify")
 
-fun FunctionEmbedding.isFormverPluginFunctionNamed(className: String? = null, name: String): Boolean =
+fun CallableEmbedding.isFormverPluginFunctionNamed(className: String? = null, name: String): Boolean =
     this is FullySpecialKotlinFunction && NameMatcher.Companion.matchClassScope(this.embedName()) {
         ifPackageName(SpecialPackages.formver) {
             if (className == null) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -54,7 +54,7 @@ object SpecialKotlinFunctions {
         ClassKotlinName(listOf("InvariantBuilder"))
     }
 
-    val byName: Map<SymbolicName, CallableEmbedding> = buildFullySpecialFunctions {
+    val byName: Map<SymbolicName, FullySpecialKotlinFunction> = buildFullySpecialFunctions {
         val intIntToIntType = buildFunctionPretype {
             withDispatchReceiver { int() }
             withParam { int() }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunctionBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunctionBuilder.kt
@@ -22,7 +22,7 @@ class FullySpecialKotlinFunctionImpl(
 }
 
 class FullySpecialKotlinFunctionBuilder {
-    private val byName = mutableMapOf<SymbolicName, CallableEmbedding>()
+    private val byName = mutableMapOf<SymbolicName, FullySpecialKotlinFunction>()
 
     fun withCallableType(
         callableType: FunctionTypeEmbedding,
@@ -67,8 +67,8 @@ class FullySpecialKotlinFunctionBuilder {
         }
     }
 
-    fun complete(): Map<SymbolicName, CallableEmbedding> = byName
+    fun complete(): Map<SymbolicName, FullySpecialKotlinFunction> = byName
 }
 
-fun buildFullySpecialFunctions(functionsBlock: FullySpecialKotlinFunctionBuilder.() -> Unit): Map<SymbolicName, CallableEmbedding> =
+fun buildFullySpecialFunctions(functionsBlock: FullySpecialKotlinFunctionBuilder.() -> Unit): Map<SymbolicName, FullySpecialKotlinFunction> =
     FullySpecialKotlinFunctionBuilder().apply(functionsBlock).complete()

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunctionBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunctionBuilder.kt
@@ -22,7 +22,7 @@ class FullySpecialKotlinFunctionImpl(
 }
 
 class FullySpecialKotlinFunctionBuilder {
-    private val byName = mutableMapOf<SymbolicName, FunctionEmbedding>()
+    private val byName = mutableMapOf<SymbolicName, CallableEmbedding>()
 
     fun withCallableType(
         callableType: FunctionTypeEmbedding,
@@ -67,8 +67,8 @@ class FullySpecialKotlinFunctionBuilder {
         }
     }
 
-    fun complete(): Map<SymbolicName, FunctionEmbedding> = byName
+    fun complete(): Map<SymbolicName, CallableEmbedding> = byName
 }
 
-fun buildFullySpecialFunctions(functionsBlock: FullySpecialKotlinFunctionBuilder.() -> Unit): Map<SymbolicName, FunctionEmbedding> =
+fun buildFullySpecialFunctions(functionsBlock: FullySpecialKotlinFunctionBuilder.() -> Unit): Map<SymbolicName, CallableEmbedding> =
     FullySpecialKotlinFunctionBuilder().apply(functionsBlock).complete()

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionEmbedding.kt
@@ -6,33 +6,37 @@
 package org.jetbrains.kotlin.formver.core.embeddings.callables
 
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
-import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Function
-import org.jetbrains.kotlin.formver.viper.ast.Method
 
-interface FunctionEmbedding : CallableEmbedding {
-    fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method?
-}
-
-interface PureFunctionEmbedding : CallableEmbedding {
-    fun viperFunction(ctx: TypeResolver, body: Exp?): Function?
-}
+/**
+ * Marker for embeddings that live in the `methods` bucket of a `ProgramConverter`.
+ * The hierarchy is sealed so renderers can dispatch over the leaves exhaustively.
+ */
+sealed interface FunctionEmbedding : CallableEmbedding
 
 /**
  * An embedding of a user-defined function.
  */
-class UserFunctionEmbedding(private val callable: RichCallableEmbedding) : FunctionEmbedding,
-    CallableEmbedding by callable {
-    override fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method? =
-        body?.toViperMethod(callable, ctx) ?: callable.toViperMethodHeader(ctx)
-}
+class UserFunctionEmbedding(val callable: RichCallableEmbedding) : FunctionEmbedding,
+    CallableEmbedding by callable
 
 
 /**
- * An embedding of a user-defined pure function
+ * An embedding of a user-defined pure function.
  */
-class PureUserFunctionEmbedding(private val callable: RichCallableEmbedding) : PureFunctionEmbedding,
-    CallableEmbedding by callable {
-    override fun viperFunction(ctx: TypeResolver, body: Exp?): Function = callable.toViperFunction(ctx, body)
+class PureUserFunctionEmbedding(val callable: RichCallableEmbedding) : CallableEmbedding by callable {
+    fun viperFunction(ctx: TypeResolver, body: Exp?): Function = callable.toViperFunction(ctx, body)
+}
+
+/**
+ * The underlying user-function callable that this embedding renders to, if any.
+ *
+ * Returns `null` for `FullySpecialKotlinFunction`s (which never emit a Viper method) and for
+ * `PartiallySpecialKotlinFunction`s whose `baseEmbedding` has not been initialised.
+ */
+fun FunctionEmbedding.userCallable(): RichCallableEmbedding? = when (this) {
+    is UserFunctionEmbedding -> callable
+    is FullySpecialKotlinFunction -> null
+    is PartiallySpecialKotlinFunction -> (baseEmbedding as? UserFunctionEmbedding)?.callable
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionEmbedding.kt
@@ -10,16 +10,9 @@ import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Function
 
 /**
- * Marker for embeddings that live in the `methods` bucket of a `ProgramConverter`.
- * The hierarchy is sealed so renderers can dispatch over the leaves exhaustively.
- */
-sealed interface FunctionEmbedding : CallableEmbedding
-
-/**
  * An embedding of a user-defined function.
  */
-class UserFunctionEmbedding(val callable: RichCallableEmbedding) : FunctionEmbedding,
-    CallableEmbedding by callable
+class UserFunctionEmbedding(val callable: RichCallableEmbedding) : CallableEmbedding by callable
 
 
 /**
@@ -27,16 +20,4 @@ class UserFunctionEmbedding(val callable: RichCallableEmbedding) : FunctionEmbed
  */
 class PureUserFunctionEmbedding(val callable: RichCallableEmbedding) : CallableEmbedding by callable {
     fun viperFunction(ctx: TypeResolver, body: Exp?): Function = callable.toViperFunction(ctx, body)
-}
-
-/**
- * The underlying user-function callable that this embedding renders to, if any.
- *
- * Returns `null` for `FullySpecialKotlinFunction`s (which never emit a Viper method) and for
- * `PartiallySpecialKotlinFunction`s whose `baseEmbedding` has not been initialised.
- */
-fun FunctionEmbedding.userCallable(): RichCallableEmbedding? = when (this) {
-    is UserFunctionEmbedding -> callable
-    is FullySpecialKotlinFunction -> null
-    is PartiallySpecialKotlinFunction -> (baseEmbedding as? UserFunctionEmbedding)?.callable
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionEmbedding.kt
@@ -5,21 +5,18 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.callables
 
-import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
-import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyConversionResult
 import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.InvalidFunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Function
 import org.jetbrains.kotlin.formver.viper.ast.Method
 
 interface FunctionEmbedding : CallableEmbedding {
-    fun viperMethod(ctx: TypeResolver): Method?
+    fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method?
 }
 
 interface PureFunctionEmbedding : CallableEmbedding {
-    fun viperFunction(ctx: TypeResolver): Function?
+    fun viperFunction(ctx: TypeResolver, body: Exp?): Function?
 }
 
 /**
@@ -27,20 +24,8 @@ interface PureFunctionEmbedding : CallableEmbedding {
  */
 class UserFunctionEmbedding(private val callable: RichCallableEmbedding) : FunctionEmbedding,
     CallableEmbedding by callable {
-    /**
-     * The presence of the body indicates that the function should be verified, as opposed to simply having a declaration available
-     */
-    var body: FunctionBodyConversionResult? = null
-
-    override fun viperMethod(ctx: TypeResolver): Method? = when (val currentBody = body) {
-            is InvalidFunctionBodyEmbedding -> throw SnaktInternalException(
-                currentBody.source,
-                "Invalid function body detected in user-defined function"
-            )
-
-        is FunctionBodyEmbedding -> currentBody.toViperMethod(callable, ctx)
-        else -> callable.toViperMethodHeader(ctx)
-        }
+    override fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method? =
+        body?.toViperMethod(callable, ctx) ?: callable.toViperMethodHeader(ctx)
 }
 
 
@@ -49,8 +34,5 @@ class UserFunctionEmbedding(private val callable: RichCallableEmbedding) : Funct
  */
 class PureUserFunctionEmbedding(private val callable: RichCallableEmbedding) : PureFunctionEmbedding,
     CallableEmbedding by callable {
-
-    var body: Exp? = null
-
-    override fun viperFunction(ctx: TypeResolver): Function = callable.toViperFunction(ctx, body)
+    override fun viperFunction(ctx: TypeResolver, body: Exp?): Function = callable.toViperFunction(ctx, body)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/PartiallySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/PartiallySpecialKotlinFunction.kt
@@ -21,13 +21,13 @@ abstract class AbstractPartiallySpecialKotlinFunction(
     override val className: String? = null,
     override val name: String,
 ) : PartiallySpecialKotlinFunction {
-    private var _baseEmbedding: FunctionEmbedding? = null
+    private var _baseEmbedding: UserFunctionEmbedding? = null
     override val baseEmbedding
         get() = _baseEmbedding
 
     override val packageName = packageName.toList()
 
-    override fun initBaseEmbedding(embedding: FunctionEmbedding) {
+    override fun initBaseEmbedding(embedding: UserFunctionEmbedding) {
         check(_baseEmbedding == null) { "Base embedding for partially special function $name already initialized." }
         _baseEmbedding = embedding
     }
@@ -56,7 +56,7 @@ class StringPlusAnyFunction : AbstractPartiallySpecialKotlinFunction("kotlin", c
  * but those functions are generated once per run anyway.
  */
 object PartiallySpecialKotlinFunctions {
-    fun generateAllByName(): Map<SymbolicName, FunctionEmbedding> =
+    fun generateAllByName(): Map<SymbolicName, CallableEmbedding> =
         buildList {
             add(StringPlusAnyFunction())
         }.associateBy { it.embedName() }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/PartiallySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/PartiallySpecialKotlinFunction.kt
@@ -56,7 +56,7 @@ class StringPlusAnyFunction : AbstractPartiallySpecialKotlinFunction("kotlin", c
  * but those functions are generated once per run anyway.
  */
 object PartiallySpecialKotlinFunctions {
-    fun generateAllByName(): Map<SymbolicName, CallableEmbedding> =
+    fun generateAllByName(): Map<SymbolicName, PartiallySpecialKotlinFunction> =
         buildList {
             add(StringPlusAnyFunction())
         }.associateBy { it.embedName() }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
  * In particular, that means that there won't be a call to the Viper method
  * sometimes.
  */
-sealed interface SpecialKotlinFunction : FunctionEmbedding {
+sealed interface SpecialKotlinFunction : CallableEmbedding {
     val packageName: List<String>
     val className: String?
         get() = null
@@ -41,12 +41,12 @@ interface PartiallySpecialKotlinFunction : SpecialKotlinFunction {
      * `baseEmbedding` stores a usual (user) embedding for the partially special function.
      * It is initialised iff the partially special function is used in the program in any way.
      */
-    val baseEmbedding: FunctionEmbedding?
+    val baseEmbedding: UserFunctionEmbedding?
     fun tryInsertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding?
     override fun insertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding {
         return tryInsertCall(args, ctx) ?: baseEmbedding?.insertCall(args, ctx)
         ?: error("Base embedding for partially special function $name not specified")
     }
 
-    fun initBaseEmbedding(embedding: FunctionEmbedding)
+    fun initBaseEmbedding(embedding: UserFunctionEmbedding)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
@@ -6,10 +6,7 @@
 package org.jetbrains.kotlin.formver.core.embeddings.callables
 
 import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
-import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
-import org.jetbrains.kotlin.formver.viper.ast.Method
 
 /**
  * Some functions are handled specially by our conversion.
@@ -19,7 +16,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Method
  * In particular, that means that there won't be a call to the Viper method
  * sometimes.
  */
-interface SpecialKotlinFunction : FunctionEmbedding {
+sealed interface SpecialKotlinFunction : FunctionEmbedding {
     val packageName: List<String>
     val className: String?
         get() = null
@@ -29,9 +26,7 @@ interface SpecialKotlinFunction : FunctionEmbedding {
 /**
  * Kotlin function that will always be handled specially, like aforementioned `Int.plus(Int)`.
  */
-interface FullySpecialKotlinFunction : SpecialKotlinFunction {
-    override fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method? = null
-}
+interface FullySpecialKotlinFunction : SpecialKotlinFunction
 
 /**
  * Kotlin function that will sometimes be handled specially depending on arguments they're called with.
@@ -54,7 +49,4 @@ interface PartiallySpecialKotlinFunction : SpecialKotlinFunction {
     }
 
     fun initBaseEmbedding(embedding: FunctionEmbedding)
-
-    override fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method? =
-        baseEmbedding?.viperMethod(ctx, body)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.core.embeddings.callables
 
 import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
+import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Method
 
@@ -29,7 +30,7 @@ interface SpecialKotlinFunction : FunctionEmbedding {
  * Kotlin function that will always be handled specially, like aforementioned `Int.plus(Int)`.
  */
 interface FullySpecialKotlinFunction : SpecialKotlinFunction {
-    override fun viperMethod(ctx: TypeResolver): Method? = null
+    override fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method? = null
 }
 
 /**
@@ -54,5 +55,6 @@ interface PartiallySpecialKotlinFunction : SpecialKotlinFunction {
 
     fun initBaseEmbedding(embedding: FunctionEmbedding)
 
-    override fun viperMethod(ctx: TypeResolver): Method? = baseEmbedding?.viperMethod(ctx)
+    override fun viperMethod(ctx: TypeResolver, body: FunctionBodyEmbedding?): Method? =
+        baseEmbedding?.viperMethod(ctx, body)
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -68,7 +68,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
             if (errorCollector.collectedPurityError()) return
             if (errorCollector.collectedAdtError()) return
             programConversionContext.linearizeAll()
-            val program = programConversionContext.program()
+            val program = programConversionContext.buildProgram()
 
             with(programConversionContext.nameResolver) {
                 program.registerAllNames()

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -56,7 +56,9 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
         val errorCollector = ErrorCollector()
         try {
             val programConversionContext = ProgramConverter(session, config, errorCollector)
-            programConversionContext.registerForVerification(declaration)
+            programConversionContext.register(declaration)
+            programConversionContext.convertAll()
+            programConversionContext.validateAll()
             errorCollector.forEachPurityError { source, errorMessage ->
                 reporter.reportOn(source, PluginErrors.PURITY_VIOLATION, errorMessage)
             }
@@ -65,7 +67,8 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
             }
             if (errorCollector.collectedPurityError()) return
             if (errorCollector.collectedAdtError()) return
-            val program = programConversionContext.program
+            programConversionContext.linearizeAll()
+            val program = programConversionContext.program()
 
             with(programConversionContext.nameResolver) {
                 program.registerAllNames()

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/binary_search.fir.diag.txt
@@ -72,7 +72,7 @@ method mid_increased_by_one(arr: Ref, target: Ref) returns (v_ret_0: Ref)
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
-  returns (ret_4: Ref)
+  returns (ret_3: Ref)
   requires acc(this.p_size, write)
   requires intFromRef(this.p_size) >= 0
   requires isSubtype(typeOf(this), List())
@@ -83,12 +83,12 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.p_size)
   ensures acc(this.p_size, write)
   ensures intFromRef(this.p_size) >= 0
-  ensures isSubtype(typeOf(ret_4), List())
-  ensures acc(ret_4.p_size, write)
-  ensures intFromRef(ret_4.p_size) >= 0
-  ensures acc(List_shared(ret_4), wildcard)
+  ensures isSubtype(typeOf(ret_3), List())
+  ensures acc(ret_3.p_size, write)
+  ensures intFromRef(ret_3.p_size) >= 0
+  ensures acc(List_shared(ret_3), wildcard)
   ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
-  ensures intFromRef(ret_4.p_size) ==
+  ensures intFromRef(ret_3.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
@@ -166,7 +166,7 @@ method mid_decreased_by_one(arr: Ref, target: Ref) returns (v_ret_0: Ref)
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
-  returns (ret_4: Ref)
+  returns (ret_3: Ref)
   requires acc(this.p_size, write)
   requires intFromRef(this.p_size) >= 0
   requires isSubtype(typeOf(this), List())
@@ -177,12 +177,12 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.p_size)
   ensures acc(this.p_size, write)
   ensures intFromRef(this.p_size) >= 0
-  ensures isSubtype(typeOf(ret_4), List())
-  ensures acc(ret_4.p_size, write)
-  ensures intFromRef(ret_4.p_size) >= 0
-  ensures acc(List_shared(ret_4), wildcard)
+  ensures isSubtype(typeOf(ret_3), List())
+  ensures acc(ret_3.p_size, write)
+  ensures intFromRef(ret_3.p_size) >= 0
+  ensures acc(List_shared(ret_3), wildcard)
   ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
-  ensures intFromRef(ret_4.p_size) ==
+  ensures intFromRef(ret_3.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 
@@ -261,7 +261,7 @@ method mid_decreased_by_one_in_rec_call(arr: Ref, target: Ref)
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
-  returns (ret_4: Ref)
+  returns (ret_3: Ref)
   requires acc(this.p_size, write)
   requires intFromRef(this.p_size) >= 0
   requires isSubtype(typeOf(this), List())
@@ -272,12 +272,12 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.p_size)
   ensures acc(this.p_size, write)
   ensures intFromRef(this.p_size) >= 0
-  ensures isSubtype(typeOf(ret_4), List())
-  ensures acc(ret_4.p_size, write)
-  ensures intFromRef(ret_4.p_size) >= 0
-  ensures acc(List_shared(ret_4), wildcard)
+  ensures isSubtype(typeOf(ret_3), List())
+  ensures acc(ret_3.p_size, write)
+  ensures intFromRef(ret_3.p_size) >= 0
+  ensures acc(List_shared(ret_3), wildcard)
   ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
-  ensures intFromRef(ret_4.p_size) ==
+  ensures intFromRef(ret_3.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -224,15 +224,15 @@ method mergeStrings(a: Ref, b: Ref) returns (ret_2: Ref)
       stringFromRef(ret_2)[anon_builtin_2])
 
 
-method subs(v_this_extension: Ref, lo: Ref, hi: Ref) returns (ret_4: Ref)
+method subs(v_this_extension: Ref, lo: Ref, hi: Ref) returns (ret_3: Ref)
   requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
     intFromRef(hi) <= |stringFromRef(v_this_extension)|
-  ensures isSubtype(typeOf(ret_4), stringType())
-  ensures |stringFromRef(ret_4)| == intFromRef(hi) - intFromRef(lo)
-  ensures (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(ret_4)| ==>
-      stringFromRef(ret_4)[anon_builtin_4] ==
-      stringFromRef(v_this_extension)[anon_builtin_4 + intFromRef(lo)])
+  ensures isSubtype(typeOf(ret_3), stringType())
+  ensures |stringFromRef(ret_3)| == intFromRef(hi) - intFromRef(lo)
+  ensures (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
+      anon_builtin_3 < |stringFromRef(ret_3)| ==>
+      stringFromRef(ret_3)[anon_builtin_3] ==
+      stringFromRef(v_this_extension)[anon_builtin_3 + intFromRef(lo)])

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.fir.diag.txt
@@ -72,7 +72,7 @@ method safe_binary_search(arr: Ref, target: Ref) returns (v_ret_0: Ref)
 }
 
 method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
-  returns (ret_4: Ref)
+  returns (ret_3: Ref)
   requires acc(this.p_size, write)
   requires intFromRef(this.p_size) >= 0
   requires isSubtype(typeOf(this), List())
@@ -83,12 +83,12 @@ method subList(this: Ref, fromIndex: Ref, toIndex: Ref)
   requires intFromRef(toIndex) <= intFromRef(this.p_size)
   ensures acc(this.p_size, write)
   ensures intFromRef(this.p_size) >= 0
-  ensures isSubtype(typeOf(ret_4), List())
-  ensures acc(ret_4.p_size, write)
-  ensures intFromRef(ret_4.p_size) >= 0
-  ensures acc(List_shared(ret_4), wildcard)
+  ensures isSubtype(typeOf(ret_3), List())
+  ensures acc(ret_3.p_size, write)
+  ensures intFromRef(ret_3.p_size) >= 0
+  ensures acc(List_shared(ret_3), wildcard)
   ensures intFromRef(this.p_size) == old(intFromRef(this.p_size))
-  ensures intFromRef(ret_4.p_size) ==
+  ensures intFromRef(ret_3.p_size) ==
     intFromRef(toIndex) - intFromRef(fromIndex)
 
 


### PR DESCRIPTION
## Summary

Refactor steps 1-3 from #148: pull function-body state off the embedding classes and split the conversion path into discrete convert/linearize halves.

- New `ConvertedBodyResolver` and `LinearizedBodyResolver` hold per-function `ExpEmbedding` and Viper outputs, keyed by `SymbolicName`. Each resolver exposes lookup, store, and (for the convert resolver) a `forEach` traversal — no live `Map` is handed out.
- `UserFunctionEmbedding.body` and `PureUserFunctionEmbedding.body` are gone; both classes are now immutable. `viperMethod` / `viperFunction` take the linearized body as a parameter and `ProgramConverter.program` looks it up.
- `convertMethodWithBody` is split into `convertImpureBody` (writes the `FunctionExp` wrap to `ConvertedBodyResolver`) and `linearizeImpureBody` (reads it back, linearizes, runs `checkValidity`, and writes `FunctionBodyEmbedding` to `LinearizedBodyResolver` if valid). The unit-invariant tail still lives at linearize time per planning. Pure counterpart split the same way.
- `debugExpEmbeddings` now sources from the convert resolver. `FunctionBodyEmbedding.debugExpEmbedding` (and the corresponding interface method on `FunctionBodyConversionResult`) was dead-weighted by the move, so dropped.
- A defensive `check(...)` in `ProgramConverter.program` asserts the invariant "if a body was converted, it was also linearized" so a future bail-condition reshuffle can't silently emit header-only Viper methods.

Out of scope (slated for the remaining steps in #148): a dedicated `check` phase between convert and linearize, and the removal of `InvalidFunctionBodyEmbedding` / `FunctionBodyConversionResult` / tightening of the now-unused return types on the convert functions.

## Test plan

- [x] `./gradlew :formver.compiler-plugin:assemble`
- [x] `./gradlew :formver.compiler-plugin:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)