### PR TITLE
Extract FieldAccessLowering for hierarchy-predicate unfolding

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
@@ -5,15 +5,11 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.types
 
-import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
-import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
-import org.jetbrains.kotlin.formver.core.linearization.pureToViper
 import org.jetbrains.kotlin.formver.core.names.PredicateName
 import org.jetbrains.kotlin.formver.core.names.ScopedName
 import org.jetbrains.kotlin.formver.core.names.asScope
-import org.jetbrains.kotlin.formver.core.names.debugMangled
 import org.jetbrains.kotlin.formver.viper.ast.DomainFunc
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
@@ -62,12 +58,3 @@ data class ClassTypeEmbedding(override val name: ScopedName) : PretypeEmbedding 
 
 
 fun ClassTypeEmbedding.embedClassTypeFunc(): DomainFunc = RuntimeTypeDomain.classTypeFunc(name)
-
-fun ClassTypeEmbedding.predicateAccess(
-    receiver: ExpEmbedding, ctx: TypeResolver, source: KtSourceElement?
-): Exp.PredicateAccess {
-    val access = (uniquePredicateAccessInvariant(ctx).fillHole(receiver)
-        .pureToViper(toBuiltin = true, ctx, source) as? Exp.PredicateAccess
-        ?: error("Translating shared predicate of ${name.debugMangled} yielded no predicate access."))
-    return access
-}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
@@ -7,37 +7,36 @@ package org.jetbrains.kotlin.formver.core.linearization
 
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.formver.core.asPosition
-import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.PermExp
+import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 /**
- * Owns the path-and-predicate computation for a [FieldAccess][org.jetbrains.kotlin.formver.core.embeddings.expression.FieldAccess]
- * on a class hierarchy.
- *
- * To reach a field declared on a superclass we must walk the chain of unique-predicates
- * from the receiver's runtime type down to the declaring class, and for each class on
- * that path emit one predicate-access expression. The three linearizers consume that
- * sequence in their preferred shape:
- *  - imperative linearization emits a `Stmt.Unfold` per access;
- *  - SSA linearization collects them as invariants on the assignment;
- *  - pure-expression linearization nests them as `Exp.Unfolding` around the body.
+ * The unique-predicate access on [classOnPath] that must be unfolded to reach a field on a superclass
+ * through [receiver]. Takes a raw [Exp] rather than going through `fillHole`/`pureToViper`.
  */
