### PR TITLE
Single source of truth for ExpEmbedding traversal; fix While.invariants

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ChildrenCollectingVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ChildrenCollectingVisitor.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.embeddings
+
+import org.jetbrains.kotlin.formver.core.embeddings.expression.*
+
+/**
+ * Single source of truth for the traversable sub-expressions of each [ExpEmbedding].
+ *
+ * Every [ExpEmbedding] node's `children()` derives from the corresponding arm here.
+ * Adding a new traversable field is a one-place edit: extend the arm for that node.
+ */
+internal object ChildrenCollectingVisitor : ExpVisitor<List<ExpEmbedding>> {
+    override fun visitDefault(e: ExpEmbedding): List<ExpEmbedding> = emptyList()
+
+    override fun visitBlock(e: Block): List<ExpEmbedding> = e.exps
+    override fun visitFunctionExp(e: FunctionExp): List<ExpEmbedding> = listOf(e.body)
+    override fun visitGotoChainNode(e: GotoChainNode): List<ExpEmbedding> = listOf(e.exp)
+    override fun visitIf(e: If): List<ExpEmbedding> = listOf(e.condition, e.thenBranch, e.elseBranch)
+    override fun visitElvis(e: Elvis): List<ExpEmbedding> = listOf(e.left, e.right)
+    override fun visitReturn(e: Return): List<ExpEmbedding> = listOf(e.returnExp)
+    override fun visitMethodCall(e: MethodCall): List<ExpEmbedding> = e.args
+    override fun visitFunctionCall(e: FunctionCall): List<ExpEmbedding> = e.args
+    override fun visitNonDeterministically(e: NonDeterministically): List<ExpEmbedding> = listOf(e.exp)
+    override fun visitWhile(e: While): List<ExpEmbedding> = listOf(e.condition, e.body) + e.invariants
+    override fun visitInvokeFunctionObject(e: InvokeFunctionObject): List<ExpEmbedding> =
+        listOf(e.receiver) + e.args
+
+    override fun visitFieldAccess(e: FieldAccess): List<ExpEmbedding> = listOf(e.receiver)
+    override fun visitPrimitiveFieldAccess(e: PrimitiveFieldAccess): List<ExpEmbedding> = listOf(e.inner)
+    override fun visitFieldModification(e: FieldModification): List<ExpEmbedding> = listOf(e.receiver, e.newValue)
+    override fun visitFieldAccessPermissions(e: FieldAccessPermissions): List<ExpEmbedding> = listOf(e.inner)
+    override fun visitPredicateAccessPermissions(e: PredicateAccessPermissions): List<ExpEmbedding> = e.args
+    override fun visitAccEmbedding(e: AccEmbedding): List<ExpEmbedding> = listOf(e.access)
+
+    override fun visitAssign(e: Assign): List<ExpEmbedding> = listOf(e.lhs, e.rhs)
+    override fun visitDeclare(e: Declare): List<ExpEmbedding> = listOfNotNull(e.variable, e.initializer)
+
+    override fun visitCast(e: Cast): List<ExpEmbedding> = listOf(e.inner)
+    override fun visitIs(e: Is): List<ExpEmbedding> = listOf(e.inner)
+    override fun visitSafeCast(e: SafeCast): List<ExpEmbedding> = listOf(e.exp)
+    // TODO: include InhaleInvariants.exp once we resolve the purity-checker false
+    // positives on inlined function bodies surfaced by validating Asserts nested
+    // inside an InhaleInvariants subtree. Including exp here unhides Asserts that
+    // the original `children() = emptySequence()` was silently skipping, and the
+    // current purity logic flags compiler-introduced Declare(return-slot, null)
+    // and InhaleInvariants in the inlined body as impure.
+
+    override fun visitEqCmp(e: EqCmp): List<ExpEmbedding> = listOf(e.left, e.right)
+    override fun visitNeCmp(e: NeCmp): List<ExpEmbedding> = listOf(e.left, e.right)
+    override fun visitBinaryOperatorExpEmbedding(e: BinaryOperatorExpEmbedding): List<ExpEmbedding> =
+        listOf(e.left, e.right)
+    override fun visitUnaryOperatorExpEmbedding(e: UnaryOperatorExpEmbedding): List<ExpEmbedding> =
+        listOf(e.inner)
+    override fun visitSequentialAnd(e: SequentialAnd): List<ExpEmbedding> = listOf(e.left, e.right)
+    override fun visitSequentialOr(e: SequentialOr): List<ExpEmbedding> = listOf(e.left, e.right)
+
+    override fun visitWithPosition(e: WithPosition): List<ExpEmbedding> = listOf(e.inner)
+    override fun visitSharingContext(e: SharingContext): List<ExpEmbedding> = listOf(e.inner)
+    override fun visitShared(e: Shared): List<ExpEmbedding> = listOf(e.inner)
+
+    override fun visitAssert(e: Assert): List<ExpEmbedding> = listOf(e.exp)
+    override fun visitInhaleDirect(e: InhaleDirect): List<ExpEmbedding> = listOf(e.exp)
+    override fun visitOld(e: Old): List<ExpEmbedding> = listOf(e.inner)
+    override fun visitForAllEmbedding(e: ForAllEmbedding): List<ExpEmbedding> = e.conditions
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/AccEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/AccEmbedding.kt
@@ -20,5 +20,4 @@ data class AccEmbedding(
         get() = buildType { boolean() }
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitAccEmbedding(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(access)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
@@ -20,8 +20,6 @@ sealed interface AnyComparisonExpression : ExpEmbedding {
         get() = buildType { boolean() }
 
     val comparisonOperation: Operator
-
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
 }
 
 data class EqCmp(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ControlFlow.kt
@@ -28,7 +28,6 @@ sealed interface Block : ExpEmbedding {
     override val type: TypeEmbedding
         get() = exps.lastOrNull()?.type ?: buildType { unit() }
 
-    override fun children(): Sequence<ExpEmbedding> = exps.asSequence()
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitBlock(this)
 }
 
@@ -40,7 +39,6 @@ data class If(
 ) :
     ExpEmbedding {
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(condition, thenBranch, elseBranch)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitIf(this)
 }
 
@@ -56,7 +54,6 @@ data class While(
     val continueLabel = LabelEmbedding(continueLabelName, invariants)
     val breakLabel = LabelEmbedding(breakLabelName)
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(condition, body)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitWhile(this)
 }
 
@@ -82,14 +79,12 @@ data class GotoChainNode(val label: LabelEmbedding?, val exp: ExpEmbedding, val 
     ExpEmbedding {
     override val type: TypeEmbedding = exp.type
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(exp)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitGotoChainNode(this)
 }
 
 data class NonDeterministically(val exp: ExpEmbedding) : ExpEmbedding {
     override val type: TypeEmbedding = buildType { unit() }
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(exp)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitNonDeterministically(this)
 }
 
@@ -97,7 +92,6 @@ data class NonDeterministically(val exp: ExpEmbedding) : ExpEmbedding {
 data class MethodCall(val method: NamedFunctionSignature, val args: List<ExpEmbedding>) : ExpEmbedding {
     override val type: TypeEmbedding = method.callableType.returnType
 
-    override fun children(): Sequence<ExpEmbedding> = args.asSequence()
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitMethodCall(this)
 }
 
@@ -106,8 +100,6 @@ data class FunctionCall(val function: NamedFunctionSignature, val args: List<Exp
 
     override fun <R> accept(v: ExpVisitor<R>): R =
         v.visitFunctionCall(this)
-
-    override fun children(): Sequence<ExpEmbedding> = args.asSequence()
 }
 
 /**
@@ -122,7 +114,6 @@ data class InvokeFunctionObject(
 ) :
     ExpEmbedding {
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(receiver) + args.asSequence()
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitInvokeFunctionObject(this)
 }
 
@@ -134,14 +125,12 @@ data class FunctionExp(
     ExpEmbedding {
     override val type: TypeEmbedding = body.type
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(body)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFunctionExp(this)
 }
 
 data class Elvis(val left: ExpEmbedding, val right: ExpEmbedding, override val type: TypeEmbedding) :
     ExpEmbedding {
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitElvis(this)
 }
 
@@ -151,6 +140,4 @@ data class Return(
     override val type = buildType { nothing() }
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitReturn(this)
-
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(returnExp)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ExpEmbedding.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.expression
 
+import org.jetbrains.kotlin.formver.core.embeddings.ChildrenCollectingVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.*
@@ -35,7 +36,7 @@ sealed interface ExpEmbedding : DebugPrintable {
 
     fun ignoringCastsAndMetaNodes(): ExpEmbedding = this
 
-    fun children(): Sequence<ExpEmbedding> = emptySequence()
+    fun children(): Sequence<ExpEmbedding> = accept(ChildrenCollectingVisitor).asSequence()
     fun <R> accept(v: ExpVisitor<R>): R
     fun isValid(ctx: PurityContext): Boolean = true
 
@@ -55,14 +56,12 @@ data class PrimitiveFieldAccess(val inner: ExpEmbedding, val field: FieldEmbeddi
         get() = this.field.type
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitPrimitiveFieldAccess(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
 data class FieldAccess(val receiver: ExpEmbedding, val field: FieldEmbedding) : ExpEmbedding {
     override val type: TypeEmbedding = field.type
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFieldAccess(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(receiver)
 }
 
 /**
@@ -72,7 +71,6 @@ data class FieldModification(val receiver: ExpEmbedding, val field: FieldEmbeddi
     ExpEmbedding {
     override val type: TypeEmbedding = buildType { unit() }
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(receiver, newValue)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFieldModification(this)
 }
 
@@ -81,7 +79,6 @@ data class FieldAccessPermissions(val inner: ExpEmbedding, val field: FieldEmbed
     override val type: TypeEmbedding = buildType { boolean() }
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFieldAccessPermissions(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
 // Ideally we would use the predicate, but due to the possibility of recursion this is inconvenient at present.
@@ -94,19 +91,16 @@ data class PredicateAccessPermissions(
     override val type: TypeEmbedding = buildType { boolean() }
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitPredicateAccessPermissions(this)
-    override fun children(): Sequence<ExpEmbedding> = args.asSequence()
 }
 
 data class Assign(val lhs: VariableEmbedding, val rhs: ExpEmbedding) : ExpEmbedding {
     override val type: TypeEmbedding = lhs.type
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(lhs, rhs)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitAssign(this)
 }
 
 data class Declare(val variable: VariableEmbedding, val initializer: ExpEmbedding?) : ExpEmbedding {
     override val type: TypeEmbedding = buildType { unit() }
 
-    override fun children(): Sequence<ExpEmbedding> = listOfNotNull(variable, initializer).asSequence()
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitDeclare(this)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ForAllEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/ForAllEmbedding.kt
@@ -19,6 +19,5 @@ data class ForAllEmbedding(
     override val type: TypeEmbedding
         get() = buildType { boolean() }
 
-    override fun children(): Sequence<ExpEmbedding> = conditions.asSequence()
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitForAllEmbedding(this)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Invariant.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Invariant.kt
@@ -12,5 +12,4 @@ data class Old(val inner: ExpEmbedding) : ExpEmbedding {
     override val type: TypeEmbedding = inner.type
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitOld(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Meta.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Meta.kt
@@ -17,8 +17,6 @@ data class WithPosition(val inner: ExpEmbedding, val source: KtSourceElement) : 
     override fun ignoringMetaNodes(): ExpEmbedding = inner.ignoringMetaNodes()
     override fun ignoringCastsAndMetaNodes(): ExpEmbedding = inner.ignoringCastsAndMetaNodes()
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitWithPosition(this)
-
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
 fun ExpEmbedding.withPosition(source: KtSourceElement?): ExpEmbedding =
@@ -57,7 +55,6 @@ data class SharingContext(val inner: ExpEmbedding) : ExpEmbedding {
     override fun ignoringCastsAndMetaNodes() = inner
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitSharingContext(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
 /**
@@ -79,7 +76,6 @@ data class Shared(val inner: ExpEmbedding) : ExpEmbedding {
 
     override fun ignoringMetaNodes() = inner
     override fun ignoringCastsAndMetaNodes() = inner
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitShared(this)
 
     fun initContext(ctx: SharingContext) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/OperatorExpEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/OperatorExpEmbedding.kt
@@ -22,16 +22,12 @@ interface BinaryOperatorExpEmbedding : InjectionBasedExpEmbedding {
     val right: ExpEmbedding
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitBinaryOperatorExpEmbedding(this)
-
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
 }
 
 interface UnaryOperatorExpEmbedding : InjectionBasedExpEmbedding {
     val inner: ExpEmbedding
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitUnaryOperatorExpEmbedding(this)
-
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
 sealed interface OperatorExpEmbeddingTemplate {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/SequentialLogicOperatorEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/SequentialLogicOperatorEmbedding.kt
@@ -28,8 +28,6 @@ sealed class SequentialLogicOperatorEmbedding : ExpEmbedding {
         LogicOperatorPolicy.CONVERT_TO_IF -> ifReplacement
         LogicOperatorPolicy.CONVERT_TO_EXPRESSION -> expressionReplacement
     }
-
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
 }
 
 data class SequentialAnd(override val left: ExpEmbedding, override val right: ExpEmbedding) :

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
@@ -31,7 +31,6 @@ data object ErrorExp : ExpEmbedding {
 data class Assert(val exp: ExpEmbedding) : ExpEmbedding {
     override val type: TypeEmbedding = buildType { unit() }
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(exp)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitAssert(this)
 
     override fun isValid(ctx: PurityContext): Boolean = exp.isPure().also {
@@ -48,6 +47,5 @@ data class Assert(val exp: ExpEmbedding) : ExpEmbedding {
 data class InhaleDirect(val exp: ExpEmbedding) : ExpEmbedding {
     override val type: TypeEmbedding = buildType { unit() }
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(exp)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitInhaleDirect(this)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/TypeOp.kt
@@ -18,7 +18,6 @@ data class Is(
     override val type = buildType { boolean() }
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitIs(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
 
@@ -31,7 +30,6 @@ data class Cast(val inner: ExpEmbedding, override val type: TypeEmbedding) : Exp
     override fun ignoringCastsAndMetaNodes(): ExpEmbedding = inner.ignoringCastsAndMetaNodes()
 
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitCast(this)
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(inner)
 }
 
 fun ExpEmbedding.withType(newType: TypeEmbedding): ExpEmbedding = if (type == newType) this else Cast(this, newType)
@@ -49,7 +47,6 @@ data class SafeCast(val exp: ExpEmbedding, val targetType: TypeEmbedding) : ExpE
     override val type: TypeEmbedding
         get() = targetType.getNullable()
 
-    override fun children(): Sequence<ExpEmbedding> = sequenceOf(exp)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitSafeCast(this)
 }
 
@@ -64,7 +61,6 @@ interface InhaleInvariants : ExpEmbedding {
         get() = if (invariants.isEmpty()) exp
         else this
 
-    // TODO: add children() override (sequenceOf(exp)) once we fix corresponding tests
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitInhaleInvariants(this)
 }
 


### PR DESCRIPTION
## Summary

Eliminates the duplication between `ExpEmbedding.children()` and `ExpEmbedding.accept(visitor)`: a new `ChildrenCollectingVisitor` is the single dispatch table for "what are this node's sub-expressions"; the interface's `children()` becomes a default that calls `accept(ChildrenCollectingVisitor)`. The 14 per-class `children()` overrides go away. Adding a new traversable field is now one edit on the visitor.

- Design (a) per the slice brief — closer to the project's existing visitor-heavy style and consolidates per-node traversal decisions in one auditable file.
- Net LoC: 11 source files modified, 1 new file. `+71 / -42` (≈ +29 lines net, with the per-node arms consolidated in one place).

## Latent-bug decision

**Fixed:** `While.invariants` is now included in `children()` via `visitWhile = listOf(condition, body) + invariants`. No tests change: `While`'s linearization and debug-tree views are independent of `children()`, and the purity visitor short-circuits `While` to `false` without recursion, so invariants only become visible to `preorder`, where they validate cleanly (Asserts inside invariants are pure).

**Not yet fixed:** `InhaleInvariants.exp` stays excluded; the TODO migrates from `TypeOp.kt` to `ChildrenCollectingVisitor` with a fuller note. Including it unhides Asserts that the original `children() = emptySequence()` was silently skipping (the actual bug). Two tests (`testMultiple_receivers`, `testScoped_receivers`) then fail with PURITY_VIOLATION on user code like `verify(42.applyInlineDelta() == 84)` — the surfaced Asserts are visited by `preorder`, but the purity check on their condition falsely flags compiler-introduced `Declare(return-slot, null)` and nested `InhaleInvariants` (from inline expansion) as impure. That's not a golden-file update; it's a real false-positive in the purity logic that would need its own slice (treat nested `InhaleInvariants` as pure-when-exp-is-pure; treat `Declare(slot, null) + Assign(slot, ...)` inside an inlined `FunctionExp` as pure). I tried the small purity-visitor fix (`visitInhaleInvariants = allChildrenPure`) and it removes the `InhaleInvariants` half of the false positive but not the `Declare(slot, null)` half, so it isn't sufficient on its own.

Per the slice brief's instruction to not paper over the bug, this PR is deliberately partial on `InhaleInvariants.exp`. The visitor arm is one line away from completion (commented out next to the rest); it should land alongside the purity-checker fix for inlined-function expressions.

## Test plan

- [x] `./gradlew :formver.compiler-plugin:detekt` — passes
- [x] `./gradlew :formver.compiler-plugin:untilConversion` — 141/141 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)