### PR TITLE
Treat `forAll` as Special Kotlin Function

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -39,7 +39,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.toLink
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.equalToType
 import org.jetbrains.kotlin.formver.core.functionCallArguments
-import org.jetbrains.kotlin.formver.core.isFormverFunctionNamed
 import org.jetbrains.kotlin.text
 import org.jetbrains.kotlin.types.ConstantValueKind
 
@@ -285,33 +284,12 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         val symbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
             ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
 
-        val forAllLambda =
-            functionCall.extractFormverFirBlock { isFormverFunctionNamed("forAll") }
-        when {
-
-            forAllLambda != null -> {
-                if (!data.isValidForForAllBlock) throw SnaktInternalException(
-                    forAllLambda.source,
-                    "`forAll` scope is only allowed inside one of the `loopInvariants`, `preconditions` or `postconditions`."
-                )
-                //error("`forAll` scope is only allowed inside one of the `loopInvariants`, `preconditions` or `postconditions`.")
-                val forAllArg = forAllLambda.valueParameters.first()
-                val forAllBody = forAllLambda.body ?: throw SnaktInternalException(
-                    forAllLambda.body?.source, "Lambda body should be accessible in `forAll` function call."
-                )
-                return data.insertForAllFunctionCall(forAllArg.symbol, forAllBody)
-            }
-
-            else -> {
-                val callee = data.embedAnyFunction(symbol)
-                return callee.insertCall(
-                    functionCall.functionCallArguments.withVarargsHandled(data, callee),
-                    data,
-                    data.embedType(functionCall.resolvedType),
-                )
-            }
-
-        }
+        val callee = data.embedAnyFunction(symbol)
+        return callee.insertCall(
+            functionCall.functionCallArguments.withVarargsHandled(data, callee),
+            data,
+            data.embedType(functionCall.resolvedType),
+        )
     }
 
     override fun visitImplicitInvokeCall(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -5,8 +5,9 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.callables
 
-import org.jetbrains.kotlin.formver.core.embeddings.expression.Assert
-import org.jetbrains.kotlin.formver.core.embeddings.expression.IntLit
+import org.jetbrains.kotlin.formver.common.SnaktInternalException
+import org.jetbrains.kotlin.formver.core.conversion.insertForAllFunctionCall
+import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.AddCharInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.AddIntInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.And
@@ -22,8 +23,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubCharInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubIntInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.Xor
-import org.jetbrains.kotlin.formver.core.embeddings.expression.UnitLit
-import org.jetbrains.kotlin.formver.core.embeddings.expression.toBlock
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildFunctionPretype
 import org.jetbrains.kotlin.formver.core.embeddings.types.nullableAny
 import org.jetbrains.kotlin.formver.core.names.*
@@ -51,6 +50,10 @@ object SpecialKotlinFunctions {
     private val booleanArrayTypeName = buildName {
         packageScope(SpecialPackages.kotlin)
         ClassKotlinName(listOf("BooleanArray"))
+    }
+    private val invariantBuilderTypeName = buildName {
+        packageScope(SpecialPackages.formver)
+        ClassKotlinName(listOf("InvariantBuilder"))
     }
 
     val byName: Map<SymbolicName, FullySpecialKotlinFunction> = buildFullySpecialFunctions {
@@ -163,6 +166,41 @@ object SpecialKotlinFunctions {
         }
         addFunction(verifyCallableType, SpecialPackages.formver, name = "verify") { args, _ ->
             args.map { Assert(it) }.toBlock()
+        }
+
+        val forAllCallableType = buildFunctionPretype {
+            withParam {
+                function {
+                    withDispatchReceiver {
+                        klass {
+                            withName(invariantBuilderTypeName)
+                        }
+                    }
+                    withParam {
+                        nullableAny()
+                    }
+                    withReturnType {
+                        unit()
+                    }
+                }
+            }
+            withReturnType {
+                boolean()
+            }
+        }
+
+        addFunction(forAllCallableType, SpecialPackages.formver, name = "forAll") { args, ctx ->
+            val arg = args.first()
+            val lambda = arg.ignoringMetaNodes() as? LambdaExp ?: throw SnaktInternalException(
+                null,
+                "First argument of forAll function must be a lambda."
+            )
+            val param = lambda.function.valueParameters.first()
+            val body = lambda.function.body ?: throw SnaktInternalException(
+                null,
+                "Lambda body of forAll function must be present."
+            )
+            ctx.insertForAllFunctionCall(param.symbol, body)
         }
 
         val invariantsBuilderCallableType = buildFunctionPretype {

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/merge_sort_of_string.fir.diag.txt
@@ -1,8 +1,8 @@
 /merge_sort_of_string.kt: info: Generated Viper text for subs:
-method plus(v_this: Ref, other: Ref) returns (ret_4: Ref)
+method plus(v_this: Ref, other: Ref) returns (ret_6: Ref)
   requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret_4), stringType())
+  ensures isSubtype(typeOf(ret_6), stringType())
 
 
 method subs(v_this_extension: Ref, lo: Ref, hi: Ref) returns (v_ret_0: Ref)
@@ -171,32 +171,34 @@ method mergeStrings(a: Ref, b: Ref) returns (v_ret_0: Ref)
   label lbl_ret_0
 }
 
-method plus(this: Ref, other: Ref) returns (ret_4: Ref)
+method plus(this: Ref, other: Ref) returns (ret_7: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret_4), stringType())
+  ensures isSubtype(typeOf(ret_7), stringType())
 
 
 /merge_sort_of_string.kt: info: Generated Viper text for mergeSorted:
