### PR TITLE
Add early returns (rebased)

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.formver.core.names.SsaVariableName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toDisjunction
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
 class SsaConverter(
@@ -42,7 +43,7 @@ class SsaConverter(
             thenResultHead.returns && head.returns -> Exp.BoolLit(false)
             thenResultHead.returns -> head.fullBranchingCondition
             head.returns -> thenResultHead.fullBranchingCondition
-            else -> splitPoint.fullBranchingCondition
+            else -> listOf(thenResultHead.fullBranchingCondition, head.fullBranchingCondition).toDisjunction()
         }
         head = SsaBlockNode(joinNode, branchCondition)
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -38,7 +38,13 @@ class SsaConverter(
             condition,
             this
         )
-        head = SsaBlockNode(joinNode, splitPoint.fullBranchingCondition)
+        val branchCondition = when {
+            thenResultHead.returns && head.returns -> Exp.BoolLit(false)
+            thenResultHead.returns -> head.fullBranchingCondition
+            head.returns -> thenResultHead.fullBranchingCondition
+            else -> splitPoint.fullBranchingCondition
+        }
+        head = SsaBlockNode(joinNode, branchCondition)
     }
 
     fun constructExpression(): Exp {
@@ -92,6 +98,7 @@ class SsaConverter(
     }
 
     fun addReturn(returnExp: Exp) {
+        head.returns = true
         returnExpressions.add(head.fullBranchingCondition to returnExp)
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaConverter.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.formver.core.names.SsaVariableName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
-import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toDisjunction
 import org.jetbrains.kotlin.formver.viper.ast.Type
 
 class SsaConverter(
@@ -39,11 +38,14 @@ class SsaConverter(
             condition,
             this
         )
+        // The branching condition of the join is "under what condition is code after the
+        // if-else reachable". A branch that ends in `return` contributes no reachable
+        // continuation, so we drop its side of the disjunction.
         val branchCondition = when {
             thenResultHead.returns && head.returns -> Exp.BoolLit(false)
             thenResultHead.returns -> head.fullBranchingCondition
             head.returns -> thenResultHead.fullBranchingCondition
-            else -> listOf(thenResultHead.fullBranchingCondition, head.fullBranchingCondition).toDisjunction()
+            else -> Exp.Or(thenResultHead.fullBranchingCondition, head.fullBranchingCondition)
         }
         head = SsaBlockNode(joinNode, branchCondition)
     }
@@ -99,7 +101,7 @@ class SsaConverter(
     }
 
     fun addReturn(returnExp: Exp) {
-        head.returns = true
+        head.markAsReturning()
         returnExpressions.add(head.fullBranchingCondition to returnExp)
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
@@ -23,9 +23,10 @@ class SsaStartNode : SsaNode {
 
 class SsaBlockNode(
     private val predecessor: SsaNode,
-    val fullBranchingCondition: Exp
+    val fullBranchingCondition: Exp,
 ) : SsaNode {
     val latestName: MutableMap<SymbolicName, SsaVariableName> = mutableMapOf()
+    var returns: Boolean = false
 
     fun generateBranchingBlockNodeFromThisNode(condition: Exp): SsaBlockNode =
         SsaBlockNode(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/SsaNode.kt
@@ -27,6 +27,11 @@ class SsaBlockNode(
 ) : SsaNode {
     val latestName: MutableMap<SymbolicName, SsaVariableName> = mutableMapOf()
     var returns: Boolean = false
+        private set
+
+    fun markAsReturning() {
+        returns = true
+    }
 
     fun generateBranchingBlockNodeFromThisNode(condition: Exp): SsaBlockNode =
         SsaBlockNode(

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/branching.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/branching.fir.diag.txt
@@ -6,7 +6,9 @@ function noAssignmentInBlocks(a: Ref): Ref
   (let l0_result_0 ==
     (intToRef(0)) in
     (let l0_result_1 ==
-      (plusInts(l0_result_0, intToRef(1))) in
+      ((boolFromRef(a) || !boolFromRef(a) ?
+        plusInts(l0_result_0, intToRef(1)) :
+        null)) in
       l0_result_1))
 }
 
@@ -22,7 +24,9 @@ function simpleBranching(a: Ref): Ref
       (let l0_result_2 ==
         ((!boolFromRef(a) ? plusInts(l0_result_0, intToRef(2)) : null)) in
         (let l0_result_3 ==
-          ((boolFromRef(a) ? l0_result_1 : l0_result_2)) in
+          ((boolFromRef(a) || !boolFromRef(a) ?
+            (boolFromRef(a) ? l0_result_1 : l0_result_2) :
+            null)) in
           l0_result_3))))
 }
 
@@ -53,19 +57,36 @@ function nestedBranching(a: Ref, b: Ref): Ref
                 plusInts(intToRef(5), l0_result_0) :
                 null)) in
               (let l0_result_6 ==
-                ((!boolFromRef(a) ?
+                ((!boolFromRef(a) && boolFromRef(b) ||
+                !boolFromRef(a) && !boolFromRef(b) ?
                   (boolFromRef(b) ? l0_result_4 : l0_result_5) :
                   null)) in
                 (let l0_result_7 ==
-                  ((!boolFromRef(a) ?
+                  ((!boolFromRef(a) && boolFromRef(b) ||
+                  !boolFromRef(a) && !boolFromRef(b) ?
                     plusInts(intToRef(6), l0_result_6) :
                     null)) in
                   (let l0_result_8 ==
-                    ((boolFromRef(b) ? l0_result_2 : l0_result_3)) in
+                    ((boolFromRef(a) && boolFromRef(b) ||
+                    boolFromRef(a) && !boolFromRef(b) ||
+                    (!boolFromRef(a) && boolFromRef(b) ||
+                    !boolFromRef(a) && !boolFromRef(b)) ?
+                      (boolFromRef(b) ? l0_result_2 : l0_result_3) :
+                      null)) in
                     (let l0_result_9 ==
-                      ((boolFromRef(a) ? l0_result_8 : l0_result_7)) in
+                      ((boolFromRef(a) && boolFromRef(b) ||
+                      boolFromRef(a) && !boolFromRef(b) ||
+                      (!boolFromRef(a) && boolFromRef(b) ||
+                      !boolFromRef(a) && !boolFromRef(b)) ?
+                        (boolFromRef(a) ? l0_result_8 : l0_result_7) :
+                        null)) in
                       (let l0_result_10 ==
-                        (plusInts(intToRef(7), l0_result_9)) in
+                        ((boolFromRef(a) && boolFromRef(b) ||
+                        boolFromRef(a) && !boolFromRef(b) ||
+                        (!boolFromRef(a) && boolFromRef(b) ||
+                        !boolFromRef(a) && !boolFromRef(b)) ?
+                          plusInts(intToRef(7), l0_result_9) :
+                          null)) in
                         l0_result_10)))))))))))
 }
 
