### PR TITLE
Regenerate stale `formver.annotations` API dump

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Run detekt
         run: ./gradlew detekt
+      - name: Check public API compatibility
+        run: ./gradlew apiCheck
       - name: Run all tests (conversion + verification)
         run: ./gradlew :formver.compiler-plugin:test
       - name: Report failing test results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,6 @@ repos:
     rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
+        # Generated API dumps end with a trailing blank line that `apiCheck`
+        # requires; the fixer would strip it and break the check.
+        exclude: '\.api$'

--- a/formver.annotations/api/formver.annotations.api
+++ b/formver.annotations/api/formver.annotations.api
@@ -5,10 +5,12 @@ public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/B
 }
 
 public final class org/jetbrains/kotlin/formver/plugin/BuiltinsKt {
+	public static final fun forAll (Lkotlin/jvm/functions/Function2;)Z
 	public static final fun implies (ZZ)Z
-	public static final fun loopInvariants (Lkotlin/jvm/functions/Function1;)V
-	public static final fun postconditions (Lkotlin/jvm/functions/Function2;)V
-	public static final fun preconditions (Lkotlin/jvm/functions/Function1;)V
+	public static final fun loopInvariants (Lkotlin/jvm/functions/Function0;)V
+	public static final fun old (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun postconditions (Lkotlin/jvm/functions/Function1;)V
+	public static final fun preconditions (Lkotlin/jvm/functions/Function0;)V
 	public static final fun verify ([Z)V
 }
 
@@ -17,7 +19,6 @@ public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/D
 
 public final class org/jetbrains/kotlin/formver/plugin/InvariantBuilder {
 	public fun <init> ()V
-	public final fun forAll (Lkotlin/jvm/functions/Function1;)Z
 	public final fun triggers ([Ljava/lang/Object;)V
 }
 
@@ -35,3 +36,4 @@ public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/P
 
 public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/Unique : java/lang/annotation/Annotation {
 }
+


### PR DESCRIPTION
The checked-in `formver.annotations/api/formver.annotations.api` had drifted from the module's actual public surface, so `./gradlew apiCheck` (and therefore `build`) fails on a clean `main`. Missing/outdated entries:

- top-level `forAll` and `old` builtins were absent;
- `loopInvariants`/`preconditions` now take `Function0`, `postconditions` takes `Function1` (the dump still had the old `Function1`/`Function2` shapes);
- `InvariantBuilder.forAll` was removed but still listed.

Regenerated with `./gradlew apiDump`; `apiCheck` passes again.

This drift went unnoticed because `.github/workflows/gradle.yml` only ran `detekt` and `:formver.compiler-plugin:test` — it never invoked `apiCheck`, `check`, or `build`. This PR also adds an `apiCheck` step to CI so the dump can't silently drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)