### PR TITLE
Review fixes: manual folds/unfolds

### DIFF
--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
@@ -20,5 +20,11 @@ annotation class Borrowed
 @Target(AnnotationTarget.FUNCTION)
 annotation class Pure
 
+/**
+ * Disables automatic permission management for the annotated element.
+ *
+ * On a class, the automatic folding, unfolding, and havoc of that class's uniqueness predicate
+ * are turned off, leaving its permissions to be managed explicitly.
+ */
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class Manual

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -45,7 +45,14 @@ fun acc(
 ): Boolean =
     throw FormverFunctionCalledInRuntimeException("acc")
 
+/**
+ * An amount of permission to a location, such as full ([write]) or read-only ([read]).
+ */
 interface Permission
+
+/**
+ * A verification predicate over [exp].
+ */
 abstract class Predicate(val exp: Any)
 
 /**
@@ -60,15 +67,27 @@ fun read(): Permission =
 fun write(): Permission =
     throw FormverFunctionCalledInRuntimeException("write")
 
-
+/**
+ * The uniqueness predicate of [data]: exclusive access to [data] and its fields.
+ */
 data class UniquePred(val data: Any) : Predicate(data)
 
+/**
+ * Exchanges [exp] for access to its body, exposing the underlying fields. The inverse of [fold].
+ *
+ * [permission] is the amount of the predicate to unfold, defaulting to full ([write]).
+ */
 fun unfold(
     @Suppress("UNUSED_PARAMETER") exp: Predicate,
     @Suppress("UNUSED_PARAMETER") permission: Permission? = null
 ): Unit =
     throw FormverFunctionCalledInRuntimeException("unfold")
 