-method mergeSorted(this: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method mergeSorted(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(this)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_0: Int ::1 <= anon_builtin_0 &&
       anon_builtin_0 < |stringFromRef(v_ret_0)| ==>
       stringFromRef(v_ret_0)[anon_builtin_0 - 1] <=
       stringFromRef(v_ret_0)[anon_builtin_0])
 {
-  if (|stringFromRef(this)| <= 1) {
-    v_ret_0 := this
+  if (|stringFromRef(v_this_extension)| <= 1) {
+    v_ret_0 := v_this_extension
   } else {
     var anon_0: Ref
     var anon_1: Ref
     var anon_2: Ref
     var anon_3: Ref
-    anon_1 := subs(this, intToRef(0), divInts(stringLength(this), intToRef(2)))
+    anon_1 := subs(v_this_extension, intToRef(0), divInts(stringLength(v_this_extension),
+      intToRef(2)))
     anon_0 := mergeSorted(anon_1)
-    anon_3 := subs(this, divInts(stringLength(this), intToRef(2)), stringLength(this))
+    anon_3 := subs(v_this_extension, divInts(stringLength(v_this_extension),
+      intToRef(2)), stringLength(v_this_extension))
     anon_2 := mergeSorted(anon_3)
     v_ret_0 := mergeStrings(anon_0, anon_2)
   }
@@ -204,7 +206,7 @@ method mergeSorted(this: Ref) returns (v_ret_0: Ref)
   label lbl_ret_0
 }
 
-method mergeStrings(a: Ref, b: Ref) returns (ret_2: Ref)
+method mergeStrings(a: Ref, b: Ref) returns (ret_3: Ref)
   requires isSubtype(typeOf(a), stringType())
   requires isSubtype(typeOf(b), stringType())
   requires (forall anon_builtin_1: Int ::(1 <= anon_builtin_1 &&
@@ -214,23 +216,23 @@ method mergeStrings(a: Ref, b: Ref) returns (ret_2: Ref)
       (1 <= anon_builtin_1 && anon_builtin_1 < |stringFromRef(b)| ==>
       stringFromRef(b)[anon_builtin_1 - 1] <=
       stringFromRef(b)[anon_builtin_1]))
-  ensures isSubtype(typeOf(ret_2), stringType())
-  ensures |stringFromRef(ret_2)| == |stringFromRef(a)| + |stringFromRef(b)|
+  ensures isSubtype(typeOf(ret_3), stringType())
+  ensures |stringFromRef(ret_3)| == |stringFromRef(a)| + |stringFromRef(b)|
   ensures (forall anon_builtin_2: Int ::1 <= anon_builtin_2 &&
-      anon_builtin_2 < |stringFromRef(ret_2)| ==>
-      stringFromRef(ret_2)[anon_builtin_2 - 1] <=
-      stringFromRef(ret_2)[anon_builtin_2])
+      anon_builtin_2 < |stringFromRef(ret_3)| ==>
+      stringFromRef(ret_3)[anon_builtin_2 - 1] <=
+      stringFromRef(ret_3)[anon_builtin_2])
 
 
-method subs(this: Ref, lo: Ref, hi: Ref) returns (ret_3: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method subs(v_this_extension: Ref, lo: Ref, hi: Ref) returns (ret_6: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(lo), intType())
   requires isSubtype(typeOf(hi), intType())
   requires 0 <= intFromRef(lo) && intFromRef(lo) <= intFromRef(hi) &&
-    intFromRef(hi) <= |stringFromRef(this)|
-  ensures isSubtype(typeOf(ret_3), stringType())
-  ensures |stringFromRef(ret_3)| == intFromRef(hi) - intFromRef(lo)
+    intFromRef(hi) <= |stringFromRef(v_this_extension)|
+  ensures isSubtype(typeOf(ret_6), stringType())
+  ensures |stringFromRef(ret_6)| == intFromRef(hi) - intFromRef(lo)
   ensures (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
-      anon_builtin_3 < |stringFromRef(ret_3)| ==>
-      stringFromRef(ret_3)[anon_builtin_3] ==
-      stringFromRef(this)[anon_builtin_3 + intFromRef(lo)])
+      anon_builtin_3 < |stringFromRef(ret_6)| ==>
+      stringFromRef(ret_6)[anon_builtin_3] ==
+      stringFromRef(v_this_extension)[anon_builtin_3 + intFromRef(lo)])

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/quick_sort_of_string.fir.diag.txt
@@ -1,52 +1,56 @@
 /quick_sort_of_string.kt: info: Generated Viper text for minOrMaxChar:
-method minOrMaxChar(this: Ref, calcMin: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method minOrMaxChar(v_this_extension: Ref, calcMin: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(this)| >= 1
+  requires |stringFromRef(v_this_extension)| >= 1
   ensures isSubtype(typeOf(v_ret_0), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_0: Int ::0 <= anon_builtin_0 &&
-      anon_builtin_0 < |stringFromRef(this)| ==>
-      charFromRef(v_ret_0) <= stringFromRef(this)[anon_builtin_0])
+      anon_builtin_0 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(v_ret_0) <=
+      stringFromRef(v_this_extension)[anon_builtin_0])
   ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(this)| ==>
-      charFromRef(v_ret_0) >= stringFromRef(this)[anon_builtin_1])
+      anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(v_ret_0) >=
+      stringFromRef(v_this_extension)[anon_builtin_1])
 {
   var res: Ref
   var i: Ref
   var anon_0: Ref
-  res := stringGet(this, intToRef(0))
+  res := stringGet(v_this_extension, intToRef(0))
   i := intToRef(1)
   label cont
     invariant isSubtype(typeOf(res), charType())
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(calcMin), boolType())
-    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+    invariant 0 <= intFromRef(i) &&
+      intFromRef(i) <= |stringFromRef(v_this_extension)|
     invariant boolFromRef(calcMin) ==>
       (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
         anon_builtin_2 < intFromRef(i) ==>
-        charFromRef(res) <= stringFromRef(this)[anon_builtin_2])
+        charFromRef(res) <= stringFromRef(v_this_extension)[anon_builtin_2])
     invariant !boolFromRef(calcMin) ==>
       (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
         anon_builtin_3 < intFromRef(i) ==>
-        charFromRef(res) >= stringFromRef(this)[anon_builtin_3])
-  anon_0 := ltInts(i, stringLength(this))
+        charFromRef(res) >= stringFromRef(v_this_extension)[anon_builtin_3])
+  anon_0 := ltInts(i, stringLength(v_this_extension))
   if (boolFromRef(anon_0)) {
     var anon_1: Ref
     var anon_2: Ref
     if (boolFromRef(calcMin)) {
-      anon_2 := ltChars(stringGet(this, i), res)
+      anon_2 := ltChars(stringGet(v_this_extension, i), res)
     } else {
       anon_2 := boolToRef(false)}
     if (boolFromRef(anon_2)) {
       anon_1 := boolToRef(true)
     } elseif (!boolFromRef(calcMin)) {
-      anon_1 := gtChars(stringGet(this, i), res)
+      anon_1 := gtChars(stringGet(v_this_extension, i), res)
     } else {
       anon_1 := boolToRef(false)}
     if (boolFromRef(anon_1)) {
-      res := stringGet(this, i)
+      res := stringGet(v_this_extension, i)
     }
     i := plusInts(i, intToRef(1))
     goto cont
@@ -55,92 +59,96 @@ method minOrMaxChar(this: Ref, calcMin: Ref) returns (v_ret_0: Ref)
   assert isSubtype(typeOf(res), charType())
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(calcMin), boolType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+  assert 0 <= intFromRef(i) &&
+    intFromRef(i) <= |stringFromRef(v_this_extension)|
   assert boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
       anon_builtin_2 < intFromRef(i) ==>
-      charFromRef(res) <= stringFromRef(this)[anon_builtin_2])
+      charFromRef(res) <= stringFromRef(v_this_extension)[anon_builtin_2])
   assert !boolFromRef(calcMin) ==>
     (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
       anon_builtin_3 < intFromRef(i) ==>
-      charFromRef(res) >= stringFromRef(this)[anon_builtin_3])
+      charFromRef(res) >= stringFromRef(v_this_extension)[anon_builtin_3])
   v_ret_0 := res
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSort:
-method minOrMaxChar(this: Ref, calcMin: Ref) returns (ret_2: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method minOrMaxChar(v_this_extension: Ref, calcMin: Ref)
+  returns (ret_3: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(calcMin), boolType())
-  requires |stringFromRef(this)| >= 1
-  ensures isSubtype(typeOf(ret_2), charType())
+  requires |stringFromRef(v_this_extension)| >= 1
+  ensures isSubtype(typeOf(ret_3), charType())
   ensures boolFromRef(calcMin) ==>
     (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(this)| ==>
-      charFromRef(ret_2) <= stringFromRef(this)[anon_builtin_1])
+      anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(ret_3) <= stringFromRef(v_this_extension)[anon_builtin_1])
   ensures !boolFromRef(calcMin) ==>
     (forall anon_builtin_2: Int ::0 <= anon_builtin_2 &&
-      anon_builtin_2 < |stringFromRef(this)| ==>
-      charFromRef(ret_2) >= stringFromRef(this)[anon_builtin_2])
+      anon_builtin_2 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(ret_3) >= stringFromRef(v_this_extension)[anon_builtin_2])
 
 
-method quickSort(this: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method quickSort(v_this_extension: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   ensures isSubtype(typeOf(v_ret_0), stringType())
-  ensures |stringFromRef(v_ret_0)| == |stringFromRef(this)|
+  ensures |stringFromRef(v_ret_0)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_0: Int ::1 <= anon_builtin_0 &&
-      anon_builtin_0 < |stringFromRef(this)| ==>
+      anon_builtin_0 < |stringFromRef(v_this_extension)| ==>
       stringFromRef(v_ret_0)[anon_builtin_0 - 1] <=
       stringFromRef(v_ret_0)[anon_builtin_0])
 {
   var l0_minVal: Ref
   var l0_maxVal: Ref
-  if (|stringFromRef(this)| <= 1) {
-    v_ret_0 := this
+  if (|stringFromRef(v_this_extension)| <= 1) {
+    v_ret_0 := v_this_extension
     goto lbl_ret_0
   }
-  l0_minVal := minOrMaxChar(this, boolToRef(true))
-  l0_maxVal := minOrMaxChar(this, boolToRef(false))
-  v_ret_0 := quickSortRec(this, l0_minVal, l0_maxVal)
+  l0_minVal := minOrMaxChar(v_this_extension, boolToRef(true))
+  l0_maxVal := minOrMaxChar(v_this_extension, boolToRef(false))
+  v_ret_0 := quickSortRec(v_this_extension, l0_minVal, l0_maxVal)
   goto lbl_ret_0
   label lbl_ret_0
 }
 
-method quickSortRec(this: Ref, par_minVal: Ref, par_maxVal: Ref)
-  returns (ret_3: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method quickSortRec(v_this_extension: Ref, par_minVal: Ref, par_maxVal: Ref)
+  returns (ret_6: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(par_minVal), charType())
   requires isSubtype(typeOf(par_maxVal), charType())
   requires (forall anon_builtin_3: Int ::0 <= anon_builtin_3 &&
-      anon_builtin_3 < |stringFromRef(this)| ==>
-      charFromRef(par_minVal) <= stringFromRef(this)[anon_builtin_3] &&
-      stringFromRef(this)[anon_builtin_3] <= charFromRef(par_maxVal))
-  ensures isSubtype(typeOf(ret_3), stringType())
-  ensures |stringFromRef(ret_3)| == |stringFromRef(this)|
+      anon_builtin_3 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(par_minVal) <=
+      stringFromRef(v_this_extension)[anon_builtin_3] &&
+      stringFromRef(v_this_extension)[anon_builtin_3] <=
+      charFromRef(par_maxVal))
+  ensures isSubtype(typeOf(ret_6), stringType())
+  ensures |stringFromRef(ret_6)| == |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_4: Int ::0 <= anon_builtin_4 &&
-      anon_builtin_4 < |stringFromRef(this)| ==>
-      charFromRef(par_minVal) <= stringFromRef(ret_3)[anon_builtin_4] &&
-      stringFromRef(ret_3)[anon_builtin_4] <= charFromRef(par_maxVal))
+      anon_builtin_4 < |stringFromRef(v_this_extension)| ==>
+      charFromRef(par_minVal) <= stringFromRef(ret_6)[anon_builtin_4] &&
+      stringFromRef(ret_6)[anon_builtin_4] <= charFromRef(par_maxVal))
   ensures (forall anon_builtin_5: Int ::1 <= anon_builtin_5 &&
-      anon_builtin_5 < |stringFromRef(this)| ==>
-      stringFromRef(ret_3)[anon_builtin_5 - 1] <=
-      stringFromRef(ret_3)[anon_builtin_5])
+      anon_builtin_5 < |stringFromRef(v_this_extension)| ==>
+      stringFromRef(ret_6)[anon_builtin_5 - 1] <=
+      stringFromRef(ret_6)[anon_builtin_5])
 
 
 /quick_sort_of_string.kt: info: Generated Viper text for quickSortRec:
