### PR TITLE
Adapted Predicates to Final Fields

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/AccessPolicy.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/AccessPolicy.kt
@@ -9,9 +9,6 @@ enum class AccessPolicy {
     /** var fields **/
     BY_RECEIVER_UNIQUENESS,
 
-    /** val fields **/
-    ALWAYS_READABLE,
-
     /** special fields (like the length of a list) **/
     ALWAYS_WRITEABLE,
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -266,9 +266,7 @@ class ProgramConverter(
         val name = symbol.embedGetterName(this)
         val signature = ImpureGetterFunctionSignature(name, symbol)
         val callable = NonInlineNamedFunction(signature)
-        val function = UserFunctionEmbedding(
-            callable
-        )
+        val function = UserFunctionEmbedding(callable)
         impureFunctions.putIfAbsent(name, function)
         return callable
     }
@@ -279,9 +277,7 @@ class ProgramConverter(
         val returnType = embedType(symbol.resolvedReturnType)
         val signature = PureGetterFunctionSignature(name, symbol, classType, returnType)
         val callable = NonInlineNamedFunction(signature)
-        val function = PureUserFunctionEmbedding(
-            callable
-        )
+        val function = PureUserFunctionEmbedding(callable)
         pureFunctions.putIfAbsent(name, function)
         return callable
     }
@@ -290,9 +286,7 @@ class ProgramConverter(
         val name = symbol.embedSetterName(this)
         val signature = SetterFunctionSignature(name, symbol)
         val callable = NonInlineNamedFunction(signature)
-        val function = UserFunctionEmbedding(
-            callable
-        )
+        val function = UserFunctionEmbedding(callable)
         impureFunctions.putIfAbsent(name, function)
         return callable
     }
@@ -444,8 +438,7 @@ class ProgramConverter(
                     isDefaultProperty -> {
                         // use pure function
                         Pair(
-                            CustomGetter(embedPureGetterFunction(symbol)),
-                            null
+                            CustomGetter(embedPureGetterFunction(symbol)), null
                         )
                     }
 
@@ -454,18 +447,12 @@ class ProgramConverter(
                         // use impure function
                         Pair(
                             CustomGetter(embedImpureGetterFunction(symbol)),
-                            symbol.isVar.ifTrue { CustomSetter(embedSetterFunction(symbol)) }
-                        )
+                            symbol.isVar.ifTrue { CustomSetter(embedSetterFunction(symbol)) })
                     }
                 }
 
                 return@getOrPutProperty PropertyEmbedding(
-                    getter,
-                    setter,
-                    isDefaultProperty || isManual,
-                    isUnique,
-                    isImmutable,
-                    type
+                    getter, setter, isDefaultProperty || isManual, isUnique, isImmutable, type
                 )
 
             }
@@ -652,9 +639,9 @@ class ProgramConverter(
         CustomGetter(embedImpureGetterFunction(symbol)),
         symbol.isVar.ifTrue { CustomSetter(embedSetterFunction(symbol)) },
         hasDefaultBehaviour = false,
-        false,
-        symbol.isVal,
-        embedType(symbol.resolvedReturnType)
+        isUnique = false,
+        isVal = symbol.isVal,
+        type = embedType(symbol.resolvedReturnType)
     )
 
     @OptIn(SymbolInternals::class)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -262,36 +262,39 @@ class ProgramConverter(
         }
     }
 
