### PR TITLE
Generate locality tests before compiling them

### DIFF
--- a/formver.compiler-plugin/locality/build.gradle.kts
+++ b/formver.compiler-plugin/locality/build.gradle.kts
@@ -77,6 +77,10 @@ val generateTests by tasks.registering(JavaExec::class) {
     workingDir = rootDir
 }
 
+tasks.compileTestKotlin {
+    dependsOn(generateTests)
+}
+
 // Run locality checks
 tasks.test {
     configureFormverTest()


### PR DESCRIPTION
`formver.compiler-plugin`'s `compileTestKotlin` depends on `generateTests`, so a
new testData file there is picked up on the next build. The locality module has
no such dependency, so a newly added locality test stays invisible until
`generateTests` is run by hand.

Adding the same dependency brings the two modules in line.

Task graph for `:formver.compiler-plugin:locality:compileTestKotlin --dry-run`,
before and after:

    -                                     (generateTests absent)
    +   :formver.compiler-plugin:locality:generateTests
        :formver.compiler-plugin:locality:compileTestKotlin

🤖 Generated with [Claude Code](https://claude.com/claude-code)