### PR TITLE
Follow-ups: drop redundant param conditions, add ArrayList contract

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConditions.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConditions.kt
@@ -36,58 +36,54 @@ data class ReceiverSatisfies(val conditions: List<TypeCondition>) : FunctionCond
 /** Matches functions with no dispatch receiver */
 data object HasNoReceiver : FunctionCondition {
     context(typeResolver: TypeResolver)
-    override fun matches(funcName: NamedFunctionSignature): Boolean {
-        var result = false
-        NameMatcher.matchClassScope(funcName.name) {
-            ifNoReceiver { result = true }
-            return result
+    override fun matches(funcName: NamedFunctionSignature): Boolean =
+        NameMatcher.matchesClassScope(funcName.name) {
+            ifNoReceiver { return@matchesClassScope true }
+            false
         }
-    }
 }
 
 /** Matches functions whose simple name equals [name]. */
 data class HasFunctionName(val name: String) : FunctionCondition {
     context(typeResolver: TypeResolver)
-    override fun matches(funcName: NamedFunctionSignature): Boolean {
-        var result = false
-        NameMatcher.matchClassScope(funcName.name) {
-            ifFunctionName(this@HasFunctionName.name) { result = true }
-            return result
+    override fun matches(funcName: NamedFunctionSignature): Boolean =
+        NameMatcher.matchesClassScope(funcName.name) {
+            ifFunctionName(this@HasFunctionName.name) { return@matchesClassScope true }
+            false
         }
-    }
+}
+
+/** Matches functions with exactly [count] value parameters. */
+data class HasParamCount(val count: Int) : FunctionCondition {
+    context(typeResolver: TypeResolver)
+    override fun matches(funcName: NamedFunctionSignature): Boolean = funcName.params.size == count
 }
 
 /** Matches constructors of the class named [className]. */
 data class IsConstructorOf(val className: String) : FunctionCondition {
     context(typeResolver: TypeResolver)
-    override fun matches(funcName: NamedFunctionSignature): Boolean {
-        var result = false
-        NameMatcher.matchClassScope(funcName.name) {
-            ifConstructorOf(this@IsConstructorOf.className) { result = true }
-            return result
+    override fun matches(funcName: NamedFunctionSignature): Boolean =
+        NameMatcher.matchesClassScope(funcName.name) {
+            ifConstructorOf(this@IsConstructorOf.className) { return@matchesClassScope true }
+            false
         }
-    }
 }
 
 /** Matches functions / types whose declaring package equals [pkg]. */
 data class InPackage(val pkg: List<String>) : FunctionCondition, TypeCondition {
     context(typeResolver: TypeResolver)
-    override fun matches(funcName: NamedFunctionSignature): Boolean {
-        var result = false
-        NameMatcher.matchClassScope(funcName.name) {
-            ifPackageName(pkg) { result = true }
-            return result
+    override fun matches(funcName: NamedFunctionSignature): Boolean =
+        NameMatcher.matchesClassScope(funcName.name) {
+            ifPackageName(pkg) { return@matchesClassScope true }
+            false
         }
-    }
 
     context(typeResolver: TypeResolver)
-    override fun matches(type: TypeEmbedding): Boolean {
-        var result = false
-        NameMatcher.matchClassScope(type.pretype.name) {
-            ifPackageName(pkg) { result = true }
-            return result
+    override fun matches(type: TypeEmbedding): Boolean =
+        NameMatcher.matchesClassScope(type.pretype.name) {
+            ifPackageName(pkg) { return@matchesClassScope true }
+            false
         }
-    }
 }
 
 /** Matches types that are a subtype of [pkg].[className]. */

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StdLibConverter.kt
@@ -14,7 +14,6 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbedd
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.LeIntInt
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.Not
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.SubIntInt
-import org.jetbrains.kotlin.formver.core.embeddings.types.PretypeEmbedding
 import org.jetbrains.kotlin.formver.core.names.SpecialPackages
 
 private fun VariableEmbedding.sameSize(): ExpEmbedding =
@@ -26,18 +25,13 @@ private fun VariableEmbedding.increasedSize(amount: Int): ExpEmbedding = EqCmp(
 )
 
 /**
- * Matches any parameter whose pretype is a subtype of `[pkg].[paramTypeInherits]`.
- * If the parameter type is nullable, the generated embeddings are wrapped as
- * `param != null implies condition`.
+ * A function-level stdlib contract clause.
+ *
+ * A clause applies when every one of its [conditions] holds. All applicable clauses
+ * contribute their embeddings: the conditions no longer race for a single winner, the
+ * embeddings of every matching clause are combined (see [stdLibPreconditions] /
+ * [stdLibPostconditions]).
  */
-data class StdLibParamSpec(
-    val pkg: List<String>,
-    val paramTypeInherits: String,
-) {
-    fun matches(paramPretype: PretypeEmbedding, typeResolver: TypeResolver): Boolean =
-        typeResolver.isInheritorOf(paramPretype, pkg, paramTypeInherits)
-}
-
 sealed interface StdLibCondition {
     val conditions: List<FunctionCondition>
     fun matches(function: NamedFunctionSignature, typeResolver: TypeResolver): Boolean =
@@ -60,34 +54,11 @@ sealed interface StdLibPostcondition : StdLibCondition {
             GetPostcondition,
             SubListPostcondition,
             AddPostcondition,
+            EmptyArrayListPostcondition,
         )
     }
 
     fun getEmbeddings(returnVariable: VariableEmbedding, function: NamedFunctionSignature): List<ExpEmbedding>
-}
-
-sealed interface StdLibParamPrecondition {
-    val spec: StdLibParamSpec
-    fun matches(paramPretype: PretypeEmbedding, typeResolver: TypeResolver): Boolean =
-        spec.matches(paramPretype, typeResolver)
-
-    fun getEmbeddings(param: VariableEmbedding): List<ExpEmbedding>
-
-    companion object {
-        val all: List<StdLibParamPrecondition> = listOf()
-    }
-}
-
-sealed interface StdLibParamPostcondition {
-    val spec: StdLibParamSpec
-    fun matches(paramPretype: PretypeEmbedding, typeResolver: TypeResolver): Boolean =
-        spec.matches(paramPretype, typeResolver)
-
-    fun getEmbeddings(returnVariable: VariableEmbedding, param: VariableEmbedding): List<ExpEmbedding>
-
-    companion object {
-        val all: List<StdLibParamPostcondition> = listOf()
-    }
 }
 
 data object GetPrecondition : StdLibPrecondition {
@@ -211,25 +182,27 @@ data object AddPostcondition : StdLibPostcondition {
     ): List<ExpEmbedding> = listOf(function.dispatchReceiver!!.increasedSize(1))
 }
 
-fun NamedFunctionSignature.stdLibPreconditions(ctx: TypeResolver): List<ExpEmbedding> {
-    val fromFunction = StdLibPrecondition.all.filter { it.matches(this, ctx) }.flatMap { it.getEmbeddings(this) }
-    val fromParams = params.flatMap { param ->
-        StdLibParamPrecondition.all.filter { it.matches(param.type.pretype, ctx) }.flatMap { it.getEmbeddings(param) }
-            .map { if (param.type.isNullable) Implies(param.notNullCmp(), it) else it }
-    }
-    return fromFunction + fromParams
+data object EmptyArrayListPostcondition : StdLibPostcondition {
+    override val conditions = listOf(
+        IsConstructorOf("ArrayList"),
+        HasParamCount(0),
+    )
+
+    override fun getEmbeddings(
+        returnVariable: VariableEmbedding,
+        function: NamedFunctionSignature
+    ): List<ExpEmbedding> = listOf(EqCmp(FieldAccess(returnVariable, CollectionSizeFieldEmbedding), IntLit(0)))
 }
+
+/**
+ * Every clause whose [conditions][StdLibCondition.conditions] all hold contributes its
+ * embeddings; the clauses no longer race for a single winner.
+ */
+fun NamedFunctionSignature.stdLibPreconditions(ctx: TypeResolver): List<ExpEmbedding> =
+    StdLibPrecondition.all.filter { it.matches(this, ctx) }.flatMap { it.getEmbeddings(this) }
 
 fun NamedFunctionSignature.stdLibPostconditions(
     returnVariable: VariableEmbedding,
     ctx: TypeResolver,
-): List<ExpEmbedding> {
-    val fromFunction =
-        StdLibPostcondition.all.filter { it.matches(this, ctx) }.flatMap { it.getEmbeddings(returnVariable, this) }
-    val fromParams = params.flatMap { param ->
-        StdLibParamPostcondition.all.filter { it.matches(param.type.pretype, ctx) }
-            .flatMap { it.getEmbeddings(returnVariable, param) }
-            .map { if (param.type.isNullable) Implies(param.notNullCmp(), it) else it }
-    }
-    return fromFunction + fromParams
-}
+): List<ExpEmbedding> =
+    StdLibPostcondition.all.filter { it.matches(this, ctx) }.flatMap { it.getEmbeddings(returnVariable, this) }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
@@ -141,9 +141,6 @@ class TypeResolver {
         }
     }
 
-    fun isInheritorOfCollectionTypeNamed(pretypeEmbedding: PretypeEmbedding, name: String) =
-        isInheritorOf(pretypeEmbedding, SpecialPackages.collections, name)
-
     fun isCollectionInheritor(pretype: PretypeEmbedding) =
         isInheritorOf(pretype, SpecialPackages.collections, "Collection")
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ClassScopeNameMatcher.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/ClassScopeNameMatcher.kt
@@ -18,6 +18,9 @@ internal sealed class NameMatcher(val name: SymbolicName) {
         inline fun matchGlobalScope(name: SymbolicName, action: GlobalScopeNameMatcher.() -> Nothing): Nothing {
             GlobalScopeNameMatcher(name).action()
         }
+
+        inline fun matchesClassScope(name: SymbolicName, predicate: ClassScopeNameMatcher.() -> Boolean): Boolean =
+            ClassScopeNameMatcher(name).predicate()
     }
 
     protected val scopedName = name as? ScopedName

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -96,6 +96,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("array_list_constructor.kt")
+      public void testArray_list_constructor() {
+        runTest("formver.compiler-plugin/testData/diagnostics/stdlib/list/array_list_constructor.kt");
+      }
+
+      @Test
       @TestMetadata("binary_search.kt")
       public void testBinary_search() {
         runTest("formver.compiler-plugin/testData/diagnostics/stdlib/list/binary_search.kt");

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/array_list_constructor.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/array_list_constructor.fir.diag.txt
@@ -1,0 +1,21 @@
+/array_list_constructor.kt: info: Generated Viper text for empty_array_list:
+field size: Ref
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), ArrayList())
+  ensures acc(ret_1.size, write)
+  ensures intFromRef(ret_1.size) >= 0
+  ensures acc(ArrayList_unique(ret_1), write)
+  ensures intFromRef(ret_1.size) == 0
+
+
+method empty_array_list() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var l: Ref
+  l := con()
+  v_ret_0 := l.size
+  inhale isSubtype(typeOf(v_ret_0), intType())
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/array_list_constructor.kt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/array_list_constructor.kt
@@ -1,0 +1,10 @@
+// FULL_JDK
+// WITH_STDLIB
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>empty_array_list<!>() : Int {
+    val l = ArrayList<Int>()
+    return l.size
+}


### PR DESCRIPTION
@The-Ray-Man — reworked follow-ups on #193. The headline change from my first version: I'm proposing we **drop** the type-keyed parameter-condition machinery rather than exercise it, because it turns out to duplicate the type-invariant machinery. Reasoning below — happy to be argued out of it.

## Why the param conditions come out

`StdLibParamPrecondition` / `StdLibParamPostcondition` match a parameter purely by its *type* and attach a fact to it. But a fact that is sound for *every* parameter of a type is, by definition, a fact about every *value* of that type — i.e. a type invariant. So this path can only ever restate a type invariant, which the invariant machinery already emits. Concretely it's a partial re-implementation of `TypeInvariantEmbedding`:

| param-condition piece | already exists as |
|---|---|
| `StdLibParamSpec.matches` (type match) | the type/field simply *carrying* the invariant — no match step |
| `wrapForNullableParam` (`p != null ==> P`) | `IfNonNullInvariant` / `TypeEmbeddingFlags.adjustInvariant`, applied automatically to nullable types |
| param loop in `stdLibPreconditions` | `VariableEmbedding.accessInvariants/pureInvariants`, filled per-arg in `ContractBuilder` |
| a `size >= 0` param condition | already emitted by `CollectionSizeFieldEmbedding` via `extraAccessInvariantsForParameter` |

`TypeInvariantEmbedding` is literally "an `ExpEmbedding` with a hole" (`fillHole(exp)`) — the same shape the param conditions produce — so there's nothing the param path can express that an invariant can't. The only universally-sound fact for a bare `Collection` param, `size >= 0`, is exactly the last row, so "exercising" the machinery meant emitting `size >= 0` twice.

The genuinely useful case — a stdlib clause that *constrains* a parameter — is the **function**-level condition, which is kept: `List.get`'s `0 <= index < size` relates the param to the receiver's size, precisely because it keys on the function, not the type.

## What this PR does

- Removes `StdLibParamSpec`, `StdLibParamPrecondition` / `StdLibParamPostcondition`, `getWrappedEmbeddings`, and the param loops in `stdLibPreconditions` / `stdLibPostconditions`. Type-universal stdlib facts belong in the invariant machinery (a `TypeInvariantEmbedding` on the type/field, as `size >= 0` already is).
- Adds `EmptyArrayListPostcondition` (`result.size == 0`) for the no-argument `ArrayList` constructor, matched with `IsConstructorOf("ArrayList")` + a new `HasParamCount(0)` — needed because `ArrayList` also has the initial-capacity and copy constructors, for which `size == 0` would be unsound. This is a real, non-redundant function contract (`size == 0` isn't free), and confirms `IsConstructorOf` works despite the `kotlin.collections.ArrayList` → `java.util.ArrayList` typealias.
- Adds `NameMatcher.matchesClassScope`, a Boolean-returning helper replacing the `var result = false; matchClassScope { ifX { result = true }; return result }` idiom in `HasNoReceiver` / `HasFunctionName` / `IsConstructorOf` / `InPackage`.
- Removes the now-unused `TypeResolver.isInheritorOfCollectionTypeNamed`.
- Documents that every matching clause contributes to the contract (the refactor's change from "first match wins").

## Tests

New: `stdlib/list/array_list_constructor.kt` — `ArrayList<Int>()` gets `ensures size == 0`. No existing goldens change: dropping the param conditions leaves every collection contract exactly as it is on this branch. The `Stdlib` diagnostics group passes under FULL verification.

## Optional follow-up (not in this PR)

`StdLibCondition` is really a function *contract*, not an invariant; renaming it (e.g. `StdLibContract`) would make the boundary with the invariant machinery unmistakable and head off the confusion that produced this rework. Left out to keep the diff focused — say the word if you'd like it.