### PR TITLE
Replace name-resolver walker with per-node accessors

### DIFF
--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/AccessPredicate.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/AccessPredicate.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.viper.ast
 
+import org.jetbrains.kotlin.formver.viper.AnyName
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.toScalaOption
 
@@ -20,6 +21,8 @@ sealed interface AccessPredicate : Exp {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : AccessPredicate {
         override val type: Type.Bool = Type.Bool
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(access)
 
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.AccessPredicate =

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/AdtDecl.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/AdtDecl.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.viper.ast
 
+import org.jetbrains.kotlin.formver.viper.AnyName
 import org.jetbrains.kotlin.formver.viper.IntoSilver
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.SymbolicName
@@ -29,7 +30,10 @@ data class AdtConstructorDecl(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.plugin.standard.adt.AdtConstructor> {
+) : IntoSilver<viper.silver.plugin.standard.adt.AdtConstructor>, NameHolder {
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder> get() = formalArgs
+
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.plugin.standard.adt.AdtConstructor = viper.silver.plugin.standard.adt.AdtConstructor(
             name.mangled,
@@ -50,7 +54,10 @@ data class AdtDecl(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<Adt> {
+) : IntoSilver<Adt>, NameHolder {
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder> get() = constructors
+
     context(nameResolver: NameResolver)
     override fun toSilver(): Adt =
         Adt(

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Declaration.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Declaration.kt
@@ -7,7 +7,10 @@ package org.jetbrains.kotlin.formver.viper.ast
 
 import org.jetbrains.kotlin.formver.viper.*
 
-sealed interface Declaration : IntoSilver<viper.silver.ast.Declaration> {
+sealed interface Declaration : IntoSilver<viper.silver.ast.Declaration>, NameHolder {
+    override val directlyReferencedNames: List<AnyName>
+    override val children: List<NameHolder>
+
     data class LocalVarDecl(
         val name: SymbolicName,
         val type: Type,
@@ -15,6 +18,8 @@ sealed interface Declaration : IntoSilver<viper.silver.ast.Declaration> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Declaration {
+        override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LocalVarDecl =
             viper.silver.ast.LocalVarDecl(
@@ -33,6 +38,8 @@ sealed interface Declaration : IntoSilver<viper.silver.ast.Declaration> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Declaration {
+        override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+        override val children: List<NameHolder> get() = invariants
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Label = viper.silver.ast.Label(
             name.mangled,

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Domain.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Domain.kt
@@ -20,7 +20,10 @@ data class DomainFunc(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.ast.DomainFunc>, Applicable {
+) : IntoSilver<viper.silver.ast.DomainFunc>, Applicable, NameHolder {
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder> get() = formalArgs
+
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.DomainFunc =
         viper.silver.ast.DomainFunc(
@@ -46,7 +49,10 @@ class DomainAxiom(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.ast.DomainAxiom> {
+) : IntoSilver<viper.silver.ast.DomainAxiom>, NameHolder {
+    override val directlyReferencedNames: List<AnyName> get() = listOfNotNull(name)
+    override val children: List<NameHolder> get() = listOf(exp)
+
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.DomainAxiom =
         when (name) {
@@ -74,13 +80,15 @@ abstract class Domain(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.ast.Domain> {
+) : IntoSilver<viper.silver.ast.Domain>, NameHolder {
 
 
     open val includeInShortDump: Boolean = true
     abstract val typeVars: List<Type.TypeVar>
     abstract val functions: List<DomainFunc>
     abstract val axioms: List<DomainAxiom>
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder> get() = functions + axioms
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.Domain =
         viper.silver.ast.Domain(

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -11,10 +11,15 @@ import viper.silver.ast.*
 sealed interface BinaryExp : Exp {
     val left: Exp
     val right: Exp
+    override val directlyReferencedNames: List<AnyName> get() = emptyList()
+    override val children: List<NameHolder> get() = listOf(left, right)
 }
-sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
+sealed interface Exp : IntoSilver<viper.silver.ast.Exp>, NameHolder {
 
     val type: Type
+
+    override val directlyReferencedNames: List<AnyName>
+    override val children: List<NameHolder>
 
     data class Minus(
         val arg: Exp,
@@ -23,6 +28,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Int
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(arg)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Minus =
             Minus(arg.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -224,6 +231,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Bool
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(arg)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Not =
             Not(arg.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -251,6 +260,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Bool
+        override val directlyReferencedNames: List<AnyName> get() = variables.map { it.name }
+        override val children: List<NameHolder> get() = listOf(exp)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Forall =
             Forall(
@@ -272,6 +283,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Bool
+        override val directlyReferencedNames: List<AnyName> get() = variables.map { it.name }
+        override val children: List<NameHolder> get() = listOf(exp)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Exists =
             Exists(
@@ -292,6 +305,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Int
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.IntLit =
             IntLit(value.toScalaBigInt(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -303,6 +318,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Ref
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.NullLit = NullLit(pos.toSilver(), info.toSilver(), trafos.toSilver())
     }
@@ -314,6 +331,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Bool
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.BoolLit =
             viper.silver.ast.BoolLit.apply(value, pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -327,6 +346,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LocalVar =
             LocalVar(name.mangled, type.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -340,6 +361,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = field.type
+        override val directlyReferencedNames: List<AnyName> get() = listOf(this.field.name)
+        override val children: List<NameHolder> get() = listOf(rcv)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.FieldAccess =
             FieldAccess(rcv.toSilver(), field.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -351,6 +374,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Result =
             Result(type.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -364,6 +389,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = listOf(functionName)
+        override val children: List<NameHolder> get() = args
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.FuncApp = FuncApp(
             functionName.mangled,
@@ -394,6 +421,9 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         private val scalaTypeVarMap: scala.collection.immutable.Map<TypeVar, viper.silver.ast.Type>
             get() = typeVarMap.mapKeys { it.key.toSilver() }.mapValues { it.value.toSilver() }.toScalaMap()
         override val type = function.returnType.substitute(typeVarMap)
+        override val directlyReferencedNames: List<AnyName>
+            get() = listOf(function.name) + function.formalArgs.map { it.name }
+        override val children: List<NameHolder> get() = args
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Exp =
             viper.silver.ast.DomainFuncApp.apply(
@@ -416,6 +446,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type: Type = Type.Adt(constructor.adtName)
+        override val directlyReferencedNames: List<AnyName> get() = listOf(constructor.name)
+        override val children: List<NameHolder> get() = args
 
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Exp =
@@ -435,6 +467,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = args
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.ExplicitSeq =
             ExplicitSeq(
@@ -453,6 +487,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.EmptySeq =
             viper.silver.ast.EmptySeq.apply(
@@ -471,6 +507,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(seq)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.SeqLength =
             viper.silver.ast.SeqLength.apply(
@@ -490,6 +528,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(seq, idx)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.SeqTake =
             viper.silver.ast.SeqTake.apply(
@@ -510,6 +550,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(seq, idx)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.SeqIndex =
             viper.silver.ast.SeqIndex.apply(
@@ -550,6 +592,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = exp.type
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(exp)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Old =
             Old(exp.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -565,6 +609,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     ) : Exp {
         // The type is set to Bool just to be consistent with Silver type. Probably it will never be used
         override val type: Type = Type.Bool
+        override val directlyReferencedNames: List<AnyName> get() = listOf(predicateName)
+        override val children: List<NameHolder> get() = formalArgs
 
         // Note: since the simple syntax P(...) has the same meaning as acc(P(...)), which in turn has the same meaning as acc(P(...), write)
         // It is always better to deal with PredicateAccessPredicate because PredicateAccess seems not working well with Silver
@@ -595,6 +641,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = body.type
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(predicateAccess, body)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Unfolding =
             Unfolding(predicateAccess.toSilver(), body.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())
@@ -608,6 +656,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Exp {
         override val type = Type.Bool
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(this.field)
 
         context(nameResolver: NameResolver)
         override fun toSilver() = FieldAccessPredicate(
@@ -628,6 +678,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos,
     ): Exp {
         override val type: Type = variable.type
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(variable, varExp, body)
 
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Let =
@@ -643,6 +695,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val trafos: Trafos = Trafos.NoTrafos
     ): Exp {
         override val type: Type = thenExp.type.also { assert(it == elseExp.type) }
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(condExp, thenExp, elseExp)
 
         context(nameResolver: NameResolver)
         override fun toSilver(): CondExp =

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Field.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Field.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.viper.ast
 
+import org.jetbrains.kotlin.formver.viper.AnyName
 import org.jetbrains.kotlin.formver.viper.IntoSilver
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.NameResolver
@@ -17,7 +18,9 @@ class Field(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.ast.Field> {
+) : IntoSilver<viper.silver.ast.Field>, NameHolder {
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder> get() = emptyList()
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.Field =
         viper.silver.ast.Field(name.mangled, type.toSilver(), pos.toSilver(), info.toSilver(), trafos.toSilver())

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Function.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Function.kt
@@ -28,7 +28,7 @@ interface Applicable {
         toFuncApp(args.toList(), pos, info, trafos)
 }
 
-interface Function : IntoSilver<viper.silver.ast.Function>, Applicable {
+interface Function : IntoSilver<viper.silver.ast.Function>, Applicable, NameHolder {
     val name: SymbolicName
     val pos: Position
         get() = Position.NoPosition
@@ -45,6 +45,10 @@ interface Function : IntoSilver<viper.silver.ast.Function>, Applicable {
         get() = listOf()
     val body: Exp?
         get() = null
+
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder>
+        get() = formalArgs + pres + posts + listOfNotNull(body)
 
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.Function = viper.silver.ast.Function(

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Method.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Method.kt
@@ -12,13 +12,17 @@ abstract class Method(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.ast.Method> {
+) : IntoSilver<viper.silver.ast.Method>, NameHolder {
     open val includeInShortDump: Boolean = true
     abstract val formalArgs: List<Declaration.LocalVarDecl>
     abstract val formalReturns: List<Declaration.LocalVarDecl>
     open val pres: List<Exp> = listOf()
     open val posts: List<Exp> = listOf()
     open val body: Stmt.Seqn? = null
+
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder>
+        get() = formalArgs + formalReturns + pres + posts + listOfNotNull(body)
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.Method =
         viper.silver.ast.Method(

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/NameHolder.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/NameHolder.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.viper.ast
+
+import org.jetbrains.kotlin.formver.viper.AnyName
+
+/**
+ * A node that may reference [AnyName]s and contains child nodes to recurse into.
+ *
+ * Implementations describe their own contribution to the resolver-registration
+ * walk: [directlyReferencedNames] for names that appear in this node, and
+ * [children] for sub-nodes whose names must also be registered. Adding a new
+ * Exp/Stmt variant requires implementing these accessors locally; there is no
+ * central walker to forget to extend.
+ */
+interface NameHolder {
+    val directlyReferencedNames: List<AnyName> get() = emptyList()
+    val children: List<NameHolder> get() = emptyList()
+}

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Predicate.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Predicate.kt
@@ -15,7 +15,10 @@ class Predicate(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.ast.Predicate> {
+) : IntoSilver<viper.silver.ast.Predicate>, NameHolder {
+    override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+    override val children: List<NameHolder> get() = formalArgs + listOf(body)
+
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.Predicate =
         viper.silver.ast.Predicate(

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
@@ -18,7 +18,12 @@ data class Program(
     val pos: Position = Position.NoPosition,
     val info: Info = Info.NoInfo,
     val trafos: Trafos = Trafos.NoTrafos,
-) : IntoSilver<viper.silver.ast.Program> {
+) : IntoSilver<viper.silver.ast.Program>, NameHolder {
+
+    override val directlyReferencedNames: List<AnyName> get() = emptyList()
+    override val children: List<NameHolder>
+        get() = domains + fields + functions + predicates + methods + adts
+
     context(nameResolver: NameResolver)
     override fun toSilver(): viper.silver.ast.Program = viper.silver.ast.Program(
         domains.sortedBy { it.name.mangled }.toSilver().toScalaSeq(),
@@ -54,182 +59,10 @@ data class Program(
 }
 
 context(nameResolver: NameResolver)
-private fun registerExpNames(exp: Exp) {
-    when (exp) {
-        is Exp.LocalVar -> nameResolver.register(exp.name)
-        is Exp.FieldAccess -> {
-            nameResolver.register(exp.field.name)
-            registerExpNames(exp.rcv)
-        }
-
-        is Exp.PredicateAccess -> {
-            nameResolver.register(exp.predicateName)
-            exp.formalArgs.forEach { registerExpNames(it) }
-        }
-
-        is BinaryExp -> {
-            registerExpNames(exp.left)
-            registerExpNames(exp.right)
-        }
-
-        is Exp.FuncApp -> {
-            nameResolver.register(exp.functionName)
-            exp.args.forEach { registerExpNames(it) }
-        }
-
-        is Exp.DomainFuncApp -> {
-            nameResolver.register(exp.function.name)
-            exp.function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-            exp.args.forEach { registerExpNames(it) }
-        }
-
-        is Exp.Forall -> {
-            exp.variables.forEach { nameResolver.register(it.name) }
-            registerExpNames(exp.exp)
-        }
-
-        is Exp.Exists -> {
-            exp.variables.forEach { nameResolver.register(it.name) }
-            registerExpNames(exp.exp)
-        }
-
-        is Exp.LetBinding -> {
-            nameResolver.register(exp.variable.name)
-            registerExpNames(exp.body)
-        }
-
-        is Exp.Old -> registerExpNames(exp.exp)
-        is Exp.TernaryExp -> {
-            registerExpNames(exp.thenExp)
-            registerExpNames(exp.elseExp)
-        }
-
-        is AccessPredicate.FieldAccessPredicate -> {}
-        is Exp.Acc -> registerExpNames(exp.field)
-        is Exp.ExplicitSeq -> exp.args.forEach { registerExpNames(it) }
-        is Exp.Minus -> registerExpNames(exp.arg)
-        is Exp.Not -> registerExpNames(exp.arg)
-        is Exp.SeqIndex -> {
-            registerExpNames(exp.seq)
-            registerExpNames(exp.idx)
-        }
-
-        is Exp.SeqLength -> registerExpNames(exp.seq)
-        is Exp.SeqTake -> {
-            registerExpNames(exp.seq)
-            registerExpNames(exp.idx)
-        }
-
-        is Exp.Unfolding -> {
-            registerExpNames(exp.predicateAccess)
-            registerExpNames(exp.body)
-        }
-        is Exp.AdtConstructorApp -> {
-            nameResolver.register(exp.constructor.name)
-            exp.args.forEach { registerExpNames(it) }
-        }
-        // no else branch to make decisions explicit.
-        is Exp.Result, is Exp.BoolLit, is Exp.EmptySeq, is Exp.IntLit, is Exp.NullLit -> {}
-    }
-}
-
-context(nameResolver: NameResolver)
-private fun Program.registerStmtNames(stmt: Stmt) = when (stmt) {
-    is Stmt.Label -> {
-        nameResolver.register(stmt.name)
-        stmt.invariants.forEach { registerExpNames(it) }
-    }
-
-    is Stmt.Seqn -> registerSeqnNames(stmt)
-    is Stmt.Goto -> nameResolver.register(stmt.name)
-    is Stmt.MethodCall -> {
-        stmt.args.forEach { registerExpNames(it) }
-        stmt.targets.forEach { registerExpNames(it) }
-        nameResolver.register(stmt.methodName)
-    }
-
-    is Stmt.If -> {
-        registerExpNames(stmt.cond)
-        registerSeqnNames(stmt.then)
-        stmt.els?.let { registerSeqnNames(it) }
-    }
-
-    is Stmt.While -> {
-        registerExpNames(stmt.cond)
-        registerSeqnNames(stmt.body)
-        stmt.invariants.forEach { registerExpNames(it) }
-    }
-
-    is Stmt.LocalVarAssign -> {
-        nameResolver.register(stmt.lhs.name)
-        registerExpNames(stmt.rhs)
-    }
-
-    is Stmt.Fold -> nameResolver.register(stmt.acc.predicateName)
-    is Stmt.Unfold -> nameResolver.register(stmt.acc.predicateName)
-    is Stmt.Assert -> registerExpNames(stmt.exp)
-    is Stmt.Exhale -> registerExpNames(stmt.exp)
-    is Stmt.Inhale -> registerExpNames(stmt.exp)
-    is Stmt.FieldAssign -> {
-        registerExpNames(stmt.lhs)
-        registerExpNames(stmt.rhs)
-    }
-}
-
-context(nameResolver: NameResolver)
-private fun Program.registerSeqnNames(seqn: Stmt.Seqn) {
-    seqn.scopedSeqnDeclarations.forEach { decl ->
-        when (decl) {
-            is Declaration.LocalVarDecl -> nameResolver.register(decl.name)
-            is Declaration.LabelDecl -> nameResolver.register(decl.name)
-        }
-    }
-    seqn.stmts.forEach { registerStmtNames(it) }
-}
-
-context(nameResolver: NameResolver)
 fun Program.registerAllNames() {
-    domains.forEach { domain ->
-        nameResolver.register(domain.name)
-        domain.functions.forEach { function ->
-            nameResolver.register(function.name)
-            function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-        }
-        domain.axioms.forEach { axiom ->
-            axiom.name?.let { nameResolver.register(it) }
-            registerExpNames(axiom.exp)
-        }
+    fun NameHolder.visit() {
+        directlyReferencedNames.forEach(nameResolver::register)
+        children.forEach { it.visit() }
     }
-    fields.forEach { nameResolver.register(it.name) }
-
-    functions.forEach { function ->
-        nameResolver.register(function.name)
-        function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-        function.pres.forEach { arg -> registerExpNames(arg) }
-        function.posts.forEach { arg -> registerExpNames(arg) }
-        function.body?.let { exp -> registerExpNames(exp) }
-    }
-
-    predicates.forEach { predicate ->
-        nameResolver.register(predicate.name)
-        predicate.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-        registerExpNames(predicate.body)
-    }
-
-    methods.forEach { method ->
-        nameResolver.register(method.name)
-        method.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-        method.formalReturns.forEach { ret -> nameResolver.register(ret.name) }
-        method.pres.forEach { arg -> registerExpNames(arg) }
-        method.posts.forEach { arg -> registerExpNames(arg) }
-        method.body?.let { seqn -> registerSeqnNames(seqn) }
-    }
-
-    adts.forEach { adt ->
-        nameResolver.register(adt.name)
-        adt.constructors.forEach { constructor ->
-            nameResolver.register(constructor.name)
-            constructor.formalArgs.forEach { nameResolver.register(it.name) }
-        }
-    }
+    visit()
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Stmt.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Stmt.kt
@@ -7,7 +7,10 @@ package org.jetbrains.kotlin.formver.viper.ast
 
 import org.jetbrains.kotlin.formver.viper.*
 
-sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
+sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt>, NameHolder {
+
+    override val directlyReferencedNames: List<AnyName>
+    override val children: List<NameHolder>
 
     data class LocalVarAssign(
         val lhs: Exp.LocalVar,
@@ -16,6 +19,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(lhs, rhs)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LocalVarAssign =
             viper.silver.ast.LocalVarAssign(
@@ -34,6 +39,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(lhs, rhs)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.FieldAssign =
             viper.silver.ast.FieldAssign(
@@ -73,6 +80,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = listOf(methodName)
+        override val children: List<NameHolder> get() = args + targets
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.MethodCall = viper.silver.ast.MethodCall(
             methodName.mangled,
@@ -90,6 +99,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(exp)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Exhale = viper.silver.ast.Exhale(
             exp.toSilver(),
@@ -105,6 +116,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(exp)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Inhale = viper.silver.ast.Inhale(
             exp.toSilver(),
@@ -120,6 +133,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(exp)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Assert = viper.silver.ast.Assert(
             exp.toSilver(),
@@ -136,6 +151,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = scopedSeqnDeclarations + stmts
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Seqn = viper.silver.ast.Seqn(
             stmts.toSilver().toScalaSeq(),
@@ -154,6 +171,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOfNotNull(cond, then, els)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.If = viper.silver.ast.If(
             cond.toSilver(),
@@ -173,6 +192,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(cond, body) + invariants
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.While = viper.silver.ast.While(
             cond.toSilver(),
@@ -191,6 +212,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+        override val children: List<NameHolder> get() = invariants
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Label = viper.silver.ast.Label(
             name.mangled,
@@ -207,6 +230,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = listOf(name)
+        override val children: List<NameHolder> get() = emptyList()
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Goto = viper.silver.ast.Goto(
             name.mangled,
@@ -222,6 +247,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(acc)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Fold = viper.silver.ast.Fold(
             acc.toSilver(),
@@ -237,6 +264,8 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val info: Info = Info.NoInfo,
         val trafos: Trafos = Trafos.NoTrafos,
     ) : Stmt {
+        override val directlyReferencedNames: List<AnyName> get() = emptyList()
+        override val children: List<NameHolder> get() = listOf(acc)
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Unfold = viper.silver.ast.Unfold(
             acc.toSilver(),


### PR DESCRIPTION
## Summary

Eliminate the central ~135-line structural walker in
`Program.kt` and replace it with a per-node `NameHolder` interface
implemented locally on each AST class. Adding a new Exp/Stmt variant
now requires overriding the sealed-interface members locally; you
cannot forget to extend the walker because there is no central walker.

## Shape

```kotlin
interface NameHolder {
    val directlyReferencedNames: List<AnyName> get() = emptyList()
    val children: List<NameHolder> get() = emptyList()
}
```

`Exp`, `Stmt`, and `Declaration` are `sealed interface`s that
re-abstract the two members, so every variant must explicitly provide
them. `BinaryExp` provides defaults that cover its 15 subclasses.
Top-level program elements (`Program`, `Domain`, `Method`, `Function`,
`Predicate`, `Field`, `AdtDecl`, `DomainFunc`, `DomainAxiom`,
`AdtConstructorDecl`) also implement `NameHolder` so the recursion is
uniform.

`Program.registerAllNames` collapses to:

```kotlin
context(nameResolver: NameResolver)
fun Program.registerAllNames() {
    fun NameHolder.visit() {
        directlyReferencedNames.forEach(nameResolver::register)
        children.forEach { it.visit() }
    }
    visit()
}
```

## Behavior notes

The resolver registers into a `Set`, so duplicate `register(name)`
calls are no-ops and call order does not affect resolution. This let
me describe each node faithfully rather than reproducing the old
walker's specific traversal quirks. As a result, three nodes now visit
sub-expressions that the old walker silently skipped:

- `Exp.LetBinding.varExp`
- `Exp.TernaryExp.condExp`
- `AccessPredicate.FieldAccessPredicate.access`

In practice these were dead code paths (names already registered via
other walks) — `:untilConversion` golden output is unchanged.

## Test plan

- [x] `./gradlew :formver.compiler-plugin:untilConversion` (passes,
  golden-file output unchanged)
- [x] `./gradlew :formver.compiler-plugin:detekt` (passes)