@@ -85,9 +106,15 @@ function whenExpressionSimple(x: Ref): Ref
             intToRef(30) :
             null)) in
           (let y_3 ==
-            ((intFromRef(anon_0_0) == 2 ? y_0 : y_2)) in
+            ((intFromRef(anon_0_0) == 1 ||
+            !(intFromRef(anon_0_0) == 1) && !(intFromRef(anon_0_0) == 2) ?
+              (intFromRef(anon_0_0) == 2 ? y_0 : y_2) :
+              null)) in
             (let y_4 ==
-              ((intFromRef(anon_0_0) == 1 ? y_1 : y_3)) in
+              ((intFromRef(anon_0_0) == 1 ||
+              !(intFromRef(anon_0_0) == 1) && !(intFromRef(anon_0_0) == 2) ?
+                (intFromRef(anon_0_0) == 1 ? y_1 : y_3) :
+                null)) in
               (!(intFromRef(anon_0_0) == 1) && intFromRef(anon_0_0) == 2 ?
                 intToRef(20) :
                 plusInts(y_4, intToRef(1)))))))))
@@ -132,13 +159,23 @@ function stringEqualityBranching(input: Ref): Ref
           boolToRef(false) :
           null)) in
         (let isValid_3 ==
-          ((stringFromRef(input) == Seq(117, 115, 101, 114) ?
-            isValid_1 :
-            isValid_2)) in
+          ((!(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) &&
+          stringFromRef(input) == Seq(117, 115, 101, 114) ||
+          !(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) &&
+          !(stringFromRef(input) == Seq(117, 115, 101, 114)) ?
+            (stringFromRef(input) == Seq(117, 115, 101, 114) ?
+              isValid_1 :
+              isValid_2) :
+            null)) in
           (let isValid_4 ==
-            ((stringFromRef(input) == Seq(97, 100, 109, 105, 110) ?
-              isValid_0 :
-              isValid_3)) in
+            ((!(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) &&
+            stringFromRef(input) == Seq(117, 115, 101, 114) ||
+            !(stringFromRef(input) == Seq(97, 100, 109, 105, 110)) &&
+            !(stringFromRef(input) == Seq(117, 115, 101, 114)) ?
+              (stringFromRef(input) == Seq(97, 100, 109, 105, 110) ?
+                isValid_0 :
+                isValid_3) :
+              null)) in
             (stringFromRef(input) == Seq(97, 100, 109, 105, 110) ?
               boolToRef(true) :
               isValid_4))))))
