### PR TITLE
Restrict TypeInvariantHolder to TypeEmbedding; flatten TypeEmbeddingFlags

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassPredicateBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassPredicateBuilder.kt
@@ -34,7 +34,7 @@ internal class ClassPredicateBuilder private constructor(
         ): Predicate {
             val typeEmbedding = ctx.lookupClassTypeEmbedding(name)!!
             val builder = ClassPredicateBuilder(
-                TypeEmbedding(typeEmbedding, TypeEmbeddingFlags(nullable = false)),
+                TypeEmbedding(typeEmbedding, nullable = false),
                 ctx.lookupClassFields(name),
                 ctx.lookupSuperTypes(name)
             )

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
@@ -45,15 +45,6 @@ data class ClassTypeEmbedding(override val name: ScopedName) : PretypeEmbedding 
             addAccessToUniquePredicate()
         }
     }
-
-    override fun accessInvariants(ctx: TypeResolver): List<TypeInvariantEmbedding> =
-        ctx.flatMapUniqueFields(name) { field ->
-            field.accessInvariantsForParameter()
-        }
-
-    override fun uniquePredicateAccessInvariant(ctx: TypeResolver) =
-        PredicateAccessTypeInvariantEmbedding(uniquePredicateName, PermExp.FullPerm())
-
 }
 
 
