### PR TITLE
Route unsupported-Kotlin-feature sites through one funnel

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
@@ -12,42 +12,54 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.formver.core.isFormverFunctionNamed
 
-fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Boolean): FirAnonymousFunction? {
+fun FirStatement.extractFormverFirBlock(
+    ctx: ProgramConversionContext,
+    predicate: FirFunctionSymbol<*>.() -> Boolean,
+): FirAnonymousFunction? {
     if (this !is FirFunctionCall) return null
     val firFunction = toResolvedCallableSymbol() as? FirFunctionSymbol<*> ?: return null
     if (!predicate(firFunction)) return null
     val formverInvariantsArgument = argument
-    if (formverInvariantsArgument !is FirAnonymousFunctionExpression)
-        error("Only lambdas are allowed as arguments of ${firFunction.name}.")
+    if (formverInvariantsArgument !is FirAnonymousFunctionExpression) {
+        return ctx.handleUnsupportedFeature(
+            source, "Only lambdas are allowed as arguments of ${firFunction.name}."
+        ) { null }
+    }
     return formverInvariantsArgument.anonymousFunction
 }
 
-fun extractLoopInvariants(parentBlock: FirBlock): FirBlock? {
+fun extractLoopInvariants(parentBlock: FirBlock, ctx: ProgramConversionContext): FirBlock? {
     val firstStmt = parentBlock.statements.firstOrNull() ?: return null
-    return firstStmt.extractFormverFirBlock { isFormverFunctionNamed("loopInvariants") }?.body
+    return firstStmt.extractFormverFirBlock(ctx) { isFormverFunctionNamed("loopInvariants") }?.body
 }
 
 data class FirSpecification(val precond: FirBlock?, val postcond: FirBlock?, val returnVar: FirValueParameterSymbol?) {
     constructor() : this(null, null, null)
 }
 
-private fun FirAnonymousFunction.extractFormverReturnVar(returnType: ConeKotlinType): FirValueParameterSymbol {
+private fun FirAnonymousFunction.extractFormverReturnVar(
+    returnType: ConeKotlinType,
+    ctx: ProgramConversionContext,
+): FirValueParameterSymbol? {
     val param = valueParameters.first()
-    if (param.symbol.resolvedReturnType != returnType)
-        error("Expected type ${returnType} based on signature, got ${param.symbol.resolvedReturnType}")
+    if (param.symbol.resolvedReturnType != returnType) {
+        return ctx.handleUnsupportedFeature(
+            source, "Expected type ${returnType} based on signature, got ${param.symbol.resolvedReturnType}"
+        ) { null }
+    }
     return param.symbol
 }
 
-fun extractFirSpecification(parentBlock: FirBlock, returnType: ConeKotlinType): FirSpecification {
+fun extractFirSpecification(parentBlock: FirBlock, returnType: ConeKotlinType, ctx: ProgramConversionContext): FirSpecification {
     val firstStmt = parentBlock.statements.firstOrNull() ?: return FirSpecification()
 
-    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }?.let { lambda ->
-        return FirSpecification(null, lambda.body, lambda.extractFormverReturnVar(returnType))
+    firstStmt.extractFormverFirBlock(ctx) { isFormverFunctionNamed("postconditions") }?.let { lambda ->
+        return FirSpecification(null, lambda.body, lambda.extractFormverReturnVar(returnType, ctx))
     }
 
-    val precond = firstStmt.extractFormverFirBlock { isFormverFunctionNamed("preconditions") }
+    val precond = firstStmt.extractFormverFirBlock(ctx) { isFormverFunctionNamed("preconditions") }
         ?: return FirSpecification()
     val postcond =
-        parentBlock.statements.getOrNull(1)?.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
-    return FirSpecification(precond.body, postcond?.body, postcond?.extractFormverReturnVar(returnType))
+        parentBlock.statements.getOrNull(1)?.extractFormverFirBlock(ctx) { isFormverFunctionNamed("postconditions") }
+    return FirSpecification(precond.body, postcond?.body, postcond?.extractFormverReturnVar(returnType, ctx))
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
-import org.jetbrains.kotlin.formver.common.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.formver.core.*
 import org.jetbrains.kotlin.formver.core.diagnostics.ConversionErrors
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
@@ -376,7 +375,7 @@ class ProgramConverter(
             return Pair(emptyList(), emptyList())
         }
 
-        val firSpec = extractFirSpecification(body, declaration.symbol.resolvedReturnType)
+        val firSpec = extractFirSpecification(body, declaration.symbol.resolvedReturnType, this)
 
 
         val (preconditionContext, postconditionContext) = createContractConversionContext(
@@ -433,9 +432,19 @@ class ProgramConverter(
 
                 val classSymbol = symbol.dispatchReceiverType?.toClassSymbol(session)
 
-                val regularClass = classSymbol as? FirRegularClassSymbol ?: throw SnaktInternalException(
-                    symbol.source, "Properties dispatch receiver is not a regular class"
-                )
+                val regularClass = classSymbol as? FirRegularClassSymbol
+                    ?: return@getOrPutProperty handleUnsupportedFeature(
+                        symbol.source, "Properties dispatch receiver is not a regular class"
+                    ) {
+                        PropertyEmbedding(
+                            getter = null,
+                            setter = null,
+                            hasDefaultBehaviour = false,
+                            isUnique = false,
+                            isVal = symbol.isVal,
+                            type = embedType(symbol.resolvedReturnType),
+                        )
+                    }
 
                 val isDefaultProperty = isGuaranteedDefaultProperty(symbol)
                 val isImmutable = symbol.isVal
@@ -669,14 +678,8 @@ class ProgramConverter(
         returnsUnique = symbol.isUnique(session) || symbol is FirConstructorSymbol
     }
 
-    private fun TypeBuilder.unimplementedTypeEmbedding(type: ConeKotlinType): PretypeBuilder = when (config.behaviour) {
-        UnsupportedFeatureBehaviour.THROW_EXCEPTION -> throw NotImplementedError("The embedding for type $type is not yet implemented.")
-
-        UnsupportedFeatureBehaviour.ASSUME_UNREACHABLE -> {
-            reportMinorInternalError("Requested type $type, for which we do not yet have an embedding.")
-            unit()
-        }
-    }
+    private fun TypeBuilder.unimplementedTypeEmbedding(type: ConeKotlinType): PretypeBuilder =
+        handleUnsupportedFeature(null, "The embedding for type $type is not yet implemented.") { unit() }
 
     // endregion
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -20,7 +20,6 @@ import org.jetbrains.kotlin.fir.types.isUnit
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
-import org.jetbrains.kotlin.formver.common.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.formver.core.embeddings.LabelLink
 import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.insertCall
@@ -113,11 +112,12 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     ): ExpEmbedding {
         val combinedLiteral = stringConcatenationCall.arguments.joinToString("") { arg ->
             if (arg !is FirLiteralExpression) {
-                throw SnaktInternalException(
+                data.handleUnsupportedFeature(
                     arg.source, "${arg::class.simpleName} is not supported as an element of string concatenation."
-                )
+                ) { "" }
+            } else {
+                arg.stringValue
             }
-            arg.stringValue
         }
         return StringLit(combinedLiteral)
     }
@@ -267,12 +267,13 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             when (arg) {
                 is FirVarargArgumentsExpression -> {
                     if (function == null || !function.isVerifyFunction) {
-                        throw SnaktInternalException(
+                        data.handleUnsupportedFeature(
                             arg.source, "Vararg arguments are currently supported for `verify` function only."
-                        )
-                    }
-                    data.withNoScope {
-                        arg.arguments.map { this.convert(it) }
+                        ) { listOf(ErrorExp) }
+                    } else {
+                        data.withNoScope {
+                            arg.arguments.map { this.convert(it) }
+                        }
                     }
                 }
 
@@ -282,7 +283,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
 
     override fun visitFunctionCall(functionCall: FirFunctionCall, data: StmtConversionContext): ExpEmbedding {
         val symbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
-            ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
+            ?: throw SnaktInternalException(
+                functionCall.source, "Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}"
+            )
 
         val callee = data.embedAnyFunction(symbol)
         return callee.insertCall(
@@ -297,10 +300,11 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         data: StmtConversionContext,
     ): ExpEmbedding {
         val receiver =
-            implicitInvokeCall.dispatchReceiver as? FirPropertyAccessExpression ?: throw SnaktInternalException(
-                implicitInvokeCall.source,
-                "Implicit invoke calls only support a limited range of receivers at the moment."
-            )
+            implicitInvokeCall.dispatchReceiver as? FirPropertyAccessExpression
+                ?: return data.handleUnsupportedFeature(
+                    implicitInvokeCall.source,
+                    "Implicit invoke calls only support a limited range of receivers at the moment."
+                ) { ErrorExp }
         val returnType = data.embedType(implicitInvokeCall.resolvedType)
         val receiverSymbol = receiver.calleeReference.toResolvedSymbol<FirBasedSymbol<*>>()!!
         val args = implicitInvokeCall.argumentList.arguments.withVarargsHandled(data, function = null)
@@ -335,7 +339,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             data.retrievePropertiesAndParameters().forEach {
                 addAll(it.provenInvariants())
             }
-            extractLoopInvariants(whileLoop.block)?.let {
+            extractLoopInvariants(whileLoop.block, data)?.let {
                 addAll(data.withScopeImpl(ScopeIndex.NoScope) { data.collectInvariants(it) })
             }
         }
@@ -439,10 +443,10 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             }
 
             return resolved
-                ?: throw SnaktInternalException(
+                ?: data.handleUnsupportedFeature(
                     thisReceiverExpression.source,
                     "Can't resolve the 'this' receiver since the function does not have one."
-                )
+                ) { ErrorExp }
         }
 
         val symbol = thisReceiverExpression.calleeReference.boundSymbol
@@ -450,11 +454,11 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         val declSymbol = when (symbol) {
             is FirReceiverParameterSymbol -> symbol.containingDeclarationSymbol
             is FirValueParameterSymbol -> symbol.containingDeclarationSymbol
-            else -> throw SnaktInternalException(symbol.source, "Unsupported receiver expression type.")
+            else -> return data.handleUnsupportedFeature(symbol.source, "Unsupported receiver expression type.") { ErrorExp }
         }
         tryResolve(declSymbol)?.let { return it }
 
-        throw SnaktInternalException(thisReceiverExpression.source, "No resolution approach to this symbol worked.")
+        return data.handleUnsupportedFeature(thisReceiverExpression.source, "No resolution approach to this symbol worked.") { ErrorExp }
     }
 
     override fun visitTypeOperatorCall(
@@ -570,13 +574,5 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
 
     private fun handleUnimplementedElement(
         source: KtSourceElement?, msg: String, data: StmtConversionContext
-    ): ExpEmbedding = when (data.config.behaviour) {
-        UnsupportedFeatureBehaviour.THROW_EXCEPTION ->
-            throw SnaktInternalException(source, msg)
-
-        UnsupportedFeatureBehaviour.ASSUME_UNREACHABLE -> {
-            data.reportMinorInternalError(msg)
-            ErrorExp
-        }
-    }
+    ): ExpEmbedding = data.handleUnsupportedFeature(source, msg) { ErrorExp }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UnsupportedFeatureHandling.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/UnsupportedFeatureHandling.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.conversion
+
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.formver.common.SnaktInternalException
+import org.jetbrains.kotlin.formver.common.UnsupportedFeatureBehaviour
+
+/**
+ * Single entry point for reporting that the plugin does not support some construct the user
+ * wrote (as opposed to an internal invariant violation, which should keep using
+ * `SnaktInternalException`/`error` directly).
+ *
+ * Honors `config.behaviour`: in `THROW_EXCEPTION` mode this throws; in `ASSUME_UNREACHABLE`
+ * mode it reports a minor internal error diagnostic and falls back to [onUnreachable], which
+ * lets callers keep converting the rest of the program instead of aborting.
+ */
+inline fun <T> ProgramConversionContext.handleUnsupportedFeature(
+    source: KtSourceElement?,
+    msg: String,
+    onUnreachable: () -> T,
+): T = when (config.behaviour) {
+    UnsupportedFeatureBehaviour.THROW_EXCEPTION -> throw SnaktInternalException(source, msg)
+    UnsupportedFeatureBehaviour.ASSUME_UNREACHABLE -> {
+        reportMinorInternalError(msg)
+        onUnreachable()
+    }
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FullySpecialKotlinFunction.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.core.embeddings.callables
 
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
+import org.jetbrains.kotlin.formver.core.conversion.handleUnsupportedFeature
 import org.jetbrains.kotlin.formver.core.conversion.insertForAllFunctionCall
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
 import org.jetbrains.kotlin.formver.core.embeddings.expression.OperatorExpEmbeddings.AddCharInt
@@ -214,10 +215,10 @@ object SpecialKotlinFunctions {
 
         addFunction(forAllCallableType, SpecialPackages.formver, name = "forAll") { args, ctx ->
             val arg = args.first()
-            val lambda = arg.ignoringMetaNodes() as? LambdaExp ?: throw SnaktInternalException(
+            val lambda = arg.ignoringMetaNodes() as? LambdaExp ?: return@addFunction ctx.handleUnsupportedFeature(
                 null,
                 "First argument of forAll function must be a lambda."
-            )
+            ) { ErrorExp }
             val param = lambda.function.valueParameters.first()
             val body = lambda.function.body ?: throw SnaktInternalException(
                 null,
@@ -281,17 +282,24 @@ object SpecialKotlinFunctions {
         }
         addFunction(accCallableType, SpecialPackages.formver, name = "acc") { args, ctx ->
             val source = (args.firstOrNull() as? WithPosition)?.source
-            val perm = extractPermission(args.getOrNull(1))
+            val perm = when (val permArg = args.getOrNull(1)?.ignoringCastsAndMetaNodes()) {
+                null, NullLit -> PermissionLit(PermExp.FullPerm())
+                is PermissionLit -> permArg
+                else -> return@addFunction ctx.handleUnsupportedFeature(
+                    source,
+                    "Second argument of `acc` must be `read()` or `write()`."
+                ) { ErrorExp }
+            }
             ctx.withNoScope {
                 when (val exp = args.firstOrNull()?.ignoringCastsAndMetaNodes()) {
-                    null -> throw SnaktInternalException(
+                    null -> ctx.handleUnsupportedFeature(
                         source, "First argument of `acc` must be a field access like `x.a`."
-                    )
+                    ) { ErrorExp }
                     is FieldAccess -> AccEmbedding(exp.receiver, exp.field, perm.perm)
                     is MethodCall -> extractPredicate(exp, perm)
-                    else -> throw SnaktInternalException(
+                    else -> ctx.handleUnsupportedFeature(
                         source, "First argument of `acc` must be a field access like `x.a` or a predicate."
-                    )
+                    ) { ErrorExp }
                 }
             }
         }
@@ -391,18 +399,22 @@ object SpecialKotlinFunctions {
             withReturnType { unit() }
         }
         addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "unfold") { args, ctx ->
-            val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
-                null, "First argument of `unfold` must be a predicate constructor call like `UniquePred(x)`."
-            )
+            val exp = (args[0].ignoringMetaNodes() as? MethodCall)
+                ?: return@addFunction ctx.handleUnsupportedFeature(
+                    (args.firstOrNull() as? WithPosition)?.source,
+                    "First argument of `unfold` must be a predicate constructor call like `UniquePred(x)`."
+                ) { ErrorExp }
             Unfold(
                 extractPredicate(exp, extractPermission(args.getOrNull(1)))
             )
         }
 
         addFunction(uniquePredicatePermissionsToUnit, SpecialPackages.formver, name = "fold") { args, ctx ->
-            val exp = (args[0].ignoringMetaNodes() as? MethodCall) ?: throw SnaktInternalException(
-                null, "First argument of `fold` must be a predicate constructor call like `UniquePred(x)`."
-            )
+            val exp = (args[0].ignoringMetaNodes() as? MethodCall)
+                ?: return@addFunction ctx.handleUnsupportedFeature(
+                    (args.firstOrNull() as? WithPosition)?.source,
+                    "First argument of `fold` must be a predicate constructor call like `UniquePred(x)`."
+                ) { ErrorExp }
             Fold(
                 extractPredicate(exp, extractPermission(args.getOrNull(1)))
             )


### PR DESCRIPTION
## Summary
- Adds `handleUnsupportedFeature`, a single extension on `ProgramConversionContext` honoring `UnsupportedFeatureBehaviour` (throw vs. report-and-fallback), and folds the two existing config-aware sites (`StmtConversionVisitor.handleUnimplementedElement`, `ProgramConverter.unimplementedTypeEmbedding`) into it.
- Reroutes 12 hard-throw sites classified as unsupported-user-code through the funnel: non-literal string-template elements, non-`verify` vararg calls, exotic implicit-invoke receivers, incomplete `this`-receiver resolution (3 sites), non-regular-class property receivers, non-literal lambda arguments to `loopInvariants`/`preconditions`/`postconditions` (2 sites, required threading `ProgramConversionContext` through `FormverFirBlock.kt`), and malformed `forAll`/`acc` DSL usage (3 sites).
- Fixes two `throw NotImplementedError(...)` sites that were `Throwable`, not `Exception`, and so escaped the plugin's top-level `catch (e: Exception)` uncaught in THROW_EXCEPTION mode. No golden exercised this path.
- Leaves internal-invariant sites (bookkeeping/state-machine violations that only fire on a plugin bug, not from any user-writable Kotlin) as `SnaktInternalException`/`error()`/`require()`/`check()`.

One notable site is flagged but *not* rerouted: `ContractBuilder.kt`'s `checkNoPermInPurePostcondition` ("Postcondition tries to acquire permissions...") looks like genuine unsupported-user-code, but `FunctionConditionBuilder` has no `ProgramConversionContext` reachable without threading it through several widely-used builder classes — left as a follow-up rather than force it into this PR.

## Test plan
- [x] `:formver.compiler-plugin:core:compileKotlin` — BUILD SUCCESSFUL
- [x] `detekt` (whole repo) — BUILD SUCCESSFUL, no findings
- [x] `:formver.compiler-plugin:untilConversion` — BUILD SUCCESSFUL, no golden files changed
- [ ] Full verification tests (Z3-backed) — left to CI; Z3 is not installed on the dev host used for this change