@@ -155,8 +192,13 @@ function sequentialIfWithMutation(): Ref
       (let x_2 ==
         ((!(intFromRef(x_0) > 5) ? intToRef(20) : null)) in
         (let x_3 ==
-          ((intFromRef(x_0) > 5 ? x_1 : x_2)) in
-          (intFromRef(x_3) == 2 ? intToRef(100) : intToRef(0))))))
+          ((intFromRef(x_0) > 5 || !(intFromRef(x_0) > 5) ?
+            (intFromRef(x_0) > 5 ? x_1 : x_2) :
+            null)) in
+          ((intFromRef(x_0) > 5 || !(intFromRef(x_0) > 5)) &&
+          intFromRef(x_3) == 2 ?
+            intToRef(100) :
+            intToRef(0))))))
 }
 
 /branching.kt: info: Generated Viper text for complexBooleanReturn:
@@ -165,18 +207,31 @@ function complexBooleanReturn(x: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
 {
   (let l0_result_0 ==
-    (boolToRef(false)) in
+    ((!(intFromRef(x) > 100) ? boolToRef(false) : null)) in
     (let l0_result_1 ==
-      ((intFromRef(x) > 50 ? boolToRef(true) : null)) in
+      ((!(intFromRef(x) > 100) && intFromRef(x) > 50 ?
+        boolToRef(true) :
+        null)) in
       (let l0_result_2 ==
-        ((!(intFromRef(x) > 50) ? boolToRef(true) : null)) in
+        ((!(intFromRef(x) > 100) && !(intFromRef(x) > 50) &&
+        !(intFromRef(x) < 0) ?
+          boolToRef(true) :
+          null)) in
         (let l0_result_3 ==
-          ((intFromRef(x) > 50 ? l0_result_1 : l0_result_2)) in
+          ((!(intFromRef(x) > 100) && intFromRef(x) > 50 ||
+          !(intFromRef(x) > 100) && !(intFromRef(x) > 50) &&
+          !(intFromRef(x) < 0) ?
+            (intFromRef(x) > 50 ? l0_result_1 : l0_result_2) :
+            null)) in
           (intFromRef(x) > 100 ?
             boolToRef(true) :
-            (!(intFromRef(x) > 50) && intFromRef(x) < 0 ?
+            (!(intFromRef(x) > 100) && !(intFromRef(x) > 50) &&
+            intFromRef(x) < 0 ?
               boolToRef(false) :
-              (boolFromRef(l0_result_3) ?
+              ((!(intFromRef(x) > 100) && intFromRef(x) > 50 ||
+              !(intFromRef(x) > 100) && !(intFromRef(x) > 50) &&
+              !(intFromRef(x) < 0)) &&
+              boolFromRef(l0_result_3) ?
                 boolToRef(false) :
                 boolToRef(true))))))))
 }
@@ -192,7 +247,9 @@ function safeDivide(x: Ref, y: Ref): Ref
     (let res_1 ==
       ((!(intFromRef(y) == 0) ? divInts(x, y) : null)) in
       (let res_2 ==
-        ((!(intFromRef(y) == 0) ? res_1 : res_0)) in
+        ((!(intFromRef(y) == 0) || !!(intFromRef(y) == 0) ?
+          (!(intFromRef(y) == 0) ? res_1 : res_0) :
+          null)) in
         res_2)))
 }
 
@@ -206,7 +263,10 @@ function getStringLength(obj: Ref): Ref
     (let len_1 ==
       ((isSubtype(typeOf(obj), stringType()) ? stringLength(obj) : null)) in
       (let len_2 ==
-        ((isSubtype(typeOf(obj), stringType()) ? len_1 : len_0)) in
+        ((isSubtype(typeOf(obj), stringType()) ||
+        !isSubtype(typeOf(obj), stringType()) ?
+          (isSubtype(typeOf(obj), stringType()) ? len_1 : len_0) :
+          null)) in
         len_2)))
 }
 