-method chooseIndex(v_this_extension: Ref) returns (ret_3: Ref)
+method chooseIndex(v_this_extension: Ref) returns (ret_6: Ref)
   requires isSubtype(typeOf(v_this_extension), stringType())
   requires |stringFromRef(v_this_extension)| >= 1
-  ensures isSubtype(typeOf(ret_3), intType())
-  ensures 0 <= intFromRef(ret_3) &&
-    intFromRef(ret_3) < |stringFromRef(v_this_extension)|
+  ensures isSubtype(typeOf(ret_6), intType())
+  ensures 0 <= intFromRef(ret_6) &&
+    intFromRef(ret_6) < |stringFromRef(v_this_extension)|
 
 
-method plus(v_this: Ref, other: Ref) returns (ret_5: Ref)
+method plus(v_this: Ref, other: Ref) returns (ret_11: Ref)
   requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret_5), stringType())
+  ensures isSubtype(typeOf(ret_11), stringType())
 
 
 method quickSortRec(v_this_extension: Ref, minVal: Ref, maxVal: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/z_function.fir.diag.txt
@@ -59,14 +59,14 @@ method zFuncHelper(s: Ref, res: Ref, i: Ref, checkedLeft: Ref, checkedRight: Ref
 }
 
 /z_function.kt: info: Generated Viper text for zFunction:
-method plus(v_this: Ref, other: Ref) returns (ret_2: Ref)
+method plus(v_this: Ref, other: Ref) returns (ret_4: Ref)
   requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret_2), stringType())