-    private fun embedImpureGetterFunction(symbol: FirPropertySymbol): CallableEmbedding {
+    private fun embedImpureGetterFunction(symbol: FirPropertySymbol): NonInlineNamedFunction {
         val name = symbol.embedGetterName(this)
-        return impureFunctions.getOrPut(name) {
-            val signature = ImpureGetterFunctionSignature(name, symbol)
-            UserFunctionEmbedding(
-                NonInlineNamedFunction(signature)
-            )
-        }
+        val signature = ImpureGetterFunctionSignature(name, symbol)
+        val callable = NonInlineNamedFunction(signature)
+        val function = UserFunctionEmbedding(
+            callable
+        )
+        impureFunctions.putIfAbsent(name, function)
+        return callable
     }
 
-    private fun embedPureGetterFunction(symbol: FirPropertySymbol): CallableEmbedding {
+    private fun embedPureGetterFunction(symbol: FirPropertySymbol): NonInlineNamedFunction {
         val name = symbol.embedGetterName(this)
-        return pureFunctions.getOrPut(name) {
-            val classType = embedType(symbol.dispatchReceiverType!!)
-            val returnType = embedType(symbol.resolvedReturnType)
-            val signature = PureGetterFunctionSignature(name, symbol, classType, returnType)
-            PureUserFunctionEmbedding(
-                NonInlineNamedFunction(signature)
-            )
-        }
+        val classType = embedType(symbol.dispatchReceiverType!!)
+        val returnType = embedType(symbol.resolvedReturnType)
+        val signature = PureGetterFunctionSignature(name, symbol, classType, returnType)
+        val callable = NonInlineNamedFunction(signature)
+        val function = PureUserFunctionEmbedding(
+            callable
+        )
+        pureFunctions.putIfAbsent(name, function)
+        return callable
     }
 
-    private fun embedSetterFunction(symbol: FirPropertySymbol): CallableEmbedding {
+    private fun embedSetterFunction(symbol: FirPropertySymbol): NonInlineNamedFunction {
         val name = symbol.embedSetterName(this)
-        return impureFunctions.getOrPut(name) {
-            val signature = SetterFunctionSignature(name, symbol)
-            UserFunctionEmbedding(
-                NonInlineNamedFunction(signature)
-            )
-        }
+        val signature = SetterFunctionSignature(name, symbol)
+        val callable = NonInlineNamedFunction(signature)
+        val function = UserFunctionEmbedding(
+            callable
+        )
+        impureFunctions.putIfAbsent(name, function)
+        return callable
     }
 
     override fun embedFunction(symbol: FirFunctionSymbol<*>): CallableEmbedding {
@@ -580,12 +583,10 @@ class ProgramConverter(
                 }
             }.toMap()
 
-            val context = createBodyConversionContext(subSignature, returnTarget)
-
             val fieldPostconditions = signature.params.mapNotNull { param ->
                 require(param is FirVariableEmbedding) { "Constructor parameters must be represented by FirVariableEmbeddings" }
                 parameterMatching[param.symbol]?.let { property ->
-                    EqCmp(property.getter!!.getValueSimple(returnTarget.variable, context), param)
+                    EqCmp(property.getter!!.getValueSimple(returnTarget.variable, typeResolver), param)
                 }
             }
             ConstructorSignature(subSignature, symbol, fieldPostconditions, typeResolver)
@@ -636,7 +637,7 @@ class ProgramConverter(
         return backingField
     }
 
-    private fun embedCustomProperty(symbol: FirPropertySymbol) = PropertyEmbedding(
+    private fun embedExtensionProperty(symbol: FirPropertySymbol) = PropertyEmbedding(
         CustomGetter(embedImpureGetterFunction(symbol)),
         symbol.isVar.ifTrue { CustomSetter(embedSetterFunction(symbol)) },
         hasDefaultBehaviour = false

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -410,7 +410,7 @@ class ProgramConverter(
     override fun embedProperty(symbol: FirPropertySymbol): PropertyEmbedding {
 
         if (symbol.receiverParameterSymbol != null) {
-            return embedCustomProperty(symbol)
+            return embedExtensionProperty(symbol)
         } else {
             val name = symbol.embedMemberPropertyName(this)
             return typeResolver.getOrPutProperty(name) {
@@ -430,33 +430,44 @@ class ProgramConverter(
                 val isDefaultProperty = isGuaranteedDefaultProperty(symbol)
                 val isImmutable = symbol.isVal
                 val isManual = symbol.isManual(session)
+                val isUnique = symbol.isUnique(session)
 
-                return@getOrPutProperty when {
+                val type = embedType(symbol.resolvedReturnType)
+
+                val (getter, setter) = when {
                     (isDefaultProperty && !isImmutable) || isManual -> {
                         // use a backing field
                         val field = embedBackingField(symbol, regularClass)
-                        PropertyEmbedding(
-                            BackingFieldGetter(field), BackingFieldSetter(field), hasDefaultBehaviour = true
-                        )
+                        Pair(BackingFieldGetter(field), BackingFieldSetter(field))
                     }
 
                     isDefaultProperty -> {
                         // use pure function
-                        PropertyEmbedding(
-                            CustomGetter(embedPureGetterFunction(symbol)), null, hasDefaultBehaviour = true
+                        Pair(
+                            CustomGetter(embedPureGetterFunction(symbol)),
+                            null
                         )
                     }
 
                     else -> {
                         // The property could be overridden by anything, or has a custom getter/setter.
                         // use impure function
-                        PropertyEmbedding(
+                        Pair(
                             CustomGetter(embedImpureGetterFunction(symbol)),
-                            symbol.isVar.ifTrue { CustomSetter(embedSetterFunction(symbol)) },
-                            hasDefaultBehaviour = false
+                            symbol.isVar.ifTrue { CustomSetter(embedSetterFunction(symbol)) }
                         )
                     }
                 }
+
+                return@getOrPutProperty PropertyEmbedding(
+                    getter,
+                    setter,
+                    isDefaultProperty || isManual,
+                    isUnique,
+                    isImmutable,
+                    type
+                )
+
             }
         }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -651,7 +651,10 @@ class ProgramConverter(
     private fun embedExtensionProperty(symbol: FirPropertySymbol) = PropertyEmbedding(
         CustomGetter(embedImpureGetterFunction(symbol)),
         symbol.isVar.ifTrue { CustomSetter(embedSetterFunction(symbol)) },
-        hasDefaultBehaviour = false
+        hasDefaultBehaviour = false,
+        false,
+        symbol.isVal,
+        embedType(symbol.resolvedReturnType)
     )
 
     @OptIn(SymbolInternals::class)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
@@ -92,10 +92,16 @@ class TypeResolver {
     /**
      * Returns all the fields belonging directly to a class.
      */
-    fun lookupClassFields(name: SymbolicName) =
+    fun lookupClassBackingFields(name: SymbolicName) =
         properties.filterKeys { it.className == name }.values.mapNotNull { toBackingField(it) }
 
     fun lookupBackingField(name: ClassPropertyPair): FieldEmbedding? = properties[name]?.let { toBackingField(it) }
+
+    fun lookupClassDefaultBehavingProperties(name: SymbolicName): List<PropertyEmbedding> =
+        lookupClassProperties(name).filter { it.hasDefaultBehaviour }
+
+    fun lookupClassProperties(name: SymbolicName): List<PropertyEmbedding> =
+        properties.filterKeys { it.className == name }.values.toList()
 
     fun lookupDefaultBehavingProperties(name: ClassPropertyPair): PropertyEmbedding? =
         properties[name]?.takeIf { it.hasDefaultBehaviour }
@@ -109,7 +115,7 @@ class TypeResolver {
      * They are unique with regard to their name.
      */
     private fun collectFields(className: SymbolicName): List<FieldEmbedding> {
-        return lookupSuperTypes(className).fold(lookupClassFields(className)) { acc, type ->
+        return lookupSuperTypes(className).fold(lookupClassBackingFields(className)) { acc, type ->
             acc + collectFields(type.name)
         }.distinctBy { it.name }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/NonInlineNamedFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/NonInlineNamedFunction.kt
@@ -20,13 +20,17 @@ class NonInlineNamedFunction(val signature: FullNamedFunctionSignature) :
     override fun insertCall(
         args: List<ExpEmbedding>,
         ctx: StmtConversionContext,
-    ): ExpEmbedding {
-        return if (signature.isPure) {
+    ): ExpEmbedding = insertCall(args)
+
+    fun insertCall(
+        args: List<ExpEmbedding>,
+    ): ExpEmbedding =
+        if (signature.isPure) {
             FunctionCall(signature, args)
         } else {
             MethodCall(signature, args)
         }
-    }
+
 
     override fun toViperMethodHeader(ctx: TypeResolver): Method =
         signature.toViperMethod(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
@@ -12,8 +12,8 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
     override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {
         return when (field.accessPolicy) {
-            AccessPolicy.ALWAYS_READABLE, AccessPolicy.BY_RECEIVER_UNIQUENESS -> FieldAccess(receiver, field)
             else -> FieldAccess(receiver, field).withInvariants(ctx.typeResolver) {
+            AccessPolicy.BY_RECEIVER_UNIQUENESS -> FieldAccess(receiver, field)
                 proven = true
                 access = true
             }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
@@ -7,10 +7,11 @@ package org.jetbrains.kotlin.formver.core.embeddings.properties
 
 import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
 import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
+import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 
 class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
-    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {
+    override fun getValue(receiver: ExpEmbedding, ctx: TypeResolver): ExpEmbedding {
         return when (field.accessPolicy) {
             else -> FieldAccess(receiver, field).withInvariants(ctx.typeResolver) {
             AccessPolicy.BY_RECEIVER_UNIQUENESS -> FieldAccess(receiver, field)
@@ -22,7 +23,7 @@ class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
 
     override fun getValueSimple(
         receiver: ExpEmbedding,
-        ctx: StmtConversionContext
+        ctx: TypeResolver
     ): ExpEmbedding = FieldAccess(receiver, field)
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
@@ -13,8 +13,8 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
     override fun getValue(receiver: ExpEmbedding, ctx: TypeResolver): ExpEmbedding {
         return when (field.accessPolicy) {
-            else -> FieldAccess(receiver, field).withInvariants(ctx.typeResolver) {
             AccessPolicy.BY_RECEIVER_UNIQUENESS -> FieldAccess(receiver, field)
+            else -> FieldAccess(receiver, field).withInvariants(ctx) {
                 proven = true
                 access = true
             }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 class ClassPropertyAccess(val receiver: ExpEmbedding, val property: PropertyEmbedding, val type: TypeEmbedding) :
     PropertyAccessEmbedding {
     override fun getValue(ctx: StmtConversionContext): ExpEmbedding =
-        property.getter!!.getValue(receiver, ctx).withNewTypeInvariants(type, ctx.typeResolver) {
+        property.getter!!.getValue(receiver, ctx.typeResolver).withNewTypeInvariants(type, ctx.typeResolver) {
             proven = true
             access = true
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/CustomAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/CustomAccessors.kt
@@ -6,24 +6,25 @@
 package org.jetbrains.kotlin.formver.core.embeddings.properties
 
 import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
-import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
+import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
+import org.jetbrains.kotlin.formver.core.embeddings.callables.NonInlineNamedFunction
 import org.jetbrains.kotlin.formver.core.embeddings.callables.insertCall
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 
-class CustomGetter(val getterMethod: CallableEmbedding) : GetterEmbedding {
+class CustomGetter(val getterMethod: NonInlineNamedFunction) : GetterEmbedding {
     override fun getValue(
         receiver: ExpEmbedding,
-        ctx: StmtConversionContext,
-    ): ExpEmbedding = getterMethod.insertCall(listOf(receiver), ctx, getterMethod.callableType.returnType)
+        ctx: TypeResolver
+    ): ExpEmbedding = getterMethod.insertCall(listOf(receiver))
 
 
     override fun getValueSimple(
         receiver : ExpEmbedding,
-        ctx: StmtConversionContext,
-    ) : ExpEmbedding = getterMethod.insertCall(listOf(receiver), ctx)
+        ctx: TypeResolver,
+    ): ExpEmbedding = getterMethod.insertCall(listOf(receiver))
 }
 
-class CustomSetter(val setterMethod: CallableEmbedding) : SetterEmbedding {
+class CustomSetter(val setterMethod: NonInlineNamedFunction) : SetterEmbedding {
     override fun setValue(
         receiver: ExpEmbedding,
         value: ExpEmbedding,

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/FieldEmbedding.kt
@@ -8,20 +8,15 @@ package org.jetbrains.kotlin.formver.core.embeddings.properties
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
-import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
-import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.expression.FieldAccess
-import org.jetbrains.kotlin.formver.core.embeddings.expression.IntLit
-import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings
-import org.jetbrains.kotlin.formver.core.embeddings.types.*
-import org.jetbrains.kotlin.formver.core.names.NameMatcher
+import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.FieldAccessTypeInvariantEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeInvariantEmbedding
 import org.jetbrains.kotlin.formver.core.names.ScopedName
-import org.jetbrains.kotlin.formver.core.names.SpecialFieldName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Field
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Type
-import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 /**
  * Embedding of a backing field of a property.
@@ -50,7 +45,7 @@ interface FieldEmbedding {
     fun accessInvariantsForParameter(): List<TypeInvariantEmbedding> =
         when (accessPolicy) {
             AccessPolicy.ALWAYS_WRITEABLE -> listOf(FieldAccessTypeInvariantEmbedding(this, PermExp.FullPerm()))
-            AccessPolicy.BY_RECEIVER_UNIQUENESS, AccessPolicy.ALWAYS_READABLE, AccessPolicy.MANUAL -> listOf()
+            AccessPolicy.BY_RECEIVER_UNIQUENESS, AccessPolicy.MANUAL -> listOf()
         } + extraAccessInvariantsForParameter()
 
 }
@@ -67,7 +62,6 @@ data class UserFieldEmbedding(
     override val accessPolicy: AccessPolicy =
         when {
             isManual -> AccessPolicy.MANUAL
-            symbol.isVal -> AccessPolicy.ALWAYS_READABLE
             symbol.isVar -> AccessPolicy.BY_RECEIVER_UNIQUENESS
             else -> throw SnaktInternalException(
                 symbol.initializerSource,
@@ -75,6 +69,6 @@ data class UserFieldEmbedding(
             )
         }
     override val unfoldToAccess: Boolean
-        get() = accessPolicy == AccessPolicy.ALWAYS_READABLE || accessPolicy == AccessPolicy.BY_RECEIVER_UNIQUENESS
+        get() = accessPolicy == AccessPolicy.BY_RECEIVER_UNIQUENESS
     override val includeInShortDump: Boolean = true
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/GetterEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/GetterEmbedding.kt
@@ -5,14 +5,14 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.properties
 
-import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
+import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 
 interface GetterEmbedding {
-    fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding
+    fun getValue(receiver: ExpEmbedding, ctx: TypeResolver): ExpEmbedding
 
     /**
      * Gets the values without adding type invariants.
      */
-    fun getValueSimple(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding
+    fun getValueSimple(receiver: ExpEmbedding, ctx: TypeResolver): ExpEmbedding
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/PropertyEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/PropertyEmbedding.kt
@@ -5,8 +5,13 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.properties
 
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+
 data class PropertyEmbedding(
     val getter: GetterEmbedding?,
     val setter: SetterEmbedding?,
-    val hasDefaultBehaviour: Boolean
+    val hasDefaultBehaviour: Boolean,
+    val isUnique: Boolean,
+    val isVal: Boolean,
+    val type: TypeEmbedding,
 )

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialAccessors.kt
@@ -5,16 +5,16 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.properties
 
-import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
+import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings
 
 object LengthFieldGetter : GetterEmbedding {
-    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext) =
+    override fun getValue(receiver: ExpEmbedding, ctx: TypeResolver) =
         OperatorExpEmbeddings.StringLength(receiver)
 
     override fun getValueSimple(
         receiver: ExpEmbedding,
-        ctx: StmtConversionContext
+        ctx: TypeResolver
     ): ExpEmbedding = OperatorExpEmbeddings.StringLength(receiver)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialProperties.kt
@@ -12,6 +12,8 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.formver.core.conversion.CollectionSizeFieldEmbedding
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
+import org.jetbrains.kotlin.formver.core.embeddings.types.IntTypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.asTypeEmbedding
 import org.jetbrains.kotlin.formver.core.kotlinCallableId
 import org.jetbrains.kotlin.formver.core.names.MemberEmbeddingPolicy
 import org.jetbrains.kotlin.formver.core.names.NameMatcher
@@ -25,7 +27,16 @@ abstract class SpecialProperty(val property: PropertyEmbedding) {
 
 
 object StringSizeProperty :
-    SpecialProperty(PropertyEmbedding(LengthFieldGetter, setter = null, hasDefaultBehaviour = true)) {
+    SpecialProperty(
+        PropertyEmbedding(
+            LengthFieldGetter,
+            setter = null,
+            hasDefaultBehaviour = true,
+            isUnique = true,
+            isVal = true,
+            type = IntTypeEmbedding.asTypeEmbedding()
+        )
+    ) {
     context(typeResolver: TypeResolver, session: FirSession)
     override fun match(symbol: FirPropertySymbol): Boolean = symbol.callableId == kotlinCallableId("String", "length")
 }
@@ -35,7 +46,10 @@ object CollectionSizeProperty :
         PropertyEmbedding(
             BackingFieldGetter(CollectionSizeFieldEmbedding),
             setter = null,
-            hasDefaultBehaviour = true
+            hasDefaultBehaviour = true,
+            isUnique = true,
+            isVal = true,
+            type = CollectionSizeFieldEmbedding.type,
         )
     ) {
     context(typeResolver: TypeResolver, session: FirSession)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassPredicateBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassPredicateBuilder.kt
@@ -8,8 +8,9 @@ package org.jetbrains.kotlin.formver.core.embeddings.types
 import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
+import org.jetbrains.kotlin.formver.core.embeddings.properties.BackingFieldGetter
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.properties.UserFieldEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.properties.PropertyEmbedding
 import org.jetbrains.kotlin.formver.core.linearization.pureToViper
 import org.jetbrains.kotlin.formver.core.names.DispatchReceiverName
 import org.jetbrains.kotlin.formver.viper.SymbolicName
@@ -18,8 +19,8 @@ import org.jetbrains.kotlin.formver.viper.ast.Predicate
 import org.jetbrains.kotlin.utils.addIfNotNull
 
 internal class ClassPredicateBuilder private constructor(
-    typeEmbedding: TypeEmbedding,
-    val fields: List<FieldEmbedding>,
+    val typeEmbedding: TypeEmbedding,
+    val properties: List<PropertyEmbedding>,
     val classSuperTypes: List<ClassTypeEmbedding>
 ) {
     private val subject = PlaceholderVariableEmbedding(DispatchReceiverName, typeEmbedding)
@@ -35,7 +36,7 @@ internal class ClassPredicateBuilder private constructor(
             val typeEmbedding = ctx.lookupClassTypeEmbedding(name)!!
             val builder = ClassPredicateBuilder(
                 TypeEmbedding(typeEmbedding, TypeEmbeddingFlags(nullable = false)),
-                ctx.lookupClassFields(name),
+                ctx.lookupClassProperties(name),
                 ctx.lookupSuperTypes(name)
             )
             builder.action()
@@ -47,11 +48,14 @@ internal class ClassPredicateBuilder private constructor(
         }
     }
 
-    fun forEachField(action: FieldAssertionsBuilder.() -> Unit) =
-        fields
-            .filterIsInstance<UserFieldEmbedding>()
-            .forEach { field ->
-                val builder = FieldAssertionsBuilder(subject, field)
+    fun includeSubTypeInvariants() = body.add(
+        SubTypeInvariantEmbedding(typeEmbedding).fillHole(subject)
+    )
+
+    fun forEachPropertyField(action: PropertyAssertionsBuilder.() -> Unit) =
+        properties
+            .forEach { property ->
+                val builder = PropertyAssertionsBuilder(subject, property)
                 builder.action()
                 body.addAll(builder.toAssertionsList())
             }
@@ -64,26 +68,58 @@ internal class ClassPredicateBuilder private constructor(
         }
 }
 
-class FieldAssertionsBuilder(private val subject: VariableEmbedding, private val field: UserFieldEmbedding) {
+class PropertyAssertionsBuilder(private val subject: VariableEmbedding, private val property: PropertyEmbedding) {
     private val assertions = mutableListOf<ExpEmbedding>()
     fun toAssertionsList() = assertions.toList()
 
-    val isAlwaysReadable = field.accessPolicy == AccessPolicy.ALWAYS_READABLE
-    val isUnique = field.isUnique
+    val isUnique = property.isUnique
+
+    context(ctx: TypeResolver)
+    private fun getPlainValue() = when (val getter = property.getter!!) {
+        is BackingFieldGetter -> PrimitiveFieldAccess(subject, getter.field)
+        else -> getter.getValueSimple(subject, ctx)
+    }
+
+
+    context(ctx: TypeResolver)
+    fun forType(action: TypeInvariantsBuilder.() -> Unit) {
+        val builder = TypeInvariantsBuilder(property.type)
+        builder.action()
+        assertions.addAll(builder.toInvariantsList().fillHoles(getPlainValue()))
+    }
+
+    fun forBackingField(action: BackingFieldAssertionsBuilder.() -> Unit) {
+        (property.getter as? BackingFieldGetter)?.field?.let { field ->
+            val builder = BackingFieldAssertionsBuilder(subject, field)
+            builder.action()
+            assertions.addAll(builder.toAssertionsList())
+        }
+    }
+
+    context(ctx: TypeResolver)
+    fun addEqualsGuarantee(block: ExpEmbedding.() -> ExpEmbedding) {
+        assertions.add(EqCmp(property.getter!!.getValue(subject, ctx), subject.block()))
+    }
+}
+
+class BackingFieldAssertionsBuilder(private val subject: VariableEmbedding, private val field: FieldEmbedding) {
+    private val assertions = mutableListOf<ExpEmbedding>()
+
+    val isAlwaysWriteable = field.accessPolicy == AccessPolicy.ALWAYS_WRITEABLE
+
+    fun toAssertionsList() = assertions.toList()
+
+    fun addAccessPermissions(perm: PermExp) =
+        assertions.add(FieldAccessTypeInvariantEmbedding(field, perm).fillHole(subject))
+
 
     fun forType(action: TypeInvariantsBuilder.() -> Unit) {
         val builder = TypeInvariantsBuilder(field.type)
         builder.action()
         assertions.addAll(builder.toInvariantsList().fillHoles(PrimitiveFieldAccess(subject, field)))
     }
-
-    fun addAccessPermissions(perm: PermExp) =
-        assertions.add(FieldAccessTypeInvariantEmbedding(field, perm).fillHole(subject))
-
-    fun addEqualsGuarantee(block: ExpEmbedding.() -> ExpEmbedding) {
-        assertions.add(FieldEqualsInvariant(field, subject.block()).fillHole(subject))
-    }
 }
+
 
 class TypeInvariantsBuilder(private val type: TypeEmbedding) {
     private val invariants = mutableListOf<TypeInvariantEmbedding>()

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
@@ -28,17 +28,21 @@ data class ClassTypeEmbedding(override val name: ScopedName) : PretypeEmbedding 
 
     context(ctx: TypeResolver)
     fun uniquePredicate(): Predicate = ClassPredicateBuilder.build(name, uniquePredicateName) {
-        forEachField {
-            if (isAlwaysReadable) {
-                addAccessPermissions(PermExp.WildcardPerm())
-            } else {
-                addAccessPermissions(PermExp.FullPerm())
+        includeSubTypeInvariants()
+        forEachPropertyField {
+            forBackingField {
+                if (!isAlwaysWriteable) {
+                    addAccessPermissions(PermExp.FullPerm())
+
+                    forType {
+                        includeSubTypeInvariants()
+                    }
+                }
             }
             forType {
                 if (isUnique) {
                     addAccessToUniquePredicate()
                 }
-                includeSubTypeInvariants()
             }
         }
         forEachSuperType {

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
@@ -10,20 +10,21 @@ function size(this: Ref): Ref
 
 
 predicate BooleanArray_unique(this: Ref) {
+  isSubtype(typeOf(this), BooleanArray()) &&
   acc(Cloneable_unique(this), write) &&
   acc(Serializable_unique(this), write)
 }
 
 predicate Cloneable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Cloneable())
 }
 
 predicate Serializable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Serializable())
 }
 
 predicate StringBox_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), StringBox())
 }
 
 method con(par_str: Ref) returns (ret_1: Ref)
@@ -63,20 +64,21 @@ function size(this: Ref): Ref
 
 
 predicate BooleanArray_unique(this: Ref) {
+  isSubtype(typeOf(this), BooleanArray()) &&
   acc(Cloneable_unique(this), write) &&
   acc(Serializable_unique(this), write)
 }
 
 predicate Cloneable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Cloneable())
 }
 
 predicate Serializable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Serializable())
 }
 
 predicate StringBox_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), StringBox())
 }
 
 method con(par_str: Ref) returns (ret_1: Ref)
@@ -108,16 +110,17 @@ function size(this: Ref): Ref
 
 
 predicate BooleanArray_unique(this: Ref) {
+  isSubtype(typeOf(this), BooleanArray()) &&
   acc(Cloneable_unique(this), write) &&
   acc(Serializable_unique(this), write)
 }
 
 predicate Cloneable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Cloneable())
 }
 
 predicate Serializable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Serializable())
 }
 
 method plus(this: Ref, other: Ref) returns (ret_1: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates.fir.diag.txt
@@ -17,19 +17,20 @@ function pf(this: Ref): Ref
 
 
 predicate Baz_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Baz())
 }
 
 predicate PrimitiveFields_unique(this: Ref) {
-  acc(this.b, write) && isSubtype(typeOf(this.b), intType())
+  isSubtype(typeOf(this), PrimitiveFields()) && acc(this.b, write) &&
+  isSubtype(typeOf(this.b), intType())
 }
 
 predicate Recursive_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Recursive())
 }
 
 predicate ReferenceField_unique(this: Ref) {
-  acc(Baz_unique(this), write)
+  isSubtype(typeOf(this), ReferenceField()) && acc(Baz_unique(this), write)
 }
 
 method useClasses(rf: Ref, rec: Ref) returns (v_ret_0: Ref)
@@ -50,15 +51,16 @@ function x(this: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  acc(this.y, write) && isSubtype(typeOf(this.y), intType())
+  isSubtype(typeOf(this), A()) && acc(this.y, write) &&
+  isSubtype(typeOf(this.y), intType())
 }
 
 predicate B_unique(this: Ref) {
-  acc(A_unique(this), write)
+  isSubtype(typeOf(this), B()) && acc(A_unique(this), write)
 }
 
 predicate C_unique(this: Ref) {
-  acc(B_unique(this), write)
+  isSubtype(typeOf(this), C()) && acc(B_unique(this), write)
 }
 
 method threeLayersHierarchy(c: Ref) returns (v_ret_0: Ref)
@@ -73,28 +75,31 @@ method threeLayersHierarchy(c: Ref) returns (v_ret_0: Ref)
 field size: Ref
 
 predicate Collection_unique(this: Ref) {
+  isSubtype(typeOf(this), Collection()) &&
   acc(Iterable_unique(this), write)
 }
 
 predicate Iterable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Iterable())
 }
 
 predicate List_unique(this: Ref) {
-  acc(Collection_unique(this), write)
+  isSubtype(typeOf(this), List()) && acc(Collection_unique(this), write)
 }
 
 predicate MutableCollection_unique(this: Ref) {
+  isSubtype(typeOf(this), MutableCollection()) &&
   acc(Collection_unique(this), write) &&
   acc(MutableIterable_unique(this), write)
 }
 
 predicate MutableIterable_unique(this: Ref) {
+  isSubtype(typeOf(this), MutableIterable()) &&
   acc(Iterable_unique(this), write)
 }
 
 predicate MutableList_unique(this: Ref) {
-  acc(List_unique(this), write) &&
+  isSubtype(typeOf(this), MutableList()) && acc(List_unique(this), write) &&
   acc(MutableCollection_unique(this), write)
 }
 
@@ -126,19 +131,21 @@ function y(this: Ref): Ref
 
 
 predicate Foo_unique(this: Ref) {
-  acc(this.x, write) && isSubtype(typeOf(this.x), intType()) &&
+  isSubtype(typeOf(this), Foo()) && acc(this.x, write) &&
+  isSubtype(typeOf(this.x), intType()) &&
+  acc(T_unique(y(this)), write) &&
   acc(this.z, write) &&
-  acc(T_unique(this.z), write) &&
   isSubtype(typeOf(this.z), T()) &&
+  acc(T_unique(this.z), write) &&
   acc(S_unique(this), write)
 }
 
 predicate S_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), S())
 }
 
 predicate T_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), T())
 }
 
 method unique_foo_arg(foo: Ref) returns (v_ret_0: Ref)
@@ -152,7 +159,7 @@ method unique_foo_arg(foo: Ref) returns (v_ret_0: Ref)
 
 /predicates.kt: info: Generated Viper text for nullable_unique_arg:
 predicate T_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), T())
 }
 
 method nullable_unique_arg(par_t: Ref) returns (v_ret_0: Ref)
@@ -166,7 +173,7 @@ method nullable_unique_arg(par_t: Ref) returns (v_ret_0: Ref)
 
 /predicates.kt: info: Generated Viper text for borrowed_unique_arg:
 predicate T_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), T())
 }
 
 method borrowed_unique_arg(par_t: Ref) returns (v_ret_0: Ref)
@@ -181,7 +188,7 @@ method borrowed_unique_arg(par_t: Ref) returns (v_ret_0: Ref)
 
 /predicates.kt: info: Generated Viper text for unique_receiver:
 predicate T_unique(v_this: Ref) {
-  true
+  isSubtype(typeOf(v_this), T())
 }
 
 method unique_receiver(v_this_extension: Ref) returns (v_ret_0: Ref)
@@ -195,7 +202,7 @@ method unique_receiver(v_this_extension: Ref) returns (v_ret_0: Ref)
 
 /predicates.kt: info: Generated Viper text for borrowed_unique_receiver:
 predicate T_unique(v_this: Ref) {
-  true
+  isSubtype(typeOf(v_this), T())
 }
 
 method borrowed_unique_receiver(v_this_extension: Ref)
@@ -211,7 +218,7 @@ method borrowed_unique_receiver(v_this_extension: Ref)
 
 /predicates.kt: info: Generated Viper text for unique_result:
 predicate T_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), T())
 }
 
 method con() returns (ret_1: Ref)
@@ -230,7 +237,7 @@ method unique_result() returns (v_ret_0: Ref)
 
 /predicates.kt: info: Generated Viper text for unique_nullable_result:
 predicate T_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), T())
 }
 
 method unique_nullable_result() returns (v_ret_0: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates_access.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates_access.fir.diag.txt
@@ -17,21 +17,22 @@ function x(this: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), A())
 }
 
 predicate B_unique(this: Ref) {
-  acc(A_unique(this), write)
+  isSubtype(typeOf(this), B()) && acc(A_unique(this), write)
 }
 
 predicate C_unique(this: Ref) {
-  acc(this.y, write) && isSubtype(typeOf(this.y), A()) &&
+  isSubtype(typeOf(this), C()) && acc(this.y, write) &&
+  isSubtype(typeOf(this.y), A()) &&
   acc(D_unique(this), write) &&
   acc(B_unique(this), write)
 }
 
 predicate D_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), D())
 }
 
 method accessSuperTypeProperty(c: Ref) returns (v_ret_0: Ref)