@@ -224,9 +284,17 @@ function safeNestedDivide(x: Ref, y: Ref, z: Ref): Ref
         divInts(divInts(x, y), z) :
         null)) in
       (let res_2 ==
-        ((!(intFromRef(z) == 0) ? res_1 : res_0)) in
+        ((!(intFromRef(y) == 0) && !(intFromRef(z) == 0) ||
+        !(intFromRef(y) == 0) && !!(intFromRef(z) == 0) ||
+        !!(intFromRef(y) == 0) ?
+          (!(intFromRef(z) == 0) ? res_1 : res_0) :
+          null)) in
         (let res_3 ==
-          ((!(intFromRef(y) == 0) ? res_2 : res_0)) in
+          ((!(intFromRef(y) == 0) && !(intFromRef(z) == 0) ||
+          !(intFromRef(y) == 0) && !!(intFromRef(z) == 0) ||
+          !!(intFromRef(y) == 0) ?
+            (!(intFromRef(y) == 0) ? res_2 : res_0) :
+            null)) in
           res_3))))
 }
 
@@ -243,6 +311,9 @@ function safeInverseDifference(x: Ref, y: Ref): Ref
         divInts(intToRef(100), minusInts(x, y)) :
         null)) in
       (let res_2 ==
-        ((!(intFromRef(x) == intFromRef(y)) ? res_1 : res_0)) in
+        ((!(intFromRef(x) == intFromRef(y)) ||
+        !!(intFromRef(x) == intFromRef(y)) ?
+          (!(intFromRef(x) == intFromRef(y)) ? res_1 : res_0) :
+          null)) in
         res_2)))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/heap_dependent_specifications.fir.diag.txt
@@ -13,17 +13,34 @@ function isAlternating(node: Ref, expectsPositive: Ref): Ref
         ltInts(value(node), intToRef(0)) :
         null)) in
       (let isCurrentValid_0 ==
-        ((boolFromRef(expectsPositive) ? anon_0_0 : anon_1_0)) in
+        ((boolFromRef(expectsPositive) || !boolFromRef(expectsPositive) ?
+          (boolFromRef(expectsPositive) ? anon_0_0 : anon_1_0) :
+          null)) in
         (let nextNode_0 ==
-          (next(node)) in
+          ((boolFromRef(expectsPositive) || !boolFromRef(expectsPositive) ?
+            next(node) :
+            null)) in
           (let anon_3_0 ==
-            ((!(nextNode_0 == nullValue()) ?
+            (((boolFromRef(expectsPositive) ||
+            !boolFromRef(expectsPositive)) &&
+            !(nextNode_0 == nullValue()) ?
               isAlternating(nextNode_0, notBool(expectsPositive)) :
               null)) in
             (let anon_4_0 ==
-              ((!!(nextNode_0 == nullValue()) ? boolToRef(true) : null)) in
+              (((boolFromRef(expectsPositive) ||
+              !boolFromRef(expectsPositive)) &&
+              !!(nextNode_0 == nullValue()) ?
+                boolToRef(true) :
+                null)) in
               (let anon_2_0 ==
-                ((!(nextNode_0 == nullValue()) ? anon_3_0 : anon_4_0)) in
+                (((boolFromRef(expectsPositive) ||
+                !boolFromRef(expectsPositive)) &&
+                !(nextNode_0 == nullValue()) ||
+                (boolFromRef(expectsPositive) ||
+                !boolFromRef(expectsPositive)) &&
+                !!(nextNode_0 == nullValue()) ?
+                  (!(nextNode_0 == nullValue()) ? anon_3_0 : anon_4_0) :
+                  null)) in
                 andBools(isCurrentValid_0, anon_2_0))))))))
 }
 
@@ -55,13 +72,22 @@ function isStrictlyAscendingAndPositive(node: Ref): Ref
           andBools(gtInts(value(nextNode_0), value(node)), isStrictlyAscendingAndPositive(nextNode_0)) :
           null)) in
         (let anon_1_0 ==
-          ((!(nextNode_0 == nullValue()) ?
+          ((!(nextNode_0 == nullValue()) &&
+          intFromRef(value(nextNode_0)) < 0 ||
+          !(nextNode_0 == nullValue()) &&
+          !(intFromRef(value(nextNode_0)) < 0) ?
             (intFromRef(value(nextNode_0)) < 0 ? anon_2_0 : anon_3_0) :
             null)) in
           (let anon_4_0 ==
             ((!!(nextNode_0 == nullValue()) ? boolToRef(true) : null)) in
             (let anon_0_0 ==
-              ((!(nextNode_0 == nullValue()) ? anon_1_0 : anon_4_0)) in
+              ((!(nextNode_0 == nullValue()) &&
+              intFromRef(value(nextNode_0)) < 0 ||
+              !(nextNode_0 == nullValue()) &&
+              !(intFromRef(value(nextNode_0)) < 0) ||
+              !!(nextNode_0 == nullValue()) ?
+                (!(nextNode_0 == nullValue()) ? anon_1_0 : anon_4_0) :
+                null)) in
               anon_0_0))))))
 }
 