+/**
+ * Exchanges access to [exp]'s body for the predicate itself. The inverse of [unfold].
+ *
+ * [permission] is the amount of the predicate to fold, defaulting to full ([write]).
+ */
 fun fold(
     @Suppress("UNUSED_PARAMETER") exp: Predicate,
     @Suppress("UNUSED_PARAMETER") permission: Permission? = null

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -80,8 +79,6 @@ fun FirBasedSymbol<*>.isBorrowed(session: FirSession) = hasAnnotation(annotation
 fun FirBasedSymbol<*>.isPure(session: FirSession) = hasAnnotation(annotationId("Pure"), session)
 
 fun FirBasedSymbol<*>.isManual(session: FirSession) = hasAnnotation(annotationId("Manual"), session)
-
-fun FirClassSymbol<*>.isManual(session: FirSession) = hasAnnotation(annotationId("Manual"), session)
 
 fun FirAnnotationContainer.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -580,11 +580,13 @@ class ProgramConverter(
 
         val embedding = typeResolver.getEmbeddingOrExecute(className) {
             val classEmbedding = buildClassPretype {
-                isManual = symbol.isManual(session)
                 withName(className)
             }
 
             typeResolver.register(classEmbedding, symbol.classKind.isInterface)
+            if (symbol.isManual(session)) {
+                typeResolver.markManual(className)
+            }
 
             symbol.resolvedSuperTypes.forEach {
                 val superTypeName = embedType(it).pretype.name

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/TypeResolver.kt
@@ -36,6 +36,11 @@ class TypeResolver {
     private val properties = mutableMapOf<ClassPropertyPair, PropertyEmbedding>()
 
     /**
+     * Names of classes marked `@Manual`.
+     */
+    private val manualClassNames = mutableSetOf<SymbolicName>()
+
+    /**
      * Register a class or interface type embedding.
      * This is needed to know which classes were already registered.
      */
@@ -43,6 +48,13 @@ class TypeResolver {
         true -> interfaceEmbedding.putIfAbsent(typeEmbedding.name, typeEmbedding)
         false -> classEmbedding.putIfAbsent(typeEmbedding.name, typeEmbedding)
     }
+
+    fun markManual(name: SymbolicName) {
+        manualClassNames.add(name)
+    }
+
+    val ClassTypeEmbedding.isManual: Boolean
+        get() = name in manualClassNames
 
     private fun toBackingField(property: PropertyEmbedding): FieldEmbedding? =
         (property.getter as? BackingFieldGetter)?.field

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -130,19 +130,28 @@ object SpecialKotlinFunctions {
 
         withCallableType(booleanBooleanToBooleanType) {
             addFunction(
-                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "and"
+                booleanBooleanToBooleanType,
+                SpecialPackages.kotlin,
+                className = "Boolean",
+                name = "and"
             ) { args, _ ->
                 And(args[0], args[1])
             }
 
             addFunction(
-                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "or"
+                booleanBooleanToBooleanType,
+                SpecialPackages.kotlin,
+                className = "Boolean",
+                name = "or"
             ) { args, _ ->
                 Or(args[0], args[1])
             }
 
             addFunction(
-                booleanBooleanToBooleanType, SpecialPackages.kotlin, className = "Boolean", name = "xor"
+                booleanBooleanToBooleanType,
+                SpecialPackages.kotlin,
+                className = "Boolean",
+                name = "xor"
             ) { args, _ ->
                 Xor(args[0], args[1])
             }
@@ -206,11 +215,13 @@ object SpecialKotlinFunctions {
         addFunction(forAllCallableType, SpecialPackages.formver, name = "forAll") { args, ctx ->
             val arg = args.first()
             val lambda = arg.ignoringMetaNodes() as? LambdaExp ?: throw SnaktInternalException(
-                null, "First argument of forAll function must be a lambda."
+                null,
+                "First argument of forAll function must be a lambda."
             )
             val param = lambda.function.valueParameters.first()
             val body = lambda.function.body ?: throw SnaktInternalException(
-                null, "Lambda body of forAll function must be present."
+                null,
+                "Lambda body of forAll function must be present."
             )
             ctx.insertForAllFunctionCall(param.symbol, body)
         }
@@ -237,13 +248,13 @@ object SpecialKotlinFunctions {
             }
         }
 
-        fun extractPredicate(exp: MethodCall, permissions: ExpEmbedding?): PredicateAccessPermissions {
-
-            val permissions = extractPermission(permissions)
-
-            return when (exp.type.pretype.name) {
+        fun extractPredicate(exp: MethodCall, perm: PermissionLit): PredicateAccessPermissions =
+            when (exp.type.pretype.name) {
                 uniquePredTypeName -> {
-                    val arg = exp.args.firstOrNull()!!
+                    val arg = exp.args.firstOrNull() ?: throw SnaktInternalException(
+                        null,
+                        "Predicate constructor call is missing its argument."
+                    )
                     val type = arg.type.pretype as? ClassTypeEmbedding ?: throw SnaktInternalException(
                         null,
                         "Can only unfold the unique predicates of classes"
@@ -251,13 +262,12 @@ object SpecialKotlinFunctions {
                     PredicateAccessPermissions(
                         type.uniquePredicateName,
                         listOf(arg.ignoringCastsAndMetaNodes()),
-                        permissions.perm
+                        perm.perm
                     )
                 }
 
                 else -> throw SnaktInternalException(null, "Unknown predicate")
             }
-        }
 
         val accCallableType = buildFunctionPretype {
             withParam { nullableAny() }
@@ -271,23 +281,19 @@ object SpecialKotlinFunctions {
         }
         addFunction(accCallableType, SpecialPackages.formver, name = "acc") { args, ctx ->
             val source = (args.firstOrNull() as? WithPosition)?.source
-
             val perm = extractPermission(args.getOrNull(1))
-
-            when (val exp = args.firstOrNull()?.ignoringCastsAndMetaNodes()) {
-                null -> throw SnaktInternalException(
-                    source, "First argument of `acc` must be a field access like `x.a`."
-                )
-
-                is FieldAccess -> AccEmbedding(exp.receiver, exp.field, perm.perm)
-                is MethodCall -> extractPredicate(exp, args.getOrNull(1))
-
-                else -> throw SnaktInternalException(
-                    source, "First argument of `acc` must be a field access like `x.a` or a predicate."
-                )
+            ctx.withNoScope {
+                when (val exp = args.firstOrNull()?.ignoringCastsAndMetaNodes()) {
+                    null -> throw SnaktInternalException(
+                        source, "First argument of `acc` must be a field access like `x.a`."
+                    )
+                    is FieldAccess -> AccEmbedding(exp.receiver, exp.field, perm.perm)
+                    is MethodCall -> extractPredicate(exp, perm)
+                    else -> throw SnaktInternalException(
+                        source, "First argument of `acc` must be a field access like `x.a` or a predicate."
+                    )
+                }
             }
-
-
         }
 
         val invariantsBuilderCallableType = buildFunctionPretype {
@@ -362,10 +368,7 @@ object SpecialKotlinFunctions {
 
         val stringIntToCharType = buildFunctionPretype {
             withDispatchReceiver { string() }
-            withParam {
-
-                int()
-            }
+            withParam { int() }
             withReturnType { char() }
         }
 
@@ -389,19 +392,19 @@ object SpecialKotlinFunctions {
         }
         addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "unfold") { args, ctx ->
             val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
-                null, "First argument of unfold must be constructor to a predicate."
+                null, "First argument of `unfold` must be a predicate constructor call like `UniquePred(x)`."
             )
             Unfold(
-                extractPredicate(exp, args.getOrNull(1))
+                extractPredicate(exp, extractPermission(args.getOrNull(1)))
             )
         }
 
         addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "fold") { args, ctx ->
             val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
-                null, "First argument of unfold must be constructor to a predicate."
+                null, "First argument of `fold` must be a predicate constructor call like `UniquePred(x)`."
             )
             Fold(
-                extractPredicate(exp, args.getOrNull(1))
+                extractPredicate(exp, extractPermission(args.getOrNull(1)))
             )
         }
     }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/ClassTypeEmbedding.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Predicate
 
 // TODO: incorporate generic parameters.
-data class ClassTypeEmbedding(override val name: ScopedName, val isManual: Boolean) : PretypeEmbedding {
+data class ClassTypeEmbedding(override val name: ScopedName) : PretypeEmbedding {
 
     override val runtimeType: Exp = this.embedClassTypeFunc()()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeBuilder.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/types/PretypeBuilder.kt
@@ -105,7 +105,6 @@ fun buildFunctionPretype(init: FunctionPretypeBuilder.() -> Unit): FunctionTypeE
 
 class ClassPretypeBuilder : PretypeBuilder {
     private var className: ScopedName? = null
-    var isManual = false
 
     fun withName(name: ScopedName) {
         require(className == null) { "Class name already set" }
@@ -114,7 +113,7 @@ class ClassPretypeBuilder : PretypeBuilder {
 
     override fun complete(): ClassTypeEmbedding {
         require(className != null) { "Class name not set" }
-        return ClassTypeEmbedding(className!!, isManual)
+        return ClassTypeEmbedding(className!!)
     }
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -421,7 +421,7 @@ data class LinearizationVisitor(
 
     override fun visitFieldModification(e: FieldModification): Linearizable = object : UnitResultLinearizable(e) {
         override fun toViperUnusedResult(ctx: LinearizationContext) {
-            val accessIsManual = (e.receiver.type.pretype as? ClassTypeEmbedding)?.isManual ?: false
+            val accessIsManual = with(ctx.typeResolver) { (e.receiver.type.pretype as? ClassTypeEmbedding)?.isManual ?: false }
             when (e.field.accessPolicy) {
                 AccessPolicy.BY_RECEIVER_UNIQUENESS if !accessIsManual -> {
                     e.receiver.linearize().toViperUnusedResult(ctx)

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -111,7 +111,7 @@ data class Linearizer(
 
     override fun addFieldAccessStoringIn(receiver: Linearizable, receiverType: TypeEmbedding, field: FieldEmbedding, result: VariableEmbedding) {
         addStatement {
-            val accessIsManual = (receiverType.pretype as? ClassTypeEmbedding)?.isManual ?: false
+            val accessIsManual = with(typeResolver) { (receiverType.pretype as? ClassTypeEmbedding)?.isManual ?: false }
             when (field.accessPolicy) {
                 // TODO: Handling a unique field on a shared receiver must be added here.
                 AccessPolicy.BY_RECEIVER_UNIQUENESS if !accessIsManual -> {

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -453,6 +453,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("manualFoldingNegative.kt")
+    public void testManualFoldingNegative() {
+      runTest("formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt");
+    }
+
+    @Test
     @TestMetadata("multiple_receivers.kt")
     public void testMultiple_receivers() {
       runTest("formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.fir.diag.txt
@@ -1,0 +1,42 @@
+/manualFoldingNegative.kt: info: Generated Viper text for writeWithoutUnfold:
+field value: Ref
+
+method writeWithoutUnfold(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), Cell())
+  requires acc(Cell_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  c.value := intToRef(5)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/manualFoldingNegative.kt: info: Generated Viper text for unfoldWithoutRefold:
+field value: Ref
+
+function exp(this: Ref): Ref
+  requires isSubtype(typeOf(this), Predicate())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+function g_data(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniquePred())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+method con(par_data: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_data), anyType())
+  ensures isSubtype(typeOf(ret_1), UniquePred())
+  ensures acc(UniquePred_unique(ret_1), write)
+
+
+method unfoldWithoutRefold(c: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(c), Cell())
+  requires acc(Cell_unique(c), write)
+  ensures acc(Cell_unique(c), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  unfold acc(Cell_unique(c), write)
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt
@@ -1,0 +1,20 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+@Manual
+class Cell(
+    @Unique var value: Int
+)
+
+// Writing a field of a @Manual class without unfolding its predicate must fail:
+// the permission to the field is still held inside the folded predicate.
+fun <!VIPER_TEXT!>writeWithoutUnfold<!>(@Unique c: Cell) {
+    <!VIPER_VERIFICATION_ERROR!>c.value = 5<!>
+}
+
+// Unfolding the predicate and returning without folding it back must fail:
+// the borrowed parameter's predicate is not re-established for the caller.
+<!VIPER_VERIFICATION_ERROR!>fun <!VIPER_TEXT!>unfoldWithoutRefold<!>(@Unique @Borrowed c: Cell) {
+    unfold(UniquePred(c))
+}<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.viper.diag.txt
@@ -1,0 +1,3 @@
+/manualFoldingNegative.kt: warning: Viper verification error: Assignment might fail. There might be insufficient permission to access c.value
+
+/manualFoldingNegative.kt: warning: Viper verification error: Postcondition of unfoldWithoutRefold might not hold. There might be insufficient permission to access Cell_unique(c)


### PR DESCRIPTION
@The-Ray-Man — review fixes on top of #188, targeting your branch.

## Changes

- **Move `isManual` out of `ClassTypeEmbedding`.** It was a constructor property of the `ClassTypeEmbedding` data class, so it participated in equals/hashCode — ad-hoc embeddings built via `klass { withName(...) }` (which default to `isManual = false`) would no longer compare equal to the registered embedding of a `@Manual` class. Manual-ness now lives in `TypeResolver` (a `manualClassNames` set with `markManual`/`isManual`), populated from `ProgramConverter` and queried via the `typeResolver` already available in `LinearizationVisitor.visitFieldModification` and `Linearizer.addFieldAccessStoringIn`. Type equality is no longer affected by manual-ness.

- **`FullySpecialKotlinFunction` handler cleanups.**
  - Fixed the fold/unfold error messages (the `fold` message referenced "unfold", and both were ungrammatical): now e.g. ``First argument of `fold` must be a predicate constructor call like `UniquePred(x)`.``
  - Replaced `extractPredicate`'s `exp.args.firstOrNull()!!` with a `SnaktInternalException` carrying a message.
  - Removed the `permissions` parameter shadowing in `extractPredicate` (it now takes an already-extracted `PermissionLit`).
  - The `acc` handler extracts the permission once and threads it through both the field-access and predicate branches.
  - **`withNoScope`:** `StmtConverter.withNoScope` delegates to `withNewScopeImpl(needsScope = false)`, which pushes a child property-resolver scope (`ScopeIndex.NoScope`) and pops it after the action — so it is *not* a pure identity in general. For the `acc` body it has no observable effect, because the body only constructs embeddings from already-converted argument embeddings and resolves nothing against the scope. I restored the wrapper anyway so the field-access path stays byte-identical to `main`.

- **KDoc for the new public API:** documented `fold`, `unfold`, `Predicate`, `UniquePred`, `Permission` in `Builtins.kt`, and class-level `@Manual` in `Annotations.kt` (automatic folding/unfolding and havoc disabled; the user manages permissions with fold/unfold). `apiCheck` still passes — KDoc alone did not change the API dump.

- **Removed the redundant `FirClassSymbol<*>.isManual` overload** — `FirClassSymbol` is a `FirBasedSymbol`, so the existing extension already applies.

- **Reverted unrelated formatting churn** in `FullySpecialKotlinFunction.kt`: the Boolean and/or/xor `addFunction` calls back to multi-line, the `forAll` message reflow, the stray blank line inside `withParam { int() }`, and the doubled blank lines near the `acc` handler.

## Negative test

Added `testData/diagnostics/verification/manualFoldingNegative.kt` (the PR's only test was happy-path with an empty `.viper.diag.txt`). Two scenarios that must fail verification:
- Writing a field of a `@Manual` class without unfolding its predicate first → *Assignment might fail. There might be insufficient permission to access c.value*.
- Unfolding a borrowed unique parameter's predicate and returning without folding it back → *Postcondition of unfoldWithoutRefold might not hold*.

Golden `.fir.diag.txt`/`.viper.diag.txt` generated and the test runner regenerated via the `generateTests` task.

## Verification

- `CHECK_CONVERSION` passes suite-wide with **zero** golden-file changes, so the `isManual` refactor produces byte-identical Viper everywhere (and since verification runs deterministically on that Viper text, verification results are unchanged too).
- The new negative test and the existing happy-path `manualFolding` both pass in full (Z3) verification mode.
- `:formver.annotations:apiCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)