@@ -66,21 +67,22 @@ function x(this: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), A())
 }
 
 predicate B_unique(this: Ref) {
-  acc(A_unique(this), write)
+  isSubtype(typeOf(this), B()) && acc(A_unique(this), write)
 }
 
 predicate C_unique(this: Ref) {
-  acc(this.y, write) && isSubtype(typeOf(this.y), A()) &&
+  isSubtype(typeOf(this), C()) && acc(this.y, write) &&
+  isSubtype(typeOf(this.y), A()) &&
   acc(D_unique(this), write) &&
   acc(B_unique(this), write)
 }
 
 predicate D_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), D())
 }
 
 method accessNested(c: Ref) returns (v_ret_0: Ref)
@@ -103,7 +105,7 @@ function a(this: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), A())
 }
 
 method accessNullable(x: Ref) returns (v_ret_0: Ref)
@@ -130,11 +132,11 @@ function b(this: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), A())
 }
 
 predicate B_unique(this: Ref) {
-  acc(A_unique(this), write)
+  isSubtype(typeOf(this), B()) && acc(A_unique(this), write)
 }
 
 method accessCast(x: Ref) returns (v_ret_0: Ref)
@@ -160,11 +162,11 @@ function b(this: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), A())
 }
 
 predicate B_unique(this: Ref) {
-  acc(A_unique(this), write)
+  isSubtype(typeOf(this), B()) && acc(A_unique(this), write)
 }
 
 method accessSafeCast(x: Ref) returns (v_ret_0: Ref)