+  ensures isSubtype(typeOf(ret_4), stringType())
 
 
 method zFuncHelper(s: Ref, par_res: Ref, par_i: Ref, par_checkedLeft: Ref, par_checkedRight: Ref)
-  returns (ret_4: Ref)
+  returns (ret_9: Ref)
   requires isSubtype(typeOf(s), stringType())
   requires isSubtype(typeOf(par_res), stringType())
   requires isSubtype(typeOf(par_i), intType())
@@ -97,11 +97,11 @@ method zFuncHelper(s: Ref, par_res: Ref, par_i: Ref, par_checkedLeft: Ref, par_c
       intFromRef(par_checkedRight) - intFromRef(par_checkedLeft) ==>
       stringFromRef(s)[intFromRef(par_checkedLeft) + anon_builtin_7] ==
       stringFromRef(s)[anon_builtin_7])
-  ensures isSubtype(typeOf(ret_4), intType())
-  ensures intFromRef(par_i) <= intFromRef(ret_4) &&
-    intFromRef(ret_4) <= |stringFromRef(s)|
+  ensures isSubtype(typeOf(ret_9), intType())
+  ensures intFromRef(par_i) <= intFromRef(ret_9) &&
+    intFromRef(ret_9) <= |stringFromRef(s)|
   ensures (forall anon_builtin_8: Int ::intFromRef(par_i) <= anon_builtin_8 &&
-      anon_builtin_8 < intFromRef(ret_4) ==>
+      anon_builtin_8 < intFromRef(ret_9) ==>
       stringFromRef(s)[anon_builtin_8 - intFromRef(par_i)] ==
       stringFromRef(s)[anon_builtin_8])
 