@@ -89,17 +115,34 @@ function isLocallyValidBST(node: Ref): Ref
       (let anon_1_0 ==
         ((!!(leftNode_0 == nullValue()) ? boolToRef(true) : null)) in
         (let leftValid_0 ==
-          ((!(leftNode_0 == nullValue()) ? anon_0_0 : anon_1_0)) in
+          ((!(leftNode_0 == nullValue()) || !!(leftNode_0 == nullValue()) ?
+            (!(leftNode_0 == nullValue()) ? anon_0_0 : anon_1_0) :
+            null)) in
           (let rightNode_0 ==
-            (right(node)) in
+            ((!(leftNode_0 == nullValue()) || !!(leftNode_0 == nullValue()) ?
+              right(node) :
+              null)) in
             (let anon_2_0 ==
-              ((!(rightNode_0 == nullValue()) ?
+              (((!(leftNode_0 == nullValue()) ||
+              !!(leftNode_0 == nullValue())) &&
+              !(rightNode_0 == nullValue()) ?
                 andBools(gtInts(value(rightNode_0), value(node)), isLocallyValidBST(rightNode_0)) :
                 null)) in
               (let anon_3_0 ==
-                ((!!(rightNode_0 == nullValue()) ? boolToRef(true) : null)) in
+                (((!(leftNode_0 == nullValue()) ||
+                !!(leftNode_0 == nullValue())) &&
+                !!(rightNode_0 == nullValue()) ?
+                  boolToRef(true) :
+                  null)) in
                 (let rightValid_0 ==
-                  ((!(rightNode_0 == nullValue()) ? anon_2_0 : anon_3_0)) in
+                  (((!(leftNode_0 == nullValue()) ||
+                  !!(leftNode_0 == nullValue())) &&
+                  !(rightNode_0 == nullValue()) ||
+                  (!(leftNode_0 == nullValue()) ||
+                  !!(leftNode_0 == nullValue())) &&
+                  !!(rightNode_0 == nullValue()) ?
+                    (!(rightNode_0 == nullValue()) ? anon_2_0 : anon_3_0) :
+                    null)) in
                   andBools(leftValid_0, rightValid_0)))))))))
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/local_variables.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/local_variables.fir.diag.txt
@@ -141,17 +141,26 @@ function nestedConditionalAssignment(a: Ref, b: Ref): Ref
     (let anon_2_0 ==
       ((boolFromRef(a) && !boolFromRef(b) ? intToRef(3) : null)) in
       (let anon_0_0 ==
-        ((boolFromRef(a) ? (boolFromRef(b) ? anon_1_0 : anon_2_0) : null)) in
+        ((boolFromRef(a) && boolFromRef(b) ||
+        boolFromRef(a) && !boolFromRef(b) ?
+          (boolFromRef(b) ? anon_1_0 : anon_2_0) :
+          null)) in
         (let anon_4_0 ==
           ((!boolFromRef(a) && boolFromRef(b) ? intToRef(2) : null)) in
           (let anon_5_0 ==
             ((!boolFromRef(a) && !boolFromRef(b) ? intToRef(1) : null)) in
             (let anon_3_0 ==
-              ((!boolFromRef(a) ?
+              ((!boolFromRef(a) && boolFromRef(b) ||
+              !boolFromRef(a) && !boolFromRef(b) ?
                 (boolFromRef(b) ? anon_4_0 : anon_5_0) :
                 null)) in
               (let x_0 ==
-                ((boolFromRef(a) ? anon_0_0 : anon_3_0)) in
+                ((boolFromRef(a) && boolFromRef(b) ||
+                boolFromRef(a) && !boolFromRef(b) ||
+                (!boolFromRef(a) && boolFromRef(b) ||
+                !boolFromRef(a) && !boolFromRef(b)) ?
+                  (boolFromRef(a) ? anon_0_0 : anon_3_0) :
+                  null)) in
                 x_0)))))))
 }
 
