### PR TITLE
Fix stale Kotlin daemon setup advice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,14 @@ repositories {
 }
 ```
 
-Additionally, make sure you set Kotlin to use K2 and increase the stack size of the Kotlin Daemon:
+Additionally, increase the stack size and metaspace of the Kotlin Daemon: the shaded plugin
+jar bundles Silicon and the Scala runtime (~100 MB), and without a larger metaspace the daemon
+dies with `OutOfMemoryError: Metaspace` after roughly a dozen compiles.
 
 ```kotlin
 kotlin {
-    compilerOptions {
-        languageVersion.set(KotlinVersion.KOTLIN_2_0)
-    }
-    // Set stack size to 30mb
-    kotlinDaemonJvmArgs = listOf("-Xss30m")
+    // Set stack size to 30mb and raise the metaspace limit
+    kotlinDaemonJvmArgs = listOf("-Xss30m", "-XX:MaxMetaspaceSize=1g")
 }
 ```
 
@@ -137,6 +136,10 @@ Check that this is the case when you open a new shell, too!
 You need to (additionally) set `Z3_EXE` in `~/.xprofile` and/or
 `~/.bash_profile` depending on your shell, window manager, display
 manager, operating system, etc.
+
+The Gradle and Kotlin daemons capture `Z3_EXE` at startup, so changing it
+afterwards has no effect until both are stopped (`./gradlew --stop`, plus
+killing the Kotlin daemon).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Recommend `-XX:MaxMetaspaceSize=1g` alongside `-Xss30m` for the Kotlin daemon — the shaded plugin jar bundles Silicon and the Scala runtime (~100 MB), and without it the daemon dies with `OutOfMemoryError: Metaspace` after roughly a dozen compiles.
- Drop the stale `languageVersion.set(KotlinVersion.KOTLIN_2_0)` snippet, which is unnecessary with current Kotlin and only produces a deprecation warning.
- Note that the Gradle and Kotlin daemons capture `Z3_EXE` at startup, so changing it silently does nothing until both are stopped (`./gradlew --stop` plus the Kotlin daemon).

Found while standing up a fresh SnaKt consumer project on Kotlin 2.3.0. Only README.md carries this setup advice; docs/ doesn't repeat it.

## Test plan
- [x] Docs-only change, no build/test impact.