### PR TITLE
Allow `forAll` expression as `verify` parameter

### DIFF
--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -17,23 +17,18 @@ fun verify(@Suppress("UNUSED_PARAMETER") vararg predicates: Boolean) = Unit
 
 infix fun Boolean.implies(other: Boolean) = !this || other
 
-fun loopInvariants(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.() -> Unit) = Unit
+fun loopInvariants(@Suppress("UNUSED_PARAMETER") body: () -> Unit) = Unit
 
-fun preconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.() -> Unit) = Unit
+fun preconditions(@Suppress("UNUSED_PARAMETER") body: () -> Unit) = Unit
 
-fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) -> Unit) = Unit
+fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit) = Unit
 
 
-fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit): Boolean =
+fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) -> Unit): Boolean =
     throw FormverFunctionCalledInRuntimeException("forAll")
 
-/**
- * This class is designed as a receiver for lambda blocks of `loopInvariants`, `preconditions` and `postconditions`.
- */
-class InvariantBuilder {
-    fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit): Boolean =
-        throw FormverFunctionCalledInRuntimeException("forAll")
 
+class InvariantBuilder {
     /**
      * Specifies trigger expressions for quantifiers.
      * This function should be called within a `forAll` block to provide user-defined triggers

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -23,6 +23,10 @@ fun preconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.() -> Uni
 
 fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) -> Unit) = Unit
 
+
+fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit): Boolean =
+    throw FormverFunctionCalledInRuntimeException("forAll")
+
 /**
  * This class is designed as a receiver for lambda blocks of `loopInvariants`, `preconditions` and `postconditions`.
  */

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -43,7 +43,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.equalToType
 import org.jetbrains.kotlin.formver.core.functionCallArguments
 import org.jetbrains.kotlin.formver.core.isFormverFunctionNamed
-import org.jetbrains.kotlin.formver.core.isInvariantBuilderFunctionNamed
 import org.jetbrains.kotlin.text
 import org.jetbrains.kotlin.types.ConstantValueKind
 
@@ -295,7 +294,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                             arg.source, "Vararg arguments are currently supported for `verify` function only."
                         )
                     }
-                    arg.arguments.map(data::convert)
+                    data.withNoScope {
+                        arg.arguments.map { this.convert(it) }
+                    }
                 }
 
                 else -> listOf(data.convert(arg))
@@ -307,7 +308,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
 
         val forAllLambda =