@@ -166,13 +175,23 @@ function blockConditionalAssignment(a: Ref, b: Ref): Ref
     (let anon_2_0 ==
       ((boolFromRef(a) && !boolFromRef(b) ? intToRef(20) : null)) in
       (let y_0 ==
-        ((boolFromRef(a) ? (boolFromRef(b) ? anon_1_0 : anon_2_0) : null)) in
+        ((boolFromRef(a) && boolFromRef(b) ||
+        boolFromRef(a) && !boolFromRef(b) ?
+          (boolFromRef(b) ? anon_1_0 : anon_2_0) :
+          null)) in
         (let anon_0_0 ==
-          ((boolFromRef(a) ? plusInts(y_0, intToRef(1)) : null)) in
+          ((boolFromRef(a) && boolFromRef(b) ||
+          boolFromRef(a) && !boolFromRef(b) ?
+            plusInts(y_0, intToRef(1)) :
+            null)) in
           (let anon_3_0 ==
             ((!boolFromRef(a) ? intToRef(30) : null)) in
             (let x_0 ==
-              ((boolFromRef(a) ? anon_0_0 : anon_3_0)) in
+              ((boolFromRef(a) && boolFromRef(b) ||
+              boolFromRef(a) && !boolFromRef(b) ||
+              !boolFromRef(a) ?
+                (boolFromRef(a) ? anon_0_0 : anon_3_0) :
+                null)) in
               x_0))))))
 }
 
@@ -191,7 +210,8 @@ function whenAssignment(a: Ref, b: Ref): Ref
           intToRef(3) :
           null)) in
         (let anon_1_0 ==
-          ((intFromRef(anon_0_0) == 1 ?
+          ((intFromRef(anon_0_0) == 1 && boolFromRef(b) ||
+          intFromRef(anon_0_0) == 1 && !boolFromRef(b) ?
             (boolFromRef(b) ? anon_2_0 : anon_3_0) :
             null)) in
           (let anon_5_0 ==
@@ -204,10 +224,19 @@ function whenAssignment(a: Ref, b: Ref): Ref
                 intToRef(5) :
                 null)) in
               (let anon_4_0 ==
-                ((!(intFromRef(anon_0_0) == 1) ?
+                ((!(intFromRef(anon_0_0) == 1) && intFromRef(anon_0_0) == 2 ||
+                !(intFromRef(anon_0_0) == 1) &&
+                !(intFromRef(anon_0_0) == 2) ?
                   (intFromRef(anon_0_0) == 2 ? anon_5_0 : anon_6_0) :
                   null)) in
                 (let x_0 ==
-                  ((intFromRef(anon_0_0) == 1 ? anon_1_0 : anon_4_0)) in
+                  ((intFromRef(anon_0_0) == 1 && boolFromRef(b) ||
+                  intFromRef(anon_0_0) == 1 && !boolFromRef(b) ||
+                  (!(intFromRef(anon_0_0) == 1) &&
+                  intFromRef(anon_0_0) == 2 ||
+                  !(intFromRef(anon_0_0) == 1) &&
+                  !(intFromRef(anon_0_0) == 2)) ?
+                    (intFromRef(anon_0_0) == 1 ? anon_1_0 : anon_4_0) :
+                    null)) in
                   x_0))))))))
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -22,9 +22,16 @@ function getSafeNextValue(node: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
 {
   (let anon_1_0 ==
-    ((next(node) != nullValue() ? value(next(node)) : nullValue())) in
+    ((next(node) != nullValue() || !(next(node) != nullValue()) ?
+      (next(node) != nullValue() ? value(next(node)) : nullValue()) :
+      null)) in
     (let anon_0_0 ==
-      ((anon_1_0 != nullValue() ? anon_1_0 : intToRef(-1))) in
+      (((next(node) != nullValue() || !(next(node) != nullValue())) &&
+      anon_1_0 != nullValue() ||
+      (next(node) != nullValue() || !(next(node) != nullValue())) &&
+      !(anon_1_0 != nullValue()) ?
+        (anon_1_0 != nullValue() ? anon_1_0 : intToRef(-1)) :
+        null)) in
       anon_0_0))
 }
 
@@ -44,11 +51,29 @@ function getSafeNextNextValue(node: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
 {
   (let anon_2_0 ==
-    ((next(node) != nullValue() ? next(next(node)) : nullValue())) in
+    ((next(node) != nullValue() || !(next(node) != nullValue()) ?
+      (next(node) != nullValue() ? next(next(node)) : nullValue()) :
+      null)) in
     (let anon_1_0 ==
-      ((anon_2_0 != nullValue() ? value(anon_2_0) : nullValue())) in
+      (((next(node) != nullValue() || !(next(node) != nullValue())) &&
+      anon_2_0 != nullValue() ||
+      (next(node) != nullValue() || !(next(node) != nullValue())) &&
+      !(anon_2_0 != nullValue()) ?
+        (anon_2_0 != nullValue() ? value(anon_2_0) : nullValue()) :
+        null)) in
       (let anon_0_0 ==
-        ((anon_1_0 != nullValue() ? anon_1_0 : intToRef(0))) in
+        ((((next(node) != nullValue() || !(next(node) != nullValue())) &&
+        anon_2_0 != nullValue() ||
+        (next(node) != nullValue() || !(next(node) != nullValue())) &&
+        !(anon_2_0 != nullValue())) &&
+        anon_1_0 != nullValue() ||
+        ((next(node) != nullValue() || !(next(node) != nullValue())) &&
+        anon_2_0 != nullValue() ||
+        (next(node) != nullValue() || !(next(node) != nullValue())) &&
+        !(anon_2_0 != nullValue())) &&
+        !(anon_1_0 != nullValue()) ?
+          (anon_1_0 != nullValue() ? anon_1_0 : intToRef(0)) :
+          null)) in
         anon_0_0)))
 }
 
@@ -81,7 +106,9 @@ function sumFirstTwoNodes(node: Ref): Ref
       (let anon_2_0 ==
         ((!!(nextNode_0 == nullValue()) ? value(node) : null)) in
         (let anon_0_0 ==
-          ((!(nextNode_0 == nullValue()) ? anon_1_0 : anon_2_0)) in
+          ((!(nextNode_0 == nullValue()) || !!(nextNode_0 == nullValue()) ?
+            (!(nextNode_0 == nullValue()) ? anon_1_0 : anon_2_0) :
+            null)) in
           anon_0_0))))
 }
 
