### PR TITLE
Resolved Pure Function Permission Issue

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/ContractBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/ContractBuilder.kt
@@ -58,7 +58,7 @@ class FunctionConditionBuilder(
             args {
                 accessInvariants()
                 pureInvariants()
-                if (variable.isBorrowed && variable.isUnique) uniquePredicateInvariants()
+                if (variable.isBorrowed && variable.isUnique && !signature.isPure) uniquePredicateInvariants()
             }
             returns {
                 pureInvariants()

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.fir.diag.txt
@@ -305,3 +305,22 @@ function next(this: Ref): Ref
 function value(this: Ref): Ref
   requires isSubtype(typeOf(this), Node())
   ensures isSubtype(typeOf(result), intType())
+
+
+/pure_function_with_heap_dependent_expressions.kt: info: Generated Viper text for testBorrowed:
+function next(this: Ref): Ref
+  requires isSubtype(typeOf(this), Node())
+  ensures isSubtype(typeOf(result), nullable(Node()))
+
+
+function testBorrowed(node: Ref): Ref
+  requires isSubtype(typeOf(node), Node())
+  requires acc(Node_unique(node), write)
+  ensures isSubtype(typeOf(result), unitType())
+{
+  unitValue()
+}
+
+function value(this: Ref): Ref
+  requires isSubtype(typeOf(this), Node())
+  ensures isSubtype(typeOf(result), intType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.kt
@@ -88,3 +88,6 @@ fun <!VIPER_TEXT!>getNextValueUsingId<!>(node: Node): Int {
     val nextNode = id(node.next)
     return if (nextNode == null) 0 else nextNode.value
 }
+
+@Pure
+fun <!VIPER_TEXT!>testBorrowed<!>(@Unique @Borrowed node: Node): Unit = Unit


### PR DESCRIPTION
This PR fixes a bug introduced by #169 
In a pure function if a parameter was annotated as unique and borrowed in the postcondition the unique predicate was added. Viper does not allow to have permissions in the postcondition of pure functions.