### PR TITLE
Report how many tests a test.sh run covered

### DIFF
--- a/agent-scripts/junit_counts.py
+++ b/agent-scripts/junit_counts.py
@@ -1,0 +1,37 @@
+import sys
+import xml.etree.ElementTree as ET
+
+# Counted from the <testcase> elements rather than the <testsuite> attributes:
+# one module can emit several suites, and a suite that died early still carries
+# a count that its cases do not back.
+#
+# Golden-file mismatches are counted apart from the rest, because under
+# --update-goldens they are the expected outcome and other failures are not.
+# The types are the ones is_assertion_failure_type accepts.
+ASSERTION_TYPES = ("org.opentest4j.AssertionFailedError",)
+ASSERTION_SUFFIX = "ComparisonFailure"
+
+total = assertion_failed = other_failed = skipped = unreadable = 0
+
+for path in sys.argv[1:]:
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError:
+        unreadable += 1
+        continue
+    for testcase in root.iter("testcase"):
+        total += 1
+        node = testcase.find("failure")
+        if node is None:
+            node = testcase.find("error")
+        if node is None:
+            if testcase.find("skipped") is not None:
+                skipped += 1
+            continue
+        failure_type = node.get("type", "")
+        if failure_type in ASSERTION_TYPES or failure_type.endswith(ASSERTION_SUFFIX):
+            assertion_failed += 1
+        else:
+            other_failed += 1
+
+print(f"{total} {assertion_failed} {other_failed} {skipped} {unreadable}")

--- a/agent-scripts/junit_counts.py
+++ b/agent-scripts/junit_counts.py
@@ -1,18 +1,13 @@
 import sys
 import xml.etree.ElementTree as ET
 
-# Counted from the <testcase> elements rather than the <testsuite> attributes:
-# one module can emit several suites, and a suite that died early still carries
-# a count that its cases do not back.
-#
-# Golden-file mismatches are counted apart from the rest, because under
-# --update-goldens they are the expected outcome and other failures are not.
-# The types are the ones is_assertion_failure_type accepts.
 ASSERTION_TYPES = ("org.opentest4j.AssertionFailedError",)
 ASSERTION_SUFFIX = "ComparisonFailure"
 
 total = assertion_failed = other_failed = skipped = unreadable = 0
 
+# Counted from the <testcase> elements rather than the <testsuite> attributes:
+# a suite that died early still carries a count that its cases do not back.
 for path in sys.argv[1:]:
     try:
         root = ET.parse(path).getroot()