@@ -122,7 +149,9 @@ function length(node: Ref): Ref
           plusInts(intToRef(1), length(nextNode_0)) :
           null)) in
         (let anon_0_0 ==
-          ((nextNode_0 == nullValue() ? anon_1_0 : anon_2_0)) in
+          ((nextNode_0 == nullValue() || !(nextNode_0 == nullValue()) ?
+            (nextNode_0 == nullValue() ? anon_1_0 : anon_2_0) :
+            null)) in
           anon_0_0))))
 }
 
@@ -155,7 +184,9 @@ function sumAllNodes(node: Ref): Ref
           plusInts(value(node), sumAllNodes(nextNode_0)) :
           null)) in
         (let anon_0_0 ==
-          ((nextNode_0 == nullValue() ? anon_1_0 : anon_2_0)) in
+          ((nextNode_0 == nullValue() || !(nextNode_0 == nullValue()) ?
+            (nextNode_0 == nullValue() ? anon_1_0 : anon_2_0) :
+            null)) in
           anon_0_0))))
 }
 
@@ -171,15 +202,24 @@ function containsValue(node: Ref, target: Ref): Ref
   ensures isSubtype(typeOf(result), boolType())
 {
   (let nextNode_0 ==
-    (next(node)) in
+    ((!(intFromRef(value(node)) == intFromRef(target)) ? next(node) : null)) in
     (let anon_1_0 ==
-      ((!(nextNode_0 == nullValue()) ?
+      ((!(intFromRef(value(node)) == intFromRef(target)) &&
+      !(nextNode_0 == nullValue()) ?
         containsValue(nextNode_0, target) :
         null)) in
       (let anon_2_0 ==
-        ((!!(nextNode_0 == nullValue()) ? boolToRef(false) : null)) in
+        ((!(intFromRef(value(node)) == intFromRef(target)) &&
+        !!(nextNode_0 == nullValue()) ?
+          boolToRef(false) :
+          null)) in
         (let anon_0_0 ==
-          ((!(nextNode_0 == nullValue()) ? anon_1_0 : anon_2_0)) in
+          ((!(intFromRef(value(node)) == intFromRef(target)) &&
+          !(nextNode_0 == nullValue()) ||
+          !(intFromRef(value(node)) == intFromRef(target)) &&
+          !!(nextNode_0 == nullValue()) ?
+            (!(nextNode_0 == nullValue()) ? anon_1_0 : anon_2_0) :
+            null)) in
           (intFromRef(value(node)) == intFromRef(target) ?
             boolToRef(true) :
             anon_0_0)))))
@@ -209,9 +249,11 @@ function aliasAndReassign(node: Ref): Ref
         (let fallbackValue_1 ==
           ((!(alias2_0 == nullValue()) ? value(alias2_0) : null)) in
           (let fallbackValue_2 ==
-            ((!(alias2_0 == nullValue()) ?
-              fallbackValue_1 :
-              fallbackValue_0)) in
+            ((!(alias2_0 == nullValue()) || !!(alias2_0 == nullValue()) ?
+              (!(alias2_0 == nullValue()) ?
+                fallbackValue_1 :
+                fallbackValue_0) :
+              null)) in
             fallbackValue_2)))))
 }
 
