### PR TITLE
Refactor Stdlib Matching

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConditions.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConditions.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.conversion
+
+import org.jetbrains.kotlin.formver.core.embeddings.callables.NamedFunctionSignature
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.core.names.NameMatcher
+
+sealed interface Condition
+
+sealed interface FunctionCondition : Condition {
+    context(typeResolver: TypeResolver)
+    fun matches(funcName: NamedFunctionSignature): Boolean
+}
+
+sealed interface TypeCondition : Condition {
+    context(typeResolver: TypeResolver)
+    fun matches(type: TypeEmbedding): Boolean
+}
+
+/**
+ * The dispatch receiver must satisfy all [conditions].
+ * Returns false if the function has no dispatch receiver.
+ */
+data class ForReceiver(val conditions: List<TypeCondition>) : FunctionCondition {
+    context(typeResolver: TypeResolver)
+    override fun matches(funcName: NamedFunctionSignature): Boolean {
+        val receiverType = funcName.callableType.dispatchReceiverType ?: return false
+        return conditions.all { it.matches(receiverType) }
+    }
+}
+
+/** Matches functions with no dispatch receiver */
+data object HasNoReceiver : FunctionCondition {
+    context(typeResolver: TypeResolver)
+    override fun matches(funcName: NamedFunctionSignature): Boolean {
+        var result = false
+        NameMatcher.matchClassScope(funcName.name) {
+            ifNoReceiver { result = true }
+            return result
+        }
+    }
+}
+
+/** Matches functions whose simple name equals [name]. */
+data class HasFunctionName(val name: String) : FunctionCondition {
+    context(typeResolver: TypeResolver)
+    override fun matches(funcName: NamedFunctionSignature): Boolean {
+        var result = false
+        NameMatcher.matchClassScope(funcName.name) {
+            ifFunctionName(this@HasFunctionName.name) { result = true }
+            return result
+        }
+    }
+}
+
+/** Matches constructors of the class named [className]. */
+data class IsConstructorOf(val className: String) : FunctionCondition {
+    context(typeResolver: TypeResolver)
+    override fun matches(funcName: NamedFunctionSignature): Boolean {
+        var result = false
+        NameMatcher.matchClassScope(funcName.name) {
+            ifConstructorOf(this@IsConstructorOf.className) { result = true }
+            return result
+        }
+    }
+}
+
+/** Matches functions / types whose declaring package equals [pkg]. */
+data class InPackage(val pkg: List<String>) : FunctionCondition, TypeCondition {
+    context(typeResolver: TypeResolver)
+    override fun matches(funcName: NamedFunctionSignature): Boolean {
+        var result = false
+        NameMatcher.matchClassScope(funcName.name) {
+            ifPackageName(pkg) { result = true }
+            return result
+        }
+    }
+
+    context(typeResolver: TypeResolver)
+    override fun matches(type: TypeEmbedding): Boolean {
+        var result = false
+        NameMatcher.matchClassScope(type.pretype.name) {
+            ifPackageName(pkg) { result = true }
+            return result
+        }
+    }
+}
+
+/** Matches types that are a subtype of [pkg].[className]. */
+data class IsSubtype(val pkg: List<String>, val className: String) : TypeCondition {
+    context(typeResolver: TypeResolver)
+    override fun matches(type: TypeEmbedding): Boolean =
+        typeResolver.isInheritorOf(type.pretype, pkg, className)
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConditions.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConditions.kt
@@ -25,7 +25,7 @@ sealed interface TypeCondition : Condition {
  * The dispatch receiver must satisfy all [conditions].
  * Returns false if the function has no dispatch receiver.
  */
-data class ForReceiver(val conditions: List<TypeCondition>) : FunctionCondition {
+data class ReceiverSatisfies(val conditions: List<TypeCondition>) : FunctionCondition {
     context(typeResolver: TypeResolver)
     override fun matches(funcName: NamedFunctionSignature): Boolean {
         val receiverType = funcName.callableType.dispatchReceiverType ?: return false

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
@@ -30,56 +30,56 @@ private fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding = EqCmp(
 /**
  * Matches a stdlib function against a set of AND-combined criteria.
  *
- * [pkg] + [receiverInherits]: the dispatch receiver must be a subtype of `pkg.receiverInherits`.
+ * [pkg] + [receiverSubtypeName]: the dispatch receiver must be a subtype of `pkg.receiverInherits`.
  * [pkg] is not re-checked against the function's own package in this case — overrides in
  * user-defined classes match just as well as the original declarations.
  *
  * [pkg] + [noReceiver] / [functionName] / [constructorOf]: the function itself must live in [pkg].
  * Use this for top-level functions (e.g. `emptyList`) and constructors.
  *
- * [receiverInherits] and [noReceiver] are mutually exclusive.
+ * [receiverSubtypeName] and [noReceiver] are mutually exclusive.
  * [functionName] and [constructorOf] are mutually exclusive.
  */
-data class StdLibFunctionSpec(
+class StdLibFunctionSpec(
     val pkg: List<String>? = null,
-    val receiverInherits: String? = null,
+    val receiverSubtypeName: String? = null,
     val noReceiver: Boolean = false,
     val functionName: String? = null,
     val constructorOf: String? = null,
 ) {
     init {
-        require(!(receiverInherits != null && noReceiver)) { "receiverInherits and noReceiver are mutually exclusive" }
-        require(receiverInherits == null || pkg != null) { "pkg must be set when receiverInherits is set" }
+        require(!(receiverSubtypeName != null && noReceiver)) { "receiverInherits and noReceiver are mutually exclusive" }
+        require(receiverSubtypeName == null || pkg != null) { "pkg must be set when receiverInherits is set" }
         require(constructorOf == null || functionName == null) { "constructorOf and functionName are mutually exclusive" }
     }
 
     fun matches(function: NamedFunctionSignature, typeResolver: TypeResolver): Boolean {
-        if (!matchesReceiverInheritance(function, typeResolver)) return false
+        if (!checkReceiverSubtype(function, typeResolver)) return false
         if (!needsNameCheck()) return true
 
         return matchesNameScope(function.name)
     }
 
-    private fun matchesReceiverInheritance(
+    private fun checkReceiverSubtype(
         function: NamedFunctionSignature,
         typeResolver: TypeResolver
     ): Boolean {
-        if (receiverInherits == null) return true // Pass if there's no inheritance constraint
+        if (receiverSubtypeName == null) return true // Pass if there's no inheritance constraint
 
         val receiverPretype = function.callableType.dispatchReceiverType?.pretype ?: return false
-        return typeResolver.isInheritorOf(receiverPretype, pkg!!, receiverInherits)
+        return typeResolver.isInheritorOf(receiverPretype, pkg!!, receiverSubtypeName)
     }
 
     private fun needsNameCheck(): Boolean {
         return functionName != null ||
                 constructorOf != null ||
                 noReceiver ||
-                (pkg != null && receiverInherits == null)
+                (pkg != null && receiverSubtypeName == null)
     }
 
     private fun matchesNameScope(name: SymbolicName): Boolean {
         NameMatcher.matchClassScope(name) {
-            if (pkg != null && receiverInherits == null) {
+            if (pkg != null && receiverSubtypeName == null) {
                 var pkgMatched = false
                 ifPackageName(pkg) { pkgMatched = true }
                 if (!pkgMatched) return false
@@ -166,7 +166,7 @@ sealed interface StdLibParamPostcondition {
 data object GetPrecondition : StdLibPrecondition {
     override val spec = StdLibFunctionSpec(
         pkg = SpecialPackages.collections,
-        receiverInherits = "List",
+        receiverSubtypeName = "List",
         functionName = "get",
     )
 
@@ -191,7 +191,7 @@ data object GetPrecondition : StdLibPrecondition {
 data object SubListPrecondition : StdLibPrecondition {
     override val spec = StdLibFunctionSpec(
         pkg = SpecialPackages.collections,
-        receiverInherits = "List",
+        receiverSubtypeName = "List",
         functionName = "subList",
     )
 
@@ -227,7 +227,7 @@ data object EmptyListPostcondition : StdLibPostcondition {
 data object IsEmptyPostcondition : StdLibPostcondition {
     override val spec = StdLibFunctionSpec(
         pkg = SpecialPackages.collections,
-        receiverInherits = "Collection",
+        receiverSubtypeName = "Collection",
         functionName = "isEmpty",
     )
 
@@ -247,7 +247,7 @@ data object IsEmptyPostcondition : StdLibPostcondition {
 data object GetPostcondition : StdLibPostcondition {
     override val spec = StdLibFunctionSpec(
         pkg = SpecialPackages.collections,
-        receiverInherits = "List",
+        receiverSubtypeName = "List",
         functionName = "get",
     )
 
@@ -260,7 +260,7 @@ data object GetPostcondition : StdLibPostcondition {
 data object SubListPostcondition : StdLibPostcondition {
     override val spec = StdLibFunctionSpec(
         pkg = SpecialPackages.collections,
-        receiverInherits = "List",
+        receiverSubtypeName = "List",
         functionName = "subList",
     )
 
@@ -280,7 +280,7 @@ data object SubListPostcondition : StdLibPostcondition {
 data object AddPostcondition : StdLibPostcondition {
     override val spec = StdLibFunctionSpec(
         pkg = SpecialPackages.collections,
-        receiverInherits = "MutableList",
+        receiverSubtypeName = "MutableList",
         functionName = "add",
     )
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
@@ -15,9 +15,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.Not
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubIntInt
 import org.jetbrains.kotlin.formver.core.embeddings.types.PretypeEmbedding
-import org.jetbrains.kotlin.formver.core.names.NameMatcher
 import org.jetbrains.kotlin.formver.core.names.SpecialPackages
-import org.jetbrains.kotlin.formver.viper.SymbolicName
 
 private fun VariableEmbedding.sameSize(): ExpEmbedding =
     EqCmp(FieldAccess(this, CollectionSizeFieldEmbedding), Old(FieldAccess(this, CollectionSizeFieldEmbedding)))
@@ -26,77 +24,6 @@ private fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding = EqCmp(
     FieldAccess(this, CollectionSizeFieldEmbedding),
     OperatorExpEmbeddings.AddIntInt(Old(FieldAccess(this, CollectionSizeFieldEmbedding)), IntLit(amount)),
 )
-
-/**
- * Matches a stdlib function against a set of AND-combined criteria.
- *
- * [pkg] + [receiverSubtypeName]: the dispatch receiver must be a subtype of `pkg.receiverInherits`.
- * [pkg] is not re-checked against the function's own package in this case — overrides in
- * user-defined classes match just as well as the original declarations.
- *
- * [pkg] + [noReceiver] / [functionName] / [constructorOf]: the function itself must live in [pkg].
- * Use this for top-level functions (e.g. `emptyList`) and constructors.
- *
- * [receiverSubtypeName] and [noReceiver] are mutually exclusive.
- * [functionName] and [constructorOf] are mutually exclusive.
- */
-class StdLibFunctionSpec(
-    val pkg: List<String>? = null,
-    val receiverSubtypeName: String? = null,
-    val noReceiver: Boolean = false,
-    val functionName: String? = null,
-    val constructorOf: String? = null,
-) {
-    init {
-        require(!(receiverSubtypeName != null && noReceiver)) { "receiverInherits and noReceiver are mutually exclusive" }
-        require(receiverSubtypeName == null || pkg != null) { "pkg must be set when receiverInherits is set" }
-        require(constructorOf == null || functionName == null) { "constructorOf and functionName are mutually exclusive" }
-    }
-
-    fun matches(function: NamedFunctionSignature, typeResolver: TypeResolver): Boolean {
-        if (!checkReceiverSubtype(function, typeResolver)) return false
-        if (!needsNameCheck()) return true
-
-        return matchesNameScope(function.name)
-    }
-
-    private fun checkReceiverSubtype(
-        function: NamedFunctionSignature,
-        typeResolver: TypeResolver
-    ): Boolean {
-        if (receiverSubtypeName == null) return true // Pass if there's no inheritance constraint
-
-        val receiverPretype = function.callableType.dispatchReceiverType?.pretype ?: return false
-        return typeResolver.isInheritorOf(receiverPretype, pkg!!, receiverSubtypeName)
-    }
-
-    private fun needsNameCheck(): Boolean {
-        return functionName != null ||
-                constructorOf != null ||
-                noReceiver ||
-                (pkg != null && receiverSubtypeName == null)
-    }
-
-    private fun matchesNameScope(name: SymbolicName): Boolean {
-        NameMatcher.matchClassScope(name) {
-            if (pkg != null && receiverSubtypeName == null) {
-                var pkgMatched = false
-                ifPackageName(pkg) { pkgMatched = true }
-                if (!pkgMatched) return false
-            }
-
-            when {
-                noReceiver && functionName != null -> ifNoReceiver { ifFunctionName(functionName) { return true } }
-                noReceiver && constructorOf != null -> ifNoReceiver { ifConstructorOf(constructorOf) { return true } }
-                noReceiver -> ifNoReceiver { return true }
-                functionName != null -> ifFunctionName(functionName) { return true }
-                constructorOf != null -> ifConstructorOf(constructorOf) { return true }
-                else -> return true
-            }
-            return false
-        }
-    }
-}
 
 /**
  * Matches any parameter whose pretype is a subtype of `[pkg].[paramTypeInherits]`.
@@ -112,9 +39,9 @@ data class StdLibParamSpec(
 }
 
 sealed interface StdLibCondition {
-    val spec: StdLibFunctionSpec
+    val conditions: List<FunctionCondition>
     fun matches(function: NamedFunctionSignature, typeResolver: TypeResolver): Boolean =
-        spec.matches(function, typeResolver)
+        with(typeResolver) { conditions.all { it.matches(function) } }
 }
 
 sealed interface StdLibPrecondition : StdLibCondition {
@@ -164,10 +91,9 @@ sealed interface StdLibParamPostcondition {
 }
 
 data object GetPrecondition : StdLibPrecondition {
-    override val spec = StdLibFunctionSpec(
-        pkg = SpecialPackages.collections,
-        receiverSubtypeName = "List",
-        functionName = "get",
+    override val conditions = listOf(
+        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        HasFunctionName("get"),
     )
 
     override fun getEmbeddings(function: NamedFunctionSignature): List<ExpEmbedding> {
@@ -189,10 +115,9 @@ data object GetPrecondition : StdLibPrecondition {
 }
 
 data object SubListPrecondition : StdLibPrecondition {
-    override val spec = StdLibFunctionSpec(
-        pkg = SpecialPackages.collections,
-        receiverSubtypeName = "List",
-        functionName = "subList",
+    override val conditions = listOf(
+        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        HasFunctionName("subList"),
     )
 
     override fun getEmbeddings(function: NamedFunctionSignature): List<ExpEmbedding> {
@@ -212,10 +137,10 @@ data object SubListPrecondition : StdLibPrecondition {
 }
 
 data object EmptyListPostcondition : StdLibPostcondition {
-    override val spec = StdLibFunctionSpec(
-        pkg = SpecialPackages.collections,
-        noReceiver = true,
-        functionName = "emptyList",
+    override val conditions = listOf(
+        InPackage(SpecialPackages.collections),
+        HasNoReceiver,
+        HasFunctionName("emptyList"),
     )
 
     override fun getEmbeddings(
@@ -225,10 +150,9 @@ data object EmptyListPostcondition : StdLibPostcondition {
 }
 
 data object IsEmptyPostcondition : StdLibPostcondition {
-    override val spec = StdLibFunctionSpec(
-        pkg = SpecialPackages.collections,
-        receiverSubtypeName = "Collection",
-        functionName = "isEmpty",
+    override val conditions = listOf(
+        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "Collection"))),
+        HasFunctionName("isEmpty"),
     )
 
     override fun getEmbeddings(
@@ -245,10 +169,9 @@ data object IsEmptyPostcondition : StdLibPostcondition {
 }
 
 data object GetPostcondition : StdLibPostcondition {
-    override val spec = StdLibFunctionSpec(
-        pkg = SpecialPackages.collections,
-        receiverSubtypeName = "List",
-        functionName = "get",
+    override val conditions = listOf(
+        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        HasFunctionName("get"),
     )
 
     override fun getEmbeddings(
@@ -258,10 +181,9 @@ data object GetPostcondition : StdLibPostcondition {
 }
 
 data object SubListPostcondition : StdLibPostcondition {
-    override val spec = StdLibFunctionSpec(
-        pkg = SpecialPackages.collections,
-        receiverSubtypeName = "List",
-        functionName = "subList",
+    override val conditions = listOf(
+        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        HasFunctionName("subList"),
     )
 
     override fun getEmbeddings(
@@ -278,10 +200,9 @@ data object SubListPostcondition : StdLibPostcondition {
 }
 
 data object AddPostcondition : StdLibPostcondition {
-    override val spec = StdLibFunctionSpec(
-        pkg = SpecialPackages.collections,
-        receiverSubtypeName = "MutableList",
-        functionName = "add",
+    override val conditions = listOf(
+        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "MutableList"))),
+        HasFunctionName("add"),
     )
 
     override fun getEmbeddings(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
@@ -92,7 +92,7 @@ sealed interface StdLibParamPostcondition {
 
 data object GetPrecondition : StdLibPrecondition {
     override val conditions = listOf(
-        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        ReceiverSatisfies(listOf(IsSubtype(SpecialPackages.collections, "List"))),
         HasFunctionName("get"),
     )
 
@@ -116,7 +116,7 @@ data object GetPrecondition : StdLibPrecondition {
 
 data object SubListPrecondition : StdLibPrecondition {
     override val conditions = listOf(
-        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        ReceiverSatisfies(listOf(IsSubtype(SpecialPackages.collections, "List"))),
         HasFunctionName("subList"),
     )
 
@@ -151,7 +151,7 @@ data object EmptyListPostcondition : StdLibPostcondition {
 
 data object IsEmptyPostcondition : StdLibPostcondition {
     override val conditions = listOf(
-        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "Collection"))),
+        ReceiverSatisfies(listOf(IsSubtype(SpecialPackages.collections, "Collection"))),
         HasFunctionName("isEmpty"),
     )
 
@@ -170,7 +170,7 @@ data object IsEmptyPostcondition : StdLibPostcondition {
 
 data object GetPostcondition : StdLibPostcondition {
     override val conditions = listOf(
-        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        ReceiverSatisfies(listOf(IsSubtype(SpecialPackages.collections, "List"))),
         HasFunctionName("get"),
     )
 
@@ -182,7 +182,7 @@ data object GetPostcondition : StdLibPostcondition {
 
 data object SubListPostcondition : StdLibPostcondition {
     override val conditions = listOf(
-        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "List"))),
+        ReceiverSatisfies(listOf(IsSubtype(SpecialPackages.collections, "List"))),
         HasFunctionName("subList"),
     )
 
@@ -201,7 +201,7 @@ data object SubListPostcondition : StdLibPostcondition {
 
 data object AddPostcondition : StdLibPostcondition {
     override val conditions = listOf(
-        ForReceiver(listOf(IsSubtype(SpecialPackages.collections, "MutableList"))),
+        ReceiverSatisfies(listOf(IsSubtype(SpecialPackages.collections, "MutableList"))),
         HasFunctionName("add"),
     )
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
@@ -14,69 +14,107 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.LeIntInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.Not
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubIntInt
+import org.jetbrains.kotlin.formver.core.embeddings.types.PretypeEmbedding
 import org.jetbrains.kotlin.formver.core.names.NameMatcher
+import org.jetbrains.kotlin.formver.core.names.SpecialPackages
+import org.jetbrains.kotlin.formver.viper.SymbolicName
 
 private fun VariableEmbedding.sameSize(): ExpEmbedding =
     EqCmp(FieldAccess(this, CollectionSizeFieldEmbedding), Old(FieldAccess(this, CollectionSizeFieldEmbedding)))
 
-private fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding =
-    EqCmp(
-        FieldAccess(this, CollectionSizeFieldEmbedding),
-        OperatorExpEmbeddings.AddIntInt(Old(FieldAccess(this, CollectionSizeFieldEmbedding)), IntLit(amount)),
-    )
+private fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding = EqCmp(
+    FieldAccess(this, CollectionSizeFieldEmbedding),
+    OperatorExpEmbeddings.AddIntInt(Old(FieldAccess(this, CollectionSizeFieldEmbedding)), IntLit(amount)),
+)
 
-sealed interface StdLibReceiverInterface {
-    fun match(function: NamedFunctionSignature, ctx: TypeResolver): Boolean
-}
+/**
+ * Matches a stdlib function against a set of AND-combined criteria.
+ *
+ * [pkg] + [receiverInherits]: the dispatch receiver must be a subtype of `pkg.receiverInherits`.
+ * [pkg] is not re-checked against the function's own package in this case — overrides in
+ * user-defined classes match just as well as the original declarations.
+ *
+ * [pkg] + [noReceiver] / [functionName] / [constructorOf]: the function itself must live in [pkg].
+ * Use this for top-level functions (e.g. `emptyList`) and constructors.
+ *
+ * [receiverInherits] and [noReceiver] are mutually exclusive.
+ * [functionName] and [constructorOf] are mutually exclusive.
+ */
+data class StdLibFunctionSpec(
+    val pkg: List<String>? = null,
+    val receiverInherits: String? = null,
+    val noReceiver: Boolean = false,
+    val functionName: String? = null,
+    val constructorOf: String? = null,
+) {
+    init {
+        require(!(receiverInherits != null && noReceiver)) { "receiverInherits and noReceiver are mutually exclusive" }
+        require(receiverInherits == null || pkg != null) { "pkg must be set when receiverInherits is set" }
+        require(constructorOf == null || functionName == null) { "constructorOf and functionName are mutually exclusive" }
+    }
 
-sealed interface PresentInterface : StdLibReceiverInterface {
-    val interfaceName: String
-    override fun match(function: NamedFunctionSignature, ctx: TypeResolver): Boolean =
-        function.callableType.dispatchReceiverType?.pretype?.let {
-            ctx.isInheritorOfCollectionTypeNamed(
-                it,
-                interfaceName
-            )
-        }
-            ?: false
-}
+    fun matches(function: NamedFunctionSignature, typeResolver: TypeResolver): Boolean {
+        if (!matchesReceiverInheritance(function, typeResolver)) return false
+        if (!needsNameCheck()) return true
 
-data object CollectionInterface : PresentInterface {
-    override val interfaceName = "Collection"
-}
+        return matchesNameScope(function.name)
+    }
 
-data object ListInterface : PresentInterface {
-    override val interfaceName = "List"
-}
+    private fun matchesReceiverInheritance(
+        function: NamedFunctionSignature,
+        typeResolver: TypeResolver
+    ): Boolean {
+        if (receiverInherits == null) return true // Pass if there's no inheritance constraint
 
-data object MutableListInterface : PresentInterface {
-    override val interfaceName = "MutableList"
-}
+        val receiverPretype = function.callableType.dispatchReceiverType?.pretype ?: return false
+        return typeResolver.isInheritorOf(receiverPretype, pkg!!, receiverInherits)
+    }
 
-data object NoInterface : StdLibReceiverInterface {
-    override fun match(function: NamedFunctionSignature, ctx: TypeResolver): Boolean =
-        NameMatcher.matchClassScope(function.name) {
-            ifInCollectionsPkg {
-                ifNoReceiver {
-                    return true
-                }
+    private fun needsNameCheck(): Boolean {
+        return functionName != null ||
+                constructorOf != null ||
+                noReceiver ||
+                (pkg != null && receiverInherits == null)
+    }
+
+    private fun matchesNameScope(name: SymbolicName): Boolean {
+        NameMatcher.matchClassScope(name) {
+            if (pkg != null && receiverInherits == null) {
+                var pkgMatched = false
+                ifPackageName(pkg) { pkgMatched = true }
+                if (!pkgMatched) return false
             }
-            return false
-        }
-}
 
-sealed interface StdLibCondition {
-    val stdLibInterface: StdLibReceiverInterface
-    val functionName: String
-
-    fun match(function: NamedFunctionSignature): Boolean {
-        NameMatcher.matchClassScope(function.name) {
-            ifFunctionName(functionName) {
-                return true
+            when {
+                noReceiver && functionName != null -> ifNoReceiver { ifFunctionName(functionName) { return true } }
+                noReceiver && constructorOf != null -> ifNoReceiver { ifConstructorOf(constructorOf) { return true } }
+                noReceiver -> ifNoReceiver { return true }
+                functionName != null -> ifFunctionName(functionName) { return true }
+                constructorOf != null -> ifConstructorOf(constructorOf) { return true }
+                else -> return true
             }
             return false
         }
     }
+}
+
+/**
+ * Matches any parameter whose pretype is a subtype of `[pkg].[paramTypeInherits]`.
+ * If the parameter type is nullable, the generated embeddings are wrapped as
+ * `param != null implies condition`.
+ */
+data class StdLibParamSpec(
+    val pkg: List<String>,
+    val paramTypeInherits: String,
+) {
+    fun matches(paramPretype: PretypeEmbedding, typeResolver: TypeResolver): Boolean =
+        typeResolver.isInheritorOf(paramPretype, pkg, paramTypeInherits)
+}
+
+sealed interface StdLibCondition {
+    val spec: StdLibFunctionSpec
+    fun matches(function: NamedFunctionSignature, typeResolver: TypeResolver): Boolean =
+        spec.matches(function, typeResolver)
 }
 
 sealed interface StdLibPrecondition : StdLibCondition {
@@ -94,17 +132,47 @@ sealed interface StdLibPostcondition : StdLibCondition {
             IsEmptyPostcondition,
             GetPostcondition,
             SubListPostcondition,
-            AddPostcondition
+            AddPostcondition,
         )
     }
 
     fun getEmbeddings(returnVariable: VariableEmbedding, function: NamedFunctionSignature): List<ExpEmbedding>
 }
 
+sealed interface StdLibParamPrecondition {
+    val spec: StdLibParamSpec
+    fun matches(paramPretype: PretypeEmbedding, typeResolver: TypeResolver): Boolean =
+        spec.matches(paramPretype, typeResolver)
+
+    fun getEmbeddings(param: VariableEmbedding): List<ExpEmbedding>
+
+    companion object {
+        val all: List<StdLibParamPrecondition> = listOf()
+    }
+}
+
+sealed interface StdLibParamPostcondition {
+    val spec: StdLibParamSpec
+    fun matches(paramPretype: PretypeEmbedding, typeResolver: TypeResolver): Boolean =
+        spec.matches(paramPretype, typeResolver)
+
+    fun getEmbeddings(returnVariable: VariableEmbedding, param: VariableEmbedding): List<ExpEmbedding>
+
+    companion object {
+        val all: List<StdLibParamPostcondition> = listOf()
+    }
+}
+
 data object GetPrecondition : StdLibPrecondition {
+    override val spec = StdLibFunctionSpec(
+        pkg = SpecialPackages.collections,
+        receiverInherits = "List",
+        functionName = "get",
+    )
+
     override fun getEmbeddings(function: NamedFunctionSignature): List<ExpEmbedding> {
         val receiver = function.dispatchReceiver!!
-        val indexArg = function.formalArgs[1]
+        val indexArg = function.params[0]
         return listOf(
             GeIntInt(
                 indexArg,
@@ -118,42 +186,51 @@ data object GetPrecondition : StdLibPrecondition {
             ),
         )
     }
-
-    override val stdLibInterface = ListInterface
-    override val functionName = "get"
 }
 
 data object SubListPrecondition : StdLibPrecondition {
+    override val spec = StdLibFunctionSpec(
+        pkg = SpecialPackages.collections,
+        receiverInherits = "List",
+        functionName = "subList",
+    )
+
     override fun getEmbeddings(function: NamedFunctionSignature): List<ExpEmbedding> {
         val receiver = function.dispatchReceiver!!
-        val fromIndexArg = function.formalArgs[1]
-        val toIndexArg = function.formalArgs[2]
+        val fromIndexArg = function.params[0]
+        val toIndexArg = function.params[1]
         return listOf(
             LeIntInt(fromIndexArg, toIndexArg, SourceRole.SubListCreation.CheckInSize),
             GeIntInt(fromIndexArg, IntLit(0), SourceRole.SubListCreation.CheckNegativeIndices),
-            LeIntInt(toIndexArg, FieldAccess(receiver, CollectionSizeFieldEmbedding), SourceRole.SubListCreation.CheckInSize)
+            LeIntInt(
+                toIndexArg,
+                FieldAccess(receiver, CollectionSizeFieldEmbedding),
+                SourceRole.SubListCreation.CheckInSize
+            )
         )
     }
-
-    override val stdLibInterface = ListInterface
-    override val functionName = "subList"
 }
 
 data object EmptyListPostcondition : StdLibPostcondition {
+    override val spec = StdLibFunctionSpec(
+        pkg = SpecialPackages.collections,
+        noReceiver = true,
+        functionName = "emptyList",
+    )
+
     override fun getEmbeddings(
         returnVariable: VariableEmbedding,
         function: NamedFunctionSignature
-    ): List<ExpEmbedding> {
-        return listOf(
-            EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), IntLit(0))
-        )
-    }
-
-    override val stdLibInterface = NoInterface
-    override val functionName = "emptyList"
+    ): List<ExpEmbedding> = listOf(EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), IntLit(0)))
 }
 
 data object IsEmptyPostcondition : StdLibPostcondition {
+    override val spec = StdLibFunctionSpec(
+        pkg = SpecialPackages.collections,
+        receiverInherits = "Collection",
+        functionName = "isEmpty",
+    )
+
     override fun getEmbeddings(
         returnVariable: VariableEmbedding,
         function: NamedFunctionSignature
@@ -165,82 +242,73 @@ data object IsEmptyPostcondition : StdLibPostcondition {
             Implies(Not(returnVariable), GtIntInt(FieldAccess(receiver, CollectionSizeFieldEmbedding), IntLit(0)))
         )
     }
-
-    override val stdLibInterface = CollectionInterface
-    override val functionName = "isEmpty"
 }
 
 data object GetPostcondition : StdLibPostcondition {
+    override val spec = StdLibFunctionSpec(
+        pkg = SpecialPackages.collections,
+        receiverInherits = "List",
+        functionName = "get",
+    )
+
     override fun getEmbeddings(
         returnVariable: VariableEmbedding,
         function: NamedFunctionSignature
-    ): List<ExpEmbedding> {
-        return listOf(function.dispatchReceiver!!.sameSize())
-    }
-
-    override val stdLibInterface = ListInterface
-    override val functionName = "get"
+    ): List<ExpEmbedding> = listOf(function.dispatchReceiver!!.sameSize())
 }
 
 data object SubListPostcondition : StdLibPostcondition {
+    override val spec = StdLibFunctionSpec(
+        pkg = SpecialPackages.collections,
+        receiverInherits = "List",
+        functionName = "subList",
+    )
+
     override fun getEmbeddings(
         returnVariable: VariableEmbedding,
         function: NamedFunctionSignature
     ): List<ExpEmbedding> {
-        val fromIndexArg = function.formalArgs[1]
-        val toIndexArg = function.formalArgs[2]
+        val fromIndexArg = function.params[0]
+        val toIndexArg = function.params[1]
         return listOf(
             function.dispatchReceiver!!.sameSize(),
             EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), SubIntInt(toIndexArg, fromIndexArg))
         )
     }
-
-    override val stdLibInterface = ListInterface
-    override val functionName = "subList"
 }
 
 data object AddPostcondition : StdLibPostcondition {
+    override val spec = StdLibFunctionSpec(
+        pkg = SpecialPackages.collections,
+        receiverInherits = "MutableList",
+        functionName = "add",
+    )
+
     override fun getEmbeddings(
         returnVariable: VariableEmbedding,
         function: NamedFunctionSignature
-    ): List<ExpEmbedding> {
-        return listOf(function.dispatchReceiver!!.increasedSize(1))
-    }
-
-    override val stdLibInterface = MutableListInterface
-    override val functionName = "add"
+    ): List<ExpEmbedding> = listOf(function.dispatchReceiver!!.increasedSize(1))
 }
 
 fun NamedFunctionSignature.stdLibPreconditions(ctx: TypeResolver): List<ExpEmbedding> {
-    StdLibPrecondition.all.groupBy {
-        it.stdLibInterface
-    }.forEach { (stdLibInterface, preconditions) ->
-        if (stdLibInterface.match(this, ctx)) {
-            preconditions.forEach {
-                if (it.match(this)) {
-                    return it.getEmbeddings(this)
-                }
-            }
-        }
+    val fromFunction = StdLibPrecondition.all.filter { it.matches(this, ctx) }.flatMap { it.getEmbeddings(this) }
+    val fromParams = params.flatMap { param ->
+        StdLibParamPrecondition.all.filter { it.matches(param.type.pretype, ctx) }.flatMap { it.getEmbeddings(param) }
+            .map { if (param.type.isNullable) Implies(param.notNullCmp(), it) else it }
     }
-    return listOf()
+    return fromFunction + fromParams
 }
-
 
 fun NamedFunctionSignature.stdLibPostconditions(
     returnVariable: VariableEmbedding,
-    ctx: TypeResolver
+    ctx: TypeResolver,
 ): List<ExpEmbedding> {
-    StdLibPostcondition.all.groupBy {
-        it.stdLibInterface
-    }.forEach { (stdLibInterface, postconditions) ->
-        if (stdLibInterface.match(this, ctx)) {
-            postconditions.forEach {
-                if (it.match(this)) {
-                    return it.getEmbeddings(returnVariable, this)
-                }
-            }
-        }
+    val fromFunction =
+        StdLibPostcondition.all.filter { it.matches(this, ctx) }.flatMap { it.getEmbeddings(returnVariable, this) }
+    val fromParams = params.flatMap { param ->
+        StdLibParamPostcondition.all.filter { it.matches(param.type.pretype, ctx) }
+            .flatMap { it.getEmbeddings(returnVariable, param) }
+            .map { if (param.type.isNullable) Implies(param.notNullCmp(), it) else it }
     }
-    return listOf()
+    return fromFunction + fromParams
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.PretypeEmbedding
 import org.jetbrains.kotlin.formver.core.names.NameMatcher
 import org.jetbrains.kotlin.formver.core.names.NameScope
 import org.jetbrains.kotlin.formver.core.names.ScopedName
+import org.jetbrains.kotlin.formver.core.names.SpecialPackages
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.name.Name
 
@@ -133,22 +134,23 @@ class TypeResolver {
         }
     }
 
-    /**
-     * Returns true if the [pretypeEmbedding] is a subtype of Collection with [name]
-     */
-    fun isInheritorOfCollectionTypeNamed(pretypeEmbedding: PretypeEmbedding, name: String): Boolean {
+    fun isInheritorOf(pretypeEmbedding: PretypeEmbedding, pkg: List<String>, name: String): Boolean {
         val classEmbedding = pretypeEmbedding as? ClassTypeEmbedding ?: return false
-        return classEmbedding.isCollectionTypeNamed(name) || lookupSuperTypes(classEmbedding.name).any {
-            isInheritorOfCollectionTypeNamed(it, name)
+        return classEmbedding.isPkgTypeNamed(pkg, name) || lookupSuperTypes(classEmbedding.name).any {
+            isInheritorOf(it, pkg, name)
         }
     }
 
-    fun isCollectionInheritor(pretype: PretypeEmbedding) = isInheritorOfCollectionTypeNamed(pretype, "Collection")
+    fun isInheritorOfCollectionTypeNamed(pretypeEmbedding: PretypeEmbedding, name: String) =
+        isInheritorOf(pretypeEmbedding, SpecialPackages.collections, name)
 
-    fun PretypeEmbedding.isCollectionTypeNamed(name: String): Boolean {
+    fun isCollectionInheritor(pretype: PretypeEmbedding) =
+        isInheritorOf(pretype, SpecialPackages.collections, "Collection")
+
+    private fun PretypeEmbedding.isPkgTypeNamed(pkg: List<String>, name: String): Boolean {
         val classEmbedding = this as? ClassTypeEmbedding ?: return false
         NameMatcher.matchGlobalScope(classEmbedding.name) {
-            ifInCollectionsPkg {
+            ifPackageName(pkg) {
                 ifClassName(name) {
                     return true
                 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ClassScopeNameMatcher.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ClassScopeNameMatcher.kt
@@ -66,6 +66,11 @@ internal class ClassScopeNameMatcher(name: SymbolicName) : NameMatcher(name) {
         if (scopedName?.name == BackingFieldKotlinName(Name.identifier(name)))
             this.action()
     }
+
+    inline fun ifConstructorOf(vararg classSegments: String, action: ClassScopeNameMatcher.() -> Unit) {
+        if (scopedName?.name is ConstructorKotlinName && className == ClassKotlinName(classSegments.toList()))
+            this.action()
+    }
 }
 
 internal class GlobalScopeNameMatcher(name: SymbolicName) : NameMatcher(name) {


### PR DESCRIPTION
In my opinion the way we matched a function to stdlib functions to add various pre+post conditions was more complicated then it needs to be and it did not allow us to match for constructors.

This PR cleans it up and supports matching constructors.