### PR TITLE
Drop redundant safe call on `hierarchyPathTo` result

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -430,7 +430,7 @@ data class LinearizationVisitor(
                     if (e.field.unfoldToAccess) {
                         val receiverWrapper = ExpWrapper(receiverViper, e.receiver.type)
                         val hierarchyPath = ctx.typeResolver.hierarchyPathTo(e.receiver.type.pretype, e.field)
-                        hierarchyPath?.forEach { classType ->
+                        hierarchyPath.forEach { classType ->
                             val predAcc = classType.predicateAccess(receiverWrapper, ctx.typeResolver, ctx.source)
                             ctx.addStatement { Stmt.Unfold(predAcc) }
                         }


### PR DESCRIPTION
`TypeResolver.hierarchyPathTo` returns a non-null `Sequence<ClassTypeEmbedding>`, but `visitFieldModification` in `LinearizationVisitor` called `hierarchyPath?.forEach`, producing an "unnecessary safe call on a non-null receiver" compiler warning. The other three callers (`Linearizer`, `PureExpLinearizer`, `PureFunBodyLinearizer`) already use plain member access; this aligns the last one.

No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)