@@ -263,9 +305,16 @@ function useIdentityFunction(node: Ref): Ref
   (let sameNode_0 ==
     (id(node)) in
     (let anon_1_0 ==
-      ((sameNode_0 != nullValue() ? value(sameNode_0) : nullValue())) in
+      ((sameNode_0 != nullValue() || !(sameNode_0 != nullValue()) ?
+        (sameNode_0 != nullValue() ? value(sameNode_0) : nullValue()) :
+        null)) in
       (let anon_0_0 ==
-        ((anon_1_0 != nullValue() ? anon_1_0 : intToRef(0))) in
+        (((sameNode_0 != nullValue() || !(sameNode_0 != nullValue())) &&
+        anon_1_0 != nullValue() ||
+        (sameNode_0 != nullValue() || !(sameNode_0 != nullValue())) &&
+        !(anon_1_0 != nullValue()) ?
+          (anon_1_0 != nullValue() ? anon_1_0 : intToRef(0)) :
+          null)) in
         anon_0_0)))
 }
 
@@ -286,7 +335,9 @@ function getNextValueUsingId(node: Ref): Ref
       (let anon_2_0 ==
         ((!(nextNode_0 == nullValue()) ? value(nextNode_0) : null)) in
         (let anon_0_0 ==
-          ((nextNode_0 == nullValue() ? anon_1_0 : anon_2_0)) in
+          ((nextNode_0 == nullValue() || !(nextNode_0 == nullValue()) ?
+            (nextNode_0 == nullValue() ? anon_1_0 : anon_2_0) :
+            null)) in
           anon_0_0))))
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/factorial.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/factorial.fir.diag.txt
@@ -15,6 +15,8 @@ function fact(n: Ref): Ref
         timesInts(n, fact(minusInts(n, intToRef(1)))) :
         null)) in
       (let anon_0_0 ==
-        ((intFromRef(n) == 0 ? anon_1_0 : anon_2_0)) in
+        ((intFromRef(n) == 0 || !(intFromRef(n) == 0) ?
+          (intFromRef(n) == 0 ? anon_1_0 : anon_2_0) :
+          null)) in
         anon_0_0)))
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -653,6 +653,13 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         fun List<Exp>.toConjunction(): Exp =
             if (isEmpty()) BoolLit(true)
             else reduce { l, r -> And(l, r) }
+
+        /**
+         * Take the disjunction of the given expressions.
+         */
+        fun List<Exp>.toDisjunction(): Exp =
+            if (isEmpty()) BoolLit(false)
+            else reduce { l, r -> Or(l, r) }
     }
 
     /**


### PR DESCRIPTION
Rebased version of #87 on top of latest `main`.

## Summary
Original PR (by @AlexFalter) introduces proper handling of early returns in pure functions by adding a `returns` value to `SSABlockNode`, updating it to true once a return is encountered, and inferring the full branching condition of a `BlockNode` after a join accordingly. The second commit takes the disjunction of branch conditions when joining.

## Rebase notes
- The original PR predated #127 ("Move some Conversion Tests to Verification"), which renamed/moved several test data files. Conflicts in deleted `.fir.diag.txt` files under `testData/diagnostics/conversion/...` were resolved by accepting the deletion (the tests now live under `testData/diagnostics/verification/...`).
- Conflicts in `heap_dependent_specifications.fir.diag.txt` (PR-side identifiers were stale — e.g. `df$rt$boolFromRef` vs current unprefixed names) were resolved by taking `main`'s version.
- Golden `.fir.diag.txt` files were regenerated via `./gradlew :formver.compiler-plugin:update`. The full test suite (`./gradlew :formver.compiler-plugin:test`) passes locally.

## Test plan
- [x] `./gradlew :formver.compiler-plugin:test` passes locally