### PR TITLE
Use Uniqueness Information for Havoc

### DIFF
--- a/formver.compiler-plugin/core/build.gradle.kts
+++ b/formver.compiler-plugin/core/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     compileOnly(project(":formver.common"))
     compileOnly(project(":formver.compiler-plugin:viper"))
+    compileOnly(project(":formver.compiler-plugin:uniqueness"))
     compileOnly(kotlin("compiler"))
 
     // TODO: figure out how to avoid this dependency

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConversionContext.kt
@@ -44,6 +44,7 @@ interface MethodConversionContext : ProgramConversionContext {
     val signature: FunctionSignature
     val defaultResolvedReturnTarget: ReturnTarget
     val isValidForForAllBlock: Boolean
+    val uniquenessInformation: UniquenessInformation?
 
     fun resolveParameter(symbol: FirValueParameterSymbol): ExpEmbedding
     fun resolveLocal(symbol: FirVariableSymbol<*>): VariableEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/MethodConverter.kt
@@ -29,6 +29,7 @@ class MethodConverter(
     private val paramResolver: ParameterResolver,
     scopeDepth: ScopeIndex,
     private val parent: MethodConversionContext? = null,
+    override val uniquenessInformation: UniquenessInformation? = null,
 ) : MethodConversionContext, ProgramConversionContext by programCtx {
     private var propertyResolver = PropertyResolver(scopeDepth)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConversionContext.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.names.CatchLabelName
 import org.jetbrains.kotlin.formver.core.names.TryExitLabelName
 import org.jetbrains.kotlin.formver.viper.NameResolver
+import org.jetbrains.kotlin.formver.viper.SymbolicName
 
 interface ProgramConversionContext {
     val config: PluginConfiguration
@@ -41,6 +42,7 @@ interface ProgramConversionContext {
     val typeResolver: TypeResolver
     val convertedBodyResolver: ConvertedBodyResolver
     val linearizedBodyResolver: LinearizedBodyResolver
+    val uniquenessInformationResolver: MutableMap<SymbolicName, UniquenessInformation>
 
     fun embedFunction(symbol: FirFunctionSymbol<*>): CallableEmbedding
     fun embedPureFunction(symbol: FirFunctionSymbol<*>): PureUserFunctionEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -13,6 +13,8 @@ import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.correspondingValueParameterFromPrimaryConstructor
 import org.jetbrains.kotlin.fir.declarations.utils.isData
 import org.jetbrains.kotlin.fir.declarations.utils.isFinal
+import org.jetbrains.kotlin.fir.declarations.utils.visibility
+import org.jetbrains.kotlin.fir.resolve.dfa.controlFlowGraph
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -92,11 +94,22 @@ class ProgramConverter(
         adts = typeResolver.adtTypeEmbeddings().map { it.toViper() },
     )
 
-    /**
-     * Embed the declaration's signature and queue its body for later processing by [convertAll].
-     */
-    fun register(declaration: FirSimpleFunction) {
-        val (returnTarget, signature) = embedFullSignature(declaration.symbol)
+    fun extractUniquenessInformation(declaration: FirSimpleFunction): UniquenessInformation {
+        val graph = declaration.controlFlowGraphReference?.controlFlowGraph
+            ?: error("Control flow graph is null for declaration: ${declaration.name}")
+        val resolver = UniquenessResolver(session)
+        val initial = UniquenessTrie(resolver)
+        val graphChecker = UniquenessGraphChecker(session, initial, errorCollector)
+        graphChecker.check(graph)
+        val analyzer = UniquenessGraphAnalyzer(resolver, initial)
+        val facts = analyzer.analyze(graph)
+        return UniquenessInformation(graph.nodes.first(), facts)
+    }
+
+    fun registerForVerification(declaration: FirSimpleFunction) {
+        val signature = embedFullSignature(declaration.symbol)
+        // Note: it is important that `body` is only set after embedding is complete, as we need to
+        // place the embedding in the map before processing the body.
         if (declaration.symbol.isPure(session)) {
             ensurePureUserFunctionEmbedding(declaration.symbol, signature)
         } else {
@@ -203,6 +216,7 @@ class ProgramConverter(
         signature: NamedFunctionSignature, target: ReturnTarget
     ): StmtConversionContext {
 
+        val uniqueness = extractUniquenessInformation(declaration)
         val paramResolver = RootParameterResolver(
             this@ProgramConverter, signature, signature.symbol.valueParameterSymbols, signature.labelName, target
         )
@@ -211,6 +225,7 @@ class ProgramConverter(
             signature,
             paramResolver,
             scopeIndexProducer.getFresh(),
+            uniqueness,
         ).statementCtxt()
         return stmtCtx
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.utils.correspondingValueParameterFromPrimaryConstructor
 import org.jetbrains.kotlin.fir.declarations.utils.isData
 import org.jetbrains.kotlin.fir.declarations.utils.isFinal
-import org.jetbrains.kotlin.fir.declarations.utils.visibility
 import org.jetbrains.kotlin.fir.resolve.dfa.controlFlowGraph
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
@@ -33,6 +32,10 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.*
 import org.jetbrains.kotlin.formver.core.names.*
 import org.jetbrains.kotlin.formver.core.purity.checkValidity
 import org.jetbrains.kotlin.formver.core.purity.isPure
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessGraphAnalyzer
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessGraphChecker
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessResolver
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Program
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
@@ -77,6 +80,7 @@ class ProgramConverter(
     override val nameResolver = ShortNameResolver()
     override val convertedBodyResolver = ConvertedBodyResolver()
     override val linearizedBodyResolver = LinearizedBodyResolver()
+    override val uniquenessInformationResolver: MutableMap<SymbolicName, UniquenessInformation> = mutableMapOf()
 
 
     fun buildProgram(): Program = Program(
@@ -106,10 +110,10 @@ class ProgramConverter(
         return UniquenessInformation(graph.nodes.first(), facts)
     }
 
-    fun registerForVerification(declaration: FirSimpleFunction) {
-        val signature = embedFullSignature(declaration.symbol)
-        // Note: it is important that `body` is only set after embedding is complete, as we need to
-        // place the embedding in the map before processing the body.
+    fun register(declaration: FirSimpleFunction) {
+        val (returnTarget, signature) = embedFullSignature(declaration.symbol)
+        val uniqueness = extractUniquenessInformation(declaration)
+        uniquenessInformationResolver.putIfAbsent(signature.name, uniqueness)
         if (declaration.symbol.isPure(session)) {
             ensurePureUserFunctionEmbedding(declaration.symbol, signature)
         } else {
@@ -213,10 +217,10 @@ class ProgramConverter(
     }
 
     private fun createBodyConversionContext(
-        signature: NamedFunctionSignature, target: ReturnTarget
+        signature: NamedFunctionSignature,
+        target: ReturnTarget
     ): StmtConversionContext {
 
-        val uniqueness = extractUniquenessInformation(declaration)
         val paramResolver = RootParameterResolver(
             this@ProgramConverter, signature, signature.symbol.valueParameterSymbols, signature.labelName, target
         )
@@ -225,7 +229,8 @@ class ProgramConverter(
             signature,
             paramResolver,
             scopeIndexProducer.getFresh(),
-            uniqueness,
+            null,
+            uniquenessInformationResolver[signature.name]
         ).statementCtxt()
         return stmtCtx
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SpecialFields.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SpecialFields.kt
@@ -7,9 +7,9 @@ package org.jetbrains.kotlin.formver.core.conversion
 
 
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.expression.FieldAccess
 import org.jetbrains.kotlin.formver.core.embeddings.expression.IntLit
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings
+import org.jetbrains.kotlin.formver.core.embeddings.expression.PrimitiveFieldAccess
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeInvariantEmbedding
@@ -38,6 +38,6 @@ val CollectionSizeFieldEmbedding: FieldEmbedding = SpecialField(
 ) { field ->
     listOf(object : TypeInvariantEmbedding {
         override fun fillHole(exp: ExpEmbedding): ExpEmbedding =
-            OperatorExpEmbeddings.GeIntInt(FieldAccess(exp, field), IntLit(0))
+            OperatorExpEmbeddings.GeIntInt(PrimitiveFieldAccess(exp, field), IntLit(0))
     })
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
@@ -17,12 +17,15 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.names.NameMatcher
 
 private fun VariableEmbedding.sameSize(): ExpEmbedding =
-    EqCmp(FieldAccess(this, CollectionSizeFieldEmbedding), Old(FieldAccess(this, CollectionSizeFieldEmbedding)))
+    EqCmp(
+        PrimitiveFieldAccess(this, CollectionSizeFieldEmbedding),
+        Old(PrimitiveFieldAccess(this, CollectionSizeFieldEmbedding))
+    )
 
 private fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding =
     EqCmp(
-        FieldAccess(this, CollectionSizeFieldEmbedding),
-        OperatorExpEmbeddings.AddIntInt(Old(FieldAccess(this, CollectionSizeFieldEmbedding)), IntLit(amount)),
+        PrimitiveFieldAccess(this, CollectionSizeFieldEmbedding),
+        OperatorExpEmbeddings.AddIntInt(Old(PrimitiveFieldAccess(this, CollectionSizeFieldEmbedding)), IntLit(amount)),
     )
 
 sealed interface StdLibReceiverInterface {
@@ -112,7 +115,7 @@ data object GetPrecondition : StdLibPrecondition {
                 SourceRole.ListElementAccessCheck(SourceRole.ListElementAccessCheck.AccessCheckType.LESS_THAN_ZERO)
             ),
             GtIntInt(
-                FieldAccess(receiver, CollectionSizeFieldEmbedding),
+                PrimitiveFieldAccess(receiver, CollectionSizeFieldEmbedding),
                 indexArg,
                 SourceRole.ListElementAccessCheck(SourceRole.ListElementAccessCheck.AccessCheckType.GREATER_THAN_LIST_SIZE)
             ),
@@ -131,7 +134,11 @@ data object SubListPrecondition : StdLibPrecondition {
         return listOf(
             LeIntInt(fromIndexArg, toIndexArg, SourceRole.SubListCreation.CheckInSize),
             GeIntInt(fromIndexArg, IntLit(0), SourceRole.SubListCreation.CheckNegativeIndices),
-            LeIntInt(toIndexArg, FieldAccess(receiver, CollectionSizeFieldEmbedding), SourceRole.SubListCreation.CheckInSize)
+            LeIntInt(
+                toIndexArg,
+                PrimitiveFieldAccess(receiver, CollectionSizeFieldEmbedding),
+                SourceRole.SubListCreation.CheckInSize
+            )
         )
     }
 
@@ -145,7 +152,7 @@ data object EmptyListPostcondition : StdLibPostcondition {
         function: NamedFunctionSignature
     ): List<ExpEmbedding> {
         return listOf(
-            EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), IntLit(0))
+            EqCmp(PrimitiveFieldAccess(returnVariable, CollectionSizeFieldEmbedding), IntLit(0))
         )
     }
 
@@ -161,8 +168,11 @@ data object IsEmptyPostcondition : StdLibPostcondition {
         val receiver = function.dispatchReceiver!!
         return listOf(
             receiver.sameSize(),
-            Implies(returnVariable, EqCmp(FieldAccess(receiver, CollectionSizeFieldEmbedding), IntLit(0))),
-            Implies(Not(returnVariable), GtIntInt(FieldAccess(receiver, CollectionSizeFieldEmbedding), IntLit(0)))
+            Implies(returnVariable, EqCmp(PrimitiveFieldAccess(receiver, CollectionSizeFieldEmbedding), IntLit(0))),
+            Implies(
+                Not(returnVariable),
+                GtIntInt(PrimitiveFieldAccess(receiver, CollectionSizeFieldEmbedding), IntLit(0))
+            )
         )
     }
 
@@ -191,7 +201,10 @@ data object SubListPostcondition : StdLibPostcondition {
         val toIndexArg = function.formalArgs[2]
         return listOf(
             function.dispatchReceiver!!.sameSize(),
-            EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), SubIntInt(toIndexArg, fromIndexArg))
+            EqCmp(
+                PrimitiveFieldAccess(returnVariable, CollectionSizeFieldEmbedding),
+                SubIntInt(toIndexArg, fromIndexArg)
+            )
         )
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -415,7 +415,6 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     ): ExpEmbedding {
         val embedding = when (val lValue = variableAssignment.lValue) {
             is FirPropertyAccessExpression -> {
-                val receiverIsUnique = data.uniquenessInformation?.receiverIsUnique(variableAssignment.lValue) ?: false
                 data.embedPropertyAccess(lValue)
             }
 
@@ -427,8 +426,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 variableAssignment.source, "Lvalue must be either property access or desugared assignment."
             )
         }
+        val receiverIsUnique = data.uniquenessInformation?.receiverIsUnique(variableAssignment.lValue) ?: false
         val convertedRValue = data.convert(variableAssignment.rValue)
-        return embedding.setValue(convertedRValue, false, data)
+        return embedding.setValue(convertedRValue, receiverIsUnique, data)
     }
 
     override fun visitSmartCastExpression(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -427,7 +427,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             )
         }
         val convertedRValue = data.convert(variableAssignment.rValue)
-        return embedding.setValue(convertedRValue, data)
+        return embedding.setValue(convertedRValue, false, data)
     }
 
     override fun visitSmartCastExpression(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -415,6 +415,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     ): ExpEmbedding {
         val embedding = when (val lValue = variableAssignment.lValue) {
             is FirPropertyAccessExpression -> {
+                val receiverIsUnique = data.uniquenessInformation?.receiverIsUnique(variableAssignment.lValue) ?: false
                 data.embedPropertyAccess(lValue)
             }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -198,7 +198,8 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         data: StmtConversionContext,
     ): ExpEmbedding {
         val propertyAccess = data.embedPropertyAccess(propertyAccessExpression)
-        return propertyAccess.getValue(data)
+        val isUnique = data.uniquenessInformation?.receiverIsUnique(propertyAccessExpression) ?: false
+        return propertyAccess.getValue(data, isUnique)
     }
 
     override fun visitEqualityOperatorCall(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.conversion
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.EnterNodeMarker
+import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ExitNodeMarker
+import org.jetbrains.kotlin.formver.uniqueness.FlowFacts
+import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
+
+
+class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<UniquenessTrie>) {
+
+    private val nodeCollectionMap by lazy { extract() }
+
+    fun flowBefore(firElement: FirElement): UniquenessTrie? {
+        return nodeCollectionMap[firElement]?.entry?.let { flowFacts.flowBefore(it) }
+    }
+
+    fun flowAfter(firElement: FirElement): UniquenessTrie? {
+        return nodeCollectionMap[firElement]?.exit?.let { flowFacts.flowAfter(it) }
+    }
+
+    class NodeCollection {
+        private var _entry: CFGNode<*>? = null
+        private var _exit: CFGNode<*>? = null
+        private val _all: MutableList<CFGNode<*>> = mutableListOf()
+
+
+        val entry: CFGNode<*>? get() = _entry ?: _all.firstOrNull()
+        val exit: CFGNode<*>? get() = _exit ?: _all.lastOrNull()
+
+        fun update(node: CFGNode<*>) {
+            when (node) {
+                is EnterNodeMarker -> _entry = node
+                is ExitNodeMarker -> _exit = node
+                else -> {}
+            }
+            _all.add(node)
+        }
+    }
+
+    fun extract(): Map<FirElement, NodeCollection> {
+        val visited = mutableSetOf<CFGNode<*>>()
+        val result = mutableMapOf<FirElement, NodeCollection>()
+
+        val stack = mutableListOf(root)
+
+        while (stack.isNotEmpty()) {
+            val node = stack.removeAt(stack.size - 1)
+            if (!visited.add(node)) continue
+
+            result.getOrPut(node.fir) { NodeCollection() }.update(node)
+
+            for (followingNode in node.followingNodes) {
+                stack.add(followingNode)
+            }
+        }
+
+        return result
+    }
+}
+

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
@@ -36,11 +36,11 @@ class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<Uniqu
     class NodeCollection {
         private var _entry: CFGNode<*>? = null
         private var _exit: CFGNode<*>? = null
-        private val _all: MutableList<CFGNode<*>> = mutableListOf()
+        private val all: MutableList<CFGNode<*>> = mutableListOf()
 
 
-        val entry: CFGNode<*>? get() = _entry ?: _all.firstOrNull()
-        val exit: CFGNode<*>? get() = _exit ?: _all.lastOrNull()
+        val entry: CFGNode<*>? get() = _entry ?: all.firstOrNull()
+        val exit: CFGNode<*>? get() = _exit ?: all.lastOrNull()
 
         fun update(node: CFGNode<*>) {
             when (node) {
@@ -48,7 +48,7 @@ class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<Uniqu
                 is ExitNodeMarker -> _exit = node
                 else -> {}
             }
-            _all.add(node)
+            all.add(node)
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
@@ -6,11 +6,11 @@
 package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.EnterNodeMarker
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ExitNodeMarker
-import org.jetbrains.kotlin.formver.uniqueness.FlowFacts
-import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
+import org.jetbrains.kotlin.formver.uniqueness.*
 
 /**
  * Represents information about the uniqueness of paths through a control flow graph (CFG).
@@ -24,6 +24,15 @@ import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<UniquenessTrie>) {
 
     private val nodeCollectionMap by lazy { extract() }
+
+    fun receiverIsUnique(propertyAccess: FirPropertyAccessExpression): Boolean {
+        val flowBefore = flowBefore(propertyAccess) ?: return false
+        val accessedPath = propertyAccess.receiverPath ?: return false
+        val type = flowBefore.ensure(accessedPath).parentsJoin
+        val activeUniquenessLevel = (type as? UniquenessType.Active)?.uniqueLevel ?: return false
+        return activeUniquenessLevel == UniqueLevel.Unique
+    }
+
 
     fun flowBefore(firElement: FirElement): UniquenessTrie? {
         return nodeCollectionMap[firElement]?.entry?.let { flowFacts.flowBefore(it) }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
@@ -6,7 +6,6 @@
 package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.fir.FirElement
-import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.EnterNodeMarker
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ExitNodeMarker
@@ -25,9 +24,9 @@ class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<Uniqu
 
     private val nodeCollectionMap by lazy { extract() }
 
-    fun receiverIsUnique(propertyAccess: FirPropertyAccessExpression): Boolean {
-        val flowBefore = flowBefore(propertyAccess) ?: return false
-        val accessedPath = propertyAccess.receiverPath ?: return false
+    fun receiverIsUnique(firElement: FirElement): Boolean {
+        val flowBefore = flowBefore(firElement) ?: return false
+        val accessedPath = firElement.receiverPath ?: return false
         val type = flowBefore.ensure(accessedPath).parentsJoin
         val activeUniquenessLevel = (type as? UniquenessType.Active)?.uniqueLevel ?: return false
         return activeUniquenessLevel == UniqueLevel.Unique

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UniquenessInformation.kt
@@ -12,7 +12,15 @@ import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ExitNodeMarker
 import org.jetbrains.kotlin.formver.uniqueness.FlowFacts
 import org.jetbrains.kotlin.formver.uniqueness.UniquenessTrie
 
-
+/**
+ * Represents information about the uniqueness of paths through a control flow graph (CFG).
+ * It provides mechanisms to access dataflow facts and analyze paths before and after a specific
+ * FirElement
+ *
+ * @property root The root node of the control flow graph (CFG) from which traversal begins.
+ * @property flowFacts The dataflow facts associated with each node in the CFG, which store
+ *                     information before and after execution of those nodes.
+ */
 class UniquenessInformation(val root: CFGNode<*>, val flowFacts: FlowFacts<UniquenessTrie>) {
 
     private val nodeCollectionMap by lazy { extract() }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -7,12 +7,15 @@ package org.jetbrains.kotlin.formver.core.embeddings.expression
 
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
-import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.*
+import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.DebugPrintable
+import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.DebugTreeViewVisitor
+import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.TreeView
+import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.print
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildType
-import org.jetbrains.kotlin.formver.core.purity.PurityContext
 import org.jetbrains.kotlin.formver.core.names.SimpleNameResolver
+import org.jetbrains.kotlin.formver.core.purity.PurityContext
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -58,7 +61,8 @@ data class PrimitiveFieldAccess(val inner: ExpEmbedding, val field: FieldEmbeddi
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
-data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : ExpEmbedding {
+data class FieldAccess(val receiver: ExpEmbedding, val receiverIsUnique: Boolean, val field: FieldEmbedding) :
+    ExpEmbedding {
     override val type: TypeEmbedding = field.type
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFieldAccess(this)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -72,7 +72,12 @@ data class FieldAccess(val receiver: ExpEmbedding, val receiverIsUnique: Boolean
 /**
  * Represents a combination of `Assign` + `FieldAccess`.
  */
-data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbedding, val newValue: ExpEmbedding) :
+data class FieldModification(
+    val receiver: ExpEmbedding,
+    val receiverIsUnique: Boolean,
+    val field: FieldEmbedding,
+    val newValue: ExpEmbedding
+) :
     ExpEmbedding {
     override val type: TypeEmbedding = buildType { unit() }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
@@ -62,7 +62,8 @@ sealed interface VariableEmbedding : ExpEmbedding, PropertyAccessEmbedding {
         get() = true
 
     override fun getValue(ctx: StmtConversionContext, receiverIsUnique: Boolean): ExpEmbedding = this
-    override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding = Assign(this, value.withType(type))
+    override fun setValue(value: ExpEmbedding, receiverIsUnique: Boolean, ctx: StmtConversionContext): ExpEmbedding =
+        Assign(this, value.withType(type))
 
     fun pureInvariants(): List<ExpEmbedding> = type.pureInvariants().fillHoles(this)
     fun provenInvariants(): List<ExpEmbedding> = listOf(type.subTypeInvariant().fillHole(this))

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/VariableEmbedding.kt
@@ -61,7 +61,7 @@ sealed interface VariableEmbedding : ExpEmbedding, PropertyAccessEmbedding {
     val isOriginallyRef: Boolean
         get() = true
 
-    override fun getValue(ctx: StmtConversionContext): ExpEmbedding = this
+    override fun getValue(ctx: StmtConversionContext, receiverIsUnique: Boolean): ExpEmbedding = this
     override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding = Assign(this, value.withType(type))
 
     fun pureInvariants(): List<ExpEmbedding> = type.pureInvariants().fillHoles(this)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
@@ -32,6 +32,11 @@ class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
 }
 
 class BackingFieldSetter(val field: FieldEmbedding) : SetterEmbedding {
-    override fun setValue(receiver: ExpEmbedding, value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding =
-        FieldModification(receiver, field, value.withType(field.type))
+    override fun setValue(
+        receiver: ExpEmbedding,
+        receiverIsUnique: Boolean,
+        value: ExpEmbedding,
+        ctx: StmtConversionContext
+    ): ExpEmbedding =
+        FieldModification(receiver, receiverIsUnique, field, value.withType(field.type))
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/BackingFieldAccessors.kt
@@ -10,10 +10,15 @@ import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 
 class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
-    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {
+    override fun getValue(receiver: ExpEmbedding, receiverIsUnique: Boolean, ctx: StmtConversionContext): ExpEmbedding {
         return when (field.accessPolicy) {
-            AccessPolicy.ALWAYS_READABLE, AccessPolicy.BY_RECEIVER_UNIQUENESS -> FieldAccess(receiver, field)
-            else -> FieldAccess(receiver, field).withInvariants(ctx.typeResolver) {
+            AccessPolicy.ALWAYS_READABLE, AccessPolicy.BY_RECEIVER_UNIQUENESS -> FieldAccess(
+                receiver,
+                receiverIsUnique,
+                field
+            )
+
+            else -> FieldAccess(receiver, receiverIsUnique, field).withInvariants(ctx.typeResolver) {
                 proven = true
                 access = true
             }
@@ -23,7 +28,7 @@ class BackingFieldGetter(val field: FieldEmbedding) : GetterEmbedding {
     override fun getValueSimple(
         receiver: ExpEmbedding,
         ctx: StmtConversionContext
-    ): ExpEmbedding = FieldAccess(receiver, field)
+    ): ExpEmbedding = FieldAccess(receiver, true, field)
 }
 
 class BackingFieldSetter(val field: FieldEmbedding) : SetterEmbedding {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
@@ -14,8 +14,8 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 // missing getter or setter will never be accessed.
 class ClassPropertyAccess(val receiver: ExpEmbedding, val property: PropertyEmbedding, val type: TypeEmbedding) :
     PropertyAccessEmbedding {
-    override fun getValue(ctx: StmtConversionContext): ExpEmbedding =
-        property.getter!!.getValue(receiver, ctx).withNewTypeInvariants(type, ctx.typeResolver) {
+    override fun getValue(ctx: StmtConversionContext, receiverIsUnique: Boolean): ExpEmbedding =
+        property.getter!!.getValue(receiver, receiverIsUnique, ctx).withNewTypeInvariants(type, ctx.typeResolver) {
             proven = true
             access = true
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/ClassPropertyAccess.kt
@@ -21,6 +21,6 @@ class ClassPropertyAccess(val receiver: ExpEmbedding, val property: PropertyEmbe
         }
 
     // set value must already have correct type so no need to worry
-    override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding =
-        property.setter!!.setValue(receiver, value, ctx)
+    override fun setValue(value: ExpEmbedding, receiverIsUnique: Boolean, ctx: StmtConversionContext): ExpEmbedding =
+        property.setter!!.setValue(receiver, receiverIsUnique, value, ctx)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/CustomAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/CustomAccessors.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 class CustomGetter(val getterMethod: CallableEmbedding) : GetterEmbedding {
     override fun getValue(
         receiver: ExpEmbedding,
+        receiverIsUnique: Boolean,
         ctx: StmtConversionContext,
     ): ExpEmbedding = getterMethod.insertCall(listOf(receiver), ctx, getterMethod.callableType.returnType)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/CustomAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/CustomAccessors.kt
@@ -27,6 +27,7 @@ class CustomGetter(val getterMethod: CallableEmbedding) : GetterEmbedding {
 class CustomSetter(val setterMethod: CallableEmbedding) : SetterEmbedding {
     override fun setValue(
         receiver: ExpEmbedding,
+        receiverIsUnique: Boolean,
         value: ExpEmbedding,
         ctx: StmtConversionContext,
     ): ExpEmbedding = setterMethod.insertCall(listOf(receiver, value), ctx, setterMethod.callableType.returnType)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/GetterEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/GetterEmbedding.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 
 interface GetterEmbedding {
-    fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding
+    fun getValue(receiver: ExpEmbedding, receiverIsUnique: Boolean, ctx: StmtConversionContext): ExpEmbedding
 
     /**
      * Gets the values without adding type invariants.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/PropertyAccessEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/PropertyAccessEmbedding.kt
@@ -9,14 +9,14 @@ import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 
 interface PropertyAccessEmbedding {
-    fun getValue(ctx: StmtConversionContext): ExpEmbedding
+    fun getValue(ctx: StmtConversionContext, receiverIsUnique: Boolean): ExpEmbedding
     fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding
 }
 
 fun ExpEmbedding.asPropertyAccess() = when (this) {
     is PropertyAccessEmbedding -> this
     else -> object : PropertyAccessEmbedding {
-        override fun getValue(ctx: StmtConversionContext): ExpEmbedding =
+        override fun getValue(ctx: StmtConversionContext, receiverIsUnique: Boolean): ExpEmbedding =
             this@asPropertyAccess
 
         override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/PropertyAccessEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/PropertyAccessEmbedding.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 
 interface PropertyAccessEmbedding {
     fun getValue(ctx: StmtConversionContext, receiverIsUnique: Boolean): ExpEmbedding
-    fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding
+    fun setValue(value: ExpEmbedding, receiverIsUnique: Boolean, ctx: StmtConversionContext): ExpEmbedding
 }
 
 fun ExpEmbedding.asPropertyAccess() = when (this) {
@@ -19,7 +19,11 @@ fun ExpEmbedding.asPropertyAccess() = when (this) {
         override fun getValue(ctx: StmtConversionContext, receiverIsUnique: Boolean): ExpEmbedding =
             this@asPropertyAccess
 
-        override fun setValue(value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding {
+        override fun setValue(
+            value: ExpEmbedding,
+            receiverIsUnique: Boolean,
+            ctx: StmtConversionContext
+        ): ExpEmbedding {
             error("Property does not have a settable value")
         }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SetterEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SetterEmbedding.kt
@@ -9,5 +9,10 @@ import org.jetbrains.kotlin.formver.core.conversion.StmtConversionContext
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 
 interface SetterEmbedding {
-    fun setValue(receiver: ExpEmbedding, value: ExpEmbedding, ctx: StmtConversionContext): ExpEmbedding
+    fun setValue(
+        receiver: ExpEmbedding,
+        receiverIsUnique: Boolean,
+        value: ExpEmbedding,
+        ctx: StmtConversionContext
+    ): ExpEmbedding
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialAccessors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/properties/SpecialAccessors.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings
 
 object LengthFieldGetter : GetterEmbedding {
-    override fun getValue(receiver: ExpEmbedding, ctx: StmtConversionContext) =
+    override fun getValue(receiver: ExpEmbedding, receiverIsUnique: Boolean, ctx: StmtConversionContext) =
         OperatorExpEmbeddings.StringLength(receiver)
 
     override fun getValueSimple(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
@@ -56,9 +56,20 @@ interface LinearizationContext {
         result: VariableEmbedding?
     )
 
-    fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp
+    fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding
+    ): Exp
 
-    fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding)
+    fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding,
+        result: VariableEmbedding
+    )
 
     fun addModifier(mod: StmtModifier)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.core.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.asPosition
 import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
@@ -429,19 +430,32 @@ data class LinearizationVisitor(
         override fun toViperUnusedResult(ctx: LinearizationContext) {
             when (e.field.accessPolicy) {
                 AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
-                    e.receiver.linearize().toViperUnusedResult(ctx)
-                    e.newValue.linearize().toViperUnusedResult(ctx)
-                }
-                else -> {
-                    val receiverViper = e.receiver.linearize().toViper(ctx)
-                    if (e.field.unfoldToAccess) {
-                        val receiverWrapper = ExpWrapper(receiverViper, e.receiver.type)
-                        val hierarchyPath = ctx.typeResolver.hierarchyPathTo(e.receiver.type.pretype, e.field)
-                        hierarchyPath?.forEach { classType ->
-                            val predAcc = classType.predicateAccess(receiverWrapper, ctx.typeResolver, ctx.source)
-                            ctx.addStatement { Stmt.Unfold(predAcc) }
+                    if (e.receiverIsUnique) {
+                        val receiverViper = e.receiver.linearize().toViper(ctx)
+                        if (e.field.unfoldToAccess) {
+                            val receiverWrapper = ExpWrapper(receiverViper, e.receiver.type)
+                            val hierarchyPath = ctx.typeResolver.hierarchyPathTo(e.receiver.type.pretype, e.field)
+                            hierarchyPath?.forEach { classType ->
+                                val predAcc = classType.predicateAccess(receiverWrapper, ctx.typeResolver, ctx.source)
+                                ctx.addStatement { Stmt.Unfold(predAcc) }
+                            }
                         }
+                        val newValueViper = e.newValue.linearize().toViper(ctx)
+                        ctx.addStatement {
+                            Stmt.FieldAssign(
+                                Exp.FieldAccess(receiverViper, e.field.toViper()),
+                                newValueViper,
+                                ctx.source.asPosition
+                            )
+                        }
+                    } else {
+                        e.receiver.linearize().toViperUnusedResult(ctx)
+                        e.newValue.linearize().toViperUnusedResult(ctx)
                     }
+                }
+
+                AccessPolicy.MANUAL, AccessPolicy.ALWAYS_WRITEABLE -> {
+                    val receiverViper = e.receiver.linearize().toViper(ctx)
                     val newValueViper = e.newValue.linearize().toViper(ctx)
                     ctx.addStatement {
                         Stmt.FieldAssign(
@@ -451,6 +465,11 @@ data class LinearizationVisitor(
                         )
                     }
                 }
+
+                AccessPolicy.ALWAYS_READABLE -> throw SnaktInternalException(
+                    null,
+                    "Always readable field access not supported"
+                )
             }
         }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -405,11 +405,11 @@ data class LinearizationVisitor(
             if (e.field.accessPolicy == AccessPolicy.ALWAYS_WRITEABLE) {
                 return PrimitiveFieldAccess(e.receiver, e.field).linearize().toViper(ctx)
             }
-            return ctx.addFieldAccess(receiverLinearizable, e.receiver.type, e.field)
+            return ctx.addFieldAccess(receiverLinearizable, e.receiver.type, e.receiverIsUnique, e.field)
         }
 
         override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) {
-            ctx.addFieldAccessStoringIn(receiverLinearizable, e.receiver.type, e.field, result)
+            ctx.addFieldAccessStoringIn(receiverLinearizable, e.receiver.type, e.receiverIsUnique, e.field, result)
         }
 
         override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -99,9 +99,14 @@ data class Linearizer(
             Stmt.If(condViper, thenViper, elseViper, source.asPosition)
         }
 
-    override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
+    override fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding
+    ): Exp {
         val result = freshAnonVar(field.type)
-        addFieldAccessStoringIn(receiver, receiverType, field, result)
+        addFieldAccessStoringIn(receiver, receiverType, receiverIsUnique, field, result)
         return result.toViperExp(this)
     }
 
@@ -109,7 +114,13 @@ data class Linearizer(
         stmtModifierTracker?.add(mod) ?: error("Not in a statement")
     }
 
-    override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
+    override fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding,
+        result: VariableEmbedding
+    ) {
         addStatement {
             when (field.accessPolicy) {
                 // TODO: Handling a unique field on a shared receiver must be added here.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -123,8 +123,7 @@ data class Linearizer(
     ) {
         addStatement {
             when (field.accessPolicy) {
-                // TODO: Handling a unique field on a shared receiver must be added here.
-                AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+                AccessPolicy.BY_RECEIVER_UNIQUENESS if !receiverIsUnique -> {
                     receiver.toViperUnusedResult(this)
                     SpecialMethods.havocMethod.toMethodCall(
                         listOf(field.type.runtimeType),
@@ -132,7 +131,7 @@ data class Linearizer(
                     )
                 }
 
-                else -> {
+                AccessPolicy.BY_RECEIVER_UNIQUENESS if receiverIsUnique -> {
                     val receiverViper = receiver.toViper(this)
                     // If the field access is not replaced with havoc,
                     // we might need to unfold some predicate to access it.
@@ -144,6 +143,18 @@ data class Linearizer(
                     Stmt.assign(
                         result.toLocalVarUse(), Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
                     )
+                }
+
+                AccessPolicy.MANUAL, AccessPolicy.ALWAYS_WRITEABLE, AccessPolicy.ALWAYS_READABLE -> {
+                    val receiverViper = receiver.toViper(this)
+                    Stmt.assign(
+                        result.toLocalVarUse(), Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
+                    )
+                }
+
+                else -> {
+                    // The when is exhaustive
+                    throw SnaktInternalException(source, "Unexpected access policy: ${field.accessPolicy}")
                 }
             }
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
@@ -77,11 +77,22 @@ data class PureExpLinearizer(
         throw PureExpLinearizerMisuseException("addBranch")
     }
 
-    override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
+    override fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding,
+        result: VariableEmbedding
+    ) {
         throw PureExpLinearizerMisuseException("addFieldAccessWithResult")
     }
 
-    override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
+    override fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding
+    ): Exp {
         val receiverViper = receiver.toViper(this)
         val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field)
         val primitiveAccess: Exp = Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
@@ -99,7 +99,13 @@ data class PureFunBodyLinearizer(
         }
     }
 
-    override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
+    override fun addFieldAccessStoringIn(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding,
+        result: VariableEmbedding
+    ) {
         val viperReceiver = receiver.toViper(this)
         if (viperReceiver !is Exp.LocalVar) throw SnaktInternalException(
             source,
@@ -113,9 +119,14 @@ data class PureFunBodyLinearizer(
         ssaConverter.addAssignment(result.name, primitiveAccess, accessInvariants)
     }
 
-    override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
+    override fun addFieldAccess(
+        receiver: Linearizable,
+        receiverType: TypeEmbedding,
+        receiverIsUnique: Boolean,
+        field: FieldEmbedding
+    ): Exp {
         val result = freshAnonVar(field.type)
-        addFieldAccessStoringIn(receiver, receiverType, field, result)
+        addFieldAccessStoringIn(receiver, receiverType, receiverIsUnique, field, result)
         return result.toViperExp(this)
     }
 

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -792,6 +792,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       public void testFieldRead() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldRead.kt");
       }
+
+      @Test
+      @TestMetadata("fieldWrite.kt")
+      public void testFieldWrite() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldWrite.kt");
+      }
     }
 
     @Nested

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -779,6 +779,22 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/permissions")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Permissions {
+      @Test
+      public void testAllFilesPresentInPermissions() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/verification/permissions"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("fieldRead.kt")
+      public void testFieldRead() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldRead.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/pure_functions")
     @TestDataPath("$PROJECT_ROOT")
     public class Pure_functions {

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldRead.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldRead.fir.diag.txt
@@ -1,0 +1,235 @@
+/fieldRead.kt: info: Generated Viper text for uniq_uniq:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  unfold acc(C_unique(c), write)
+  l := c.uniq
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_shared:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(B())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_uniq_uniq:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  var anon: Ref
+  unfold acc(C_unique(c), write)
+  anon := c.uniq
+  unfold acc(B_unique(anon), write)
+  l := anon.uniq
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_shared_uniq:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_shared_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(A())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_uniq_shared:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(A())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_shared_shared:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_shared_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(A())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_uniq_uniq_uniq:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_uniq_uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  var anon_0: Ref
+  var anon_1: Ref
+  unfold acc(C_unique(c), write)
+  anon_1 := c.uniq
+  unfold acc(B_unique(anon_1), write)
+  anon_0 := anon_1.uniq
+  unfold acc(A_unique(anon_0), write)
+  l := anon_0.uniq
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_shared_uniq_uniq:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_shared_uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_uniq_shared_uniq:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_uniq_shared_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_shared_shared_uniq:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_shared_shared_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_uniq_uniq_shared:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_uniq_uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_shared_uniq_shared:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_shared_uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_uniq_shared_shared:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_uniq_shared_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldRead.kt: info: Generated Viper text for uniq_shared_shared_shared:
+field shared: Ref
+
+field uniq: Ref
+
+method uniq_shared_shared_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var l: Ref
+  l := havoc(intType())
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldRead.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldRead.kt
@@ -1,0 +1,76 @@
+import org.jetbrains.kotlin.formver.plugin.*
+
+class A() {
+    @Unique
+    var unique: Int = 1
+    var shared: Int = 2
+}
+
+class B() {
+    @Unique
+    var unique: A = A()
+    var shared: A = A()
+}
+
+class C() {
+    @Unique
+    var unique: B = B()
+    var shared: B = B()
+}
+
+
+fun <!VIPER_TEXT!>uniq_uniq<!>(@Unique c : C) {
+    @Unique val l = c.unique
+}
+
+fun <!VIPER_TEXT!>uniq_shared<!>(@Unique c: C) {
+    val l = c.shared
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_uniq<!>(@Unique c : C) {
+    @Unique val l = c.unique.unique
+}
+
+fun <!VIPER_TEXT!>uniq_shared_uniq<!>(@Unique c: C) {
+    val l = c.shared.unique
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_shared<!>(@Unique c : C) {
+    val l = c.unique.shared
+}
+
+fun <!VIPER_TEXT!>uniq_shared_shared<!>(@Unique c: C) {
+    val l = c.shared.shared
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_uniq_uniq<!>(@Unique c : C) {
+    @Unique val l = c.unique.unique.unique
+}
+
+fun <!VIPER_TEXT!>uniq_shared_uniq_uniq<!>(@Unique c: C) {
+    val l = c.shared.unique.unique
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_shared_uniq<!>(@Unique c : C) {
+    val l = c.unique.shared.unique
+}
+
+fun <!VIPER_TEXT!>uniq_shared_shared_uniq<!>(@Unique c: C) {
+    val l = c.shared.shared.unique
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_uniq_shared<!>(@Unique c : C) {
+    val l = c.unique.unique.shared
+}
+
+fun <!VIPER_TEXT!>uniq_shared_uniq_shared<!>(@Unique c: C) {
+    val l = c.shared.unique.shared
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_shared_shared<!>(@Unique c : C) {
+    val l = c.unique.shared.shared
+}
+
+fun <!VIPER_TEXT!>uniq_shared_shared_shared<!>(@Unique c: C) {
+    val l = c.shared.shared.shared
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldWrite.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldWrite.fir.diag.txt
@@ -1,0 +1,237 @@
+/fieldWrite.kt: info: Generated Viper text for uniq_uniq:
+field bf_unique: Ref
+
+field shared: Ref
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), B())
+  ensures acc(B_unique(ret_1), write)
+
+
+method uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon: Ref
+  anon := con()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_shared:
+field bf_unique: Ref
+
+field shared: Ref
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), B())
+  ensures acc(B_unique(ret_1), write)
+
+
+method uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon: Ref
+  anon := con()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_uniq_uniq:
+field bf_unique: Ref
+
+field shared: Ref
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), A())
+  ensures acc(A_unique(ret_1), write)
+
+
+method uniq_uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon: Ref
+  anon := con()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_shared_uniq:
+field bf_unique: Ref
+
+field shared: Ref
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), A())
+  ensures acc(A_unique(ret_1), write)
+
+
+method uniq_shared_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon: Ref
+  anon := con()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_uniq_shared:
+field bf_unique: Ref
+
+field shared: Ref
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), A())
+  ensures acc(A_unique(ret_1), write)
+
+
+method uniq_uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon: Ref
+  anon := con()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_shared_shared:
+field bf_unique: Ref
+
+field shared: Ref
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), A())
+  ensures acc(A_unique(ret_1), write)
+
+
+method uniq_shared_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon: Ref
+  anon := con()
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_uniq_uniq_uniq:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_uniq_uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_shared_uniq_uniq:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_shared_uniq_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_uniq_shared_uniq:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_uniq_shared_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_shared_shared_uniq:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_shared_shared_uniq(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_uniq_uniq_shared:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_uniq_uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_shared_uniq_shared:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_shared_uniq_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_uniq_shared_shared:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_uniq_shared_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/fieldWrite.kt: info: Generated Viper text for uniq_shared_shared_shared:
+field bf_unique: Ref
+
+field shared: Ref
+
+method uniq_shared_shared_shared(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldWrite.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/permissions/fieldWrite.kt
@@ -1,0 +1,76 @@
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class A() {
+    @Unique
+    var unique: Int = 1
+    var shared: Int = 2
+}
+
+class B() {
+    @Unique
+    var unique: A = A()
+    var shared: A = A()
+}
+
+class C() {
+    @Unique
+    var unique: B = B()
+    var shared: B = B()
+}
+
+
+fun <!VIPER_TEXT!>uniq_uniq<!>(@Unique c : C) {
+    c.unique = B()
+}
+
+fun <!VIPER_TEXT!>uniq_shared<!>(@Unique c: C) {
+    c.shared = B()
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_uniq<!>(@Unique c : C) {
+    c.unique.unique = A()
+}
+
+fun <!VIPER_TEXT!>uniq_shared_uniq<!>(@Unique c: C) {
+    c.shared.unique = A()
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_shared<!>(@Unique c : C) {
+    c.unique.shared = A()
+}
+
+fun <!VIPER_TEXT!>uniq_shared_shared<!>(@Unique c: C) {
+    c.shared.shared = A()
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_uniq_uniq<!>(@Unique c : C) {
+    c.unique.unique.unique = 1
+}
+
+fun <!VIPER_TEXT!>uniq_shared_uniq_uniq<!>(@Unique c: C) {
+    c.shared.unique.unique = 2
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_shared_uniq<!>(@Unique c : C) {
+    c.unique.shared.unique = 3
+}
+
+fun <!VIPER_TEXT!>uniq_shared_shared_uniq<!>(@Unique c: C) {
+    c.shared.shared.unique = 4
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_uniq_shared<!>(@Unique c : C) {
+    c.unique.unique.shared = 5
+}
+
+fun <!VIPER_TEXT!>uniq_shared_uniq_shared<!>(@Unique c: C) {
+    c.shared.unique.shared = 6
+}
+
+fun <!VIPER_TEXT!>uniq_uniq_shared_shared<!>(@Unique c : C) {
+    c.unique.shared.shared = 7
+}
+
+fun <!VIPER_TEXT!>uniq_shared_shared_shared<!>(@Unique c: C) {
+    c.shared.shared.shared = 8
+}


### PR DESCRIPTION
I looked at #134.  There were some good ideas, but it went a bit too far (looked at the folding back etc.). I tried to take the useful approaches and build it in a way that it already prepares for the full permission management. 

This requires some more work:
- Deep testing
- writing is not fully supported, because we miss uniqueness information. In the added write test the uniqueness checker does not tell us that before the writing `c.unique` is unique. 