### PR TITLE
Treat exhaustive `when` fallthrough as unreachable

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -137,9 +137,14 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
     private fun convertWhenBranches(
         whenBranches: Iterator<FirWhenBranch>,
         type: TypeEmbedding,
+        fallthroughUnreachable: Boolean,
         data: StmtConversionContext,
     ): ExpEmbedding {
-        if (!whenBranches.hasNext()) return UnitLit
+        // When Kotlin proves the `when` exhaustive but there is no syntactic `else`, the missing
+        // fallthrough is unreachable. We trust that determination (as we trust smart-casts, see
+        // `visitSmartCastExpression`) and emit `ErrorExp` (`inhale false`) rather than fabricating a
+        // `UnitLit` of the wrong type.
+        if (!whenBranches.hasNext()) return if (fallthroughUnreachable) ErrorExp else UnitLit
 
         val branch = whenBranches.next()
 
@@ -149,7 +154,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         } else {
             val cond = data.convert(branch.condition).withType { boolean() }
             val thenExp = data.withNewScope { convert(branch.result) }
-            val elseExp = convertWhenBranches(whenBranches, type, data)
+            val elseExp = convertWhenBranches(whenBranches, type, fallthroughUnreachable, data)
             If(cond, thenExp.withType(type), elseExp.withType(type), type)
         }
     }
@@ -164,8 +169,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
                 else
                     declareLocalVariable(firSubjVar.symbol, subjExp)
             }
+            val fallthroughUnreachable = whenExpression.exhaustivenessStatus is ExhaustivenessStatus.ProperlyExhaustive
             val body = withWhenSubject(subj?.variable) {
-                convertWhenBranches(whenExpression.branches.iterator(), type, this)
+                convertWhenBranches(whenExpression.branches.iterator(), type, fallthroughUnreachable, this)
             }
             subj?.let { blockOf(it, body) } ?: body
         }

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -554,6 +554,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("exhaustive_when.kt")
+      public void testExhaustive_when() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/control_flow/exhaustive_when.kt");
+      }
+
+      @Test
       @TestMetadata("exp_side_effects.kt")
       public void testExp_side_effects() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/control_flow/exp_side_effects.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/control_flow/exhaustive_when.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/control_flow/exhaustive_when.fir.diag.txt
@@ -1,0 +1,65 @@
+/exhaustive_when.kt: info: Generated Viper text for eval:
+function operand(this: Ref): Ref
+  requires isSubtype(typeOf(this), Neg())
+  ensures isSubtype(typeOf(result), Const())
+
+
+function value(this: Ref): Ref
+  requires isSubtype(typeOf(this), Const())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method eval(e: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(e), Expr())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var anon: Ref
+  anon := e
+  if (isSubtype(typeOf(anon), Const())) {
+    v_ret_0 := value(e)
+  } elseif (isSubtype(typeOf(anon), Neg())) {
+    v_ret_0 := negInt(value(operand(e)))
+  } else {
+    inhale false
+    v_ret_0 := unitValue()
+  }
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/exhaustive_when.kt: info: Generated Viper text for evalNonNeg:
+function operand(this: Ref): Ref
+  requires isSubtype(typeOf(this), Neg())
+  ensures isSubtype(typeOf(result), Const())
+
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function value(this: Ref): Ref
+  requires isSubtype(typeOf(this), Const())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method evalNonNeg(e: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(e), Expr())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var l0_r: Ref
+  var anon: Ref
+  anon := e
+  if (isSubtype(typeOf(anon), Const())) {
+    l0_r := value(e)
+  } elseif (isSubtype(typeOf(anon), Neg())) {
+    l0_r := negInt(value(operand(e)))
+  } else {
+    inhale false
+    l0_r := unitValue()
+  }
+  assert intFromRef(l0_r) >= 0
+  v_ret_0 := l0_r
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/control_flow/exhaustive_when.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/control_flow/exhaustive_when.kt
@@ -1,0 +1,28 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.verify
+
+sealed interface Expr
+class Const(val value: Int) : Expr
+class Neg(val operand: Const) : Expr
+
+// An exhaustive `when` over a sealed interface with no `else` is total: the missing fallthrough is
+// unreachable (`inhale false`), so the function verifies as always returning an Int.
+@AlwaysVerify
+fun <!VIPER_TEXT!>eval<!>(e: Expr): Int = when (e) {
+    is Const -> e.value
+    is Neg -> -e.operand.value
+}
+
+// Totality is trusted, but branch bodies are still checked. `r` may be negative (e.g. Const(-1)),
+// so the assertion below fails to verify even though the `when` is total.
+@AlwaysVerify
+fun <!VIPER_TEXT!>evalNonNeg<!>(e: Expr): Int {
+    val r = when (e) {
+        is Const -> e.value
+        is Neg -> -e.operand.value
+    }
+    verify(<!VIPER_VERIFICATION_ERROR!>r >= 0<!>)
+    return r
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/control_flow/exhaustive_when.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/control_flow/exhaustive_when.viper.diag.txt
@@ -1,0 +1,1 @@
+/exhaustive_when.kt: warning: Viper verification error: Assert might fail. Assertion intFromRef(l0_r) >= 0 might not hold.


### PR DESCRIPTION
## Summary

An expression-position `when` that Kotlin accepts as exhaustive without an
`else` was lowered with a `UnitLit` fallthrough. On the
compiler-guaranteed-impossible fallthrough this fabricated a value of the wrong
type, and without exhaustiveness information Viper believed the path reachable —
so a total function over a sealed interface failed to verify.

This reads the frontend's exhaustiveness decision in `convertWhenBranches`:
when the `when` is `ExhaustivenessStatus.ProperlyExhaustive` and has no
syntactic `else`, the missing fallthrough emits the existing `ErrorExp`
(`inhale false`) path instead of `UnitLit`. Exhaustiveness is trusted from FIR,
matching SnaKt's existing smart-cast trust model — no `RuntimeTypeDomain`
changes.

Because exhaustiveness is read from FIR, the change is generic: sealed
interfaces, sealed classes, and exhaustive Boolean `when`s all flow through the
same path.

## Verification

Verified against the `pipeline/sealed-interfaces` branch of
`komiputer/snakt-usage-example`: a recursive sealed-interface `Expr` evaluator
(exhaustive `when`, no `else`) plus positive smart-cast narrowing, building with
0 Viper verification errors.

Golden diagnostic tests cover the sealed-interface total `when` (verifies) and
the still-checked branch body — an exhaustive `when` whose body violates a
contract still fails to verify. Trust applies to totality, not to branch bodies.

## Future work

The fix is generic over FIR exhaustiveness and would cover exhaustive enum
`when` for free, but converting an enum class declaration currently fails
earlier in SnaKt (pre-existing, unrelated). Enum exhaustiveness becomes
reachable once enum-declaration support lands, with no further work on this
path.

PRD: https://bot.jesyspa.dev/kotlin/snakt/prd/sealed-interfaces/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
