### PR TITLE
Ignore Empty Pre/Postconditions

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -302,9 +302,13 @@ data class InvariantsAndTriggers(
     val triggers: List<ExpEmbedding>
 )
 
+private fun FirBlock.isEmptyLambdaBody(): Boolean {
+    if (statements.isEmpty()) return false
+    return (statements.size == 1 && (statements.first() as? FirReturnExpression)?.result?.resolvedType?.isUnit ?: false)
+}
+
 fun StmtConversionContext.collectInvariants(block: FirBlock) = buildList {
-    // if the lambda is empty the compiler inserts a return Unit
-    if (block.statements.size == 1 && (block.statements.first() as? FirReturnExpression)?.result?.resolvedType?.isUnit ?: false) {
+    if (block.isEmptyLambdaBody()) {
         return@buildList
     }
     block.statements.forEach { stmt ->

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.references.symbol
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.fir.types.isBoolean
+import org.jetbrains.kotlin.fir.types.isUnit
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
@@ -302,6 +303,10 @@ data class InvariantsAndTriggers(
 )
 
 fun StmtConversionContext.collectInvariants(block: FirBlock) = buildList {
+    // if the lambda is empty the compiler inserts a return Unit
+    if (block.statements.size == 1 && (block.statements.first() as? FirReturnExpression)?.result?.resolvedType?.isUnit ?: false) {
+        return@buildList
+    }
     block.statements.forEach { stmt ->
         check(stmt is FirExpression && stmt.resolvedType.isBoolean) {
             INVALID_STATEMENT_MSG

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -816,6 +816,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("empty.kt")
+      public void testEmpty() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.kt");
+      }
+
+      @Test
       @TestMetadata("factorial.kt")
       public void testFactorial() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/factorial.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
@@ -1,0 +1,48 @@
+/empty.kt: info: Generated Viper text for bothEmpty:
+method bothEmpty(par_arg: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_arg), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+{
+  v_ret_0 := par_arg
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/empty.kt: info: Generated Viper text for preEmpty:
+method preEmpty(par_arg: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_arg), boolType())
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures boolFromRef(v_ret_0) == boolFromRef(par_arg)
+{
+  v_ret_0 := par_arg
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/empty.kt: info: Generated Viper text for postEmpty:
+method postEmpty(par_arg: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_arg), boolType())
+  requires boolFromRef(par_arg) == true
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+{
+  v_ret_0 := par_arg
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/empty.kt: info: Generated Viper text for testInsertedReturn:
+method testInsertedReturn() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  goto lbl_ret_0
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/empty.kt: error: 'return' is prohibited here.
+
+/empty.kt: error: 'return' is prohibited here.
+
+/empty.kt: error: An internal error has occurred.
+Details: Every statement in invariant block must be a pure boolean invariant.
+Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
@@ -39,10 +39,6 @@ method testInsertedReturn() returns (v_ret_0: Ref)
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
 
-/empty.kt: error: 'return' is prohibited here.
-
-/empty.kt: error: 'return' is prohibited here.
-
 /empty.kt: error: An internal error has occurred.
 Details: Every statement in invariant block must be a pure boolean invariant.
 Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.kt
@@ -1,0 +1,44 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+
+fun <!VIPER_TEXT!>bothEmpty<!>(arg: Boolean): Boolean {
+    preconditions {}
+    postconditions<Boolean> {}
+    return arg
+}
+
+fun <!VIPER_TEXT!>preEmpty<!>(arg: Boolean): Boolean {
+    preconditions {}
+    postconditions<Boolean> { ret -> ret == arg }
+    return arg
+}
+
+fun <!VIPER_TEXT!>postEmpty<!>(arg: Boolean): Boolean {
+    preconditions {
+        arg == true
+    }
+    postconditions<Boolean> {}
+    return arg
+}
+
+fun <!VIPER_TEXT!>testInsertedReturn<!>() {
+    preconditions {
+        <!RETURN_NOT_ALLOWED!>return<!> Unit
+    }
+    postconditions<Unit> {
+        <!RETURN_NOT_ALLOWED!>return<!> Unit
+    }
+    return
+}
+
+<!INTERNAL_ERROR!>fun testInsertedUnit() {
+    preconditions {
+        Unit
+    }
+    postconditions<Unit> {
+        Unit
+    }
+    return
+}<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.kt
@@ -25,10 +25,9 @@ fun <!VIPER_TEXT!>postEmpty<!>(arg: Boolean): Boolean {
 
 fun <!VIPER_TEXT!>testInsertedReturn<!>() {
     preconditions {
-        <!RETURN_NOT_ALLOWED!>return<!> Unit
+        return@preconditions Unit
     }
     postconditions<Unit> {
-        <!RETURN_NOT_ALLOWED!>return<!> Unit
     }
     return
 }


### PR DESCRIPTION
This PR resolves the issue that an internal error is thrown if a user has a empty lambda as pre/postcondition