@@ -274,10 +274,10 @@ method zFunction(v_this_extension: Ref) returns (v_ret_0: Ref)
 }
 
 /z_function.kt: info: Generated Viper text for zFunctionNaive:
-method plus(v_this: Ref, other: Ref) returns (ret_2: Ref)
+method plus(v_this: Ref, other: Ref) returns (ret_4: Ref)
   requires isSubtype(typeOf(v_this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret_2), stringType())
+  ensures isSubtype(typeOf(ret_4), stringType())
 
 
 method zFunctionNaive(v_this_extension: Ref) returns (v_ret_0: Ref)

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/string_iterations.fir.diag.txt
@@ -1,15 +1,15 @@
 /string_iterations.kt: info: Generated Viper text for firstAtLeast:
-method firstAtLeast(this: Ref, c: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method firstAtLeast(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures 0 <= intFromRef(v_ret_0) &&
-    intFromRef(v_ret_0) <= |stringFromRef(this)|
+    intFromRef(v_ret_0) <= |stringFromRef(v_this_extension)|
   ensures (forall anon_builtin_0: Int ::0 <= anon_builtin_0 &&
       anon_builtin_0 < intFromRef(v_ret_0) ==>
-      stringFromRef(this)[anon_builtin_0] < charFromRef(c))
-  ensures !(intFromRef(v_ret_0) == |stringFromRef(this)|) ==>
-    stringFromRef(this)[intFromRef(v_ret_0)] >= charFromRef(c)
+      stringFromRef(v_this_extension)[anon_builtin_0] < charFromRef(c))
+  ensures !(intFromRef(v_ret_0) == |stringFromRef(v_this_extension)|) ==>
+    stringFromRef(v_this_extension)[intFromRef(v_ret_0)] >= charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
@@ -17,13 +17,14 @@ method firstAtLeast(this: Ref, c: Ref) returns (v_ret_0: Ref)
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
-    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+    invariant 0 <= intFromRef(i) &&
+      intFromRef(i) <= |stringFromRef(v_this_extension)|
     invariant (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
         anon_builtin_1 < intFromRef(i) ==>
-        stringFromRef(this)[anon_builtin_1] < charFromRef(c))
-  anon_0 := ltInts(i, stringLength(this))
+        stringFromRef(v_this_extension)[anon_builtin_1] < charFromRef(c))
+  anon_0 := ltInts(i, stringLength(v_this_extension))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(this)[intFromRef(i)] >= charFromRef(c)) {
+    if (stringFromRef(v_this_extension)[intFromRef(i)] >= charFromRef(c)) {
       goto break
     }
     i := plusInts(i, intToRef(1))
@@ -32,42 +33,44 @@ method firstAtLeast(this: Ref, c: Ref) returns (v_ret_0: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(this)|
+  assert 0 <= intFromRef(i) &&
+    intFromRef(i) <= |stringFromRef(v_this_extension)|
   assert (forall anon_builtin_1: Int ::0 <= anon_builtin_1 &&
       anon_builtin_1 < intFromRef(i) ==>
-      stringFromRef(this)[anon_builtin_1] < charFromRef(c))
+      stringFromRef(v_this_extension)[anon_builtin_1] < charFromRef(c))
   v_ret_0 := i
   goto lbl_ret_0
   label lbl_ret_0
 }
 
 /string_iterations.kt: info: Generated Viper text for lastLess:
