### PR TITLE
Add Char domain bound [0, 65536)

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.*
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toFuncApp
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toMethodCall
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
+import org.jetbrains.kotlin.formver.core.embeddings.types.CharTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
@@ -504,14 +505,18 @@ data class LinearizationVisitor(
             val viperTriggers = e.triggerExpressions.map { triggerExpr ->
                 Exp.Trigger(listOf(triggerExpr.linearize().toViperBuiltinType(ctx)))
             }
+            val charBound = e.variable.charDomainBoundOrNull()
             return Exp.Forall(
                 variables = listOf(e.variable.toLocalVarDecl()),
                 triggers = viperTriggers,
-                exp = if (e.variable.isOriginallyRef) Exp.Implies(
-                    e.variable.toViperExp(ctx).isOf(e.variable.type.runtimeType),
-                    conjunction
-                )
-                else conjunction,
+                exp = when {
+                    e.variable.isOriginallyRef -> Exp.Implies(
+                        e.variable.toViperExp(ctx).isOf(e.variable.type.runtimeType),
+                        conjunction
+                    )
+                    charBound != null -> Exp.Implies(charBound, conjunction)
+                    else -> conjunction
+                },
                 pos = ctx.source.asPosition,
                 info = e.sourceRole.asInfo,
             )
@@ -618,3 +623,18 @@ data class LinearizationVisitor(
 
     // endregion
 }
+
+// Exclusive upper bound of the Unicode code-point range a Kotlin `Char` occupies.
+private const val CHAR_CODE_POINT_UPPER_BOUND = 65536
+
+/**
+ * A `Char` quantifier variable is lowered to a Viper `Int`, so without a bound it
+ * ranges over every integer including negative code points. Constrain it to the
+ * Unicode code-point range `[0, 65536)` so `forAll<Char>` doesn't need a manual
+ * guard. Returns `null` for non-`Char` variables.
+ */
+private fun VariableEmbedding.charDomainBoundOrNull(): Exp? =
+    if (type.pretype == CharTypeEmbedding && !type.flags.nullable) {
+        val v = toLocalVarUse()
+        Exp.And(Exp.LeCmp(Exp.IntLit(0), v), Exp.LtCmp(v, Exp.IntLit(CHAR_CODE_POINT_UPPER_BOUND)))
+    } else null

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -840,6 +840,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("forall_char_domain.kt")
+      public void testForall_char_domain() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_char_domain.kt");
+      }
+
+      @Test
       @TestMetadata("forall_with_triggers.kt")
       public void testForall_with_triggers() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_with_triggers.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_char_domain.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_char_domain.fir.diag.txt
@@ -1,0 +1,9 @@
+/forall_char_domain.kt: info: Generated Viper text for forallCharNonNegative:
+method forallCharNonNegative() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), boolType())
+  ensures (forall anon: Int ::0 <= anon && anon < 65536 ==> anon >= 0)
+{
+  v_ret_0 := boolToRef(true)
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_char_domain.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/forall_char_domain.kt
@@ -1,0 +1,15 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+// Intended contract (CH-1): a Char-typed forAll quantifier variable should stay within
+// the Unicode code-point range [0, 65536), since every real Kotlin Char value does.
+// Without the domain bound the quantifier ranges over unbounded Viper Ints, so
+// "forall x: Int, x >= 0" is not provable from the empty body.
+@AlwaysVerify
+fun <!VIPER_TEXT!>forallCharNonNegative<!>(): Boolean {
+    postconditions<Boolean> {
+        forAll<Char> { it >= '\u0000' }
+    }
+    return true
+}


### PR DESCRIPTION
A Char quantifier variable lowers to a Viper Int, which is unbounded. Without an explicit domain bound, forAll<Char> ranges over all integers including negative code points that no real Kotlin Char can hold. Constrain it to [0, 65536) so the verifier can discharge properties that hold for all valid chars without a manual guard.

Adds charDomainBoundOrNull() helper and forall_char_domain.kt regression test.