### PR TITLE
Dedup FIR extension registration between CLI and test-fixture

### DIFF
--- a/formver.compiler-plugin/cli/build.gradle.kts
+++ b/formver.compiler-plugin/cli/build.gradle.kts
@@ -6,7 +6,6 @@ dependencies {
     compileOnly(kotlin("compiler"))
     implementation(project(":formver.common"))
     implementation(project(":formver.compiler-plugin:plugin"))
-    implementation(project(":formver.compiler-plugin:locality"))
 }
 
 sourceSets {

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
@@ -8,10 +8,8 @@ package org.jetbrains.kotlin.formver.cli
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.common.*
-import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
-import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
+import org.jetbrains.kotlin.formver.plugin.compiler.registerFormverExtensions
 
 @OptIn(ExperimentalCompilerApi::class)
 class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
@@ -47,10 +45,6 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
             logLevel, errorStyle, behaviour, conversionSelection, verificationSelection,
             checkLocality, checkUniqueness, dumpUniquenessCFG
         )
-        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
-
-        if (config.checkLocality) {
-            FirExtensionRegistrarAdapter.registerExtension(LocalityExtensionRegistrar())
-        }
+        registerFormverExtensions(config)
     }
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginExtensionRegistrar.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginExtensionRegistrar.kt
@@ -5,9 +5,13 @@
 
 package org.jetbrains.kotlin.formver.plugin.compiler
 
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar.ExtensionStorage
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.core.diagnostics.ConversionErrors
+import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
 
 class FormalVerificationPluginExtensionRegistrar(private val config: PluginConfiguration) : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
@@ -15,5 +19,13 @@ class FormalVerificationPluginExtensionRegistrar(private val config: PluginConfi
         registerDiagnosticContainers(VerificationErrors)
         registerDiagnosticContainers(ConversionErrors)
         +PluginAdditionalCheckers.getFactory(config)
+    }
+}
+
+@OptIn(ExperimentalCompilerApi::class)
+fun ExtensionStorage.registerFormverExtensions(config: PluginConfiguration) {
+    FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
+    if (config.checkLocality) {
+        FirExtensionRegistrarAdapter.registerExtension(LocalityExtensionRegistrar())
     }
 }

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -7,10 +7,8 @@ package org.jetbrains.kotlin.formver.plugin.services
 
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar.ExtensionStorage
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.common.*
-import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
-import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
+import org.jetbrains.kotlin.formver.plugin.compiler.registerFormverExtensions
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.ALWAYS_VALIDATE
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DUMP_UNIQUENESS_CFG
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.FULL_VIPER_DUMP
@@ -74,10 +72,7 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
             dumpUniquenessCFG = dumpUniquenessCFG,
             checkLocality = checkLocality,
         )
-        FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
-        if (config.checkLocality) {
-            FirExtensionRegistrarAdapter.registerExtension(LocalityExtensionRegistrar())
-        }
+        registerFormverExtensions(config)
     }
 }
 


### PR DESCRIPTION
## Summary

- Extract `ExtensionStorage.registerFormverExtensions(config)` helper alongside `FormalVerificationPluginExtensionRegistrar` in the `plugin/` module.
- Both the CLI's `CompilerPluginRegistrar` and the in-process `ExtensionRegistrarConfigurator` test fixture now call the helper instead of independently registering the main extension and conditionally registering `LocalityExtensionRegistrar`. Future per-feature registrars land in one place.
- Drop the direct `implementation(project(":formver.compiler-plugin:locality"))` line from `cli/build.gradle.kts`: the CLI no longer references `LocalityExtensionRegistrar` by class and gets locality transitively via `plugin/`.

No behavior change — same extensions registered in the same order, same conditional on `config.checkLocality`.

## Test plan

- [x] `./gradlew :formver.compiler-plugin:detekt`
- [x] `./gradlew :formver.compiler-plugin:untilConversion`