### PR TITLE
Added Manual Folds + Unfolds

### DIFF
--- a/formver.annotations/api/formver.annotations.api
+++ b/formver.annotations/api/formver.annotations.api
@@ -5,17 +5,21 @@ public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/B
 }
 
 public final class org/jetbrains/kotlin/formver/plugin/BuiltinsKt {
-	public static final fun acc (Ljava/lang/Object;Ljava/lang/Object;)Z
-	public static synthetic fun acc$default (Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Z
+	public static final fun acc (Ljava/lang/Object;Lorg/jetbrains/kotlin/formver/plugin/Permission;)Z
+	public static synthetic fun acc$default (Ljava/lang/Object;Lorg/jetbrains/kotlin/formver/plugin/Permission;ILjava/lang/Object;)Z
+	public static final fun fold (Lorg/jetbrains/kotlin/formver/plugin/Predicate;Lorg/jetbrains/kotlin/formver/plugin/Permission;)V
+	public static synthetic fun fold$default (Lorg/jetbrains/kotlin/formver/plugin/Predicate;Lorg/jetbrains/kotlin/formver/plugin/Permission;ILjava/lang/Object;)V
 	public static final fun forAll (Lkotlin/jvm/functions/Function2;)Z
 	public static final fun implies (ZZ)Z
 	public static final fun loopInvariants (Lkotlin/jvm/functions/Function0;)V
 	public static final fun old (Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun postconditions (Lkotlin/jvm/functions/Function1;)V
 	public static final fun preconditions (Lkotlin/jvm/functions/Function0;)V
-	public static final fun read ()Ljava/lang/Object;
+	public static final fun read ()Lorg/jetbrains/kotlin/formver/plugin/Permission;
+	public static final fun unfold (Lorg/jetbrains/kotlin/formver/plugin/Predicate;Lorg/jetbrains/kotlin/formver/plugin/Permission;)V
+	public static synthetic fun unfold$default (Lorg/jetbrains/kotlin/formver/plugin/Predicate;Lorg/jetbrains/kotlin/formver/plugin/Permission;ILjava/lang/Object;)V
 	public static final fun verify ([Z)V
-	public static final fun write ()Ljava/lang/Object;
+	public static final fun write ()Lorg/jetbrains/kotlin/formver/plugin/Permission;
 }
 
 public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/DumpExpEmbeddings : java/lang/annotation/Annotation {
@@ -35,9 +39,28 @@ public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/N
 public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/NeverVerify : java/lang/annotation/Annotation {
 }
 
+public abstract interface class org/jetbrains/kotlin/formver/plugin/Permission {
+}
+
+public abstract class org/jetbrains/kotlin/formver/plugin/Predicate {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getExp ()Ljava/lang/Object;
+}
+
 public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/Pure : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class org/jetbrains/kotlin/formver/plugin/Unique : java/lang/annotation/Annotation {
+}
+
+public final class org/jetbrains/kotlin/formver/plugin/UniquePred : org/jetbrains/kotlin/formver/plugin/Predicate {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lorg/jetbrains/kotlin/formver/plugin/UniquePred;
+	public static synthetic fun copy$default (Lorg/jetbrains/kotlin/formver/plugin/UniquePred;Ljava/lang/Object;ILjava/lang/Object;)Lorg/jetbrains/kotlin/formver/plugin/UniquePred;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
@@ -20,5 +20,11 @@ annotation class Borrowed
 @Target(AnnotationTarget.FUNCTION)
 annotation class Pure
 
+/**
+ * Disables automatic permission management for the annotated element.
+ *
+ * On a class, the automatic folding, unfolding, and havoc of that class's uniqueness predicate
+ * are turned off, leaving its permissions to be managed explicitly.
+ */
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class Manual

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
@@ -20,5 +20,5 @@ annotation class Borrowed
 @Target(AnnotationTarget.FUNCTION)
 annotation class Pure
 
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class Manual

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -45,7 +45,14 @@ fun acc(
 ): Boolean =
     throw FormverFunctionCalledInRuntimeException("acc")
 
+/**
+ * An amount of permission to a location, such as full ([write]) or read-only ([read]).
+ */
 interface Permission
+
+/**
+ * A verification predicate over [exp].
+ */
 abstract class Predicate(val exp: Any)
 
 /**
@@ -60,15 +67,27 @@ fun read(): Permission =
 fun write(): Permission =
     throw FormverFunctionCalledInRuntimeException("write")
 
-
+/**
+ * The uniqueness predicate of [data]: exclusive access to [data] and its fields.
+ */
 data class UniquePred(val data: Any) : Predicate(data)
 
+/**
+ * Exchanges [exp] for access to its body, exposing the underlying fields. The inverse of [fold].
+ *
+ * [permission] is the amount of the predicate to unfold, defaulting to full ([write]).
+ */
 fun unfold(
     @Suppress("UNUSED_PARAMETER") exp: Predicate,
     @Suppress("UNUSED_PARAMETER") permission: Permission? = null
 ): Unit =
     throw FormverFunctionCalledInRuntimeException("unfold")
 
+/**
+ * Exchanges access to [exp]'s body for the predicate itself. The inverse of [unfold].
+ *
+ * [permission] is the amount of the predicate to fold, defaulting to full ([write]).
+ */
 fun fold(
     @Suppress("UNUSED_PARAMETER") exp: Predicate,
     @Suppress("UNUSED_PARAMETER") permission: Permission? = null

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -39,20 +39,40 @@ fun <T> old(@Suppress("UNUSED_PARAMETER") body: T): T =
  * permission is requested; use [write] for full (the default) or [read] for a read-only
  * (wildcard) fraction.
  */
-fun acc(@Suppress("UNUSED_PARAMETER") path: Any?, @Suppress("UNUSED_PARAMETER") permission: Any? = null): Boolean =
+fun acc(
+    @Suppress("UNUSED_PARAMETER") path: Any?,
+    @Suppress("UNUSED_PARAMETER") permission: Permission? = null
+): Boolean =
     throw FormverFunctionCalledInRuntimeException("acc")
+
+interface Permission
+abstract class Predicate(val exp: Any)
 
 /**
  * Denotes a read-only (wildcard) permission amount. Only meaningful as the second argument of [acc].
  */
-fun read(): Any? =
+fun read(): Permission =
     throw FormverFunctionCalledInRuntimeException("read")
 
 /**
  * Denotes a full (write) permission amount. Only meaningful as the second argument of [acc].
  */
-fun write(): Any? =
+fun write(): Permission =
     throw FormverFunctionCalledInRuntimeException("write")
+
+
+data class UniquePred(val data: Any) : Predicate(data)
+
+fun unfold(
+    @Suppress("UNUSED_PARAMETER") exp: Predicate,
+    @Suppress("UNUSED_PARAMETER") permission: Permission? = null
+): Unit =
+    throw FormverFunctionCalledInRuntimeException("unfold")
+
+fun fold(
+    @Suppress("UNUSED_PARAMETER") exp: Predicate,
+    @Suppress("UNUSED_PARAMETER") permission: Permission? = null
+): Unit = throw FormverFunctionCalledInRuntimeException("fold")
 
 class InvariantBuilder {
     /**

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -79,6 +80,8 @@ fun FirBasedSymbol<*>.isBorrowed(session: FirSession) = hasAnnotation(annotation
 fun FirBasedSymbol<*>.isPure(session: FirSession) = hasAnnotation(annotationId("Pure"), session)
 
 fun FirBasedSymbol<*>.isManual(session: FirSession) = hasAnnotation(annotationId("Manual"), session)
+
+fun FirClassSymbol<*>.isManual(session: FirSession) = hasAnnotation(annotationId("Manual"), session)
 
 fun FirAnnotationContainer.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -80,8 +79,6 @@ fun FirBasedSymbol<*>.isBorrowed(session: FirSession) = hasAnnotation(annotation
 fun FirBasedSymbol<*>.isPure(session: FirSession) = hasAnnotation(annotationId("Pure"), session)
 
 fun FirBasedSymbol<*>.isManual(session: FirSession) = hasAnnotation(annotationId("Manual"), session)
-
-fun FirClassSymbol<*>.isManual(session: FirSession) = hasAnnotation(annotationId("Manual"), session)
 
 fun FirAnnotationContainer.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -580,11 +580,13 @@ class ProgramConverter(
 
         val embedding = typeResolver.getEmbeddingOrExecute(className) {
             val classEmbedding = buildClassPretype {
-                isManual = symbol.isManual(session)
                 withName(className)
             }
 
             typeResolver.register(classEmbedding, symbol.classKind.isInterface)
+            if (symbol.isManual(session)) {
+                typeResolver.markManual(className)
+            }
 
             symbol.resolvedSuperTypes.forEach {
                 val superTypeName = embedType(it).pretype.name

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -580,6 +580,7 @@ class ProgramConverter(
 
         val embedding = typeResolver.getEmbeddingOrExecute(className) {
             val classEmbedding = buildClassPretype {
+                isManual = symbol.isManual(session)
                 withName(className)
             }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
@@ -36,6 +36,11 @@ class TypeResolver {
     private val properties = mutableMapOf<ClassPropertyPair, PropertyEmbedding>()
 
     /**
+     * Names of classes marked `@Manual`.
+     */
+    private val manualClassNames = mutableSetOf<SymbolicName>()
+
+    /**
      * Register a class or interface type embedding.
      * This is needed to know which classes were already registered.
      */
@@ -43,6 +48,13 @@ class TypeResolver {
         true -> interfaceEmbedding.putIfAbsent(typeEmbedding.name, typeEmbedding)
         false -> classEmbedding.putIfAbsent(typeEmbedding.name, typeEmbedding)
     }
+
+    fun markManual(name: SymbolicName) {
+        manualClassNames.add(name)
+    }
+
+    val ClassTypeEmbedding.isManual: Boolean
+        get() = name in manualClassNames
 
     private fun toBackingField(property: PropertyEmbedding): FieldEmbedding? =
         (property.getter as? BackingFieldGetter)?.field

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
@@ -54,4 +54,6 @@ interface ExpVisitor<R> {
     fun visitExpWrapper(e: ExpWrapper): R = visitDefault(e)
     fun visitVariableEmbedding(e: VariableEmbedding): R = visitDefault(e)
     fun visitAccEmbedding(e: AccEmbedding): R = visitDefault(e)
+    fun visitFold(e: Fold): R = visitDefault(e)
+    fun visitUnfold(e: Unfold): R = visitDefault(e)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -130,19 +130,28 @@ object SpecialKotlinFunctions {
 
         withCallableType(booleanBooleanToBooleanType) {
             addFunction(
-                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "and"
+                booleanBooleanToBooleanType,
+                SpecialPackages.kotlin,
+                className = "Boolean",
+                name = "and"
             ) { args, _ ->
                 And(args[0], args[1])
             }
 
             addFunction(
-                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "or"
+                booleanBooleanToBooleanType,
+                SpecialPackages.kotlin,
+                className = "Boolean",
+                name = "or"
             ) { args, _ ->
                 Or(args[0], args[1])
             }
 
             addFunction(
-                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "xor"
+                booleanBooleanToBooleanType,
+                SpecialPackages.kotlin,
+                className = "Boolean",
+                name = "xor"
             ) { args, _ ->
                 Xor(args[0], args[1])
             }
@@ -206,11 +215,13 @@ object SpecialKotlinFunctions {
         addFunction(forAllCallableType, SpecialPackages.formver, name = "forAll") { args, ctx ->
             val arg = args.first()
             val lambda = arg.ignoringMetaNodes() as? LambdaExp ?: throw SnaktInternalException(
-                null, "First argument of forAll function must be a lambda."
+                null,
+                "First argument of forAll function must be a lambda."
             )
             val param = lambda.function.valueParameters.first()
             val body = lambda.function.body ?: throw SnaktInternalException(
-                null, "Lambda body of forAll function must be present."
+                null,
+                "Lambda body of forAll function must be present."
             )
             ctx.insertForAllFunctionCall(param.symbol, body)
         }
@@ -237,13 +248,13 @@ object SpecialKotlinFunctions {
             }
         }
 
-        fun extractPredicate(exp: MethodCall, permissions: ExpEmbedding?): PredicateAccessPermissions {
-
-            val permissions = extractPermission(permissions)
-
-            return when (exp.type.pretype.name) {
+        fun extractPredicate(exp: MethodCall, perm: PermissionLit): PredicateAccessPermissions =
+            when (exp.type.pretype.name) {
                 uniquePredTypeName -> {
-                    val arg = exp.args.firstOrNull()!!
+                    val arg = exp.args.firstOrNull() ?: throw SnaktInternalException(
+                        null,
+                        "Predicate constructor call is missing its argument."
+                    )
                     val type = arg.type.pretype as? ClassTypeEmbedding ?: throw SnaktInternalException(
                         null,
                         "Can only unfold the unique predicates of classes"
@@ -251,13 +262,12 @@ object SpecialKotlinFunctions {
                     PredicateAccessPermissions(
                         type.uniquePredicateName,
                         listOf(arg.ignoringCastsAndMetaNodes()),
-                        permissions.perm
+                        perm.perm
                     )
                 }
 
                 else -> throw SnaktInternalException(null, "Unknown predicate")
             }
-        }
 
         val accCallableType = buildFunctionPretype {
             withParam { nullableAny() }
@@ -271,23 +281,19 @@ object SpecialKotlinFunctions {
         }
         addFunction(accCallableType, SpecialPackages.formver, name = "acc") { args, ctx ->
             val source = (args.firstOrNull() as? WithPosition)?.source
-
             val perm = extractPermission(args.getOrNull(1))
-
-            when (val exp = args.firstOrNull()?.ignoringCastsAndMetaNodes()) {
-                null -> throw SnaktInternalException(
-                    source, "First argument of `acc` must be a field access like `x.a`."
-                )
-
-                is FieldAccess -> AccEmbedding(exp.receiver, exp.field, perm.perm)
-                is MethodCall -> extractPredicate(exp, args.getOrNull(1))
-
-                else -> throw SnaktInternalException(
-                    source, "First argument of `acc` must be a field access like `x.a` or a predicate."
-                )
+            ctx.withNoScope {
+                when (val exp = args.firstOrNull()?.ignoringCastsAndMetaNodes()) {
+                    null -> throw SnaktInternalException(
+                        source, "First argument of `acc` must be a field access like `x.a`."
+                    )
+                    is FieldAccess -> AccEmbedding(exp.receiver, exp.field, perm.perm)
+                    is MethodCall -> extractPredicate(exp, perm)
+                    else -> throw SnaktInternalException(
+                        source, "First argument of `acc` must be a field access like `x.a` or a predicate."
+                    )
+                }
             }
-
-
         }
 
         val invariantsBuilderCallableType = buildFunctionPretype {
@@ -362,10 +368,7 @@ object SpecialKotlinFunctions {
 
         val stringIntToCharType = buildFunctionPretype {
             withDispatchReceiver { string() }
-            withParam {
-
-                int()
-            }
+            withParam { int() }
             withReturnType { char() }
         }
 
@@ -389,19 +392,19 @@ object SpecialKotlinFunctions {
         }
         addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "unfold") { args, ctx ->
             val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
-                null, "First argument of unfold must be constructor to a predicate."
+                null, "First argument of `unfold` must be a predicate constructor call like `UniquePred(x)`."
             )
             Unfold(
-                extractPredicate(exp, args.getOrNull(1))
+                extractPredicate(exp, extractPermission(args.getOrNull(1)))
             )
         }
 
         addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "fold") { args, ctx ->
             val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
-                null, "First argument of unfold must be constructor to a predicate."
+                null, "First argument of `fold` must be a predicate constructor call like `UniquePred(x)`."
             )
             Fold(
-                extractPredicate(exp, args.getOrNull(1))
+                extractPredicate(exp, extractPermission(args.getOrNull(1)))
             )
         }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubCharInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubIntInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.Xor
+import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildFunctionPretype
 import org.jetbrains.kotlin.formver.core.embeddings.types.nullableAny
 import org.jetbrains.kotlin.formver.core.names.*
@@ -55,6 +56,19 @@ object SpecialKotlinFunctions {
     private val invariantBuilderTypeName = buildName {
         packageScope(SpecialPackages.formver)
         ClassKotlinName(listOf("InvariantBuilder"))
+    }
+    private val uniquePredTypeName = buildName {
+        packageScope(SpecialPackages.formver)
+        ClassKotlinName(listOf("UniquePred"))
+    }
+    private val predicateTypeName = buildName {
+        packageScope(SpecialPackages.formver)
+        ClassKotlinName(listOf("Predicate"))
+    }
+
+    private val permissionTypeName = buildName {
+        packageScope(SpecialPackages.formver)
+        ClassKotlinName(listOf("Permission"))
     }
 
     val byName: Map<SymbolicName, FullySpecialKotlinFunction> = buildFullySpecialFunctions {
@@ -116,28 +130,19 @@ object SpecialKotlinFunctions {
 
         withCallableType(booleanBooleanToBooleanType) {
             addFunction(
-                booleanBooleanToBooleanType,
-                SpecialPackages.kotlin,
-                className = "Boolean",
-                name = "and"
+                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "and"
             ) { args, _ ->
                 And(args[0], args[1])
             }
 
             addFunction(
-                booleanBooleanToBooleanType,
-                SpecialPackages.kotlin,
-                className = "Boolean",
-                name = "or"
+                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "or"
             ) { args, _ ->
                 Or(args[0], args[1])
             }
 
             addFunction(
-                booleanBooleanToBooleanType,
-                SpecialPackages.kotlin,
-                className = "Boolean",
-                name = "xor"
+                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "xor"
             ) { args, _ ->
                 Xor(args[0], args[1])
             }
@@ -201,13 +206,11 @@ object SpecialKotlinFunctions {
         addFunction(forAllCallableType, SpecialPackages.formver, name = "forAll") { args, ctx ->
             val arg = args.first()
             val lambda = arg.ignoringMetaNodes() as? LambdaExp ?: throw SnaktInternalException(
-                null,
-                "First argument of forAll function must be a lambda."
+                null, "First argument of forAll function must be a lambda."
             )
             val param = lambda.function.valueParameters.first()
             val body = lambda.function.body ?: throw SnaktInternalException(
-                null,
-                "Lambda body of forAll function must be present."
+                null, "Lambda body of forAll function must be present."
             )
             ctx.insertForAllFunctionCall(param.symbol, body)
         }
@@ -220,28 +223,67 @@ object SpecialKotlinFunctions {
             addFunction(SpecialPackages.formver, name = "write") { _, _ -> PermissionLit(PermExp.FullPerm()) }
         }
 
+        fun extractPermission(exp: ExpEmbedding?): PermissionLit {
+            return when (val perm = exp?.ignoringCastsAndMetaNodes()) {
+                null -> PermissionLit(PermExp.FullPerm())
+                is PermissionLit -> perm
+                else -> throw SnaktInternalException(
+                    null, "First argument of `acc` must be `read()` or `write()`."
+                )
+            }
+        }
+
+        fun extractPredicate(exp: MethodCall, permissions: ExpEmbedding?): PredicateAccessPermissions {
+
+            val permissions = extractPermission(permissions)
+
+            return when (exp.type.pretype.name) {
+                uniquePredTypeName -> {
+                    val arg = exp.args.firstOrNull()!!
+                    val type = arg.type.pretype as? ClassTypeEmbedding ?: throw SnaktInternalException(
+                        null,
+                        "Can only unfold the unique predicates of classes"
+                    )
+                    PredicateAccessPermissions(
+                        type.uniquePredicateName,
+                        listOf(arg.ignoringCastsAndMetaNodes()),
+                        permissions.perm
+                    )
+                }
+
+                else -> throw SnaktInternalException(null, "Unknown predicate")
+            }
+        }
+
         val accCallableType = buildFunctionPretype {
             withParam { nullableAny() }
-            withParam { nullableAny() }
+            withParam {
+                isNullable = true
+                klass {
+                    withName(permissionTypeName)
+                }
+            }
             withReturnType { boolean() }
         }
         addFunction(accCallableType, SpecialPackages.formver, name = "acc") { args, ctx ->
             val source = (args.firstOrNull() as? WithPosition)?.source
-            val fieldAccess = args.first().ignoringCastsAndMetaNodes() as? FieldAccess ?: throw SnaktInternalException(
-                source,
-                "First argument of `acc` must be a field access like `x.a`."
-            )
-            val perm = when (val permArg = args.getOrNull(1)?.ignoringCastsAndMetaNodes()) {
-                null, NullLit -> PermExp.FullPerm()
-                is PermissionLit -> permArg.perm
+
+            val perm = extractPermission(args.getOrNull(1))
+
+            when (val exp = args.firstOrNull()?.ignoringCastsAndMetaNodes()) {
+                null -> throw SnaktInternalException(
+                    source, "First argument of `acc` must be a field access like `x.a`."
+                )
+
+                is FieldAccess -> AccEmbedding(exp.receiver, exp.field, perm.perm)
+                is MethodCall -> extractPredicate(exp, args.getOrNull(1))
+
                 else -> throw SnaktInternalException(
-                    source,
-                    "Second argument of `acc` must be `read()` or `write()`."
+                    source, "First argument of `acc` must be a field access like `x.a` or a predicate."
                 )
             }
-            ctx.withNoScope {
-                AccEmbedding(fieldAccess.receiver, fieldAccess.field, perm)
-            }
+
+
         }
 
         val invariantsBuilderCallableType = buildFunctionPretype {
@@ -316,12 +358,47 @@ object SpecialKotlinFunctions {
 
         val stringIntToCharType = buildFunctionPretype {
             withDispatchReceiver { string() }
-            withParam { int() }
+            withParam {
+
+                int()
+            }
             withReturnType { char() }
         }
 
         addFunction(stringIntToCharType, SpecialPackages.kotlin, className = "String", name = "get") { args, _ ->
             StringGet(args[0], args[1])
+        }
+
+        val uniquePredicatePermissionsToUnit = buildFunctionPretype {
+            withParam {
+                klass {
+                    withName(predicateTypeName)
+                }
+            }
+            withParam {
+                isNullable = true
+                klass {
+                    withName(permissionTypeName)
+                }
+            }
+            withReturnType { unit() }
+        }
+        addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "unfold") { args, ctx ->
+            val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
+                null, "First argument of unfold must be constructor to a predicate."
+            )
+            Unfold(
+                extractPredicate(exp, args.getOrNull(1))
+            )
+        }
+
+        addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "fold") { args, ctx ->
+            val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
+                null, "First argument of unfold must be constructor to a predicate."
+            )
+            Fold(
+                extractPredicate(exp, args.getOrNull(1))
+            )
         }
     }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -216,7 +216,11 @@ object SpecialKotlinFunctions {
         }
 
         val permissionCallableType = buildFunctionPretype {
-            withReturnType { nullableAny() }
+            withReturnType {
+                klass {
+                    withName(permissionTypeName)
+                }
+            }
         }
         withCallableType(permissionCallableType) {
             addFunction(SpecialPackages.formver, name = "read") { _, _ -> PermissionLit(PermExp.WildcardPerm()) }
@@ -228,7 +232,7 @@ object SpecialKotlinFunctions {
                 null -> PermissionLit(PermExp.FullPerm())
                 is PermissionLit -> perm
                 else -> throw SnaktInternalException(
-                    null, "First argument of `acc` must be `read()` or `write()`."
+                    null, "Second argument of `acc` must be `read()` or `write()`."
                 )
             }
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
@@ -66,4 +66,3 @@ data class Fold(val pred: PredicateAccessPermissions) : ExpEmbedding {
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(pred)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFold(this)
 }
-

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
@@ -51,3 +51,19 @@ data class InhaleDirect(val exp: ExpEmbedding) : ExpEmbedding {
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(exp)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitInhaleDirect(this)
 }
+
+
+data class Unfold(val pred: PredicateAccessPermissions) : ExpEmbedding {
+    override val type: TypeEmbedding = buildType { unit() }
+
+    override fun children(): Sequence<ExpEmbedding> = sequenceOf(pred)
+    override fun <R> accept(v: ExpVisitor<R>): R = v.visitUnfold(this)
+}
+
+data class Fold(val pred: PredicateAccessPermissions) : ExpEmbedding {
+    override val type: TypeEmbedding = buildType { unit() }
+
+    override fun children(): Sequence<ExpEmbedding> = sequenceOf(pred)
+    override fun <R> accept(v: ExpVisitor<R>): R = v.visitFold(this)
+}
+

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/debug/DebugTreeViewVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/debug/DebugTreeViewVisitor.kt
@@ -7,7 +7,6 @@ package org.jetbrains.kotlin.formver.core.embeddings.expression.debug
 
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
-import org.jetbrains.kotlin.formver.core.embeddings.toLink
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.mangled
 
@@ -29,6 +28,29 @@ class DebugTreeViewVisitor(private val nameResolver: NameResolver) : ExpVisitor<
         val allSubtrees = anonymousSubtrees + namedSubtrees + extraSubtrees
         return if (allSubtrees.isNotEmpty()) NamedBranchingNode(name, allSubtrees)
         else PlaintextLeaf(name)
+    }
+
+    // endregion
+
+
+    // region Permissions
+
+    override fun visitFold(e: Fold): TreeView = with(nameResolver) {
+        defaultTree(
+            "Fold",
+            extraSubtrees = listOf(
+                e.pred.debugTreeView
+            ),
+        )
+    }
+
+    override fun visitUnfold(e: Unfold): TreeView = with(nameResolver) {
+        defaultTree(
+            "Unfold",
+            extraSubtrees = listOf(
+                e.pred.debugTreeView
+            ),
+        )
     }
 
     // endregion

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Predicate
 
 // TODO: incorporate generic parameters.
-data class ClassTypeEmbedding(override val name: ScopedName) : PretypeEmbedding {
+data class ClassTypeEmbedding(override val name: ScopedName, val isManual: Boolean) : PretypeEmbedding {
 
     override val runtimeType: Exp = this.embedClassTypeFunc()()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Predicate
 
 // TODO: incorporate generic parameters.
-data class ClassTypeEmbedding(override val name: ScopedName, val isManual: Boolean) : PretypeEmbedding {
+data class ClassTypeEmbedding(override val name: ScopedName) : PretypeEmbedding {
 
     override val runtimeType: Exp = this.embedClassTypeFunc()()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeBuilder.kt
@@ -105,6 +105,7 @@ fun buildFunctionPretype(init: FunctionPretypeBuilder.() -> Unit): FunctionTypeE
 
 class ClassPretypeBuilder : PretypeBuilder {
     private var className: ScopedName? = null
+    var isManual = false
 
     fun withName(name: ScopedName) {
         require(className == null) { "Class name already set" }
@@ -113,7 +114,7 @@ class ClassPretypeBuilder : PretypeBuilder {
 
     override fun complete(): ClassTypeEmbedding {
         require(className != null) { "Class name not set" }
-        return ClassTypeEmbedding(className!!)
+        return ClassTypeEmbedding(className!!, isManual)
     }
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeBuilder.kt
@@ -105,7 +105,6 @@ fun buildFunctionPretype(init: FunctionPretypeBuilder.() -> Unit): FunctionTypeE
 
 class ClassPretypeBuilder : PretypeBuilder {
     private var className: ScopedName? = null
-    var isManual = false
 
     fun withName(name: ScopedName) {
         require(className == null) { "Class name already set" }
@@ -114,7 +113,7 @@ class ClassPretypeBuilder : PretypeBuilder {
 
     override fun complete(): ClassTypeEmbedding {
         require(className != null) { "Class name not set" }
-        return ClassTypeEmbedding(className!!, isManual)
+        return ClassTypeEmbedding(className!!)
     }
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.*
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toFuncApp
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toMethodCall
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
+import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
 import org.jetbrains.kotlin.formver.core.embeddings.types.predicateAccess
@@ -421,13 +422,13 @@ data class LinearizationVisitor(
     override fun visitFieldModification(e: FieldModification): Linearizable = object : UnitResultLinearizable(e) {
         override fun toViperUnusedResult(ctx: LinearizationContext) {
             when (e.field.accessPolicy) {
-                AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+                AccessPolicy.BY_RECEIVER_UNIQUENESS if false -> {
                     e.receiver.linearize().toViperUnusedResult(ctx)
                     e.newValue.linearize().toViperUnusedResult(ctx)
                 }
                 else -> {
                     val receiverViper = e.receiver.linearize().toViper(ctx)
-                    if (e.field.unfoldToAccess) {
+                    if (e.field.unfoldToAccess && !(e.receiver.type.pretype as ClassTypeEmbedding).isManual) {
                         val receiverWrapper = ExpWrapper(receiverViper, e.receiver.type)
                         val hierarchyPath = ctx.typeResolver.hierarchyPathTo(e.receiver.type.pretype, e.field)
                         hierarchyPath.forEach { classType ->

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -458,6 +458,22 @@ data class LinearizationVisitor(
             Exp.PredicateAccess(e.predicateName, e.args.map { it.linearize().toViper(ctx) }, e.perm, ctx.source.asPosition)
     }
 
+    override fun visitUnfold(e: Unfold): Linearizable = object : UnitResultLinearizable(e) {
+        override fun toViperUnusedResult(ctx: LinearizationContext) {
+            ctx.addStatement {
+                Stmt.Unfold(e.pred.linearize().toViperBuiltinType(ctx) as Exp.PredicateAccess)
+            }
+        }
+    }
+
+    override fun visitFold(e: Fold): Linearizable = object : UnitResultLinearizable(e) {
+        override fun toViperUnusedResult(ctx: LinearizationContext) {
+            ctx.addStatement {
+                Stmt.Fold(e.pred.linearize().toViperBuiltinType(ctx) as Exp.PredicateAccess)
+            }
+        }
+    }
+
     // endregion
 
     // region Assignment / Declaration

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -421,14 +421,15 @@ data class LinearizationVisitor(
 
     override fun visitFieldModification(e: FieldModification): Linearizable = object : UnitResultLinearizable(e) {
         override fun toViperUnusedResult(ctx: LinearizationContext) {
+            val accessIsManual = (e.receiver.type.pretype as? ClassTypeEmbedding)?.isManual ?: false
             when (e.field.accessPolicy) {
-                AccessPolicy.BY_RECEIVER_UNIQUENESS if false -> {
+                AccessPolicy.BY_RECEIVER_UNIQUENESS if !accessIsManual -> {
                     e.receiver.linearize().toViperUnusedResult(ctx)
                     e.newValue.linearize().toViperUnusedResult(ctx)
                 }
                 else -> {
                     val receiverViper = e.receiver.linearize().toViper(ctx)
-                    if (e.field.unfoldToAccess && !(e.receiver.type.pretype as ClassTypeEmbedding).isManual) {
+                    if (e.field.unfoldToAccess && !accessIsManual) {
                         val receiverWrapper = ExpWrapper(receiverViper, e.receiver.type)
                         val hierarchyPath = ctx.typeResolver.hierarchyPathTo(e.receiver.type.pretype, e.field)
                         hierarchyPath.forEach { classType ->

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -421,7 +421,7 @@ data class LinearizationVisitor(
 
     override fun visitFieldModification(e: FieldModification): Linearizable = object : UnitResultLinearizable(e) {
         override fun toViperUnusedResult(ctx: LinearizationContext) {
-            val accessIsManual = (e.receiver.type.pretype as? ClassTypeEmbedding)?.isManual ?: false
+            val accessIsManual = with(ctx.typeResolver) { (e.receiver.type.pretype as? ClassTypeEmbedding)?.isManual ?: false }
             when (e.field.accessPolicy) {
                 AccessPolicy.BY_RECEIVER_UNIQUENESS if !accessIsManual -> {
                     e.receiver.linearize().toViperUnusedResult(ctx)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -111,9 +111,10 @@ data class Linearizer(
 
     override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
         addStatement {
+            val accessIsManual = (receiverType.pretype as? ClassTypeEmbedding)?.isManual ?: false
             when (field.accessPolicy) {
                 // TODO: Handling a unique field on a shared receiver must be added here.
-                AccessPolicy.BY_RECEIVER_UNIQUENESS if false -> {
+                AccessPolicy.BY_RECEIVER_UNIQUENESS if !accessIsManual -> {
                     receiver.toViperUnusedResult(this)
                     SpecialMethods.havocMethod.toMethodCall(
                         listOf(field.type.runtimeType),
@@ -125,7 +126,7 @@ data class Linearizer(
                     val receiverViper = receiver.toViper(this)
                     // If the field access is not replaced with havoc,
                     // we might need to unfold some predicate to access it.
-                    if (field.unfoldToAccess && !(receiverType.pretype as ClassTypeEmbedding).isManual) {
+                    if (field.unfoldToAccess && !accessIsManual) {
                         val receiverWrapper = ExpWrapper(receiverViper, receiverType)
                         val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field)
                         hierarchyPath.unfoldHierarchyPath(receiverWrapper, this)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -113,7 +113,7 @@ data class Linearizer(
         addStatement {
             when (field.accessPolicy) {
                 // TODO: Handling a unique field on a shared receiver must be added here.
-                AccessPolicy.BY_RECEIVER_UNIQUENESS -> {
+                AccessPolicy.BY_RECEIVER_UNIQUENESS if false -> {
                     receiver.toViperUnusedResult(this)
                     SpecialMethods.havocMethod.toMethodCall(
                         listOf(field.type.runtimeType),
@@ -125,7 +125,7 @@ data class Linearizer(
                     val receiverViper = receiver.toViper(this)
                     // If the field access is not replaced with havoc,
                     // we might need to unfold some predicate to access it.
-                    if (field.unfoldToAccess) {
+                    if (field.unfoldToAccess && !(receiverType.pretype as ClassTypeEmbedding).isManual) {
                         val receiverWrapper = ExpWrapper(receiverViper, receiverType)
                         val hierarchyPath = typeResolver.hierarchyPathTo(receiverType.pretype, field)
                         hierarchyPath.unfoldHierarchyPath(receiverWrapper, this)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -111,7 +111,7 @@ data class Linearizer(
 
     override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
         addStatement {
-            val accessIsManual = (receiverType.pretype as? ClassTypeEmbedding)?.isManual ?: false
+            val accessIsManual = with(typeResolver) { (receiverType.pretype as? ClassTypeEmbedding)?.isManual ?: false }
             when (field.accessPolicy) {
                 // TODO: Handling a unique field on a shared receiver must be added here.
                 AccessPolicy.BY_RECEIVER_UNIQUENESS if !accessIsManual -> {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
@@ -66,6 +66,8 @@ internal class ExprPurityVisitor(val declaredVariables: MutableSet<VariableEmbed
     override fun visitPredicateAccessPermissions(e: PredicateAccessPermissions): Boolean = false
     override fun visitLabelExp(e: LabelExp): Boolean = false
     override fun visitAccEmbedding(e: AccEmbedding): Boolean = false
+    override fun visitFold(e: Fold): Boolean = false
+    override fun visitUnfold(e: Unfold): Boolean = false
     override fun visitDefault(e: ExpEmbedding): Boolean = false
 }
 

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -447,6 +447,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("manualFolding.kt")
+    public void testManualFolding() {
+      runTest("formver.compiler-plugin/testData/diagnostics/verification/manualFolding.kt");
+    }
+
+    @Test
     @TestMetadata("multiple_receivers.kt")
     public void testMultiple_receivers() {
       runTest("formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.kt");

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -453,6 +453,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("manualFoldingNegative.kt")
+    public void testManualFoldingNegative() {
+      runTest("formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt");
+    }
+
+    @Test
     @TestMetadata("multiple_receivers.kt")
     public void testMultiple_receivers() {
       runTest("formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/acc_precondition.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/acc_precondition.fir.diag.txt
@@ -1,6 +1,10 @@
 /acc_precondition.kt: info: Generated Viper text for test_acc_precondition:
 field a: Ref
 
+predicate Permission_unique(this: Ref) {
+  isSubtype(typeOf(this), Permission())
+}
+
 predicate X_unique(this: Ref) {
   isSubtype(typeOf(this), X()) && acc(this.a, write) &&
   isSubtype(typeOf(this.a), anyType())
@@ -19,6 +23,10 @@ method test_acc_precondition(x: Ref) returns (v_ret_0: Ref)
 /acc_precondition.kt: info: Generated Viper text for test_acc_precondition_write:
 field a: Ref
 
+predicate Permission_unique(this: Ref) {
+  isSubtype(typeOf(this), Permission())
+}
+
 predicate X_unique(this: Ref) {
   isSubtype(typeOf(this), X()) && acc(this.a, write) &&
   isSubtype(typeOf(this.a), anyType())
@@ -36,6 +44,10 @@ method test_acc_precondition_write(x: Ref) returns (v_ret_0: Ref)
 
 /acc_precondition.kt: info: Generated Viper text for test_acc_precondition_read:
 field a: Ref
+
+predicate Permission_unique(this: Ref) {
+  isSubtype(typeOf(this), Permission())
+}
 
 predicate X_unique(this: Ref) {
   isSubtype(typeOf(this), X()) && acc(this.a, write) &&

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.fir.diag.txt
@@ -1,0 +1,157 @@
+/manualFolding.kt: info: Generated Viper text for test:
+field x: Ref
+
+function exp(this: Ref): Ref
+  requires isSubtype(typeOf(this), Predicate())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+function g_data(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniquePred())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+method con(par_data: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_data), anyType())
+  ensures isSubtype(typeOf(ret_1), UniquePred())
+  ensures acc(UniquePred_unique(ret_1), write)
+
+
+method test(p: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(p), Test())
+  requires acc(Test_unique(p), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  unfold acc(Test_unique(p), write)
+  unfold acc(Super_unique(p), write)
+  p.x := intToRef(5)
+  fold acc(Super_unique(p), write)
+  fold acc(Test_unique(p), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/manualFolding.kt: info: Generated Viper text for contains:
+field bf_data: Ref
+
+field left: Ref
+
+field right: Ref
+
+function exp(this: Ref): Ref
+  requires isSubtype(typeOf(this), Predicate())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+function g_data(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniquePred())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+method con(par_data: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_data), anyType())
+  ensures isSubtype(typeOf(ret_1), UniquePred())
+  ensures acc(UniquePred_unique(ret_1), write)
+
+
+method contains(tree: Ref, search: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(tree), nullable(Tree()))
+  requires tree != nullValue() ==> acc(Tree_unique(tree), write)
+  requires isSubtype(typeOf(search), intType())
+  ensures tree != nullValue() ==> acc(Tree_unique(tree), write)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+{
+  var anon_0: Ref
+  var res: Ref
+  var anon_1: Ref
+  var anon_2: Ref
+  if (tree == nullValue()) {
+    v_ret_0 := boolToRef(false)
+    goto lbl_ret_0
+  }
+  unfold acc(Tree_unique(tree), write)
+  anon_0 := tree.bf_data
+  if (intFromRef(anon_0) == intFromRef(search)) {
+    fold acc(Tree_unique(tree), write)
+    v_ret_0 := boolToRef(true)
+    goto lbl_ret_0
+  }
+  anon_2 := tree.left
+  anon_1 := contains(anon_2, search)
+  if (boolFromRef(anon_1)) {
+    res := boolToRef(true)
+  } else {
+    var anon_3: Ref
+    anon_3 := tree.right
+    res := contains(anon_3, search)
+  }
+  fold acc(Tree_unique(tree), write)
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/manualFolding.kt: info: Generated Viper text for combine:
+field bf_data: Ref
+
+field bf_left: Ref
+
+field bf_right: Ref
+
+function exp(this: Ref): Ref
+  requires isSubtype(typeOf(this), Predicate())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+function g_data(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniquePred())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+method combine(par_left: Ref, par_right: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_left), Tree())
+  requires acc(Tree_unique(par_left), write)
+  requires isSubtype(typeOf(par_right), Tree())
+  requires acc(Tree_unique(par_right), write)
+  ensures isSubtype(typeOf(v_ret_0), Tree())
+  ensures acc(Tree_unique(v_ret_0), write)
+{
+  var l0_data: Ref
+  var anon_0: Ref
+  var anon_1: Ref
+  var res: Ref
+  unfold acc(Tree_unique(par_left), write)
+  unfold acc(Tree_unique(par_right), write)
+  anon_0 := par_left.bf_data
+  anon_1 := par_right.bf_data
+  l0_data := plusInts(anon_0, anon_1)
+  fold acc(Tree_unique(par_left), write)
+  fold acc(Tree_unique(par_right), write)
+  res := con_Tree(par_left, par_right, l0_data)
+  v_ret_0 := res
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+method con_Tree(par_left: Ref, par_right: Ref, par_data: Ref)
+  returns (ret_2: Ref)
+  requires isSubtype(typeOf(par_left), nullable(Tree()))
+  requires par_left != nullValue() ==> acc(Tree_unique(par_left), write)
+  requires isSubtype(typeOf(par_right), nullable(Tree()))
+  requires par_right != nullValue() ==> acc(Tree_unique(par_right), write)
+  requires isSubtype(typeOf(par_data), intType())
+  ensures isSubtype(typeOf(ret_2), Tree())
+  ensures acc(Tree_unique(ret_2), write)
+  ensures (unfolding acc(Tree_unique(ret_2), write) in ret_2.bf_left) ==
+    par_left
+  ensures (unfolding acc(Tree_unique(ret_2), write) in ret_2.bf_right) ==
+    par_right
+  ensures intFromRef((unfolding acc(Tree_unique(ret_2), write) in
+      ret_2.bf_data)) ==
+    intFromRef(par_data)
+
+
+method con_UniquePred(par_data: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_data), anyType())
+  ensures isSubtype(typeOf(ret_1), UniquePred())
+  ensures acc(UniquePred_unique(ret_1), write)

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.kt
@@ -51,5 +51,3 @@ fun <!VIPER_TEXT!>combine<!>(@Unique left: Tree, @Unique right: Tree) : Tree {
     val res = Tree(left, right, data)
     return res
 }
-
-

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.kt
@@ -1,0 +1,55 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+abstract class Super(
+    @Unique var x: Int
+)
+
+@Manual
+class Test(
+    x: Int
+) : Super(x)
+
+fun <!VIPER_TEXT!>test<!>(@Unique p: Test) {
+    unfold(UniquePred(p))
+    unfold(UniquePred(p as Super))
+    p.x = 5
+    fold(UniquePred(p as Super))
+    fold(UniquePred(p))
+}
+
+
+@Manual
+class Tree(
+    @Unique var left: Tree?,
+    @Unique var right: Tree?,
+    @Unique var data: Int,
+)
+
+
+fun <!VIPER_TEXT!>contains<!>(@Unique @Borrowed tree: Tree?, search: Int) : Boolean {
+    if (tree == null) return false
+    unfold(UniquePred(tree))
+    if (tree.data == search) {
+        fold(UniquePred(tree))
+        return true
+    }
+    val res = contains(tree.left, search) || contains(tree.right, search)
+    fold(UniquePred(tree))
+    return res
+}
+
+
+@Unique
+fun <!VIPER_TEXT!>combine<!>(@Unique left: Tree, @Unique right: Tree) : Tree {
+    unfold(UniquePred(left))
+    unfold(UniquePred(right))
+    val data = left.data + right.data
+    fold(UniquePred(left))
+    fold(UniquePred(right))
+    val res = Tree(left, right, data)
+    return res
+}
+
+

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.fir.diag.txt
@@ -1,0 +1,42 @@
+/manualFoldingNegative.kt: info: Generated Viper text for writeWithoutUnfold:
+field value: Ref
+
+method writeWithoutUnfold(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), Cell())
+  requires acc(Cell_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  c.value := intToRef(5)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/manualFoldingNegative.kt: info: Generated Viper text for unfoldWithoutRefold:
+field value: Ref
+
+function exp(this: Ref): Ref
+  requires isSubtype(typeOf(this), Predicate())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+function g_data(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniquePred())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+method con(par_data: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_data), anyType())
+  ensures isSubtype(typeOf(ret_1), UniquePred())
+  ensures acc(UniquePred_unique(ret_1), write)
+
+
+method unfoldWithoutRefold(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), Cell())
+  requires acc(Cell_unique(c), write)
+  ensures acc(Cell_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  unfold acc(Cell_unique(c), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt
@@ -1,0 +1,20 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+@Manual
+class Cell(
+    @Unique var value: Int
+)
+
+// Writing a field of a @Manual class without unfolding its predicate must fail:
+// the permission to the field is still held inside the folded predicate.
+fun <!VIPER_TEXT!>writeWithoutUnfold<!>(@Unique c: Cell) {
+    <!VIPER_VERIFICATION_ERROR!>c.value = 5<!>
+}
+
+// Unfolding the predicate and returning without folding it back must fail:
+// the borrowed parameter's predicate is not re-established for the caller.
+<!VIPER_VERIFICATION_ERROR!>fun <!VIPER_TEXT!>unfoldWithoutRefold<!>(@Unique @Borrowed c: Cell) {
+    unfold(UniquePred(c))
+}<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.viper.diag.txt
@@ -1,0 +1,3 @@
+/manualFoldingNegative.kt: warning: Viper verification error: Assignment might fail. There might be insufficient permission to access c.value
+
+/manualFoldingNegative.kt: warning: Viper verification error: Postcondition of unfoldWithoutRefold might not hold. There might be insufficient permission to access Cell_unique(c)


### PR DESCRIPTION
Comment: I needed the `Fold` and `Unfold` `ExpEmbeddings` for the `intArray` stuff, so I thought I could also add the manual folds and unfolds to it. I am not a 100% sure, if we want to keep this.


This PR introduces manual permission management focused on folding and unfolding predicates. While this will eventually be rendered obsolete by the uniqueness system, having the option to manage permissions manually in the meantime is a valuable addition.

## Core Changes

* **Class-Level `@Manual` Annotation:** The `@Manual` annotation can now be applied to an entire class. This specifies that all folding and unfolding for this type must be handled manually. Specifically:
  * Predicates are still added to pre- and post-conditions as usual (based on uniqueness/locality annotations).
  * The `Unique` predicate is still created.
  * All paths not annotated as manual continue to be handled as they were previously.
  * Fields of a manual class are never havoced. (this only applies to the current type, if a superclass is annotated as manual but the actual type is not, then it is still havoced).


## Syntax

```kotlin
val x: A = A()
unfold(UniquePred(x))
```

This will unfold the unique predicate of type `A` for `x`. Because a supertype's predicate is part of the subtype's predicate, you may also need to unfold the supertype predicate. This can be achieved as follows:

```kotlin
unfold(UniquePred(x as B))
```

Note on Generics & Naming:  Specifying the type via casting is currently required. While using a generic type parameter inside UniquePred would be much cleaner, implementing it that way right now would be highly hacky due to our current lack of support for generics.

Additionally, the predicate is named `UniquePred` rather than `Unique` to avoid conflicts with the existing `@Unique` annotation.
