### PR TITLE
Exclude test-gen from detekt sources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,13 +32,14 @@ subprojects {
     tasks.withType<Detekt>().configureEach {
         jvmTarget = "21"
         // Project uses a custom layout (src/ instead of src/main/kotlin) — list the
-        // source roots explicitly so detekt scans them.
+        // source roots explicitly so detekt scans them. test-gen is not listed: it
+        // contains only generated Java test runners (produced by generateTests),
+        // which detekt does not analyze.
         setSource(
             files(
                 "src",
                 "test",
                 "test-fixtures",
-                "test-gen",
             ).filter { it.exists() }
         )
         include("**/*.kt")


### PR DESCRIPTION
`./gradlew build` (or any invocation running `generateTests` and `detekt` together) fails on main with Gradle's implicit-dependency validation:

```
Task ':formver.compiler-plugin:locality:detekt' uses this output of task
':formver.compiler-plugin:locality:generateTests' without declaring an
explicit or implicit dependency. This can lead to incorrect results being
produced, depending on what order the tasks are executed.
```

The root build script lists `test-gen` among each subproject's detekt source roots, while `generateTests` declares the same directory as its output — an undeclared producer/consumer pair. The failure only surfaces when something forces `generateTests` to re-run (e.g. after touching `testData`), which is why it can look intermittent.

Both `test-gen` directories (`formver.compiler-plugin`, `formver.compiler-plugin/locality`) contain only generated Java test runners, and detekt analyzes only `*.kt`/`*.kts` — so detekt was never analyzing anything there. This removes `test-gen` from the detekt source list, which severs the overlap without changing analysis results.

Verified: on unmodified main, `./gradlew generateTests detekt` reproduces the failure above; with this change the same invocation is green, with `locality:generateTests` and all detekt tasks executing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)