### PR TITLE
Decide comparison representation from the operands' injections

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Comparison.kt
@@ -21,10 +21,6 @@ sealed interface AnyComparisonExpression : ExpEmbedding {
 
     val comparisonOperation: Operator
 
-    /** Whether to compare the operands at their builtin type; they are compared as `Ref`s otherwise. */
-    val comparesUnwrapped: Boolean
-        get() = left.type == right.type
-
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(left, right)
 }
 
@@ -47,14 +43,18 @@ data class NeCmp(
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitNeCmp(this)
 }
 
-/** Kotlin reference equality (`===`). */
+/**
+ * Kotlin reference equality (`===`).
+ *
+ * Unlike [EqCmp], this compares the operands as `Ref`s no matter what their types are; see
+ * `LinearizationVisitor.visitIdentityCmp`.
+ */
 data class IdentityCmp(
     override val left: ExpEmbedding,
     override val right: ExpEmbedding,
     override val sourceRole: SourceRole? = null,
 ) : AnyComparisonExpression {
     override val comparisonOperation = EqAny
-    override val comparesUnwrapped = false
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitIdentityCmp(this)
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/ComparisonRepresentation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/ComparisonRepresentation.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.core.linearization
+
+import org.jetbrains.kotlin.formver.core.domains.Injection
+import org.jetbrains.kotlin.formver.core.domains.viperType
+import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.injectionOrNull
+import org.jetbrains.kotlin.formver.viper.ast.Exp
+
+/**
+ * The Viper representation in which the two operands of a comparison are compared.
+ *
+ * A Viper `==` requires both of its operands to have the same sort, so a comparison has to settle
+ * on one representation and linearize both operands into it.
+ */
+sealed interface ComparisonRepresentation {
+    /** Linearizes [operand], the embedding type of which is [type], into this representation. */
+    fun operandToViper(operand: Linearizable, type: TypeEmbedding, ctx: LinearizationContext): Exp
+
+    /**
+     * Compare the operands as the builtin type [injection] injects into.
+     *
+     * Available only when both operands are represented by [injection], and mandatory whenever it
+     * is: an injection is not required to be surjective, so two `Ref`s obtained by injecting equal
+     * builtin values need not be equal themselves, and comparing two `Int`s as `Ref`s would leave
+     * `1 == 1` unprovable.
+     */
+    data class Builtin(val injection: Injection) : ComparisonRepresentation {
+        override fun operandToViper(operand: Linearizable, type: TypeEmbedding, ctx: LinearizationContext): Exp {
+            // `toViperBuiltinType` unwraps the operand through the injection of its own type rather
+            // than through ours; `shared` picks this representation exactly when the two coincide.
+            check(type.injectionOrNull == injection) {
+                "Comparison operand is represented as ${type.injectionOrNull.viperType}, expected ${injection.viperType}."
+            }
+            return operand.toViperBuiltinType(ctx)
+        }
+    }
+
+    /**
+     * Compare the operands as `Ref`s.
+     *
+     * The only representation available when the operands have no builtin one in common: class
+     * types, `Any` and every nullable type are represented as `Ref` and nothing else. Reference
+     * equality asks for this representation whatever its operand types are.
+     */
+    data object Refs : ComparisonRepresentation {
+        override fun operandToViper(operand: Linearizable, type: TypeEmbedding, ctx: LinearizationContext): Exp =
+            operand.toViper(ctx)
+    }
+
+    companion object {
+        /** The representation that operands of types [left] and [right] have in common. */
+        fun shared(left: TypeEmbedding, right: TypeEmbedding): ComparisonRepresentation {
+            val injection = left.injectionOrNull ?: return Refs
+            return if (injection == right.injectionOrNull) Builtin(injection) else Refs
+        }
+    }
+}

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -343,12 +343,20 @@ data class LinearizationVisitor(
 
     // region Comparisons
 
-    override fun visitEqCmp(e: EqCmp): Linearizable = comparisonLinearizable(e)
-    override fun visitNeCmp(e: NeCmp): Linearizable = comparisonLinearizable(e)
+    override fun visitEqCmp(e: EqCmp): Linearizable =
+        comparisonLinearizable(e, ComparisonRepresentation.shared(e.left.type, e.right.type))
 
-    override fun visitIdentityCmp(e: IdentityCmp): Linearizable = comparisonLinearizable(e)
+    override fun visitNeCmp(e: NeCmp): Linearizable =
+        comparisonLinearizable(e, ComparisonRepresentation.shared(e.left.type, e.right.type))
 
-    private fun comparisonLinearizable(e: AnyComparisonExpression): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
+    /** `===` compares references, so its operands are never unwrapped, whatever their types are. */
+    override fun visitIdentityCmp(e: IdentityCmp): Linearizable =
+        comparisonLinearizable(e, ComparisonRepresentation.Refs)
+
+    private fun comparisonLinearizable(
+        e: AnyComparisonExpression,
+        comparedAs: ComparisonRepresentation,
+    ): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
         override fun toViper(ctx: LinearizationContext): Exp =
             RuntimeTypeDomain.boolInjection.toRef(
                 toViperBuiltinType(ctx),
@@ -357,8 +365,7 @@ data class LinearizationVisitor(
             )
 
         override fun toViperBuiltinType(ctx: LinearizationContext): Exp {
-            fun ExpEmbedding.operand(): Exp =
-                if (e.comparesUnwrapped) linearize().toViperBuiltinType(ctx) else linearize().toViper(ctx)
+            fun ExpEmbedding.operand(): Exp = comparedAs.operandToViper(linearize(), type, ctx)
             return e.comparisonOperation(
                 e.left.operand(),
                 e.right.operand(),


### PR DESCRIPTION
`comparisonLinearizable` decides, per comparison, whether to compare the operands at their builtin Viper type or as `Ref`s. The decision came from `comparesUnwrapped` on `AnyComparisonExpression`:

```kotlin
val comparesUnwrapped: Boolean
    get() = left.type == right.type
```

Equal types are a proxy for the property that matters, which is whether both operands are represented by the same injection. `injectionOrNull` is a function of the pretype and the `nullable` flag alone, so the two agree only as long as `TypeEmbeddingFlags` holds nothing else — today they can diverge only when both injections are null, which is exactly when both branches emit the same Viper, which is why no golden ever caught it.

Add a flag that does not affect the injection and the proxy breaks: `Int` with the flag and `Int` without become distinct `TypeEmbedding`s sharing `intInjection`, the guard says do-not-unwrap, and `==` on two `Int`s degrades to comparing separately injected `Ref`s. Those are not provably equal — an injection is not required to be surjective — so `1 == 1` stops being provable.

## What changed

`ComparisonRepresentation` names the choice: either the builtin type of an injection both operands share, or `Ref`s. It also linearizes an operand into itself, so the decision reaches the place that acts on it. `Builtin` checks that the injection `toViperBuiltinType` derives from the operand's own type is the one the comparison settled on; the two sites still derive it separately, but they can no longer drift apart silently.

The choice is a Viper-representation concern, so it moved out of the embedding layer into `LinearizationVisitor`. `===` now passes `ComparisonRepresentation.Refs` at `visitIdentityCmp` instead of overriding a property to `false`, which puts reference equality's unconditional boxing at the point where its operands are emitted — relevant given the intent for `EqCmp` to dispatch through `.equals()` and diverge further.

## Behaviour

Emitted Viper is unchanged. The old and new conditions disagree only when neither operand has an injection: the old condition then chose `toViperBuiltinType`, which returns the `Ref` unchanged for such an operand. That holds for every node inheriting `toViperBuiltinType`, and for the nodes overriding it: the builtin operator nodes are always `Int`/`Bool` and so have injections; `Old`, `WithPosition` and `SharingContext` delegate to an inner expression of the same type; and all four `OnlyToBuiltinLinearizable` embeddings are boolean-typed.

Unchanged golden files are the evidence. `nullableNullableComparison(x: Int?, y: Int?)` in `testData/diagnostics/verification/types/nullable.kt` is precisely the diverging case and has a `VIPER_TEXT` golden; `operators/identity_equality.kt` covers `===`.

No new test: nothing can distinguish the two conditions until a flag of the shape described above exists.

`detekt`, `apiCheck`, `:formver.compiler-plugin:locality:test` and `:formver.compiler-plugin:test` pass locally.