--- a/agent-scripts/lib.sh
+++ b/agent-scripts/lib.sh
@@ -3,6 +3,11 @@
 # $0 is the caller's, so BASH_SOURCE is what locates junit_first_failure.py.
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Where each module's Gradle test tasks write their JUnit XML. Relative to the
+# repository root, which the scripts cd to.
+COMPILER_RESULTS_DIR=formver.compiler-plugin/build/test-results
+LOCALITY_RESULTS_DIR=formver.compiler-plugin/locality/build/test-results
+
 # Missing python3 must be said out loud: reporting no failures instead reads as
 # a run that passed.
 need_python3() {
@@ -48,8 +53,7 @@ is_assertion_failure_type() {
 report_first_xml_failure() {
     need_python3 || return 1
     local marker="$1" dirs=() dir
-    for dir in formver.compiler-plugin/build/test-results \
-               formver.compiler-plugin/locality/build/test-results; do
+    for dir in "$COMPILER_RESULTS_DIR" "$LOCALITY_RESULTS_DIR"; do
         if [[ -d "$dir" ]]; then
             dirs+=("$dir")
         fi
@@ -67,6 +71,26 @@ report_first_xml_failure() {
         return 1
     fi
     python3 "$LIB_DIR/junit_first_failure.py" "${files[@]}"
+}
+
+# Print "total assertion_failed other_failed skipped unreadable" over the JUnit
+# XML in directory $1 written since marker file $2. Prints nothing and returns
+# 1 when the module left no fresh XML, 2 when the counts could not be read at
+# all; a caller that reports the two as one cause names the wrong one.
+count_xml_results() {
+    need_python3 || return 2
+    local dir="$1" marker="$2"
+    if [[ ! -d "$dir" ]]; then
+        return 1
+    fi
+    local files=()
+    while IFS= read -r f; do
+        files+=("$f")
+    done < <(find "$dir" -name '*.xml' -newer "$marker")
+    if [[ "${#files[@]}" -eq 0 ]]; then
+        return 1
+    fi
+    python3 "$LIB_DIR/junit_counts.py" "${files[@]}" || return 2
 }
 
 # Where DumpAssertionDiffExtension writes its dumps (see docs/agents-dev.md).

--- a/agent-scripts/lib.sh
+++ b/agent-scripts/lib.sh
@@ -3,8 +3,8 @@
 # $0 is the caller's, so BASH_SOURCE is what locates junit_first_failure.py.
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Where each module's Gradle test tasks write their JUnit XML. Relative to the
-# repository root, which the scripts cd to.
+# Where each module's Gradle test tasks write their JUnit XML, relative to the
+# repository root the scripts cd to.
 COMPILER_RESULTS_DIR=formver.compiler-plugin/build/test-results
 LOCALITY_RESULTS_DIR=formver.compiler-plugin/locality/build/test-results
 
@@ -74,9 +74,8 @@ report_first_xml_failure() {
 }
 
 # Print "total assertion_failed other_failed skipped unreadable" over the JUnit
-# XML in directory $1 written since marker file $2. Prints nothing and returns
-# 1 when the module left no fresh XML, 2 when the counts could not be read at
-# all; a caller that reports the two as one cause names the wrong one.
+# XML in directory $1 written since marker file $2. Returns 1 when the module
+# left no fresh XML, 2 when the counts could not be read.
 count_xml_results() {
     need_python3 || return 2
     local dir="$1" marker="$2"

--- a/agent-scripts/test.sh
+++ b/agent-scripts/test.sh
@@ -71,6 +71,15 @@ MARKER="$(mktemp)"
 
 matched=0
 overall_status=0
+total_tests=0
+total_rewritten=0
+total_failed=0
+total_skipped=0
+total_unreadable=0
+# Modules that ran but whose count could not be established. Without these the
+# summary would describe the modules it did count as if they were the whole run.
+no_results=()
+unreadable_results=()
 
 run_task() {
     if TASK_OUT="$(./gradlew "$1" "${args[@]}" 2>&1)"; then
@@ -106,15 +115,31 @@ report_locality_failure() {
     echo "  formver.compiler-plugin/locality/build/reports/tests/test/index.html"
 }
 
+tally() {
+    local module="$1" counts status ran rewritten failed skipped unreadable
+    counts="$(count_xml_results "$2" "$MARKER")" && status=0 || status=$?
+    case "$status" in
+        1) no_results+=("$module"); return ;;
+        2) unreadable_results+=("$module"); return ;;
+    esac
+    read -r ran rewritten failed skipped unreadable <<<"$counts"
+    total_tests=$((total_tests + ran))
+    total_rewritten=$((total_rewritten + rewritten))
+    total_failed=$((total_failed + failed))
+    total_skipped=$((total_skipped + skipped))
+    total_unreadable=$((total_unreadable + unreadable))
+}
+
 # In --update-goldens mode a matching test is expected to fail: assertEqualsToFile
 # writes the golden and then fails. Only "no tests found" means anything there.
 run_module() {
-    local task="$1" on_failure="$2"
+    local module="$1" task="$2" results_dir="$3" on_failure="$4"
     run_task "$task"
     if [[ -n "$PATTERN" && "$TASK_OUT" == *"No tests found for given includes"* ]]; then
         return
     fi
     matched=1
+    tally "$module" "$results_dir"
     if [[ "$MODE" == update || "$TASK_STATUS" -eq 0 ]]; then
         return
     fi
@@ -124,14 +149,52 @@ run_module() {
     "$on_failure"
 }
 
-run_module "$COMPILER_TASK" report_compiler_failure
-run_module "$LOCALITY_TASK" report_locality_failure
+run_module compiler "$COMPILER_TASK" "$COMPILER_RESULTS_DIR" report_compiler_failure
+run_module locality "$LOCALITY_TASK" "$LOCALITY_RESULTS_DIR" report_locality_failure
 rm -f "$MARKER"
 
 if [[ "$matched" -eq 0 ]]; then
     echo "No test matches '$PATTERN'."
     exit 1
 fi
+
+# A run that says nothing reads the same whether it tested everything or
+# nothing, so the count is printed even when everything passed.
+summary() {
+    local failed=$((total_rewritten + total_failed)) line
+    local passed=$((total_tests - failed - total_skipped))
+    if [[ "$total_tests" -gt 0 ]]; then
+        if [[ "$MODE" == update ]]; then
+            # assertEqualsToFile writes the golden and then fails, so a mismatch
+            # here is a golden that got rewritten. Anything else really failed.
+            line="Ran $total_tests tests, $total_rewritten golden(s) rewritten"
+            if [[ "$total_failed" -gt 0 ]]; then
+                line+=", $total_failed failed for other reasons"
+            fi
+        else
+            line="Ran $total_tests tests, $passed passed, $failed failed"
+        fi
+        if [[ "$total_skipped" -gt 0 ]]; then
+            line+=", $total_skipped skipped"
+        fi
+        echo "$line."
+    fi
+    # A module that ran and left no results is the case where a count over the
+    # other module alone reads as a clean run.
+    local module
+    for module in "${no_results[@]+"${no_results[@]}"}"; do
+        echo "The $module module produced no test results; see its output above."
+    done
+    for module in "${unreadable_results[@]+"${unreadable_results[@]}"}"; do
+        echo "The $module module's test results could not be read; it is not counted above."
+    done
+    if [[ "$total_unreadable" -gt 0 ]]; then
+        echo "$total_unreadable result file(s) were unparseable, so the count is a lower bound."
+    fi
+}
+
+echo
+summary
 
 if [[ "$MODE" != update ]]; then
     exit "$overall_status"

--- a/agent-scripts/test.sh
+++ b/agent-scripts/test.sh
@@ -76,8 +76,7 @@ total_rewritten=0
 total_failed=0
 total_skipped=0
 total_unreadable=0
-# Modules that ran but whose count could not be established. Without these the
-# summary would describe the modules it did count as if they were the whole run.
+# Modules that ran but whose count could not be established.
 no_results=()
 unreadable_results=()
 
@@ -158,15 +157,11 @@ if [[ "$matched" -eq 0 ]]; then
     exit 1
 fi
 
-# A run that says nothing reads the same whether it tested everything or
-# nothing, so the count is printed even when everything passed.
 summary() {
     local failed=$((total_rewritten + total_failed)) line
     local passed=$((total_tests - failed - total_skipped))
     if [[ "$total_tests" -gt 0 ]]; then
         if [[ "$MODE" == update ]]; then
-            # assertEqualsToFile writes the golden and then fails, so a mismatch
-            # here is a golden that got rewritten. Anything else really failed.
             line="Ran $total_tests tests, $total_rewritten golden(s) rewritten"
             if [[ "$total_failed" -gt 0 ]]; then
                 line+=", $total_failed failed for other reasons"
@@ -179,8 +174,6 @@ summary() {
         fi
         echo "$line."
     fi
-    # A module that ran and left no results is the case where a count over the
-    # other module alone reads as a clean run.
     local module
     for module in "${no_results[@]+"${no_results[@]}"}"; do
         echo "The $module module produced no test results; see its output above."

--- a/agent-scripts/tests/fixtures/skipped.xml
+++ b/agent-scripts/tests/fixtures/skipped.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="verification.BasicTest" tests="2" skipped="1" failures="0" errors="0" timestamp="1970-01-01T00:00:00" hostname="host" time="0.01">
+  <properties/>
+  <testcase name="testAssign_local" classname="verification.BasicTest" time="0.01"/>
+  <testcase name="testIgnored" classname="verification.BasicTest" time="0.0">
+    <skipped/>
+  </testcase>
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/agent-scripts/tests/run.sh
+++ b/agent-scripts/tests/run.sh
@@ -74,6 +74,23 @@ assert_eq "first_failure: only malformed XML reports nothing" \
     "" 1 \
     -- python3 "$LIB_DIR/junit_first_failure.py" "$FIXTURES/malformed.xml"
 
+# counts are "total assertion_failed other_failed skipped unreadable".
+assert_eq "counts: a passing run" \
+    "1 0 0 0 0" 0 \
+    -- python3 "$LIB_DIR/junit_counts.py" "$FIXTURES/passing.xml"
+
+assert_eq "counts: a golden mismatch is counted apart from a thrown exception" \
+    "2 1 1 0 0" 0 \
+    -- python3 "$LIB_DIR/junit_counts.py" "$FIXTURES/failure.xml" "$FIXTURES/error.xml"
+
+assert_eq "counts: a skipped test is neither passed nor failed" \
+    "2 0 0 1 0" 0 \
+    -- python3 "$LIB_DIR/junit_counts.py" "$FIXTURES/skipped.xml"
+
+assert_eq "counts: malformed XML is reported, not silently dropped" \
+    "1 0 0 0 1" 0 \
+    -- python3 "$LIB_DIR/junit_counts.py" "$FIXTURES/malformed.xml" "$FIXTURES/passing.xml"
+
 if [[ "$failures" -gt 0 ]]; then
     echo "$failures assertion(s) failed"
     exit 1

--- a/agent-scripts/tests/run.sh
+++ b/agent-scripts/tests/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Exercises junit_first_failure.py against the fixture XML in fixtures/, the way
+# Exercises the JUnit XML parsers against the fixture XML in fixtures/, the way
 # lib.sh invokes it: python3 <script> <xml files...>. Needs no build, so
 # pre-commit runs it as a hook; also runnable by hand.
 set -euo pipefail

--- a/docs/agents-dev.md
+++ b/docs/agents-dev.md
@@ -14,8 +14,9 @@ them.
   `--rerun` re-executes tests Gradle considers current.
 - `check-testdata.sh` — golden files with no source, and empty golden files.
 - `lib.sh` — sourced by the others, not run.
-- `junit_first_failure.py` — the JUnit XML parser `lib.sh` calls; `tests/run.sh`
-  exercises it against fixture XML.
+- `junit_first_failure.py`, `junit_counts.py` — the JUnit XML parsers `lib.sh`
+  calls, for the first failure and for the run's counts; `tests/run.sh`
+  exercises both against fixture XML.
 
 `test.sh` and `check-all.sh` take `--help`. `test.sh` and `lib.sh` need `python3`
 on PATH, because the test results they report from are XML; `check-testdata.sh`
@@ -43,6 +44,16 @@ Only golden-file assertions carry values to recover. For a thrown exception
 
 Diffs are printed with source-position offsets replaced by `(_,_)`, so a method
 that only moved because of an edit earlier in the file drops out.
+
+## Counts
+
+Every run closes with how many tests it ran and how they went, counted over the
+JUnit XML each module wrote since the run started. A silent success and a
+success that tested nothing are otherwise the same output. A module that ran
+and left no results says so on its own line rather than being left out of the
+total, which would make the other module's count read as the whole run. Under
+`--update-goldens` a golden-file mismatch is the expected outcome and is
+reported as a rewrite; anything else is still a failure.
 
 ## Patterns
 

--- a/docs/agents-dev.md
+++ b/docs/agents-dev.md
@@ -13,14 +13,10 @@ them.
 - `check-all.sh` — `check`, `pre-commit` and the testData checks together.
   `--rerun` re-executes tests Gradle considers current.
 - `check-testdata.sh` — golden files with no source, and empty golden files.
-- `lib.sh` — sourced by the others, not run.
-- `junit_first_failure.py`, `junit_counts.py` — the JUnit XML parsers `lib.sh`
-  calls, for the first failure and for the run's counts; `tests/run.sh`
-  exercises both against fixture XML.
 
-`test.sh` and `check-all.sh` take `--help`. `test.sh` and `lib.sh` need `python3`
-on PATH, because the test results they report from are XML; `check-testdata.sh`
-needs nothing but a checkout.
+`test.sh` and `check-all.sh` take `--help`, and need `python3` on PATH because
+the test results they report from are XML; `check-testdata.sh` needs nothing but
+a checkout.
 
 ## Exit codes
 
@@ -44,16 +40,6 @@ Only golden-file assertions carry values to recover. For a thrown exception
 
 Diffs are printed with source-position offsets replaced by `(_,_)`, so a method
 that only moved because of an edit earlier in the file drops out.
-
-## Counts
-
-Every run closes with how many tests it ran and how they went, counted over the
-JUnit XML each module wrote since the run started. A silent success and a
-success that tested nothing are otherwise the same output. A module that ran
-and left no results says so on its own line rather than being left out of the
-total, which would make the other module's count read as the whole run. Under
-`--update-goldens` a golden-file mismatch is the expected outcome and is
-reported as a rewrite; anything else is still a failure.
 
 ## Patterns
 


### PR DESCRIPTION
`test.sh` printed nothing on success, which is the same output as a run whose
pattern matched nothing. Every run now closes with a line like:

    Ran 3 tests, 3 passed, 0 failed.

Counts come from the JUnit XML each module wrote since the run began, tallied
per `<testcase>`: a suite that died early still advertises a count its cases do
not back. A module that ran and left no results gets its own line rather than
being left out of the total, since the other module's count would otherwise
read as the whole run. Under `--update-goldens` a golden-file mismatch is the
expected outcome and is reported as a rewrite; a test that threw is still a
failure.

`junit_counts.py` is covered by the existing fixture harness in
`agent-scripts/tests/run.sh`, which pre-commit runs.

Exit codes and the failure-diff output are unchanged. `check-all.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)