### PR TITLE
Consolidate build versions into a version catalog and convention plugin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Setup Z3
         id: z3
         uses: cda-tum/setup-z3@v1
@@ -36,13 +36,13 @@ jobs:
         run: $Z3_EXE --version
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'corretto'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v6
       - name: Run detekt
         run: ./gradlew detekt
       - name: Check public API compatibility

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,11 @@ import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.3.0" apply false
-    id("com.github.gmazzo.buildconfig") version "5.6.5"
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.16.3" apply false
-    id("com.gradle.plugin-publish") version "1.3.1" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.23.7"
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.buildconfig)
+    alias(libs.plugins.binary.compatibility.validator) apply false
+    alias(libs.plugins.plugin.publish) apply false
+    alias(libs.plugins.detekt)
 }
 
 allprojects {
@@ -26,7 +26,6 @@ subprojects {
     detekt {
         buildUponDefaultConfig = true
         config.setFrom(rootProject.files("config/detekt/detekt.yml"))
-        baseline = rootProject.file("config/detekt/baseline.xml")
     }
 
     tasks.withType<Detekt>().configureEach {

--- a/buildSrc/src/main/kotlin/ViperVersions.kt
+++ b/buildSrc/src/main/kotlin/ViperVersions.kt
@@ -1,3 +1,0 @@
-object ViperVersions {
-    const val silicon = "viper:silicon_2.13:2026-04-10_b005beb"
-}

--- a/buildSrc/src/main/kotlin/formver.source-layout.gradle.kts
+++ b/buildSrc/src/main/kotlin/formver.source-layout.gradle.kts
@@ -1,0 +1,15 @@
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+
+pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+    val sourceSets = project.extensions.getByType<SourceSetContainer>()
+    sourceSets.named("main") {
+        java.srcDirs("src")
+        resources.srcDir("resources")
+    }
+    sourceSets.named("test") {
+        java.setSrcDirs(emptyList<String>())
+        resources.setSrcDirs(emptyList<String>())
+    }
+}

--- a/formver.annotations/build.gradle.kts
+++ b/formver.annotations/build.gradle.kts
@@ -2,17 +2,7 @@ plugins {
     kotlin("jvm")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
     id("maven-publish")
-}
-
-sourceSets {
-    main {
-        java.srcDirs("src")
-        resources.srcDir("resources")
-    }
-    test {
-        java.setSrcDirs(emptyList<String>())
-        resources.setSrcDirs(emptyList<String>())
-    }
+    id("formver.source-layout")
 }
 
 publishing {

--- a/formver.common/build.gradle.kts
+++ b/formver.common/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm")
     id("maven-publish")
     `java-library`
+    id("formver.source-layout")
 }
 
 repositories {
@@ -11,17 +12,6 @@ repositories {
 dependencies {
     compileOnly(kotlin("compiler"))
     api(kotlin("compiler-internal-test-framework"))
-}
-
-sourceSets {
-    main {
-        java.srcDirs("src")
-        resources.srcDir("resources")
-    }
-    test {
-        java.setSrcDirs(emptyList<String>())
-        resources.setSrcDirs(emptyList<String>())
-    }
 }
 
 publishing {

--- a/formver.compiler-plugin/build.gradle.kts
+++ b/formver.compiler-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.github.gmazzo.buildconfig")
     idea
     id("maven-publish")
-    id("com.gradleup.shadow") version "9.0.0-rc1"
+    alias(libs.plugins.shadow)
 }
 
 sourceSets {
@@ -43,7 +43,7 @@ dependencies {
     testFixturesImplementation(project(":formver.common"))
     testFixturesImplementation(project(":formver.compiler-plugin:plugin"))
     testFixturesApi(project(":formver.compiler-plugin:viper"))
-    testFixturesApi("viper:silicon_2.13:1.2-SNAPSHOT")
+    testFixturesApi(libs.viper.silicon)
     testFixturesImplementation(project(":formver.compiler-plugin:core"))
     testFixturesImplementation(project(":formver.compiler-plugin:locality"))
 

--- a/formver.compiler-plugin/cli/build.gradle.kts
+++ b/formver.compiler-plugin/cli/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm")
+    id("formver.source-layout")
 }
 
 dependencies {
@@ -7,15 +8,4 @@ dependencies {
     implementation(project(":formver.common"))
     implementation(project(":formver.compiler-plugin:plugin"))
     implementation(project(":formver.compiler-plugin:locality"))
-}
-
-sourceSets {
-    main {
-        java.srcDirs("src")
-        resources.srcDir("resources")
-    }
-    test {
-        java.setSrcDirs(emptyList<String>())
-        resources.setSrcDirs(emptyList<String>())
-    }
 }

--- a/formver.compiler-plugin/core/build.gradle.kts
+++ b/formver.compiler-plugin/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm")
+    id("formver.source-layout")
 }
 
 dependencies {
@@ -8,16 +9,5 @@ dependencies {
     compileOnly(kotlin("compiler"))
 
     // TODO: figure out how to avoid this dependency
-    compileOnly(ViperVersions.silicon)
-}
-
-sourceSets {
-    main {
-        java.srcDirs("src")
-        resources.srcDir("resources")
-    }
-    test {
-        java.setSrcDirs(emptyList<String>())
-        resources.setSrcDirs(emptyList<String>())
-    }
+    compileOnly(libs.viper.silicon)
 }

--- a/formver.compiler-plugin/locality/build.gradle.kts
+++ b/formver.compiler-plugin/locality/build.gradle.kts
@@ -21,7 +21,7 @@ sourceSets {
 
 dependencies {
     compileOnly(kotlin("compiler"))
-    compileOnly("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.7")
+    compileOnly(libs.kotlinx.collections.immutable)
     testFixturesApi(kotlin("test-junit5"))
     testFixturesApi(kotlin("compiler-internal-test-framework"))
     testFixturesApi(kotlin("compiler"))

--- a/formver.compiler-plugin/plugin/build.gradle.kts
+++ b/formver.compiler-plugin/plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm")
+    id("formver.source-layout")
 }
 
 dependencies {
@@ -13,16 +14,5 @@ dependencies {
     compileOnly(kotlin("compiler"))
 
     // TODO: figure out how to avoid this dependency
-    compileOnly(ViperVersions.silicon)
-}
-
-sourceSets {
-    main {
-        java.srcDirs("src")
-        resources.srcDir("resources")
-    }
-    test {
-        java.setSrcDirs(emptyList<String>())
-        resources.setSrcDirs(emptyList<String>())
-    }
+    compileOnly(libs.viper.silicon)
 }

--- a/formver.compiler-plugin/uniqueness/build.gradle.kts
+++ b/formver.compiler-plugin/uniqueness/build.gradle.kts
@@ -1,19 +1,9 @@
 plugins {
     kotlin("jvm")
+    id("formver.source-layout")
 }
 
 dependencies {
     compileOnly(kotlin("compiler"))
     implementation(project(":formver.common"))
-}
-
-sourceSets {
-    main {
-        java.srcDirs("src")
-        resources.srcDir("resources")
-    }
-    test {
-        java.setSrcDirs(emptyList<String>())
-        resources.setSrcDirs(emptyList<String>())
-    }
 }

--- a/formver.compiler-plugin/viper/build.gradle.kts
+++ b/formver.compiler-plugin/viper/build.gradle.kts
@@ -1,18 +1,8 @@
 plugins {
     kotlin("jvm")
+    id("formver.source-layout")
 }
 
 dependencies {
-    implementation(ViperVersions.silicon)
-}
-
-sourceSets {
-    main {
-        java.srcDirs("src")
-        resources.srcDir("resources")
-    }
-    test {
-        java.setSrcDirs(emptyList<String>())
-        resources.setSrcDirs(emptyList<String>())
-    }
+    implementation(libs.viper.silicon)
 }

--- a/formver.gradle-plugin/build.gradle.kts
+++ b/formver.gradle-plugin/build.gradle.kts
@@ -4,17 +4,7 @@ plugins {
     id("java-gradle-plugin")
     id("com.gradle.plugin-publish")
     id("maven-publish")
-}
-
-sourceSets {
-    main {
-        java.setSrcDirs(listOf("src"))
-        resources.setSrcDirs(listOf("resources"))
-    }
-    test {
-        java.setSrcDirs(listOf<String>())
-        resources.setSrcDirs(listOf<String>())
-    }
+    id("formver.source-layout")
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,21 @@
+[versions]
+kotlin = "2.3.0"
+detekt = "1.23.7"
+buildconfig = "5.6.5"
+binary-compatibility-validator = "0.16.3"
+plugin-publish = "1.3.1"
+shadow = "9.4.3"
+kotlinx-collections-immutable = "0.3.7"
+silicon = "2026-04-10_b005beb"
+
+[libraries]
+viper-silicon = { module = "viper:silicon_2.13", version.ref = "silicon" }
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "kotlinx-collections-immutable" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binary-compatibility-validator" }
+plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
## Summary

- Introduce `gradle/libs.versions.toml` and move every plugin/dependency
  version there (Kotlin, detekt, buildconfig, binary-compatibility-validator,
  plugin-publish, shadow, kotlinx-collections-immutable, and the Silicon
  coordinate) so each is declared exactly once.
- Fix Silicon version drift: `buildSrc/ViperVersions.kt` pinned
  `2026-04-10_b005beb` while `formver.compiler-plugin`'s `testFixturesApi`
  hardcoded a stale `1.2-SNAPSHOT` coordinate that the April 2026 Viper
  upgrade (#95) missed. Both now resolve from the catalog's single `silicon`
  entry; `ViperVersions.kt` is removed.
- Bump the shadow plugin off the `9.0.0-rc1` release candidate to stable
  `9.4.3`.
- Extract the copy-pasted `src/` + `test/` `sourceSets {}` block — pasted
  identically across seven modules — into a `formver.source-layout`
  precompiled convention plugin in `buildSrc`, applied per module. (The
  `locality` module was restructured to its own testFixtures-based layout
  by #157 after this branch started, so it keeps a custom `sourceSets`
  block like the `compiler-plugin` root module; only its dependency
  version now comes from the catalog.)
- Drop the dangling `config/detekt/baseline.xml` reference in the root
  build file; the file doesn't exist and `maxIssues: 0` makes a baseline
  unnecessary.
- Bump deprecated CI Actions: `actions/checkout@v3`→`v7`,
  `actions/setup-java@v3`→`v5`, `gradle/gradle-build-action@v2`→
  `gradle/actions/setup-gradle@v6`.

## Test plan

- [x] `./gradlew detekt` — passes
- [x] `./gradlew build -x test` — passes, including `apiCheck`
- [x] `./gradlew :formver.compiler-plugin:untilConversion` — passes
      (conversion tests, no Z3 required)
- [ ] Full `:formver.compiler-plugin:test` (verification mode) — not run
      locally, Z3 isn't installed on this host; relying on PR CI, which
      installs Z3

🤖 Generated with [Claude Code](https://claude.com/claude-code)