### PR TITLE
Add formver.annotations as an automatic dependency of the Gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,8 @@ unless you run `gradle` with the `--info` flag.
 ### Annotations
 
 The plugin provides a number of annotations to add specifications to your code.
-To access these, add a dependency to `formver.annotations`:
-
-```kotlin
-dependencies {
-    implementation("org.jetbrains.kotlin.formver:formver.annotations:0.1.0-SNAPSHOT")
-}
-```
+Applying the Gradle plugin automatically adds a dependency on `formver.annotations`,
+so no further setup is needed to access them.
 
 ### Running from the command line
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ unless you run `gradle` with the `--info` flag.
 ### Annotations
 
 The plugin provides a number of annotations to add specifications to your code.
-Applying the Gradle plugin automatically adds a dependency on `formver.annotations`,
-so no further setup is needed to access them.
+Applying the Gradle plugin automatically adds a dependency on `formver.annotations`.
 
 ### Running from the command line
 

--- a/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
+++ b/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
@@ -31,6 +31,10 @@ class FormVerGradleSubplugin
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project
 
+        kotlinCompilation.defaultSourceSet.dependencies {
+            implementation(BuildConfig.ANNOTATIONS_LIBRARY_COORDINATES)
+        }
+
         val formVerExtension = project.extensions.getByType(FormVerExtension::class.java)
 
         return project.provider {


### PR DESCRIPTION
## Summary
- `FormVerGradleSubplugin.applyToCompilation` now adds `formver.annotations` (coordinates already computed by `BuildConfig.ANNOTATIONS_LIBRARY_COORDINATES`) as an `implementation` dependency on each compilation's default source set, following the standard `KotlinCompilerPluginSupportPlugin` pattern.
- README no longer tells consumers to manually add the `formver.annotations` dependency.

Found while standing up a fresh consumer project from `mavenLocal`: applying the Gradle plugin didn't give access to the annotations without the extra manual dependency line.

## Test plan
- Compiled `formver.gradle-plugin` (no deprecation warnings; uses `KotlinCompilation.defaultSourceSet.dependencies { implementation(...) }`).
- `./gradlew publishToMavenLocal`, then built a throwaway consumer project applying only `id("org.jetbrains.kotlin.formver")` with no manual `formver.annotations` dependency — `compileKotlin` succeeded and `dependencies --configuration compileClasspath` showed `formver.annotations` resolved automatically.
- `./agent-scripts/check-all.sh` (gradle check, check-testdata.sh, pre-commit) all pass.