### PR TITLE
Resolve primitive expressions to `shared` instead of `unique`

### DIFF
--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -195,6 +195,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("continue.kt")
+    public void testContinue() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/continue.kt");
+    }
+
+    @Test
     @TestMetadata("dump_cfg.kt")
     public void testDump_cfg() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/dump_cfg.kt");

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -231,6 +231,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("primitive.kt")
+    public void testPrimitive() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/primitive.kt");
+    }
+
+    @Test
     @TestMetadata("receiver.kt")
     public void testReceiver() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/receiver.kt");

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -171,6 +171,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("break.kt")
+    public void testBreak() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt");
+    }
+
+    @Test
     @TestMetadata("call.kt")
     public void testCall() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/call.kt");

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/assign_local.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/assign_local.kt
@@ -145,7 +145,7 @@ fun `assign unique or shared`(x: @Unique Any, y: Any) {
 fun `move unique and then reassign`(x: @Unique Any) {
     var y = x
     var z = y
-    y = 1
+    y = Any()
     consume(y)
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt
@@ -3,14 +3,14 @@
 import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
-fun `continue conforms to unique`() {
+fun `break conforms to unique`() {
     while (true) {
-        val x: @Unique Nothing = continue
+        val x: @Unique Nothing = break
     }
 }
 
-fun `continue conforms to shared`() {
+fun `break conforms to shared`() {
     while (true) {
-        val x: Nothing = continue
+        val x: Nothing = break
     }
 }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt
@@ -3,14 +3,28 @@
 import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
+fun makeUnique(): @Unique Any? = null
+
 fun `break conforms to unique`() {
     while (true) {
         val x: @Unique Nothing = break
     }
 }
 
+fun `break in elvis conforms to unique`() {
+    while (true) {
+        val x: @Unique Any = makeUnique() ?: break
+    }
+}
+
 fun `break conforms to shared`() {
     while (true) {
         val x: Nothing = break
+    }
+}
+
+fun `break in elvis conforms to shared`() {
+    while (true) {
+        val x: Any = makeUnique() ?: break
     }
 }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/continue.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/continue.kt
@@ -1,0 +1,10 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+fun `continue conforms to unique`() {
+    while (true) {
+        val x: @Unique Nothing = continue
+    }
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/continue.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/continue.kt
@@ -3,14 +3,28 @@
 import org.jetbrains.kotlin.formver.plugin.Borrowed
 import org.jetbrains.kotlin.formver.plugin.Unique
 
+fun makeUnique(): @Unique Any? = null
+
 fun `continue conforms to unique`() {
     while (true) {
         val x: @Unique Nothing = continue
     }
 }
 
+fun `continue in elvis conforms to unique`() {
+    while (true) {
+        val x: @Unique Any = makeUnique() ?: continue
+    }
+}
+
 fun `continue conforms to shared`() {
     while (true) {
         val x: Nothing = continue
+    }
+}
+
+fun `continue in elvis conforms to shared`() {
+    while (true) {
+        val x: Any = makeUnique() ?: continue
     }
 }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/primitive.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/primitive.fir.diag.txt
@@ -1,0 +1,5 @@
+/primitive.kt: error: Initializer uniqueness mismatch: expected 'unique', actual 'shared'.
+
+/primitive.kt: error: Initializer uniqueness mismatch: expected 'unique', actual 'shared'.
+
+/primitive.kt: error: Initializer uniqueness mismatch: expected 'unique', actual 'shared'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/primitive.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/primitive.kt
@@ -1,0 +1,22 @@
+// FULL_JDK
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+fun `assign primitive int literal to unique local`() {
+    val i: @Unique Int = <!UNIQUENESS_MISMATCH!>10<!>
+}
+
+fun `assign primitive int literal to shared local`() {
+    val i: Int = 10
+}
+
+fun `assign primitive operation on literals to unique local`() {
+    val i: @Unique Int = <!UNIQUENESS_MISMATCH!>10 + 10<!>
+}
+
+fun `assign primitive variable to unique local`() {
+    val x: Int = 0
+    val i: @Unique Int = <!UNIQUENESS_MISMATCH!>0<!>
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return.kt
@@ -55,3 +55,9 @@ fun `return shared from unique function`(a: Any) : @Unique Any {
 fun `return conforms to unique`() {
     val x: @Unique Nothing = return
 }
+
+fun makeUnique(): @Unique Any? = null
+
+fun `return in elvis conforms to unique`() {
+    val x: @Unique Any = makeUnique() ?: return
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return.kt
@@ -51,3 +51,7 @@ fun `return unique-borrowed subproperty`(a: @Unique @Borrowed B): Any {
 fun `return shared from unique function`(a: Any) : @Unique Any {
     return <!UNIQUENESS_MISMATCH!>a<!>
 }
+
+fun `return conforms to unique`() {
+    val x: @Unique Nothing = return
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/return.kt
@@ -61,3 +61,7 @@ fun makeUnique(): @Unique Any? = null
 fun `return in elvis conforms to unique`() {
     val x: @Unique Any = makeUnique() ?: return
 }
+
+fun `return in elvis conforms to shared`() {
+    val x: Any = makeUnique() ?: return
+}

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/ExpressionUniquenessResolver.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/ExpressionUniquenessResolver.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirJump
 import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
@@ -80,7 +81,7 @@ fun FirExpression.resolveTerminalUniqueness(): Uniqueness {
             }
         }
 
-        is FirReturnExpression, is FirThrowExpression -> Uniqueness.Unique
+        is FirJump<*>, is FirThrowExpression -> Uniqueness.Unique
 
         else -> Uniqueness.Shared
     }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/ExpressionUniquenessResolver.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/ExpressionUniquenessResolver.kt
@@ -10,16 +10,17 @@ import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
 import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirReturnExpression
 import org.jetbrains.kotlin.fir.expressions.FirSafeCallExpression
 import org.jetbrains.kotlin.fir.expressions.FirThisReceiverExpression
+import org.jetbrains.kotlin.fir.expressions.FirThrowExpression
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
 import org.jetbrains.kotlin.fir.references.symbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.types.coneType
-import org.jetbrains.kotlin.fir.types.isNothingOrNullableNothing
-import org.jetbrains.kotlin.fir.types.isPrimitive
+import org.jetbrains.kotlin.fir.types.isNullLiteral
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.type.plugin.ExpressionTypeFactResolver
 import org.jetbrains.kotlin.formver.type.plugin.UnifyingExpressionTypeFactResolver
@@ -71,16 +72,17 @@ fun FirExpression.resolveTerminalUniqueness(): Uniqueness {
             receiverUniqueness.join(resolveAccessUniqueness())
         }
 
-        else -> {
-            val resolvedType = resolvedType
-
-            // Resolve `null` and primitive values as unique
-            if (resolvedType.isNothingOrNullableNothing || resolvedType.isPrimitive) {
+        is FirLiteralExpression -> {
+            if (isNullLiteral) {
                 Uniqueness.Unique
             } else {
                 Uniqueness.Shared
             }
         }
+
+        is FirReturnExpression, is FirThrowExpression -> Uniqueness.Unique
+
+        else -> Uniqueness.Shared
     }
 }
 


### PR DESCRIPTION
This PR changes the behavior of the expression uniqueness resolver so that primitive expressions (including literals) resolve to shared instead of unique. It also adds tests covering the new cases the checker must handle.