-method lastLess(this: Ref, c: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(this), stringType())
+method lastLess(v_this_extension: Ref, c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
   requires isSubtype(typeOf(c), charType())
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures -1 <= intFromRef(v_ret_0) &&
-    intFromRef(v_ret_0) <= |stringFromRef(this)| - 1
+    intFromRef(v_ret_0) <= |stringFromRef(v_this_extension)| - 1
   ensures (forall anon_builtin_0: Int ::intFromRef(v_ret_0) <
       anon_builtin_0 &&
-      anon_builtin_0 < |stringFromRef(this)| ==>
-      stringFromRef(this)[anon_builtin_0] >= charFromRef(c))
+      anon_builtin_0 < |stringFromRef(v_this_extension)| ==>
+      stringFromRef(v_this_extension)[anon_builtin_0] >= charFromRef(c))
   ensures !(intFromRef(v_ret_0) == -1) ==>
-    stringFromRef(this)[intFromRef(v_ret_0)] < charFromRef(c)
+    stringFromRef(v_this_extension)[intFromRef(v_ret_0)] < charFromRef(c)
 {
   var i: Ref
   var anon_0: Ref
-  i := minusInts(stringLength(this), intToRef(1))
+  i := minusInts(stringLength(v_this_extension), intToRef(1))
   label cont
     invariant isSubtype(typeOf(i), intType())
     invariant isSubtype(typeOf(c), charType())
-    invariant -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(this)|
+    invariant -1 <= intFromRef(i) &&
+      intFromRef(i) < |stringFromRef(v_this_extension)|
     invariant (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-        anon_builtin_1 < |stringFromRef(this)| ==>
-        stringFromRef(this)[anon_builtin_1] >= charFromRef(c))
+        anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
+        stringFromRef(v_this_extension)[anon_builtin_1] >= charFromRef(c))
   anon_0 := gtInts(i, intToRef(-1))
   if (boolFromRef(anon_0)) {
-    if (stringFromRef(this)[intFromRef(i)] < charFromRef(c)) {
+    if (stringFromRef(v_this_extension)[intFromRef(i)] < charFromRef(c)) {
       goto break
     }
     i := minusInts(i, intToRef(1))
@@ -76,10 +79,11 @@ method lastLess(this: Ref, c: Ref) returns (v_ret_0: Ref)
   label break
   assert isSubtype(typeOf(i), intType())
   assert isSubtype(typeOf(c), charType())
-  assert -1 <= intFromRef(i) && intFromRef(i) < |stringFromRef(this)|
+  assert -1 <= intFromRef(i) &&
+    intFromRef(i) < |stringFromRef(v_this_extension)|
   assert (forall anon_builtin_1: Int ::intFromRef(i) < anon_builtin_1 &&
-      anon_builtin_1 < |stringFromRef(this)| ==>
-      stringFromRef(this)[anon_builtin_1] >= charFromRef(c))
+      anon_builtin_1 < |stringFromRef(v_this_extension)| ==>
+      stringFromRef(v_this_extension)[anon_builtin_1] >= charFromRef(c))
   v_ret_0 := i
   goto lbl_ret_0
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/strings_in_conditions.fir.diag.txt
@@ -108,7 +108,7 @@ method addCharacterTimes(s: Ref, c: Ref, n: Ref) returns (v_ret_0: Ref)
   label lbl_ret_0
 }
 
-method plus(this: Ref, other: Ref) returns (ret_4: Ref)
+method plus(this: Ref, other: Ref) returns (ret_6: Ref)
   requires isSubtype(typeOf(this), stringType())
   requires isSubtype(typeOf(other), nullable(anyType()))
-  ensures isSubtype(typeOf(ret_4), stringType())
+  ensures isSubtype(typeOf(ret_6), stringType())


### PR DESCRIPTION
This PR removes the special case (for `forAll` expression) in `visitFunctionCall`. The `forAll` expression is now handled as an `SpecialKotlinFunction`