### PR TITLE
Unify Viper AST node trailer and derive name registration from nodes

### DIFF
--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/AccessPredicate.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/AccessPredicate.kt
@@ -15,8 +15,8 @@ sealed interface AccessPredicate : Exp {
     data class FieldAccessPredicate(
         val access: Exp.FieldAccess,
         val perm: PermExp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : AccessPredicate {
         override val type: Type.Bool = Type.Bool
 
@@ -29,5 +29,8 @@ sealed interface AccessPredicate : Exp {
                 info.toSilver(),
                 silverNoTrafos
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {}
     }
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Declaration.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Declaration.kt
@@ -7,12 +7,14 @@ package org.jetbrains.kotlin.formver.viper.ast
 
 import org.jetbrains.kotlin.formver.viper.*
 
-sealed interface Declaration : IntoSilver<viper.silver.ast.Declaration> {
+sealed interface Declaration : WithSilverMetadata, IntoSilver<viper.silver.ast.Declaration> {
+    val name: SymbolicName
+
     data class LocalVarDecl(
-        val name: SymbolicName,
+        override val name: SymbolicName,
         val type: Type,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Declaration {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LocalVarDecl =
@@ -26,16 +28,16 @@ sealed interface Declaration : IntoSilver<viper.silver.ast.Declaration> {
     }
 
     data class LabelDecl(
-        val name: SymbolicName,
+        override val name: SymbolicName,
         val invariants: List<Exp>,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Declaration {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Label = viper.silver.ast.Label(
             name.mangled,
             invariants.toSilver().toScalaSeq(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -8,84 +8,120 @@ package org.jetbrains.kotlin.formver.viper.ast
 import org.jetbrains.kotlin.formver.viper.*
 import viper.silver.ast.*
 
+/**
+ * Shape shared by every binary Viper expression: two sub-expressions plus the position/info
+ * trailer, encoded into Silver as `make(left, right, pos, info, silverNoTrafos)`.
+ */
 sealed interface BinaryExp : Exp {
     val left: Exp
     val right: Exp
+
+    context(nameResolver: NameResolver)
+    override fun registerNames() {
+        left.registerNames()
+        right.registerNames()
+    }
+
+    context(nameResolver: NameResolver)
+    fun <S : viper.silver.ast.Exp> toSilverVia(
+        make: (viper.silver.ast.Exp, viper.silver.ast.Exp, viper.silver.ast.Position, viper.silver.ast.Info, ErrorTrafo) -> S,
+    ): S = make(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
 }
-sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
+
+/**
+ * Shape shared by every unary Viper expression: one sub-expression plus the position/info
+ * trailer, encoded into Silver as `make(arg, pos, info, silverNoTrafos)`.
+ */
+sealed interface UnaryExp : Exp {
+    val arg: Exp
+
+    context(nameResolver: NameResolver)
+    override fun registerNames() {
+        arg.registerNames()
+    }
+
+    context(nameResolver: NameResolver)
+    fun <S : viper.silver.ast.Exp> toSilverVia(
+        make: (viper.silver.ast.Exp, viper.silver.ast.Position, viper.silver.ast.Info, ErrorTrafo) -> S,
+    ): S = make(arg.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+}
+
+sealed interface Exp : WithSilverMetadata, IntoSilver<viper.silver.ast.Exp> {
 
     val type: Type
 
+    /**
+     * Registers the [org.jetbrains.kotlin.formver.viper.SymbolicName]s this node and its
+     * descendants introduce or reference, so they receive collision-free Viper identifiers.
+     * Must recurse into exactly the sub-nodes whose names end up in the emitted Viper program.
+     */
+    context(nameResolver: NameResolver)
+    fun registerNames()
+
     data class Minus(
-        val arg: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
-    ) : Exp {
+        override val arg: Exp,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
+    ) : UnaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Minus =
-            Minus(arg.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Minus = toSilverVia(::Minus)
     }
 
     //region Arithmetic Expressions
     data class Add(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Add =
-            Add(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Add = toSilverVia(::Add)
     }
 
     data class Sub(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Sub =
-            Sub(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Sub = toSilverVia(::Sub)
     }
 
     data class Mul(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Mul =
-            Mul(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Mul = toSilverVia(::Mul)
     }
 
     data class Div(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Div =
-            Div(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Div = toSilverVia(::Div)
     }
 
     data class Mod(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Mod =
-            Mod(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Mod = toSilverVia(::Mod)
     }
     //endregion
 
@@ -93,49 +129,45 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     data class LtCmp(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.LtCmp =
-            LtCmp(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.LtCmp = toSilverVia(::LtCmp)
     }
 
     data class LeCmp(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.LeCmp =
-            LeCmp(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.LeCmp = toSilverVia(::LeCmp)
     }
 
     data class GtCmp(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.GtCmp =
-            GtCmp(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.GtCmp = toSilverVia(::GtCmp)
     }
 
     data class GeCmp(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.GeCmp =
-            GeCmp(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.GeCmp = toSilverVia(::GeCmp)
     }
     //endregion
 
@@ -143,25 +175,23 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     data class EqCmp(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.EqCmp =
-            EqCmp(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.EqCmp = toSilverVia(::EqCmp)
     }
 
     data class NeCmp(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.NeCmp =
-            NeCmp(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.NeCmp = toSilverVia(::NeCmp)
     }
     //endregion
 
@@ -169,48 +199,44 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
     data class And(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.And =
-            And(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.And = toSilverVia(::And)
     }
 
     data class Or(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Or =
-            Or(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Or = toSilverVia(::Or)
     }
 
     data class Implies(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Implies =
-            Implies(left.toSilver(), right.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Implies = toSilverVia(::Implies)
     }
 
     data class Not(
-        val arg: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
-    ) : Exp {
+        override val arg: Exp,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
+    ) : UnaryExp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.Not =
-            Not(arg.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+        override fun toSilver(): viper.silver.ast.Not = toSilverVia(::Not)
     }
     //endregion
 
@@ -229,8 +255,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val variables: List<Declaration.LocalVarDecl>,
         val triggers: List<Trigger>,
         val exp: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
@@ -243,14 +269,20 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
                 info.toSilver(),
                 silverNoTrafos
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            variables.forEach { nameResolver.register(it.name) }
+            exp.registerNames()
+        }
     }
 
     data class Exists(
         val variables: List<Declaration.LocalVarDecl>,
         val triggers: List<Trigger>,
         val exp: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
@@ -263,80 +295,109 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
                 info.toSilver(),
                 silverNoTrafos
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            variables.forEach { nameResolver.register(it.name) }
+            exp.registerNames()
+        }
     }
 
     //region Literals
     data class IntLit(
         val value: Int,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = Type.Int
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.IntLit =
             IntLit(value.toScalaBigInt(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {}
     }
 
     data class NullLit(
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = Type.Ref
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.NullLit = NullLit(pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {}
     }
 
     data class BoolLit(
         val value: Boolean,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = Type.Bool
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.BoolLit =
             viper.silver.ast.BoolLit.apply(value, pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {}
     }
     //endregion
 
     data class LocalVar(
         val name: SymbolicName,
         override val type: Type,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LocalVar =
             LocalVar(name.mangled, type.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(name)
+        }
     }
 
     data class FieldAccess(
         val rcv: Exp,
         val field: Field,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = field.type
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.FieldAccess =
             FieldAccess(rcv.toSilver(), field.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(field.name)
+            rcv.registerNames()
+        }
     }
 
     data class Result(
         override val type: Type,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Result =
             Result(type.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {}
     }
 
     data class FuncApp(
         val functionName: SymbolicName,
         val args: List<Exp>,
         override val type: Type,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.FuncApp = FuncApp(
@@ -347,6 +408,12 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
             type.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(functionName)
+            args.forEach { it.registerNames() }
+        }
     }
 
     /**
@@ -360,8 +427,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val function: DomainFunc,
         val args: List<Exp>,
         val typeVarMap: Map<Type.TypeVar, Type>,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         private val scalaTypeVarMap: scala.collection.immutable.Map<TypeVar, viper.silver.ast.Type>
@@ -377,6 +444,13 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
                 info.toSilver(),
                 silverNoTrafos
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(function.name)
+            function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
+            args.forEach { it.registerNames() }
+        }
     }
 
     /** Represents the application of an ADT constructor. Triggered by an ADT reference in an `AdtConstructorRef`. */
@@ -384,8 +458,8 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
         val constructor: AdtConstructorDecl,
         val args: List<Exp>,
         val typeVarMap: Map<Type.TypeVar, Type> = emptyMap(),
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type: Type = Type.Adt(constructor.adtName)
 
@@ -399,12 +473,18 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
                 info.toSilver(),
                 silverNoTrafos,
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(constructor.name)
+            args.forEach { it.registerNames() }
+        }
     }
 
     data class ExplicitSeq(
         val args: List<Exp>,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.ExplicitSeq =
@@ -416,12 +496,17 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
             )
 
         override val type = Type.Seq(args.first().type)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            args.forEach { it.registerNames() }
+        }
     }
 
     data class EmptySeq(
         val elementType: Type,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.EmptySeq =
@@ -433,12 +518,15 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
             )
 
         override val type = Type.Seq(elementType)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {}
     }
 
     data class SeqLength(
         val seq: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.SeqLength =
@@ -450,13 +538,18 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
             )
 
         override val type = Type.Int
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            seq.registerNames()
+        }
     }
 
     data class SeqTake(
         val seq: Exp,
         val idx: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.SeqTake =
@@ -469,13 +562,19 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
             )
 
         override val type = seq.type
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            seq.registerNames()
+            idx.registerNames()
+        }
     }
 
     data class SeqIndex(
         val seq: Exp,
         val idx: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.SeqIndex =
@@ -488,44 +587,48 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
             )
 
         override val type = Type.Int
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            seq.registerNames()
+            idx.registerNames()
+        }
     }
 
     data class SeqAppend(
         override val left: Exp,
         override val right: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : BinaryExp {
         context(nameResolver: NameResolver)
-        override fun toSilver(): viper.silver.ast.SeqAppend =
-            viper.silver.ast.SeqAppend.apply(
-                left.toSilver(),
-                right.toSilver(),
-                pos.toSilver(),
-                info.toSilver(),
-                silverNoTrafos,
-            )
+        override fun toSilver(): viper.silver.ast.SeqAppend = toSilverVia(viper.silver.ast.SeqAppend::apply)
 
         override val type = left.type
     }
 
     data class Old(
         val exp: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = exp.type
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Old =
             Old(exp.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            exp.registerNames()
+        }
     }
 
     data class PredicateAccess(
         val predicateName: SymbolicName,
         val formalArgs: List<Exp>,
         val perm: PermExp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         // The type is set to Bool just to be consistent with Silver type. Probably it will never be used
         override val type: Type = Type.Bool
@@ -549,25 +652,37 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
                 silverNoTrafos
             )
         }
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(predicateName)
+            formalArgs.forEach { it.registerNames() }
+        }
     }
 
     data class Unfolding(
         val predicateAccess: PredicateAccess,
         val body: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = body.type
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Unfolding =
             Unfolding(predicateAccess.toSilver(), body.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            predicateAccess.registerNames()
+            body.registerNames()
+        }
     }
 
     data class Acc(
         val field: FieldAccess,
         val perm: PermExp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Exp {
         override val type = Type.Bool
 
@@ -579,34 +694,51 @@ sealed interface Exp : IntoSilver<viper.silver.ast.Exp> {
                 info.toSilver(),
                 silverNoTrafos,
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            field.registerNames()
+        }
     }
 
     data class LetBinding(
         val variable: Declaration.LocalVarDecl,
         val varExp: Exp,
         val body: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ): Exp {
         override val type: Type = variable.type
 
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Let =
             Let(variable.toSilver(), varExp.toSilver(), body.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(variable.name)
+            body.registerNames()
+        }
     }
 
     data class TernaryExp(
         val condExp: Exp,
         val thenExp: Exp,
         val elseExp: Exp,
-        val pos: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ): Exp {
         override val type: Type = thenExp.type.also { assert(it == elseExp.type) }
 
         context(nameResolver: NameResolver)
         override fun toSilver(): CondExp =
             CondExp(condExp.toSilver(), thenExp.toSilver(), elseExp.toSilver(), pos.toSilver(), info.toSilver(), silverNoTrafos)
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            thenExp.registerNames()
+            elseExp.registerNames()
+        }
     }
 
     // We can't pass all the available position and info here.

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Program.kt
@@ -52,140 +52,6 @@ data class Program(
 }
 
 context(nameResolver: NameResolver)
-private fun registerExpNames(exp: Exp) {
-    when (exp) {
-        is Exp.LocalVar -> nameResolver.register(exp.name)
-        is Exp.FieldAccess -> {
-            nameResolver.register(exp.field.name)
-            registerExpNames(exp.rcv)
-        }
-
-        is Exp.PredicateAccess -> {
-            nameResolver.register(exp.predicateName)
-            exp.formalArgs.forEach { registerExpNames(it) }
-        }
-
-        is BinaryExp -> {
-            registerExpNames(exp.left)
-            registerExpNames(exp.right)
-        }
-
-        is Exp.FuncApp -> {
-            nameResolver.register(exp.functionName)
-            exp.args.forEach { registerExpNames(it) }
-        }
-
-        is Exp.DomainFuncApp -> {
-            nameResolver.register(exp.function.name)
-            exp.function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-            exp.args.forEach { registerExpNames(it) }
-        }
-
-        is Exp.Forall -> {
-            exp.variables.forEach { nameResolver.register(it.name) }
-            registerExpNames(exp.exp)
-        }
-
-        is Exp.Exists -> {
-            exp.variables.forEach { nameResolver.register(it.name) }
-            registerExpNames(exp.exp)
-        }
-
-        is Exp.LetBinding -> {
-            nameResolver.register(exp.variable.name)
-            registerExpNames(exp.body)
-        }
-
-        is Exp.Old -> registerExpNames(exp.exp)
-        is Exp.TernaryExp -> {
-            registerExpNames(exp.thenExp)
-            registerExpNames(exp.elseExp)
-        }
-
-        is AccessPredicate.FieldAccessPredicate -> {}
-        is Exp.Acc -> registerExpNames(exp.field)
-        is Exp.ExplicitSeq -> exp.args.forEach { registerExpNames(it) }
-        is Exp.Minus -> registerExpNames(exp.arg)
-        is Exp.Not -> registerExpNames(exp.arg)
-        is Exp.SeqIndex -> {
-            registerExpNames(exp.seq)
-            registerExpNames(exp.idx)
-        }
-
-        is Exp.SeqLength -> registerExpNames(exp.seq)
-        is Exp.SeqTake -> {
-            registerExpNames(exp.seq)
-            registerExpNames(exp.idx)
-        }
-
-        is Exp.Unfolding -> {
-            registerExpNames(exp.predicateAccess)
-            registerExpNames(exp.body)
-        }
-        is Exp.AdtConstructorApp -> {
-            nameResolver.register(exp.constructor.name)
-            exp.args.forEach { registerExpNames(it) }
-        }
-        // no else branch to make decisions explicit.
-        is Exp.Result, is Exp.BoolLit, is Exp.EmptySeq, is Exp.IntLit, is Exp.NullLit -> {}
-    }
-}
-
-context(nameResolver: NameResolver)
-private fun Program.registerStmtNames(stmt: Stmt) = when (stmt) {
-    is Stmt.Label -> {
-        nameResolver.register(stmt.name)
-        stmt.invariants.forEach { registerExpNames(it) }
-    }
-
-    is Stmt.Seqn -> registerSeqnNames(stmt)
-    is Stmt.Goto -> nameResolver.register(stmt.name)
-    is Stmt.MethodCall -> {
-        stmt.args.forEach { registerExpNames(it) }
-        stmt.targets.forEach { registerExpNames(it) }
-        nameResolver.register(stmt.methodName)
-    }
-
-    is Stmt.If -> {
-        registerExpNames(stmt.cond)
-        registerSeqnNames(stmt.then)
-        stmt.els?.let { registerSeqnNames(it) }
-    }
-
-    is Stmt.While -> {
-        registerExpNames(stmt.cond)
-        registerSeqnNames(stmt.body)
-        stmt.invariants.forEach { registerExpNames(it) }
-    }
-
-    is Stmt.LocalVarAssign -> {
-        nameResolver.register(stmt.lhs.name)
-        registerExpNames(stmt.rhs)
-    }
-
-    is Stmt.Fold -> nameResolver.register(stmt.acc.predicateName)
-    is Stmt.Unfold -> nameResolver.register(stmt.acc.predicateName)
-    is Stmt.Assert -> registerExpNames(stmt.exp)
-    is Stmt.Exhale -> registerExpNames(stmt.exp)
-    is Stmt.Inhale -> registerExpNames(stmt.exp)
-    is Stmt.FieldAssign -> {
-        registerExpNames(stmt.lhs)
-        registerExpNames(stmt.rhs)
-    }
-}
-
-context(nameResolver: NameResolver)
-private fun Program.registerSeqnNames(seqn: Stmt.Seqn) {
-    seqn.scopedSeqnDeclarations.forEach { decl ->
-        when (decl) {
-            is Declaration.LocalVarDecl -> nameResolver.register(decl.name)
-            is Declaration.LabelDecl -> nameResolver.register(decl.name)
-        }
-    }
-    seqn.stmts.forEach { registerStmtNames(it) }
-}
-
-context(nameResolver: NameResolver)
 fun Program.registerAllNames() {
     domains.forEach { domain ->
         nameResolver.register(domain.name)
@@ -195,7 +61,7 @@ fun Program.registerAllNames() {
         }
         domain.axioms.forEach { axiom ->
             axiom.name?.let { nameResolver.register(it) }
-            registerExpNames(axiom.exp)
+            axiom.exp.registerNames()
         }
     }
     fields.forEach { nameResolver.register(it.name) }
@@ -203,24 +69,24 @@ fun Program.registerAllNames() {
     functions.forEach { function ->
         nameResolver.register(function.name)
         function.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-        function.pres.forEach { arg -> registerExpNames(arg) }
-        function.posts.forEach { arg -> registerExpNames(arg) }
-        function.body?.let { exp -> registerExpNames(exp) }
+        function.pres.forEach { it.registerNames() }
+        function.posts.forEach { it.registerNames() }
+        function.body?.registerNames()
     }
 
     predicates.forEach { predicate ->
         nameResolver.register(predicate.name)
         predicate.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
-        registerExpNames(predicate.body)
+        predicate.body.registerNames()
     }
 
     methods.forEach { method ->
         nameResolver.register(method.name)
         method.formalArgs.forEach { arg -> nameResolver.register(arg.name) }
         method.formalReturns.forEach { ret -> nameResolver.register(ret.name) }
-        method.pres.forEach { arg -> registerExpNames(arg) }
-        method.posts.forEach { arg -> registerExpNames(arg) }
-        method.body?.let { seqn -> registerSeqnNames(seqn) }
+        method.pres.forEach { it.registerNames() }
+        method.posts.forEach { it.registerNames() }
+        method.body?.registerNames()
     }
 
     adts.forEach { adt ->

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/SilverMetadata.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/SilverMetadata.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.viper.ast
+
+/**
+ * Trailer of source-position and diagnostic metadata carried by every Viper AST node.
+ */
+interface WithSilverMetadata {
+    val pos: Position
+    val info: Info
+}

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Stmt.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Stmt.kt
@@ -7,54 +7,74 @@ package org.jetbrains.kotlin.formver.viper.ast
 
 import org.jetbrains.kotlin.formver.viper.*
 
-sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
+sealed interface Stmt : WithSilverMetadata, IntoSilver<viper.silver.ast.Stmt> {
+
+    /**
+     * Registers the [org.jetbrains.kotlin.formver.viper.SymbolicName]s this node and its
+     * descendants introduce or reference, so they receive collision-free Viper identifiers.
+     * Must recurse into exactly the sub-nodes whose names end up in the emitted Viper program.
+     */
+    context(nameResolver: NameResolver)
+    fun registerNames()
 
     data class LocalVarAssign(
         val lhs: Exp.LocalVar,
         val rhs: Exp,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.LocalVarAssign =
             viper.silver.ast.LocalVarAssign(
                 lhs.toSilver(),
                 rhs.toSilver(),
-                position.toSilver(),
+                pos.toSilver(),
                 info.toSilver(),
                 silverNoTrafos
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(lhs.name)
+            rhs.registerNames()
+        }
     }
 
     data class FieldAssign(
         val lhs: Exp.FieldAccess,
         val rhs: Exp,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.FieldAssign =
             viper.silver.ast.FieldAssign(
                 lhs.toSilver(),
                 rhs.toSilver(),
-                position.toSilver(),
+                pos.toSilver(),
                 info.toSilver(),
                 silverNoTrafos
             )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            lhs.registerNames()
+            rhs.registerNames()
+        }
     }
 
     companion object {
         fun assign(
             lhs: Exp,
             rhs: Exp,
-            position: Position = Position.NoPosition,
+            pos: Position = Position.NoPosition,
             info: Info = Info.NoInfo,
         ): Stmt = when (lhs) {
             is Exp.LocalVar ->
-                LocalVarAssign(lhs, rhs, position, info)
+                LocalVarAssign(lhs, rhs, pos, info)
 
             is Exp.FieldAccess ->
-                FieldAssign(lhs, rhs, position, info)
+                FieldAssign(lhs, rhs, pos, info)
 
             else -> {
                 throw IllegalArgumentException("Expected an lvalue on the left-hand side of an assignment.")
@@ -66,169 +86,232 @@ sealed interface Stmt : IntoSilver<viper.silver.ast.Stmt> {
         val methodName: SymbolicName,
         val args: List<Exp>,
         val targets: List<Exp.LocalVar>,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.MethodCall = viper.silver.ast.MethodCall(
             methodName.mangled,
             args.map { it.toSilver() }.toScalaSeq(),
             targets.map { it.toSilver() }.toScalaSeq(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            args.forEach { it.registerNames() }
+            targets.forEach { it.registerNames() }
+            nameResolver.register(methodName)
+        }
     }
 
     data class Exhale(
         val exp: Exp,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Exhale = viper.silver.ast.Exhale(
             exp.toSilver(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            exp.registerNames()
+        }
     }
 
     data class Inhale(
         val exp: Exp,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Inhale = viper.silver.ast.Inhale(
             exp.toSilver(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            exp.registerNames()
+        }
     }
 
     data class Assert(
         val exp: Exp,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Assert = viper.silver.ast.Assert(
             exp.toSilver(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            exp.registerNames()
+        }
     }
 
     data class Seqn(
         val stmts: List<Stmt> = listOf(),
         val scopedSeqnDeclarations: List<Declaration> = listOf(),
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Seqn = viper.silver.ast.Seqn(
             stmts.toSilver().toScalaSeq(),
             scopedSeqnDeclarations.toSilver().toScalaSeq(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            scopedSeqnDeclarations.forEach { nameResolver.register(it.name) }
+            stmts.forEach { it.registerNames() }
+        }
     }
 
     data class If(
         val cond: Exp,
         val then: Seqn,
         val els: Seqn?,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.If = viper.silver.ast.If(
             cond.toSilver(),
             then.toSilver(),
             els?.toSilver() ?: Seqn().toSilver(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            cond.registerNames()
+            then.registerNames()
+            els?.registerNames()
+        }
     }
 
     data class While(
         val cond: Exp,
         val invariants: List<Exp>,
         val body: Seqn,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.While = viper.silver.ast.While(
             cond.toSilver(),
             invariants.map { it.toSilver() }.toScalaSeq(),
             body.toSilver(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            cond.registerNames()
+            body.registerNames()
+            invariants.forEach { it.registerNames() }
+        }
     }
 
     data class Label(
         val name: SymbolicName,
         val invariants: List<Exp>,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Label = viper.silver.ast.Label(
             name.mangled,
             invariants.map { it.toSilver() }.toScalaSeq(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(name)
+            invariants.forEach { it.registerNames() }
+        }
     }
 
     data class Goto(
         val name: SymbolicName,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Goto = viper.silver.ast.Goto(
             name.mangled,
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(name)
+        }
     }
 
     data class Fold(
         val acc: Exp.PredicateAccess,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Fold = viper.silver.ast.Fold(
             acc.toSilver(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(acc.predicateName)
+        }
     }
 
     data class Unfold(
         val acc: Exp.PredicateAccess,
-        val position: Position = Position.NoPosition,
-        val info: Info = Info.NoInfo,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
     ) : Stmt {
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Unfold = viper.silver.ast.Unfold(
             acc.toSilver(),
-            position.toSilver(),
+            pos.toSilver(),
             info.toSilver(),
             silverNoTrafos
         )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(acc.predicateName)
+        }
     }
 }


### PR DESCRIPTION
## Summary

One slice of the Viper AST maintainability push: declare each node's shape once instead of two or three times.

- Added `WithSilverMetadata`, a shared `pos`/`info` interface (upstream #173 deleted the `trafos` metadata, so the trailer is two fields now) implemented by `Exp`, `Stmt`, and `Declaration`. Renamed `Stmt`'s and `Declaration.LabelDecl`'s `position` field to `pos` to match `Exp`/`Program`/everything else (no call sites used named arguments, so this is a pure rename).
- Added `BinaryExp`/`UnaryExp` marker interfaces that collapse the mechanical `toSilver()` forwarding for the arithmetic, comparison, and boolean-operator families (15 binary + 2 unary node types) down to a one-line `toSilverVia(::Ctor)` delegation, and give the whole binary family a single shared `registerNames()` default.
- Replaced `Program.kt`'s hand-maintained `registerExpNames`/`registerStmtNames`/`registerSeqnNames` walkers (~135 lines, which had to be updated in lockstep with every new `Exp`/`Stmt` variant) with an abstract `registerNames()` member declared directly on `Exp` and `Stmt`. Every node now declares its own name-registration behavior next to its shape; a new node that omits it is a compile error, same enforcement level as the `when` exhaustiveness it replaces.

No changes to `Field.kt`/`Domain.kt`/`Method.kt`/`Predicate.kt`/`AdtDecl.kt` etc. — out of scope for this slice, which targets `Exp.kt`/`Stmt.kt`/`Program.kt` per the brief.

Design choice worth flagging: `registerNames()` bodies are colocated per-node rather than derived from a generic "expose children" traversal, because the original per-branch registration order is *not* uniform (e.g. `MethodCall` registers its args/targets before its own name; `Forall`/`LetBinding`/`TernaryExp` deliberately skip some sub-expressions). `ShortNameResolver.resolve()` breaks collision ties via `minByOrNull`, which is order-sensitive, so a generic traversal risked silently changing which of several equal-cost manglings gets picked. Preserving the exact original order per node keeps the refactor a pure move with zero behavioral risk.

## Line counts (files named in the brief)

| file | before | after |
|---|---|---|
| `Exp.kt` | 809 | 941 |
| `Stmt.kt` | 248 | 331 |
| `Program.kt` | 235 | 101 |
| `SilverMetadata.kt` (new) | — | 15 |

Net across these four files: +96 lines. `Exp.kt`/`Stmt.kt` grew because every node now carries its own `registerNames()` (even trivial no-ops, mirroring the exhaustiveness the old `when` enforced), while `Program.kt` shrank by 57%. The win is structural (one place to touch per new node), not raw LOC.

## Test plan

- [x] `./gradlew :formver.compiler-plugin:viper:compileKotlin` — compiles clean
- [x] `./gradlew :formver.compiler-plugin:core:compileKotlin :formver.compiler-plugin:plugin:compileKotlin` — downstream consumers compile clean (only a pre-existing, unrelated warning)
- [x] `./gradlew detekt` — clean
- [x] `./gradlew :formver.compiler-plugin:test` — 141 tests, 56 pass, 85 fail. All 85 failures are `viper.silicon.reporting.ExternalToolError` because Z3 is not installed on this host (`Z3_EXE` unset, no `z3` binary) — this matches the task brief's expectation exactly. Zero non-Z3 failures; the golden-file/conversion tests (which check byte-identical Viper dumps) all pass. Verification-mode tests should be validated by CI, which has Z3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