-class FieldAccessLowering(
-    private val typeResolver: TypeResolver,
-    private val source: KtSourceElement?,
-) {
-    fun pathTo(receiverType: TypeEmbedding, field: FieldEmbedding): Sequence<ClassTypeEmbedding> =
-        typeResolver.hierarchyPathTo(receiverType.pretype, field)
+fun hierarchyPredicateAccess(
+    receiver: Exp,
+    classOnPath: ClassTypeEmbedding,
+    source: KtSourceElement?,
+): Exp.PredicateAccess =
+    Exp.PredicateAccess(
+        classOnPath.uniquePredicateName,
+        listOf(receiver),
+        PermExp.FullPerm(),
+        source.asPosition,
+    )
 
-    fun predicateAccessFor(receiverViper: Exp, classOnPath: ClassTypeEmbedding): Exp.PredicateAccess =
-        Exp.PredicateAccess(
-            classOnPath.uniquePredicateName,
-            listOf(receiverViper),
-            PermExp.FullPerm(),
-            source.asPosition,
-        )
+/**
+ * Emits a `Stmt.Unfold` for each unique-predicate on the hierarchy path from [receiverType]
+ * down to the class declaring [field]. Shared by the imperative linearizer and the
+ * `FieldModification` visitor; both want the same imperative unfold shape.
+ */
+fun LinearizationContext.unfoldHierarchyPredicates(receiver: Exp, receiverType: TypeEmbedding, field: FieldEmbedding) {
+    for (classOnPath in typeResolver.hierarchyPathTo(receiverType.pretype, field)) {
+        addStatement { Stmt.Unfold(hierarchyPredicateAccess(receiver, classOnPath, source), source.asPosition) }
+    }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
@@ -31,12 +31,25 @@ fun hierarchyPredicateAccess(
     )
 
 /**
+ * The unique-predicate accesses to unfold to reach [field] through [receiver], in walk order
+ * (outermost class first). Returned ordered top-down: callers that need bottom-up nesting
+ * (e.g. [Exp.Unfolding] fold) reverse via `foldRight` or `toList().asReversed()`.
+ */
+fun LinearizationContext.hierarchyPredicateAccesses(
+    receiver: Exp,
+    receiverType: TypeEmbedding,
+    field: FieldEmbedding,
+): Sequence<Exp.PredicateAccess> =
+    typeResolver.hierarchyPathTo(receiverType.pretype, field)
+        .map { hierarchyPredicateAccess(receiver, it, source) }
+
+/**
  * Emits a `Stmt.Unfold` for each unique-predicate on the hierarchy path from [receiverType]
  * down to the class declaring [field]. Shared by the imperative linearizer and the
  * `FieldModification` visitor; both want the same imperative unfold shape.
  */
 fun LinearizationContext.unfoldHierarchyPredicates(receiver: Exp, receiverType: TypeEmbedding, field: FieldEmbedding) {
-    for (classOnPath in typeResolver.hierarchyPathTo(receiverType.pretype, field)) {
-        addStatement { Stmt.Unfold(hierarchyPredicateAccess(receiver, classOnPath, source), source.asPosition) }
+    for (predicateAccess in hierarchyPredicateAccesses(receiver, receiverType, field)) {
+        addStatement { Stmt.Unfold(predicateAccess, source.asPosition) }
     }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.linearization
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.core.asPosition
+import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
+import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.PermExp
+
+/**
+ * Owns the path-and-predicate computation for a [FieldAccess][org.jetbrains.kotlin.formver.core.embeddings.expression.FieldAccess]
+ * on a class hierarchy.
+ *
+ * To reach a field declared on a superclass we must walk the chain of unique-predicates
+ * from the receiver's runtime type down to the declaring class, and for each class on
+ * that path emit one predicate-access expression. The three linearizers consume that
+ * sequence in their preferred shape:
+ *  - imperative linearization emits a `Stmt.Unfold` per access;
+ *  - SSA linearization collects them as invariants on the assignment;
+ *  - pure-expression linearization nests them as `Exp.Unfolding` around the body.
+ */
+class FieldAccessLowering(
+    private val typeResolver: TypeResolver,
+    private val source: KtSourceElement?,
+) {
+    fun pathTo(receiverType: TypeEmbedding, field: FieldEmbedding): Sequence<ClassTypeEmbedding> =
+        typeResolver.hierarchyPathTo(receiverType.pretype, field)
+
+    fun predicateAccessFor(receiverViper: Exp, classOnPath: ClassTypeEmbedding): Exp.PredicateAccess =
+        Exp.PredicateAccess(
+            classOnPath.uniquePredicateName,
+            listOf(receiverViper),
+            PermExp.FullPerm(),
+            source.asPosition,
+        )
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 /**
  * The unique-predicate access on [classOnPath] that must be unfolded to reach a field on a superclass
- * through [receiver]. Takes a raw [Exp] rather than going through `fillHole`/`pureToViper`.
+ * through [receiver].
  */
 fun hierarchyPredicateAccess(
     receiver: Exp,
@@ -31,9 +31,8 @@ fun hierarchyPredicateAccess(
     )
 
 /**
- * The unique-predicate accesses to unfold to reach [field] through [receiver], in walk order
- * (outermost class first). Returned ordered top-down: callers that need bottom-up nesting
- * (e.g. [Exp.Unfolding] fold) reverse via `foldRight` or `toList().asReversed()`.
+ * The unique-predicate accesses to unfold to reach [field] through [receiver], ordered top-down:
+ * the class of [receiverType] first, the class declaring [field] last.
  */
 fun LinearizationContext.hierarchyPredicateAccesses(
     receiver: Exp,
@@ -45,8 +44,7 @@ fun LinearizationContext.hierarchyPredicateAccesses(
 
 /**
  * Emits a `Stmt.Unfold` for each unique-predicate on the hierarchy path from [receiverType]
- * down to the class declaring [field]. Shared by the imperative linearizer and the
- * `FieldModification` visitor; both want the same imperative unfold shape.
+ * down to the class declaring [field].
  */
 fun LinearizationContext.unfoldHierarchyPredicates(receiver: Exp, receiverType: TypeEmbedding, field: FieldEmbedding) {
     for (predicateAccess in hierarchyPredicateAccesses(receiver, receiverType, field)) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -429,10 +429,7 @@ data class LinearizationVisitor(
                 else -> {
                     val receiverViper = e.receiver.linearize().toViper(ctx)
                     if (e.field.unfoldToAccess && !accessIsManual) {
-                        val lowering = FieldAccessLowering(ctx.typeResolver, ctx.source)
-                        for (classOnPath in lowering.pathTo(e.receiver.type, e.field)) {
-                            ctx.addStatement { Stmt.Unfold(lowering.predicateAccessFor(receiverViper, classOnPath)) }
-                        }
+                        ctx.unfoldHierarchyPredicates(receiverViper, e.receiver.type, e.field)
                     }
                     val newValueViper = e.newValue.linearize().toViper(ctx)
                     ctx.addStatement {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
-import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
 import org.jetbrains.kotlin.formver.viper.ast.Exp
 import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toConjunction
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
@@ -430,11 +429,9 @@ data class LinearizationVisitor(
                 else -> {
                     val receiverViper = e.receiver.linearize().toViper(ctx)
                     if (e.field.unfoldToAccess && !accessIsManual) {
-                        val receiverWrapper = ExpWrapper(receiverViper, e.receiver.type)
-                        val hierarchyPath = ctx.typeResolver.hierarchyPathTo(e.receiver.type.pretype, e.field)
-                        hierarchyPath.forEach { classType ->
-                            val predAcc = classType.predicateAccess(receiverWrapper, ctx.typeResolver, ctx.source)
-                            ctx.addStatement { Stmt.Unfold(predAcc) }
+                        val lowering = FieldAccessLowering(ctx.typeResolver, ctx.source)
+                        for (classOnPath in lowering.pathTo(e.receiver.type, e.field)) {
+                            ctx.addStatement { Stmt.Unfold(lowering.predicateAccessFor(receiverViper, classOnPath)) }
                         }
                     }
                     val newValueViper = e.newValue.linearize().toViper(ctx)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -124,12 +124,7 @@ data class Linearizer(
                     // If the field access is not replaced with havoc,
                     // we might need to unfold some predicate to access it.
                     if (field.unfoldToAccess && !accessIsManual) {
-                        val lowering = FieldAccessLowering(typeResolver, source)
-                        for (classOnPath in lowering.pathTo(receiverType, field)) {
-                            addStatement {
-                                Stmt.Unfold(lowering.predicateAccessFor(receiverViper, classOnPath), source.asPosition)
-                            }
-                        }
+                        unfoldHierarchyPredicates(receiverViper, receiverType, field)
                     }
                     Stmt.assign(
                         result.toLocalVarUse(), Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -13,15 +13,12 @@ import org.jetbrains.kotlin.formver.core.conversion.ReturnTarget
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.callables.SpecialMethods
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpWrapper
 import org.jetbrains.kotlin.formver.core.embeddings.expression.VariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.toLink
 import org.jetbrains.kotlin.formver.core.embeddings.toViperGoto
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -127,25 +124,18 @@ data class Linearizer(
                     // If the field access is not replaced with havoc,
                     // we might need to unfold some predicate to access it.
                     if (field.unfoldToAccess && !accessIsManual) {
-                        val receiverWrapper = ExpWrapper(receiverViper, receiverType)
-                        val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field)
-                        hierarchyPath.unfoldHierarchyPath(receiverWrapper, this)
+                        val lowering = FieldAccessLowering(typeResolver, source)
+                        for (classOnPath in lowering.pathTo(receiverType, field)) {
+                            addStatement {
+                                Stmt.Unfold(lowering.predicateAccessFor(receiverViper, classOnPath), source.asPosition)
+                            }
+                        }
                     }
                     Stmt.assign(
                         result.toLocalVarUse(), Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
                     )
                 }
             }
-        }
-    }
-
-    private fun Sequence<ClassTypeEmbedding>?.unfoldHierarchyPath(
-        receiverWrapper: ExpEmbedding,
-        ctx: LinearizationContext
-    ) {
-        this?.forEach { classType ->
-            val predAcc = classType.predicateAccess(receiverWrapper, typeResolver, source)
-            ctx.addStatement { Stmt.Unfold(predAcc, source.asPosition) }
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
@@ -82,9 +82,8 @@ data class PureExpLinearizer(
     override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
         val receiverViper = receiver.toViper(this)
         val primitiveAccess: Exp = Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
-        return typeResolver.hierarchyPathTo(receiverType.pretype, field).toList().foldRight(primitiveAccess) { classOnPath, acc ->
-            Exp.Unfolding(hierarchyPredicateAccess(receiverViper, classOnPath, source), acc)
-        }
+        return hierarchyPredicateAccesses(receiverViper, receiverType, field).toList()
+            .foldRight(primitiveAccess) { predicateAccess, acc -> Exp.Unfolding(predicateAccess, acc) }
     }
 
     override fun addModifier(mod: StmtModifier) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
@@ -82,9 +82,8 @@ data class PureExpLinearizer(
     override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
         val receiverViper = receiver.toViper(this)
         val primitiveAccess: Exp = Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
-        val lowering = FieldAccessLowering(typeResolver, source)
-        return lowering.pathTo(receiverType, field).toList().foldRight(primitiveAccess) { classOnPath, acc ->
-            Exp.Unfolding(lowering.predicateAccessFor(receiverViper, classOnPath), acc)
+        return typeResolver.hierarchyPathTo(receiverType.pretype, field).toList().foldRight(primitiveAccess) { classOnPath, acc ->
+            Exp.Unfolding(hierarchyPredicateAccess(receiverViper, classOnPath, source), acc)
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
@@ -11,12 +11,10 @@ import org.jetbrains.kotlin.formver.core.conversion.ReturnTarget
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpWrapper
 import org.jetbrains.kotlin.formver.core.embeddings.expression.VariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.print
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
 import org.jetbrains.kotlin.formver.core.names.SimpleNameResolver
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
@@ -83,12 +81,10 @@ data class PureExpLinearizer(
 
     override fun addFieldAccess(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding): Exp {
         val receiverViper = receiver.toViper(this)
-        val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field)
         val primitiveAccess: Exp = Exp.FieldAccess(receiverViper, field.toViper(), source.asPosition)
-        val receiverWrapper = ExpWrapper(receiverViper, receiverType)
-        return hierarchyPath.toList().foldRight(primitiveAccess) { classType, acc ->
-            val predAcc = classType.predicateAccess(receiverWrapper, typeResolver, source)
-            Exp.Unfolding(predAcc, acc)
+        val lowering = FieldAccessLowering(typeResolver, source)
+        return lowering.pathTo(receiverType, field).toList().foldRight(primitiveAccess) { classOnPath, acc ->
+            Exp.Unfolding(lowering.predicateAccessFor(receiverViper, classOnPath), acc)
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
@@ -103,9 +103,7 @@ data class PureFunBodyLinearizer(
             source,
             "Invalid receiver encountered in pure function"
         )
-        val accessInvariants =
-            typeResolver.hierarchyPathTo(receiverType.pretype, field)
-                .map { hierarchyPredicateAccess(viperReceiver, it, source) }.toList()
+        val accessInvariants = hierarchyPredicateAccesses(viperReceiver, receiverType, field).toList()
         val primitiveAccess: Exp = Exp.FieldAccess(viperReceiver, field.toViper(), source.asPosition)
         ssaConverter.addAssignment(result.name, primitiveAccess, accessInvariants)
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
@@ -103,9 +103,9 @@ data class PureFunBodyLinearizer(
             source,
             "Invalid receiver encountered in pure function"
         )
-        val lowering = FieldAccessLowering(typeResolver, source)
         val accessInvariants =
-            lowering.pathTo(receiverType, field).map { lowering.predicateAccessFor(viperReceiver, it) }.toList()
+            typeResolver.hierarchyPathTo(receiverType.pretype, field)
+                .map { hierarchyPredicateAccess(viperReceiver, it, source) }.toList()
         val primitiveAccess: Exp = Exp.FieldAccess(viperReceiver, field.toViper(), source.asPosition)
         ssaConverter.addAssignment(result.name, primitiveAccess, accessInvariants)
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
@@ -12,11 +12,9 @@ import org.jetbrains.kotlin.formver.core.conversion.FreshEntityProducer
 import org.jetbrains.kotlin.formver.core.conversion.ReturnTarget
 import org.jetbrains.kotlin.formver.core.conversion.TypeResolver
 import org.jetbrains.kotlin.formver.core.embeddings.expression.AnonymousVariableEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpWrapper
 import org.jetbrains.kotlin.formver.core.embeddings.expression.VariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
-import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Declaration
 import org.jetbrains.kotlin.formver.viper.ast.Exp
@@ -105,10 +103,9 @@ data class PureFunBodyLinearizer(
             source,
             "Invalid receiver encountered in pure function"
         )
-        val receiverWrapper = ExpWrapper(viperReceiver, receiverType)
-        val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field)
+        val lowering = FieldAccessLowering(typeResolver, source)
         val accessInvariants =
-            hierarchyPath.map { it.predicateAccess(receiverWrapper, typeResolver, source) }.toList()
+            lowering.pathTo(receiverType, field).map { lowering.predicateAccessFor(viperReceiver, it) }.toList()
         val primitiveAccess: Exp = Exp.FieldAccess(viperReceiver, field.toViper(), source.asPosition)
         ssaConverter.addAssignment(result.name, primitiveAccess, accessInvariants)
     }


### PR DESCRIPTION
## Summary

Five sites duplicated the "lower a `FieldAccess` through the class
hierarchy's unique-predicate stack" operation: each one walked
`typeResolver.hierarchyPathTo(receiver, field)`, built a
`predicateAccess` per class, and emitted in its own shape (imperative
`Stmt.Unfold`, SSA predicate-access invariants, or nested
`Exp.Unfolding`). The underlying walk was identical at all four
linearizer call sites, but the `predicateAccess` helper on
`ClassTypeEmbedding` demanded an `ExpEmbedding` receiver, forcing each
caller to wrap an already-lowered Viper `Exp` in `ExpWrapper`.

This change introduces `FieldAccessLowering` (in
`core/linearization/`, next to the consumers) with two methods:

- `pathTo(receiverType, field): Sequence<ClassTypeEmbedding>` --- the
  hierarchy walk.
- `predicateAccessFor(receiverViper, classOnPath): Exp.PredicateAccess`
  --- the per-class predicate access, taking a raw `Exp` directly
  rather than going through `fillHole`/`pureToViper`.

The three linearizers (`Linearizer`, `LinearizationVisitor`'s
`visitFieldModification`, `PureFunBodyLinearizer`, `PureExpLinearizer`)
now each walk the path and pick their own per-class emit shape. The
old `predicateAccess` extension on `ClassTypeEmbedding` is deleted ---
it had no callers outside these four sites.

`ExpWrapper(receiverViper, receiverType)` construction sites: 6 → 2.
The two remaining sites in `LinearizationVisitor.kt` are unrelated
(equality lowering, type-cast folding); eliminating them is Slice H.

## Test plan
- [x] `./gradlew :formver.compiler-plugin:detekt` --- passes
- [x] `./gradlew :formver.compiler-plugin:untilConversion` --- passes;
  golden Viper output unchanged for every existing test.