-            functionCall.extractFormverFirBlock { isInvariantBuilderFunctionNamed("forAll") || isFormverFunctionNamed("forAll") }
+            functionCall.extractFormverFirBlock { isFormverFunctionNamed("forAll") }
         when {
 
             forAllLambda != null -> {
@@ -321,15 +322,6 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                     forAllLambda.body?.source, "Lambda body should be accessible in `forAll` function call."
                 )
                 return data.insertForAllFunctionCall(forAllArg.symbol, forAllBody)
-            }
-
-            symbol.isFormverFunctionNamed("verify") -> {
-                val callee = data.embedAnyFunction(symbol)
-                val arguments = data.withNoScope {
-                    functionCall.functionCallArguments.withVarargsHandled(this, callee)
-
-                }
-                return Block { addAll(arguments.map { Assert(it) }) }
             }
 
             else -> {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -42,6 +42,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.InvalidAdtTypeEmbeddin
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.equalToType
 import org.jetbrains.kotlin.formver.core.functionCallArguments
+import org.jetbrains.kotlin.formver.core.isFormverFunctionNamed
 import org.jetbrains.kotlin.formver.core.isInvariantBuilderFunctionNamed
 import org.jetbrains.kotlin.text
 import org.jetbrains.kotlin.types.ConstantValueKind
@@ -305,17 +306,11 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         val symbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
             ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
 
-        when (val forAllLambda = functionCall.extractFormverFirBlock { isInvariantBuilderFunctionNamed("forAll") }) {
-            null -> {
-                val callee = data.embedAnyFunction(symbol)
-                return callee.insertCall(
-                    functionCall.functionCallArguments.withVarargsHandled(data, callee),
-                    data,
-                    data.embedType(functionCall.resolvedType),
-                )
-            }
+        val forAllLambda =
+            functionCall.extractFormverFirBlock { isInvariantBuilderFunctionNamed("forAll") || isFormverFunctionNamed("forAll") }
+        when {
 
-            else -> {
+            forAllLambda != null -> {
                 if (!data.isValidForForAllBlock) throw SnaktInternalException(
                     forAllLambda.source,
                     "`forAll` scope is only allowed inside one of the `loopInvariants`, `preconditions` or `postconditions`."
@@ -327,6 +322,25 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 )
                 return data.insertForAllFunctionCall(forAllArg.symbol, forAllBody)
             }
+
+            symbol.isFormverFunctionNamed("verify") -> {
+                val callee = data.embedAnyFunction(symbol)
+                val arguments = data.withNoScope {
+                    functionCall.functionCallArguments.withVarargsHandled(this, callee)
+
+                }
+                return Block { addAll(arguments.map { Assert(it) }) }
+            }
+
+            else -> {
+                val callee = data.embedAnyFunction(symbol)
+                return callee.insertCall(
+                    functionCall.functionCallArguments.withVarargsHandled(data, callee),
+                    data,
+                    data.embedType(functionCall.resolvedType),
+                )
+            }
+
         }
     }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -52,10 +52,6 @@ object SpecialKotlinFunctions {
         packageScope(SpecialPackages.kotlin)
         ClassKotlinName(listOf("BooleanArray"))
     }
-    private val invariantBuilderTypeName = buildName {
-        packageScope(SpecialPackages.formver)
-        ClassKotlinName(listOf("InvariantBuilder"))
-    }
 
     val byName: Map<SymbolicName, FullySpecialKotlinFunction> = buildFullySpecialFunctions {
         val intIntToIntType = buildFunctionPretype {
@@ -172,11 +168,6 @@ object SpecialKotlinFunctions {
         val invariantsBuilderCallableType = buildFunctionPretype {
             withParam {
                 function {
-                    withDispatchReceiver {
-                        klass {
-                            withName(invariantBuilderTypeName)
-                        }
-                    }
                     withReturnType { unit() }
                 }
             }
@@ -190,11 +181,6 @@ object SpecialKotlinFunctions {
         val postconditionsBuilderCallableType = buildFunctionPretype {
             withParam {
                 function {
-                    withDispatchReceiver {
-                        klass {
-                            withName(invariantBuilderTypeName)
-                        }
-                    }
                     withParam { nullableAny() }
                     withReturnType { unit() }
                 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
 import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
 import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.Exp.Companion.toConjunction
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 import org.jetbrains.kotlin.formver.viper.ast.viperLiteral
 
@@ -489,7 +490,7 @@ data class LinearizationVisitor(
 
     override fun visitForAllEmbedding(e: ForAllEmbedding): Linearizable = object : OnlyToBuiltinLinearizable(e, this@LinearizationVisitor) {
         override fun toViperBuiltinType(ctx: LinearizationContext): Exp {
-            val conjunction = with(Exp) { e.conditions.map { it.linearize().toViperBuiltinType(ctx) }.toConjunction() }
+            val conjunction = e.conditions.pureToViper(true, ctx.typeResolver, ctx.source).toConjunction()
             val viperTriggers = e.triggerExpressions.map { triggerExpr ->
                 Exp.Trigger(listOf(triggerExpr.linearize().toViperBuiltinType(ctx)))
             }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
@@ -45,11 +45,11 @@ internal class ExprPurityVisitor(val declaredVariables: MutableSet<VariableEmbed
     override fun visitIs(e: Is) = e.allChildrenPure(this)
     override fun visitCast(e: Cast): Boolean = e.allChildrenPure(this)
     override fun visitShared(e: Shared) = e.allChildrenPure(this)
+    override fun visitForAllEmbedding(e: ForAllEmbedding) = e.allChildrenPure(this)
 
     /* ————— impure nodes ————— */
     override fun visitSafeCast(e: SafeCast) = false
     override fun visitOld(e: Old) = false
-    override fun visitForAllEmbedding(e: ForAllEmbedding) = false
     override fun visitMethodCall(e: MethodCall) = false
     override fun visitFunctionExp(e: FunctionExp) = false
     override fun visitLambdaExp(e: LambdaExp) = false

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -178,27 +178,25 @@ method plus(this: Ref, other: Ref) returns (ret_4: Ref)
 
 
 /merge_sort_of_string.kt: info: Generated Viper text for mergeSorted:
-method mergeSorted(v_this_extension: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+method mergeSorted(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(this)|
   ensures (forall anon_builtin_0: Int ::1 <= anon_builtin_0 &&
       anon_builtin_0 < |stringFromRef(v_ret_0)| ==>
       stringFromRef(v_ret_0)[anon_builtin_0 - 1] <=
       stringFromRef(v_ret_0)[anon_builtin_0])
 {
-  if (|stringFromRef(v_this_extension)| <= 1) {
-    v_ret_0 := v_this_extension
+  if (|stringFromRef(this)| <= 1) {
+    v_ret_0 := this
   } else {
     var anon_0: Ref
     var anon_1: Ref
     var anon_2: Ref
     var anon_3: Ref
-    anon_1 := subs(v_this_extension, intToRef(0), divInts(stringLength(v_this_extension),
-      intToRef(2)))
+    anon_1 := subs(this, intToRef(0), divInts(stringLength(this), intToRef(2)))
     anon_0 := mergeSorted(anon_1)
-    anon_3 := subs(v_this_extension, divInts(stringLength(v_this_extension),
-      intToRef(2)), stringLength(v_this_extension))
+    anon_3 := subs(this, divInts(stringLength(this), intToRef(2)), stringLength(this))
     anon_2 := mergeSorted(anon_3)
     v_ret_0 := mergeStrings(anon_0, anon_2)
   }
@@ -224,15 +222,15 @@ method mergeStrings(a: Ref, b: Ref) returns (ret_2: Ref)
       stringFromRef(ret_2)[anon_builtin_2])
 
 
-method subs(v_this_extension: Ref, lo: Ref, hi: Ref) returns (ret_3: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+method subs(this: Ref, lo: Ref, hi: Ref) returns (ret_3: Ref)
+  requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(v_this_extension)|
+    intFromRef(hi) <= |stringFromRef(this)|
   ensures isSubtype(typeOf(ret_3), stringType())
   ensures |stringFromRef(ret_3)| == intFromRef(hi) - intFromRef(lo)
   ensures (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
       anon_builtin_3 < |stringFromRef(ret_3)| ==>
       stringFromRef(ret_3)[anon_builtin_3] ==
-      stringFromRef(v_this_extension)[anon_builtin_3 + intFromRef(lo)])
+      stringFromRef(this)[anon_builtin_3 + intFromRef(lo)])

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
@@ -1,56 +1,52 @@
 /quick_sort_of_string.kt: info: Generated Viper text for minOrMaxChar:
-method minOrMaxChar(v_this_extension: Ref, calcMin: Ref)
-  returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+method minOrMaxChar(this: Ref, calcMin: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(v_this_extension)| >= 1
+  requires |stringFromRef(this)| >= 1
   ensures isSubtype(typeOf(v_ret_0), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_0: Int ::0 <= anon_builtin_0 &&
-      anon_builtin_0 < |stringFromRef(v_this_extension)| ==>
-      charFromRef(v_ret_0) <=
-      stringFromRef(v_this_extension)[anon_builtin_0])
+      anon_builtin_0 < |stringFromRef(this)| ==>
+      charFromRef(v_ret_0) <= stringFromRef(this)[anon_builtin_0])
   ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
-      charFromRef(v_ret_0) >=
-      stringFromRef(v_this_extension)[anon_builtin_1])
+      anon_builtin_1 < |stringFromRef(this)| ==>
+      charFromRef(v_ret_0) >= stringFromRef(this)[anon_builtin_1])
 {
   var res: Ref
   var i: Ref
   var anon_0: Ref
-  res := stringGet(v_this_extension, intToRef(0))
+  res := stringGet(this, intToRef(0))
   i := intToRef(1)
   label cont
     invariant isSubtype(typeOf(res), charType())
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(calcMin), boolType())
-    invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this_extension)|
+    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
     invariant boolFromRef(calcMin) ==>
       (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
-        charFromRef(res) <= stringFromRef(v_this_extension)[anon_builtin_2])
+        charFromRef(res) <= stringFromRef(this)[anon_builtin_2])
     invariant !boolFromRef(calcMin) ==>
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < intFromRef(i) ==>
-        charFromRef(res) >= stringFromRef(v_this_extension)[anon_builtin_3])
-  anon_0 := ltInts(i, stringLength(v_this_extension))
+        charFromRef(res) >= stringFromRef(this)[anon_builtin_3])
+  anon_0 := ltInts(i, stringLength(this))
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
     var anon_2: Ref
     if (boolFromRef(calcMin)) {
-      anon_2 := ltChars(stringGet(v_this_extension, i), res)
+      anon_2 := ltChars(stringGet(this, i), res)
     } else {
       anon_2 := boolToRef(false)}
     if (boolFromRef(anon_2)) {
       anon_1 := boolToRef(true)
     } elseif (!boolFromRef(calcMin)) {
-      anon_1 := gtChars(stringGet(v_this_extension, i), res)
+      anon_1 := gtChars(stringGet(this, i), res)
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
-      res := stringGet(v_this_extension, i)
+      res := stringGet(this, i)
     }
     i := plusInts(i, intToRef(1))
     goto cont
@@ -59,79 +55,75 @@ method minOrMaxChar(v_this_extension: Ref, calcMin: Ref)
   assert isSubtype(typeOf(res), charType())
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(calcMin), boolType())
-  assert 0 <= intFromRef(i) &&
-    intFromRef(i) <= |stringFromRef(v_this_extension)|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
   assert boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
-      charFromRef(res) <= stringFromRef(v_this_extension)[anon_builtin_2])
+      charFromRef(res) <= stringFromRef(this)[anon_builtin_2])
   assert !boolFromRef(calcMin) ==>
     (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
       anon_builtin_3 < intFromRef(i) ==>
-      charFromRef(res) >= stringFromRef(v_this_extension)[anon_builtin_3])
+      charFromRef(res) >= stringFromRef(this)[anon_builtin_3])
   v_ret_0 := res
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSort:
-method minOrMaxChar(v_this_extension: Ref, calcMin: Ref)
-  returns (ret_2: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+method minOrMaxChar(this: Ref, calcMin: Ref) returns (ret_2: Ref)
+  requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(v_this_extension)| >= 1
+  requires |stringFromRef(this)| >= 1
   ensures isSubtype(typeOf(ret_2), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
-      charFromRef(ret_2) <= stringFromRef(v_this_extension)[anon_builtin_1])
+      anon_builtin_1 < |stringFromRef(this)| ==>
+      charFromRef(ret_2) <= stringFromRef(this)[anon_builtin_1])
   ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
-      anon_builtin_2 < |stringFromRef(v_this_extension)| ==>
-      charFromRef(ret_2) >= stringFromRef(v_this_extension)[anon_builtin_2])
+      anon_builtin_2 < |stringFromRef(this)| ==>
+      charFromRef(ret_2) >= stringFromRef(this)[anon_builtin_2])
 
 
-method quickSort(v_this_extension: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+method quickSort(this: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(this)|
   ensures (forall anon_builtin_0: Int ::1 <= anon_builtin_0 &&
-      anon_builtin_0 < |stringFromRef(v_this_extension)| ==>
+      anon_builtin_0 < |stringFromRef(this)| ==>
       stringFromRef(v_ret_0)[anon_builtin_0 - 1] <=
       stringFromRef(v_ret_0)[anon_builtin_0])
 {
   var l0_minVal: Ref
   var l0_maxVal: Ref
-  if (|stringFromRef(v_this_extension)| <= 1) {
-    v_ret_0 := v_this_extension
+  if (|stringFromRef(this)| <= 1) {
+    v_ret_0 := this
     goto lbl_ret_0
   }
-  l0_minVal := minOrMaxChar(v_this_extension, boolToRef(true))
-  l0_maxVal := minOrMaxChar(v_this_extension, boolToRef(false))
-  v_ret_0 := quickSortRec(v_this_extension, l0_minVal, l0_maxVal)
+  l0_minVal := minOrMaxChar(this, boolToRef(true))
+  l0_maxVal := minOrMaxChar(this, boolToRef(false))
+  v_ret_0 := quickSortRec(this, l0_minVal, l0_maxVal)
   goto lbl_ret_0
   label lbl_ret_0
 }
 
-method quickSortRec(v_this_extension: Ref, par_minVal: Ref, par_maxVal: Ref)
+method quickSortRec(this: Ref, par_minVal: Ref, par_maxVal: Ref)
   returns (ret_3: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+  requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(par_minVal), charType())
   requires isSubtype(typeOf(par_maxVal), charType())
   requires (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
-      anon_builtin_3 < |stringFromRef(v_this_extension)| ==>
-      charFromRef(par_minVal) <=
-      stringFromRef(v_this_extension)[anon_builtin_3] &&
-      stringFromRef(v_this_extension)[anon_builtin_3] <=
-      charFromRef(par_maxVal))
+      anon_builtin_3 < |stringFromRef(this)| ==>
+      charFromRef(par_minVal) <= stringFromRef(this)[anon_builtin_3] &&
+      stringFromRef(this)[anon_builtin_3] <= charFromRef(par_maxVal))
   ensures isSubtype(typeOf(ret_3), stringType())
-  ensures |stringFromRef(ret_3)| == |stringFromRef(v_this_extension)|
+  ensures |stringFromRef(ret_3)| == |stringFromRef(this)|
   ensures (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(v_this_extension)| ==>
+      anon_builtin_4 < |stringFromRef(this)| ==>
       charFromRef(par_minVal) <= stringFromRef(ret_3)[anon_builtin_4] &&
       stringFromRef(ret_3)[anon_builtin_4] <= charFromRef(par_maxVal))
   ensures (forall anon_builtin_5: Int ::1 <= anon_builtin_5 &&
-      anon_builtin_5 < |stringFromRef(v_this_extension)| ==>
+      anon_builtin_5 < |stringFromRef(this)| ==>
       stringFromRef(ret_3)[anon_builtin_5 - 1] <=
       stringFromRef(ret_3)[anon_builtin_5])
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.fir.diag.txt
@@ -30,3 +30,17 @@ method verify_compound() returns (v_ret_0: Ref)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
+
+/viper_verify.kt: info: Generated Viper text for verify_forall:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method verify_forall() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  assert (forall anon: Int ::anon > 0 || anon < 0 || anon == 0)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/negative/viper_verify.kt
@@ -1,6 +1,6 @@
 // FULL_JDK
-import org.jetbrains.kotlin.formver.plugin.verify
-import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+
+import org.jetbrains.kotlin.formver.plugin.*
 
 @AlwaysVerify
 fun <!VIPER_TEXT!>verify_false<!>() {
@@ -10,4 +10,13 @@ fun <!VIPER_TEXT!>verify_false<!>() {
 @AlwaysVerify
 fun <!VIPER_TEXT!>verify_compound<!>() {
     verify(<!VIPER_VERIFICATION_ERROR!>true && false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>verify_forall<!>() {
+    verify(
+        forAll<Int> { i ->
+            i > 0 || i < 0 || i == 0
+        }
+    )
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,15 +1,15 @@
 /string_iterations.kt: info: Generated Viper text for firstAtLeast:
-method firstAtLeast(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+method firstAtLeast(this: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures 0 <= intFromRef(v_ret_0) &&
-    intFromRef(v_ret_0) <= |stringFromRef(v_this_extension)|
+    intFromRef(v_ret_0) <= |stringFromRef(this)|
   ensures (forall anon_builtin_0: Int ::0 <= anon_builtin_0 &&
       anon_builtin_0 < intFromRef(v_ret_0) ==>
-      stringFromRef(v_this_extension)[anon_builtin_0] < charFromRef(c))
-  ensures !(intFromRef(v_ret_0) == |stringFromRef(v_this_extension)|) ==>
-    stringFromRef(v_this_extension)[intFromRef(v_ret_0)] >= charFromRef(c)
+      stringFromRef(this)[anon_builtin_0] < charFromRef(c))
+  ensures !(intFromRef(v_ret_0) == |stringFromRef(this)|) ==>
+    stringFromRef(this)[intFromRef(v_ret_0)] >= charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
@@ -17,14 +17,13 @@ method firstAtLeast(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
-    invariant 0 <= intFromRef(i) &&
-      intFromRef(i) <= |stringFromRef(v_this_extension)|
+    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
     invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
         anon_builtin_1 < intFromRef(i) ==>
-        stringFromRef(v_this_extension)[anon_builtin_1] < charFromRef(c))
-  anon_0 := ltInts(i, stringLength(v_this_extension))
+        stringFromRef(this)[anon_builtin_1] < charFromRef(c))
+  anon_0 := ltInts(i, stringLength(this))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(v_this_extension)[intFromRef(i)] >= charFromRef(c)) {
+    if (stringFromRef(this)[intFromRef(i)] >= charFromRef(c)) {
       goto break
     }
     i := plusInts(i, intToRef(1))
@@ -33,44 +32,42 @@ method firstAtLeast(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert 0 <= intFromRef(i) &&
-    intFromRef(i) <= |stringFromRef(v_this_extension)|
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
   assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
       anon_builtin_1 < intFromRef(i) ==>
-      stringFromRef(v_this_extension)[anon_builtin_1] < charFromRef(c))
+      stringFromRef(this)[anon_builtin_1] < charFromRef(c))
   v_ret_0 := i
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /string_iterations.kt: info: Generated Viper text for lastLess:
-method lastLess(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(v_this_extension), stringType())
+method lastLess(this: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures -1 <= intFromRef(v_ret_0) &&
-    intFromRef(v_ret_0) <= |stringFromRef(v_this_extension)| - 1
+    intFromRef(v_ret_0) <= |stringFromRef(this)| - 1
   ensures (forall anon_builtin_0: Int ::intFromRef(v_ret_0) <
       anon_builtin_0 &&
-      anon_builtin_0 < |stringFromRef(v_this_extension)| ==>
-      stringFromRef(v_this_extension)[anon_builtin_0] >= charFromRef(c))
+      anon_builtin_0 < |stringFromRef(this)| ==>
+      stringFromRef(this)[anon_builtin_0] >= charFromRef(c))
   ensures !(intFromRef(v_ret_0) == -1) ==>
-    stringFromRef(v_this_extension)[intFromRef(v_ret_0)] < charFromRef(c)
+    stringFromRef(this)[intFromRef(v_ret_0)] < charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
-  i := minusInts(stringLength(v_this_extension), intToRef(1))
+  i := minusInts(stringLength(this), intToRef(1))
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
-    invariant -1 <= intFromRef(i) &&
-      intFromRef(i) < |stringFromRef(v_this_extension)|
+    invariant -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(this)|
     invariant (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-        anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
-        stringFromRef(v_this_extension)[anon_builtin_1] >= charFromRef(c))
+        anon_builtin_1 < |stringFromRef(this)| ==>
+        stringFromRef(this)[anon_builtin_1] >= charFromRef(c))
   anon_0 := gtInts(i, intToRef(-1))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(v_this_extension)[intFromRef(i)] < charFromRef(c)) {
+    if (stringFromRef(this)[intFromRef(i)] < charFromRef(c)) {
       goto break
     }
     i := minusInts(i, intToRef(1))
@@ -79,11 +76,10 @@ method lastLess(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert -1 <= intFromRef(i) &&
-    intFromRef(i) < |stringFromRef(v_this_extension)|
+  assert -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(this)|
   assert (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
-      stringFromRef(v_this_extension)[anon_builtin_1] >= charFromRef(c))
+      anon_builtin_1 < |stringFromRef(this)| ==>
+      stringFromRef(this)[anon_builtin_1] >= charFromRef(c))
   v_ret_0 := i
   goto lbl_ret_0
   label lbl_ret_0


### PR DESCRIPTION
This PR allows user to write `verify(forAll<Int> { i -> i == i })` (and similar).

### Note
I had to add a second `forAll` method to the builtins. I don't like this, but I don't see another way to do it. It would be possible to only have one forAll but then we need to make sure that verify also runs an `InvariantBuilder`. But then the user would need to write 
```
verify {
  forAll<Int> { i -> i == i}
}
```
which seems strange.