@@ -62,7 +53,7 @@ fun ClassTypeEmbedding.embedClassTypeFunc(): DomainFunc = RuntimeTypeDomain.clas
 fun ClassTypeEmbedding.predicateAccess(
     receiver: ExpEmbedding, ctx: TypeResolver, source: KtSourceElement?
 ): Exp.PredicateAccess {
-    val access = (uniquePredicateAccessInvariant(ctx).fillHole(receiver)
+    val access = (PredicateAccessTypeInvariantEmbedding(uniquePredicateName, PermExp.FullPerm()).fillHole(receiver)
         .pureToViper(toBuiltin = true, ctx, source) as? Exp.PredicateAccess
         ?: error("Translating shared predicate of ${name.debugMangled} yielded no predicate access."))
     return access

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeEmbedding.kt
@@ -5,12 +5,14 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.types
 
+import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.PlaintextLeaf
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.TreeView
 import org.jetbrains.kotlin.formver.core.names.PretypeName
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.SymbolicName
+import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.mangled
 
 /**
@@ -22,15 +24,18 @@ import org.jetbrains.kotlin.formver.viper.mangled
  * comparisons would not work.
  *
  * All pretype embeddings must be `data` classes or objects!
+ *
+ * Pretypes do not implement [TypeInvariantHolder]: invariant queries are only meaningful once nullability
+ * is known, so they live exclusively on [TypeEmbedding]. The pretype-side raw building blocks are exposed
+ * through the package-private [rawAccessInvariants], [rawPureInvariants] and
+ * [rawUniquePredicateAccessInvariant] helpers below, and only [TypeEmbedding] should call them.
  */
-interface PretypeEmbedding : RuntimeTypeHolder, TypeInvariantHolder {
+sealed interface PretypeEmbedding : RuntimeTypeHolder {
     val name: SymbolicName
 
     context(nameResolver: NameResolver)
     override val debugTreeView: TreeView
         get() = PlaintextLeaf(name.mangled)
-
-    override fun subTypeInvariant(): TypeInvariantEmbedding = SubTypeInvariantEmbedding(this)
 }
 
 data object UnitTypeEmbedding : PretypeEmbedding {
@@ -41,8 +46,6 @@ data object UnitTypeEmbedding : PretypeEmbedding {
 data object NothingTypeEmbedding : PretypeEmbedding {
     override val runtimeType = RuntimeTypeDomain.nothingType()
     override val name = PretypeName("Nothing")
-
-    override fun pureInvariants(): List<TypeInvariantEmbedding> = listOf(FalseTypeInvariant)
 }
 
 data object AnyTypeEmbedding : PretypeEmbedding {
@@ -70,4 +73,19 @@ data object StringTypeEmbedding : PretypeEmbedding {
     override val name = PretypeName("String")
 }
 
-fun PretypeEmbedding.asTypeEmbedding() = TypeEmbedding(this, TypeEmbeddingFlags(nullable = false))
+fun PretypeEmbedding.asTypeEmbedding() = TypeEmbedding(this, nullable = false)
+
+internal fun PretypeEmbedding.rawAccessInvariants(ctx: TypeResolver): List<TypeInvariantEmbedding> = when (this) {
+    is ClassTypeEmbedding -> ctx.flatMapUniqueFields(name) { field -> field.accessInvariantsForParameter() }
+    else -> emptyList()
+}
+
+internal fun PretypeEmbedding.rawPureInvariants(): List<TypeInvariantEmbedding> = when (this) {
+    NothingTypeEmbedding -> listOf(FalseTypeInvariant)
+    else -> emptyList()
+}
+
+internal fun PretypeEmbedding.rawUniquePredicateAccessInvariant(): TypeInvariantEmbedding? = when (this) {
+    is ClassTypeEmbedding -> PredicateAccessTypeInvariantEmbedding(uniquePredicateName, PermExp.FullPerm())
+    else -> null
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/TypeBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/TypeBuilder.kt
@@ -9,9 +9,9 @@ package org.jetbrains.kotlin.formver.core.embeddings.types
 /**
  * Builder for a `TypeEmbedding`.
  *
- * We split most of the work into `PretypeBuilder`, which builds the type modulo nullability
- * (and potentially other flags).  As a result, the builder does not contain the full building
- * state at any point, though a `TypeBuilder`, `PretypeBuilder` pair does.
+ * We split most of the work into `PretypeBuilder`, which builds the type modulo nullability.
+ * As a result, the builder does not contain the full building state at any point, though a
+ * `TypeBuilder`, `PretypeBuilder` pair does.
  */
 class TypeBuilder {
     var isNullable = false
@@ -20,7 +20,7 @@ class TypeBuilder {
 
     private fun completeWithPretypeBuilder(subBuilder: PretypeBuilder): TypeEmbedding {
         val subResult = subBuilder.complete()
-        return TypeEmbedding(subResult, TypeEmbeddingFlags(isNullable))
+        return TypeEmbedding(subResult, isNullable)
     }
 
     fun unit() = UnitPretypeBuilder

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/TypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/TypeEmbedding.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.formver.viper.mangled
  *
  * Due to name mangling, the mapping between Kotlin types and TypeEmbeddings must be 1:1.
  */
-data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbeddingFlags) : RuntimeTypeHolder,
+data class TypeEmbedding(val pretype: PretypeEmbedding, val nullable: Boolean) : RuntimeTypeHolder,
     TypeInvariantHolder {
     /**
      * Name representing the type, used for distinguishing overloads.
@@ -29,32 +29,31 @@ data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbedding
      * represent these names, but we do it inline for now.
      */
     val name: TypeName
-        get() = TypeName(pretype, flags.nullable)
+        get() = TypeName(pretype, nullable)
 
     /**
      * Get a nullable version of this type embedding.
      *
      * Note that nullability doesn't stack, hence nullable types must return themselves.
      */
-    fun getNullable(): TypeEmbedding = copy(flags = flags.copy(nullable = true))
+    fun getNullable(): TypeEmbedding = copy(nullable = true)
 
     /**
      * Drop nullability, if it is present.
      */
-    fun getNonNullable(): TypeEmbedding = copy(flags = flags.copy(nullable = false))
+    fun getNonNullable(): TypeEmbedding = copy(nullable = false)
 
-    val isNullable: Boolean
-        get() = flags.nullable
-
-    override val runtimeType: Exp = flags.adjustRuntimeType(pretype.runtimeType)
+    override val runtimeType: Exp =
+        if (nullable) RuntimeTypeDomain.nullable(pretype.runtimeType) else pretype.runtimeType
 
     override fun accessInvariants(ctx: TypeResolver): List<TypeInvariantEmbedding> =
-        flags.adjustManyInvariants(pretype.accessInvariants(ctx))
+        pretype.rawAccessInvariants(ctx).adjustForNullable()
 
-    override fun pureInvariants(): List<TypeInvariantEmbedding> = flags.adjustManyInvariants(pretype.pureInvariants())
+    override fun pureInvariants(): List<TypeInvariantEmbedding> =
+        pretype.rawPureInvariants().adjustForNullable()
 
     override fun uniquePredicateAccessInvariant(ctx: TypeResolver): TypeInvariantEmbedding? =
-        flags.adjustOptionalInvariant(pretype.uniquePredicateAccessInvariant(ctx))
+        pretype.rawUniquePredicateAccessInvariant()?.adjustForNullable()
 
     override fun subTypeInvariant(): TypeInvariantEmbedding = SubTypeInvariantEmbedding(this)
 
@@ -62,22 +61,11 @@ data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbedding
     override val debugTreeView: TreeView
         get() = PlaintextLeaf(name.mangled)
 
-}
+    private fun TypeInvariantEmbedding.adjustForNullable(): TypeInvariantEmbedding =
+        if (nullable) IfNonNullInvariant(this) else this
 
-data class TypeEmbeddingFlags(val nullable: Boolean) {
-    fun adjustRuntimeType(runtimeType: Exp): Exp =
-        if (nullable) RuntimeTypeDomain.nullable(runtimeType)
-        else runtimeType
-
-    fun adjustInvariant(invariant: TypeInvariantEmbedding): TypeInvariantEmbedding =
-        if (nullable) IfNonNullInvariant(invariant)
-        else invariant
-
-    fun adjustManyInvariants(invariants: List<TypeInvariantEmbedding>): List<TypeInvariantEmbedding> =
-        invariants.map { adjustInvariant(it) }
-
-    fun adjustOptionalInvariant(invariant: TypeInvariantEmbedding?): TypeInvariantEmbedding? =
-        invariant?.let { adjustInvariant(it) }
+    private fun List<TypeInvariantEmbedding>.adjustForNullable(): List<TypeInvariantEmbedding> =
+        if (nullable) map { IfNonNullInvariant(it) } else this
 }
 
 inline fun TypeEmbedding.injectionOr(default: (TypeEmbedding) -> Injection) = injectionOrNull ?: default(this)
@@ -89,7 +77,7 @@ val TypeEmbedding.injection
 
 val TypeEmbedding.injectionOrNull: Injection?
     get() =
-        if (flags.nullable) null
+        if (nullable) null
         else when (val p = this.pretype) {
             StringTypeEmbedding -> RuntimeTypeDomain.stringInjection
             CharTypeEmbedding -> RuntimeTypeDomain.charInjection


### PR DESCRIPTION
## Summary

Two coupled cleanups in the type-embedding layer:

**Restrict `TypeInvariantHolder` to `TypeEmbedding`.** Both `PretypeEmbedding` and `TypeEmbedding` implemented `TypeInvariantHolder` with same-named methods but different semantics. The pretype side returned raw invariants; the type side wrapped them via flag-aware `adjust*` helpers. Calling on a `PretypeEmbedding` directly silently stripped nullability handling and produced wrong Viper output.

`PretypeEmbedding` is now a `sealed interface` that no longer extends `TypeInvariantHolder`. The raw building blocks move to internal extension functions (`rawAccessInvariants`, `rawPureInvariants`, `rawUniquePredicateAccessInvariant`) that dispatch via `when` on the sealed hierarchy and are only callable from inside the `types/` package. The public invariant API is reached solely through `TypeEmbedding`, which delegates to the raw helpers and wraps results in `IfNonNullInvariant` when nullable. The redundant `subTypeInvariant()` override on `PretypeEmbedding` is removed entirely.

**Flatten `TypeEmbeddingFlags`.** The single-Boolean wrapper is gone; `TypeEmbedding` now has a plain `nullable: Boolean` field. The four `adjust*` helpers it carried were only used by `TypeEmbedding` itself and become private members or inline expressions. The 2024 TODO about "potentially other flags" never materialised; if a real second flag is ever needed the wrapper can be reintroduced then.

No behaviour change is expected. `./gradlew :formver.compiler-plugin:detekt :formver.compiler-plugin:untilConversion` passes (no golden-file diffs in conversion output).

## Test plan

- [x] `./gradlew :formver.compiler-plugin:detekt`
- [x] `./gradlew :formver.compiler-plugin:untilConversion`