### PR TITLE
SSA Condition Ordering

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
@@ -30,7 +30,7 @@ class SsaBlockNode(
     fun generateBranchingBlockNodeFromThisNode(condition: Exp): SsaBlockNode =
         SsaBlockNode(
             this,
-            if (fullBranchingCondition == Exp.BoolLit(true)) condition else Exp.And(condition, fullBranchingCondition),
+            if (fullBranchingCondition == Exp.BoolLit(true)) condition else Exp.And(fullBranchingCondition, condition),
         )
 
     context(ssaConverter: SsaConverter)

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/branching.fir.diag.txt
@@ -37,19 +37,19 @@ function nestedBranching(a: Ref, b: Ref): Ref
     (let l0_result_1 ==
       ((boolFromRef(a) ? plusInts(intToRef(1), l0_result_0) : null)) in
       (let l0_result_2 ==
-        ((boolFromRef(b) && boolFromRef(a) ?
+        ((boolFromRef(a) && boolFromRef(b) ?
           plusInts(intToRef(2), l0_result_1) :
           null)) in
         (let l0_result_3 ==
-          ((!boolFromRef(b) && boolFromRef(a) ?
+          ((boolFromRef(a) && !boolFromRef(b) ?
             plusInts(intToRef(3), l0_result_1) :
             null)) in
           (let l0_result_4 ==
-            ((boolFromRef(b) && !boolFromRef(a) ?
+            ((!boolFromRef(a) && boolFromRef(b) ?
               plusInts(intToRef(4), l0_result_0) :
               null)) in
             (let l0_result_5 ==
-              ((!boolFromRef(b) && !boolFromRef(a) ?
+              ((!boolFromRef(a) && !boolFromRef(b) ?
                 plusInts(intToRef(5), l0_result_0) :
                 null)) in
               (let l0_result_6 ==
@@ -81,14 +81,14 @@ function whenExpressionSimple(x: Ref): Ref
       (let y_1 ==
         ((intFromRef(anon_0_0) == 1 ? intToRef(10) : null)) in
         (let y_2 ==
-          ((!(intFromRef(anon_0_0) == 2) && !(intFromRef(anon_0_0) == 1) ?
+          ((!(intFromRef(anon_0_0) == 1) && !(intFromRef(anon_0_0) == 2) ?
             intToRef(30) :
             null)) in
           (let y_3 ==
             ((intFromRef(anon_0_0) == 2 ? y_0 : y_2)) in
             (let y_4 ==
               ((intFromRef(anon_0_0) == 1 ? y_1 : y_3)) in
-              (intFromRef(anon_0_0) == 2 && !(intFromRef(anon_0_0) == 1) ?
+              (!(intFromRef(anon_0_0) == 1) && intFromRef(anon_0_0) == 2 ?
                 intToRef(20) :
                 plusInts(y_4, intToRef(1)))))))))
 }
@@ -100,16 +100,16 @@ function whenNoArgumentBranching(x: Ref, y: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
 {
   (let z_0 ==
-    ((!(intFromRef(x) < 0 || intFromRef(y) < 0) &&
-    (!(intFromRef(x) > 0 && intFromRef(y) > 0) && !(intFromRef(x) == 0)) ?
+    ((!(intFromRef(x) == 0) && !(intFromRef(x) > 0 && intFromRef(y) > 0) &&
+    !(intFromRef(x) < 0 || intFromRef(y) < 0) ?
       intToRef(5) :
       null)) in
     (intFromRef(x) == 0 ?
       intToRef(0) :
-      (intFromRef(x) > 0 && intFromRef(y) > 0 && !(intFromRef(x) == 0) ?
+      (!(intFromRef(x) == 0) && (intFromRef(x) > 0 && intFromRef(y) > 0) ?
         intToRef(1) :
-        ((intFromRef(x) < 0 || intFromRef(y) < 0) &&
-        (!(intFromRef(x) > 0 && intFromRef(y) > 0) && !(intFromRef(x) == 0)) ?
+        (!(intFromRef(x) == 0) && !(intFromRef(x) > 0 && intFromRef(y) > 0) &&
+        (intFromRef(x) < 0 || intFromRef(y) < 0) ?
           intToRef(-1) :
           z_0))))
 }
@@ -122,13 +122,13 @@ function stringEqualityBranching(input: Ref): Ref
   (let isValid_0 ==
     (boolToRef(false)) in
     (let isValid_1 ==
-      ((stringFromRef(input) == Seq(117, 115, 101, 114) &&
-      !(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) ?
+      ((!(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) &&
+      stringFromRef(input) == Seq(117, 115, 101, 114) ?
         boolToRef(true) :
         null)) in
       (let isValid_2 ==
-        ((!(stringFromRef(input) == Seq(117, 115, 101, 114)) &&
-        !(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) ?
+        ((!(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) &&
+        !(stringFromRef(input) == Seq(117, 115, 101, 114)) ?
           boolToRef(false) :
           null)) in
         (let isValid_3 ==
@@ -174,7 +174,7 @@ function complexBooleanReturn(x: Ref): Ref
           ((intFromRef(x) > 50 ? l0_result_1 : l0_result_2)) in
           (intFromRef(x) > 100 ?
             boolToRef(true) :
-            (intFromRef(x) < 0 && !(intFromRef(x) > 50) ?
+            (!(intFromRef(x) > 50) && intFromRef(x) < 0 ?
               boolToRef(false) :
               (boolFromRef(l0_result_3) ?
                 boolToRef(false) :
@@ -220,7 +220,7 @@ function safeNestedDivide(x: Ref, y: Ref, z: Ref): Ref
   (let res_0 ==
     (intToRef(0)) in
     (let res_1 ==
-      ((!(intFromRef(z) == 0) && !(intFromRef(y) == 0) ?
+      ((!(intFromRef(y) == 0) && !(intFromRef(z) == 0) ?
         divInts(divInts(x, y), z) :
         null)) in
       (let res_2 ==

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -65,21 +65,21 @@ function isStrictlyAscendingAndPositive(node: Ref): Ref
             nextNode_0.value)) :
         null)) in
       (let anon_3_0 ==
-        ((intFromRef(anon_2_0) < 0 && !(nextNode_0 == nullValue()) ?
+        ((!(nextNode_0 == nullValue()) && intFromRef(anon_2_0) < 0 ?
           boolToRef(false) :
           null)) in
         (let anon_5_0 ==
-          ((!(intFromRef(anon_2_0) < 0) && !(nextNode_0 == nullValue()) ?
+          ((!(nextNode_0 == nullValue()) && !(intFromRef(anon_2_0) < 0) ?
             (unfolding acc(Node_shared(node), wildcard) in
               (unfolding acc(Node_shared(nextNode_0), wildcard) in
                 nextNode_0.value)) :
             null)) in
           (let anon_6_0 ==
-            ((!(intFromRef(anon_2_0) < 0) && !(nextNode_0 == nullValue()) ?
+            ((!(nextNode_0 == nullValue()) && !(intFromRef(anon_2_0) < 0) ?
               (unfolding acc(Node_shared(node), wildcard) in node.value) :
               null)) in
             (let anon_4_0 ==
-              ((!(intFromRef(anon_2_0) < 0) && !(nextNode_0 == nullValue()) ?
+              ((!(nextNode_0 == nullValue()) && !(intFromRef(anon_2_0) < 0) ?
                 (unfolding acc(Node_shared(node), wildcard) in
                   (unfolding acc(Node_shared(node), wildcard) in
                     (unfolding acc(Node_shared(nextNode_0), wildcard) in

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/local_variables.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/local_variables.fir.diag.txt
@@ -137,15 +137,15 @@ function nestedConditionalAssignment(a: Ref, b: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
 {
   (let anon_1_0 ==
-    ((boolFromRef(b) && boolFromRef(a) ? intToRef(4) : null)) in
+    ((boolFromRef(a) && boolFromRef(b) ? intToRef(4) : null)) in
     (let anon_2_0 ==
-      ((!boolFromRef(b) && boolFromRef(a) ? intToRef(3) : null)) in
+      ((boolFromRef(a) && !boolFromRef(b) ? intToRef(3) : null)) in
       (let anon_0_0 ==
         ((boolFromRef(a) ? (boolFromRef(b) ? anon_1_0 : anon_2_0) : null)) in
         (let anon_4_0 ==
-          ((boolFromRef(b) && !boolFromRef(a) ? intToRef(2) : null)) in
+          ((!boolFromRef(a) && boolFromRef(b) ? intToRef(2) : null)) in
           (let anon_5_0 ==
-            ((!boolFromRef(b) && !boolFromRef(a) ? intToRef(1) : null)) in
+            ((!boolFromRef(a) && !boolFromRef(b) ? intToRef(1) : null)) in
             (let anon_3_0 ==
               ((!boolFromRef(a) ?
                 (boolFromRef(b) ? anon_4_0 : anon_5_0) :
@@ -162,9 +162,9 @@ function blockConditionalAssignment(a: Ref, b: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
 {
   (let anon_1_0 ==
-    ((boolFromRef(b) && boolFromRef(a) ? intToRef(10) : null)) in
+    ((boolFromRef(a) && boolFromRef(b) ? intToRef(10) : null)) in
     (let anon_2_0 ==
-      ((!boolFromRef(b) && boolFromRef(a) ? intToRef(20) : null)) in
+      ((boolFromRef(a) && !boolFromRef(b) ? intToRef(20) : null)) in
       (let y_0 ==
         ((boolFromRef(a) ? (boolFromRef(b) ? anon_1_0 : anon_2_0) : null)) in
         (let anon_0_0 ==
@@ -185,9 +185,9 @@ function whenAssignment(a: Ref, b: Ref): Ref
   (let anon_0_0 ==
     (a) in
     (let anon_2_0 ==
-      ((boolFromRef(b) && intFromRef(anon_0_0) == 1 ? intToRef(2) : null)) in
+      ((intFromRef(anon_0_0) == 1 && boolFromRef(b) ? intToRef(2) : null)) in
       (let anon_3_0 ==
-        ((!boolFromRef(b) && intFromRef(anon_0_0) == 1 ?
+        ((intFromRef(anon_0_0) == 1 && !boolFromRef(b) ?
           intToRef(3) :
           null)) in
         (let anon_1_0 ==
@@ -195,12 +195,12 @@ function whenAssignment(a: Ref, b: Ref): Ref
             (boolFromRef(b) ? anon_2_0 : anon_3_0) :
             null)) in
           (let anon_5_0 ==
-            ((intFromRef(anon_0_0) == 2 && !(intFromRef(anon_0_0) == 1) ?
+            ((!(intFromRef(anon_0_0) == 1) && intFromRef(anon_0_0) == 2 ?
               intToRef(4) :
               null)) in
             (let anon_6_0 ==
-              ((!(intFromRef(anon_0_0) == 2) &&
-              !(intFromRef(anon_0_0) == 1) ?
+              ((!(intFromRef(anon_0_0) == 1) &&
+              !(intFromRef(anon_0_0) == 2) ?
                 intToRef(5) :
                 null)) in
               (let anon_4_0 ==


### PR DESCRIPTION
This PR solves a minor issue with the order of aggregated conditions in the SSA conversion.

Example:
```kotlin
if (nextNode != null) {
      if (nextNode.value < 0) {
          false
      } else {
          nextNode.value > node.value && isStrictlyAscendingAndPositive(nextNode)
      }
}
```
This generated the viper code :

```viper
let anon_3_0 ==
        ((intFromRef(anon_2_0) < 0 && !(nextNode_0 == nullValue()) ?
          boolToRef(false) :
          null)
```
But the order of the `&&` should be the other way around. This was not really a problem yet, because we used leaky wildcard permissions. When I removed the shared predicates and used the unique instead viper complained about missing permissions. This was the case because we first read the field `anon_2_0` and only then checked if the receiver is not null.  