### PR TITLE
Support `old` expressions in contracts

### DIFF
--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -28,6 +28,9 @@ fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) -> Unit)
     throw FormverFunctionCalledInRuntimeException("forAll")
 
 
+fun <T> old(@Suppress("UNUSED_PARAMETER") body: T): T =
+    throw FormverFunctionCalledInRuntimeException("old")
+
 class InvariantBuilder {
     /**
      * Specifies trigger expressions for quantifiers.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -156,6 +156,16 @@ object SpecialKotlinFunctions {
             Implies(args[0], args[1])
         }
 
+        val oldCallableType = buildFunctionPretype {
+            withParam {
+                nullableAny()
+            }
+            withReturnType { nullableAny() }
+        }
+        addFunction(oldCallableType, SpecialPackages.formver, name = "old") { args, _ ->
+            Old(args[0])
+        }
+
         val verifyCallableType = buildFunctionPretype {
             withParam {
                 klass {
@@ -289,7 +299,7 @@ val CallableEmbedding.isVerifyFunction: Boolean
     get() = isFormverPluginFunctionNamed(name = "verify")
 
 fun CallableEmbedding.isFormverPluginFunctionNamed(className: String? = null, name: String): Boolean =
-    this is FullySpecialKotlinFunction && NameMatcher.Companion.matchClassScope(this.embedName()) {
+    this is FullySpecialKotlinFunction && NameMatcher.matchClassScope(this.embedName()) {
         ifPackageName(SpecialPackages.formver) {
             if (className == null) {
                 ifNoReceiver {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -157,9 +157,7 @@ object SpecialKotlinFunctions {
         }
 
         val oldCallableType = buildFunctionPretype {
-            withParam {
-                nullableAny()
-            }
+            withParam { nullableAny() }
             withReturnType { nullableAny() }
         }
         addFunction(oldCallableType, SpecialPackages.formver, name = "old") { args, _ ->

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
@@ -45,10 +45,10 @@ internal class ExprPurityVisitor(val declaredVariables: MutableSet<VariableEmbed
     override fun visitCast(e: Cast): Boolean = e.allChildrenPure(this)
     override fun visitShared(e: Shared) = e.allChildrenPure(this)
     override fun visitForAllEmbedding(e: ForAllEmbedding) = e.allChildrenPure(this)
+    override fun visitOld(e: Old) = e.allChildrenPure(this)
 
     /* ————— impure nodes ————— */
     override fun visitSafeCast(e: SafeCast) = false
-    override fun visitOld(e: Old) = false
     override fun visitMethodCall(e: MethodCall) = false
     override fun visitFunctionExp(e: FunctionExp) = false
     override fun visitLambdaExp(e: LambdaExp) = false

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -377,6 +377,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("old.kt")
+    public void testOld() {
+      runTest("formver.compiler-plugin/testData/diagnostics/verification/old.kt");
+    }
+
+    @Test
     @TestMetadata("shadowing.kt")
     public void testShadowing() {
       runTest("formver.compiler-plugin/testData/diagnostics/verification/shadowing.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/old.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/old.fir.diag.txt
@@ -1,6 +1,11 @@
 /old.kt: info: Generated Viper text for test:
 field bf_field: Ref
 
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
 method inc(c: Ref) returns (ret_3: Ref)
   requires isSubtype(typeOf(c), C())
   requires acc(C_unique(c), write)
@@ -22,6 +27,7 @@ method test(c: Ref) returns (v_ret_0: Ref)
 {
   var anon: Ref
   anon := inc(c)
+  assert c == old(c)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/old.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/old.fir.diag.txt
@@ -1,0 +1,27 @@
+/old.kt: info: Generated Viper text for test:
+field bf_field: Ref
+
+method inc(c: Ref) returns (ret_3: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  ensures acc(C_unique(c), write)
+  ensures isSubtype(typeOf(ret_3), unitType())
+  ensures intFromRef((unfolding acc(C_unique(c), write) in c.bf_field)) ==
+    old(intFromRef((unfolding acc(C_unique(c), write) in c.bf_field))) + 1
+
+
+method test(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), C())
+  requires acc(C_unique(c), write)
+  requires intFromRef((unfolding acc(C_unique(c), write) in c.bf_field)) ==
+    42
+  ensures acc(C_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+  ensures intFromRef((unfolding acc(C_unique(c), write) in c.bf_field)) ==
+    43
+{
+  var anon: Ref
+  anon := inc(c)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/old.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/old.kt
@@ -15,6 +15,7 @@ fun <!VIPER_TEXT!>test<!>(@Unique @Borrowed c: C) {
         c.field == 43
     }
     inc(c)
+    verify(c == old(c))
 }
 
 @NeverConvert

--- a/formver.compiler-plugin/testData/diagnostics/verification/old.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/old.kt
@@ -18,6 +18,7 @@ fun <!VIPER_TEXT!>test<!>(@Unique @Borrowed c: C) {
     verify(c == old(c))
 }
 
+// TODO: Remove the @NeverConvert once we have uniqueness information.
 @NeverConvert
 fun inc(@Unique @Borrowed c: C) {
     postconditions<Unit> {

--- a/formver.compiler-plugin/testData/diagnostics/verification/old.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/old.kt
@@ -1,0 +1,26 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+
+class C(
+    @Unique var field: Int
+)
+
+fun <!VIPER_TEXT!>test<!>(@Unique @Borrowed c: C) {
+    preconditions {
+        c.field == 42
+    }
+    postconditions<Unit> {
+        c.field == 43
+    }
+    inc(c)
+}
+
+@NeverConvert
+fun inc(@Unique @Borrowed c: C) {
+    postconditions<Unit> {
+        c.field == old(c.field) + 1
+    }
+    c.field = c.field + 1
+}


### PR DESCRIPTION
This PR allows the user to use old in the contracts

The comment below is not true.
### Why is `old` not embedded as a `FullySpecialKotlinFunction` like `verify`?
In the Framework of the `FullySpecialKotlinFunction` we need to provide the resulting type of the expression in the signature. We can not do this, because `old` has a generic return type.