### PR TITLE
Enforce ExpVisitor coverage at compile time

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
@@ -7,53 +7,124 @@ package org.jetbrains.kotlin.formver.core.embeddings
 
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 
+/**
+ * Visitor over the concrete subclasses of [ExpEmbedding].
+ *
+ * Every concrete [ExpEmbedding] subclass has a corresponding `visitXxx` method here, and all of
+ * them are abstract. This means that implementing this interface directly requires overriding
+ * every single one of them: forgetting to handle a newly added [ExpEmbedding] subclass is a
+ * compile error, not a runtime failure.
+ *
+ * Visitors that want a generic fallback for nodes without a bespoke override (e.g. for debug
+ * rendering) should implement [DefaultingExpVisitor] instead.
+ */
 interface ExpVisitor<R> {
+    fun visitBlock(e: Block): R
+    fun visitFunctionExp(e: FunctionExp): R
+    fun visitGotoChainNode(e: GotoChainNode): R
+    fun visitIf(e: If): R
+    fun visitElvis(e: Elvis): R
+    fun visitReturn(e: Return): R
+    fun visitLambdaExp(e: LambdaExp): R
+    fun visitMethodCall(e: MethodCall): R
+    fun visitFunctionCall(e: FunctionCall): R
+    fun visitSafeCast(e: SafeCast): R
+    fun visitShared(e: Shared): R
+    fun visitAssert(e: Assert): R
+    fun visitDeclare(e: Declare): R
+    fun visitEqCmp(e: EqCmp): R
+    fun visitNeCmp(e: NeCmp): R
+    fun visitBinaryOperatorExpEmbedding(e: BinaryOperatorExpEmbedding): R
+    fun visitSequentialAnd(e: SequentialAnd): R
+    fun visitSequentialOr(e: SequentialOr): R
+    fun visitInjectionBasedExpEmbedding(e: InjectionBasedExpEmbedding): R
+    fun visitFieldAccessPermissions(e: FieldAccessPermissions): R
+    fun visitForAllEmbedding(e: ForAllEmbedding): R
+    fun visitPredicateAccessPermissions(e: PredicateAccessPermissions): R
+    fun visitCast(e: Cast): R
+    fun visitIs(e: Is): R
+    fun visitOld(e: Old): R
+    fun visitPrimitiveFieldAccess(e: PrimitiveFieldAccess): R
+    fun visitUnaryOperatorExpEmbedding(e: UnaryOperatorExpEmbedding): R
+    fun visitErrorExp(e: ErrorExp): R
+    fun visitGoto(e: Goto): R
+    fun visitInhaleDirect(e: InhaleDirect): R
+    fun visitInhaleInvariants(e: InhaleInvariants): R
+    fun visitNonDeterministically(e: NonDeterministically): R
+    fun visitWhile(e: While): R
+    fun visitFieldAccess(e: FieldAccess): R
+    fun visitInvokeFunctionObject(e: InvokeFunctionObject): R
+    fun visitAssign(e: Assign): R
+    fun visitFieldModification(e: FieldModification): R
+    fun visitLabelExp(e: LabelExp): R
+    fun visitUnitLit(e: UnitLit): R
+    fun visitSharingContext(e: SharingContext): R
+    fun visitWithPosition(e: WithPosition): R
+    fun visitLiteralEmbedding(e: LiteralEmbedding): R
+    fun visitExpWrapper(e: ExpWrapper): R
+    fun visitVariableEmbedding(e: VariableEmbedding): R
+    fun visitAccEmbedding(e: AccEmbedding): R
+    fun visitPermissionLit(e: PermissionLit): R
+    fun visitFold(e: Fold): R
+    fun visitUnfold(e: Unfold): R
+}
+
+/**
+ * An [ExpVisitor] that falls back to [visitDefault] for any concrete [ExpEmbedding] subclass
+ * without a bespoke `visitXxx` override.
+ *
+ * Implement this instead of [ExpVisitor] when a generic fallback is a legitimate design choice
+ * (e.g. debug rendering), rather than an omission.
+ */
+interface DefaultingExpVisitor<R> : ExpVisitor<R> {
     fun visitDefault(e: ExpEmbedding): R
-    fun visitBlock(e: Block): R = visitDefault(e)
-    fun visitFunctionExp(e: FunctionExp): R = visitDefault(e)
-    fun visitGotoChainNode(e: GotoChainNode): R = visitDefault(e)
-    fun visitIf(e: If): R = visitDefault(e)
-    fun visitElvis(e: Elvis): R = visitDefault(e)
-    fun visitReturn(e: Return): R = visitDefault(e)
-    fun visitLambdaExp(e: LambdaExp): R = visitDefault(e)
-    fun visitMethodCall(e: MethodCall): R = visitDefault(e)
-    fun visitFunctionCall(e: FunctionCall): R = visitDefault(e)
-    fun visitSafeCast(e: SafeCast): R = visitDefault(e)
-    fun visitShared(e: Shared): R = visitDefault(e)
-    fun visitAssert(e: Assert): R = visitDefault(e)
-    fun visitDeclare(e: Declare): R = visitDefault(e)
-    fun visitEqCmp(e: EqCmp): R = visitDefault(e)
-    fun visitNeCmp(e: NeCmp): R = visitDefault(e)
-    fun visitBinaryOperatorExpEmbedding(e: BinaryOperatorExpEmbedding): R = visitDefault(e)
-    fun visitSequentialAnd(e: SequentialAnd): R = visitDefault(e)
-    fun visitSequentialOr(e: SequentialOr): R = visitDefault(e)
-    fun visitInjectionBasedExpEmbedding(e: InjectionBasedExpEmbedding): R = visitDefault(e)
-    fun visitFieldAccessPermissions(e: FieldAccessPermissions): R = visitDefault(e)
-    fun visitForAllEmbedding(e: ForAllEmbedding): R = visitDefault(e)
-    fun visitPredicateAccessPermissions(e: PredicateAccessPermissions): R = visitDefault(e)
-    fun visitCast(e: Cast): R = visitDefault(e)
-    fun visitIs(e: Is): R = visitDefault(e)
-    fun visitOld(e: Old): R = visitDefault(e)
-    fun visitPrimitiveFieldAccess(e: PrimitiveFieldAccess): R = visitDefault(e)
-    fun visitUnaryOperatorExpEmbedding(e: UnaryOperatorExpEmbedding): R = visitDefault(e)
-    fun visitErrorExp(e: ErrorExp): R = visitDefault(e)
-    fun visitGoto(e: Goto): R = visitDefault(e)
-    fun visitInhaleDirect(e: InhaleDirect): R = visitDefault(e)
-    fun visitInhaleInvariants(e: InhaleInvariants): R = visitDefault(e)
-    fun visitNonDeterministically(e: NonDeterministically): R = visitDefault(e)
-    fun visitWhile(e: While): R = visitDefault(e)
-    fun visitFieldAccess(e: FieldAccess): R = visitDefault(e)
-    fun visitInvokeFunctionObject(e: InvokeFunctionObject): R = visitDefault(e)
-    fun visitAssign(e: Assign): R = visitDefault(e)
-    fun visitFieldModification(e: FieldModification): R = visitDefault(e)
-    fun visitLabelExp(e: LabelExp): R = visitDefault(e)
-    fun visitUnitLit(e: UnitLit): R = visitDefault(e)
-    fun visitSharingContext(e: SharingContext): R = visitDefault(e)
-    fun visitWithPosition(e: WithPosition): R = visitDefault(e)
-    fun visitLiteralEmbedding(e: LiteralEmbedding): R = visitDefault(e)
-    fun visitExpWrapper(e: ExpWrapper): R = visitDefault(e)
-    fun visitVariableEmbedding(e: VariableEmbedding): R = visitDefault(e)
-    fun visitAccEmbedding(e: AccEmbedding): R = visitDefault(e)
-    fun visitFold(e: Fold): R = visitDefault(e)
-    fun visitUnfold(e: Unfold): R = visitDefault(e)
+
+    override fun visitBlock(e: Block): R = visitDefault(e)
+    override fun visitFunctionExp(e: FunctionExp): R = visitDefault(e)
+    override fun visitGotoChainNode(e: GotoChainNode): R = visitDefault(e)
+    override fun visitIf(e: If): R = visitDefault(e)
+    override fun visitElvis(e: Elvis): R = visitDefault(e)
+    override fun visitReturn(e: Return): R = visitDefault(e)
+    override fun visitLambdaExp(e: LambdaExp): R = visitDefault(e)
+    override fun visitMethodCall(e: MethodCall): R = visitDefault(e)
+    override fun visitFunctionCall(e: FunctionCall): R = visitDefault(e)
+    override fun visitSafeCast(e: SafeCast): R = visitDefault(e)
+    override fun visitShared(e: Shared): R = visitDefault(e)
+    override fun visitAssert(e: Assert): R = visitDefault(e)
+    override fun visitDeclare(e: Declare): R = visitDefault(e)
+    override fun visitEqCmp(e: EqCmp): R = visitDefault(e)
+    override fun visitNeCmp(e: NeCmp): R = visitDefault(e)
+    override fun visitBinaryOperatorExpEmbedding(e: BinaryOperatorExpEmbedding): R = visitDefault(e)
+    override fun visitSequentialAnd(e: SequentialAnd): R = visitDefault(e)
+    override fun visitSequentialOr(e: SequentialOr): R = visitDefault(e)
+    override fun visitInjectionBasedExpEmbedding(e: InjectionBasedExpEmbedding): R = visitDefault(e)
+    override fun visitFieldAccessPermissions(e: FieldAccessPermissions): R = visitDefault(e)
+    override fun visitForAllEmbedding(e: ForAllEmbedding): R = visitDefault(e)
+    override fun visitPredicateAccessPermissions(e: PredicateAccessPermissions): R = visitDefault(e)
+    override fun visitCast(e: Cast): R = visitDefault(e)
+    override fun visitIs(e: Is): R = visitDefault(e)
+    override fun visitOld(e: Old): R = visitDefault(e)
+    override fun visitPrimitiveFieldAccess(e: PrimitiveFieldAccess): R = visitDefault(e)
+    override fun visitUnaryOperatorExpEmbedding(e: UnaryOperatorExpEmbedding): R = visitDefault(e)
+    override fun visitErrorExp(e: ErrorExp): R = visitDefault(e)
+    override fun visitGoto(e: Goto): R = visitDefault(e)
+    override fun visitInhaleDirect(e: InhaleDirect): R = visitDefault(e)
+    override fun visitInhaleInvariants(e: InhaleInvariants): R = visitDefault(e)
+    override fun visitNonDeterministically(e: NonDeterministically): R = visitDefault(e)
+    override fun visitWhile(e: While): R = visitDefault(e)
+    override fun visitFieldAccess(e: FieldAccess): R = visitDefault(e)
+    override fun visitInvokeFunctionObject(e: InvokeFunctionObject): R = visitDefault(e)
+    override fun visitAssign(e: Assign): R = visitDefault(e)
+    override fun visitFieldModification(e: FieldModification): R = visitDefault(e)
+    override fun visitLabelExp(e: LabelExp): R = visitDefault(e)
+    override fun visitUnitLit(e: UnitLit): R = visitDefault(e)
+    override fun visitSharingContext(e: SharingContext): R = visitDefault(e)
+    override fun visitWithPosition(e: WithPosition): R = visitDefault(e)
+    override fun visitLiteralEmbedding(e: LiteralEmbedding): R = visitDefault(e)
+    override fun visitExpWrapper(e: ExpWrapper): R = visitDefault(e)
+    override fun visitVariableEmbedding(e: VariableEmbedding): R = visitDefault(e)
+    override fun visitAccEmbedding(e: AccEmbedding): R = visitDefault(e)
+    override fun visitPermissionLit(e: PermissionLit): R = visitDefault(e)
+    override fun visitFold(e: Fold): R = visitDefault(e)
+    override fun visitUnfold(e: Unfold): R = visitDefault(e)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/AccEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/AccEmbedding.kt
@@ -27,6 +27,6 @@ data class PermissionLit(val perm: PermExp) : ExpEmbedding {
     override val type: TypeEmbedding
         get() = buildType { boolean() }
 
-    override fun <R> accept(v: ExpVisitor<R>): R = v.visitDefault(this)
+    override fun <R> accept(v: ExpVisitor<R>): R = v.visitPermissionLit(this)
     override fun children(): Sequence<ExpEmbedding> = emptySequence()
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/debug/DebugTreeViewVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/debug/DebugTreeViewVisitor.kt
@@ -5,12 +5,12 @@
 
 package org.jetbrains.kotlin.formver.core.embeddings.expression.debug
 
-import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
+import org.jetbrains.kotlin.formver.core.embeddings.DefaultingExpVisitor
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 import org.jetbrains.kotlin.formver.viper.NameResolver
 import org.jetbrains.kotlin.formver.viper.mangled
 
-class DebugTreeViewVisitor(private val nameResolver: NameResolver) : ExpVisitor<TreeView> {
+class DebugTreeViewVisitor(private val nameResolver: NameResolver) : DefaultingExpVisitor<TreeView> {
 
     private fun ExpEmbedding.tree(): TreeView = accept(this@DebugTreeViewVisitor)
     private fun List<ExpEmbedding>.trees(): List<TreeView> = map { it.tree() }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -534,6 +534,9 @@ data class LinearizationVisitor(
         }
     }
 
+    override fun visitPermissionLit(e: PermissionLit): Linearizable =
+        error("PermissionLit should not be linearized; it is consumed directly by `acc` argument handling")
+
     // endregion
 
     // region Meta / Sharing
@@ -608,13 +611,6 @@ data class LinearizationVisitor(
             TODO("create new function object with counter, duplicable (requires toViper restructuring)")
         }
     }
-
-    // endregion
-
-    // region Default
-
-    override fun visitDefault(e: ExpEmbedding): Linearizable =
-        error("visitDefault should not be called; all concrete ExpEmbedding types must have their own visitor method")
 
     // endregion
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
@@ -20,6 +20,7 @@ internal class ExprPurityVisitor(val declaredVariables: MutableSet<VariableEmbed
         return pure
     }
     override fun visitLiteralEmbedding(e: LiteralEmbedding) = true
+    override fun visitPermissionLit(e: PermissionLit) = true
     override fun visitExpWrapper(e: ExpWrapper) = true
     override fun visitVariableEmbedding(e: VariableEmbedding) = true
     override fun visitAssign(e: Assign): Boolean =
@@ -68,7 +69,6 @@ internal class ExprPurityVisitor(val declaredVariables: MutableSet<VariableEmbed
     override fun visitAccEmbedding(e: AccEmbedding): Boolean = false
     override fun visitFold(e: Fold): Boolean = false
     override fun visitUnfold(e: Unfold): Boolean = false
-    override fun visitDefault(e: ExpEmbedding): Boolean = false
 }
 
 private fun ExpEmbedding.allChildrenPure(v: ExprPurityVisitor): Boolean =


### PR DESCRIPTION
## Summary

`ExpVisitor<R>` previously gave every `visitXxx` method a `visitDefault`
fallback. Visitors that need full coverage relied on discipline (or a
runtime `error()` in `LinearizationVisitor`) to catch a missing case when a
new `ExpEmbedding` subclass was added — a forgotten override failed at
runtime instead of compile time, and the fallback semantics differed
per-visitor by accident rather than by declared intent.

This splits the interface in two:

- `ExpVisitor<R>` — all ~46 `visitXxx` methods are now abstract, with no
  `visitDefault`. Implementing it directly requires overriding every
  method; a missing case for a new `ExpEmbedding` subclass is now a
  compile error.
- `DefaultingExpVisitor<R>` — extends `ExpVisitor<R>` and adds
  `visitDefault`, wiring every method to fall back to it by default.
  Visitors that legitimately want a generic fallback opt in explicitly by
  implementing this instead.

`LinearizationVisitor` and `ExprPurityVisitor` (both of which already
overrode every method) now implement `ExpVisitor<R>` directly and had their
dead/defensive `visitDefault` overrides removed — the compiler now
enforces what they were previously enforcing by hand. `DebugTreeViewVisitor`
implements `DefaultingExpVisitor<TreeView>` and keeps its generic fallback
rendering unchanged.

No behavior change. Confirmed these three are the only implementors of
`ExpVisitor` in the repo.

## Test plan

- [x] `./gradlew :formver.compiler-plugin:core:compileKotlin` — clean
- [x] `./gradlew detekt` — clean
- [x] `./gradlew :formver.compiler-plugin:test` — 56 passed; 85 failures,
      all `viper.silicon.reporting.ExternalToolError` in
      `PhasedDiagnosticTestGenerated` (Z3 is not installed on this host, so
      the Silicon-backed verification golden tests can't run here — relying
      on CI for those)