@@ -198,11 +200,11 @@ function b(this: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), A())
 }
 
 predicate B_unique(this: Ref) {
-  acc(A_unique(this), write)
+  isSubtype(typeOf(this), B()) && acc(A_unique(this), write)
 }
 
 method accessSmartCast(x: Ref) returns (v_ret_0: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/full_viper_dump.fir.diag.txt
@@ -383,7 +383,7 @@ function xorBools(arg_1: Ref, arg_2: Ref): Ref
 
 
 predicate Foo_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Foo())
 }
 
 method con(par_x: Ref) returns (ret_1: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/havoc.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/havoc.fir.diag.txt
@@ -413,7 +413,8 @@ function xorBools(arg_1: Ref, arg_2: Ref): Ref
 
 
 predicate A_unique(this: Ref) {
-  acc(this.unit, write) && isSubtype(typeOf(this.unit), unitType()) &&
+  isSubtype(typeOf(this), A()) && acc(this.unit, write) &&
+  isSubtype(typeOf(this.unit), unitType()) &&
   acc(this.nothing, write) &&
   isSubtype(typeOf(this.nothing), nothingType()) &&
   acc(this.any, write) &&
@@ -447,7 +448,7 @@ predicate A_unique(this: Ref) {
 }
 
 predicate B_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), B())
 }
 
 method df_havoc(arg_1: rt) returns (v_ret_0: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/negative/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/negative/binary_tree.fir.diag.txt
@@ -12,7 +12,10 @@ function right(this: Ref): Ref
 
 
 predicate Node_unique(this: Ref) {
-  acc(this.data, write) && isSubtype(typeOf(this.data), intType())
+  isSubtype(typeOf(this), Node()) && acc(this.data, write) &&
+  isSubtype(typeOf(this.data), intType()) &&
+  (left(this) != nullValue() ==> acc(Node_unique(left(this)), write)) &&
+  (right(this) != nullValue() ==> acc(Node_unique(right(this)), write))
 }
 
 method get_left_val(n: Ref) returns (v_ret_0: Ref)
@@ -49,20 +52,24 @@ function size(this: Ref): Ref
 
 
 predicate BooleanArray_unique(this: Ref) {
+  isSubtype(typeOf(this), BooleanArray()) &&
   acc(Cloneable_unique(this), write) &&
   acc(Serializable_unique(this), write)
 }
 
 predicate Cloneable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Cloneable())
 }
 
 predicate Node_unique(this: Ref) {
-  acc(this.bf_data, write) && isSubtype(typeOf(this.bf_data), intType())
+  isSubtype(typeOf(this), Node()) && acc(this.bf_data, write) &&
+  isSubtype(typeOf(this.bf_data), intType()) &&
+  (g_left(this) != nullValue() ==> acc(Node_unique(g_left(this)), write)) &&
+  (g_right(this) != nullValue() ==> acc(Node_unique(g_right(this)), write))
 }
 
 predicate Serializable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Serializable())
 }
 
 method con(par_data: Ref, par_left: Ref, par_right: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/negative/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/negative/linked_list.fir.diag.txt
@@ -7,7 +7,9 @@ function next(this: Ref): Ref
 
 
 predicate Link_unique(this: Ref) {
-  acc(this.data, write) && isSubtype(typeOf(this.data), intType())
+  isSubtype(typeOf(this), Link()) && acc(this.data, write) &&
+  isSubtype(typeOf(this.data), intType()) &&
+  (next(this) != nullValue() ==> acc(Link_unique(next(this)), write))
 }
 
 method getVal(l: Ref) returns (v_ret_0: Ref)
@@ -39,20 +41,23 @@ function size(this: Ref): Ref
 
 
 predicate BooleanArray_unique(this: Ref) {
+  isSubtype(typeOf(this), BooleanArray()) &&
   acc(Cloneable_unique(this), write) &&
   acc(Serializable_unique(this), write)
 }
 
 predicate Cloneable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Cloneable())
 }
 
 predicate Link_unique(this: Ref) {
-  acc(this.bf_data, write) && isSubtype(typeOf(this.bf_data), intType())
+  isSubtype(typeOf(this), Link()) && acc(this.bf_data, write) &&
+  isSubtype(typeOf(this.bf_data), intType()) &&
+  (g_next(this) != nullValue() ==> acc(Link_unique(g_next(this)), write))
 }
 
 predicate Serializable_unique(this: Ref) {
-  true
+  isSubtype(typeOf(this), Serializable())
 }
 
 method con(par_data: Ref, par_next: Ref) returns (ret_1: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/loops.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/loops.fir.diag.txt
@@ -216,9 +216,9 @@ method test_while(param: Ref) returns (v_ret_0: Ref)
     invariant isSubtype(typeOf(param), ClassWithField())
   anon := ltInts(iteration, intToRef(10))
   if (boolFromRef(anon)) {
-    var l5_field: Ref
+    var l4_field: Ref
     var paramField: Ref
-    l5_field := g_field(c)
+    l4_field := g_field(c)
     paramField := g_field(param)
     iteration := plusInts(iteration, intToRef(1))
     goto cont


### PR DESCRIPTION
This PR adds the necessary information to the unique predicates. This includes the following changes:

- The `ALWAYS_READABLE` AccessPolicy was removed. It is not neaded anymore, because it was used for val fields. But val fields are now replaced by function calls. 
- To still be able to distinct different types of `PropertyEmbedding`, I added some fields on it, which are very close to the once that we have on the `UserField`.  We need those, because if we perform actions on fields of a class, we can no longer work with just the `FieldEmbeddings`, because we also have the `field-functions`. So we need to move that logic to the `PropertyEmbedding` level, and need the necessary information there.
- Because of the above change we needed to updated the `ClassPredicateBuilder` to also allow to add invariants for each property.