### PR TITLE
Diagnose a missing/unusable Z3 prover instead of reporting an internal error

### DIFF
--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
@@ -39,6 +39,11 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
         )
         map.put(
+            PluginErrors.PROVER_NOT_FOUND,
+            "{0}",
+            CommonRenderers.STRING,
+        )
+        map.put(
             VerificationErrors.UNEXPECTED_RETURNED_VALUE,
             "Function may return a {0} value.",
             CommonRenderers.STRING,

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
@@ -12,6 +12,7 @@ object PluginErrors : KtDiagnosticsContainer() {
     val VIPER_TEXT by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val EXP_EMBEDDING by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val INTERNAL_ERROR by error1<PsiElement, String>()
+    val PROVER_NOT_FOUND by error1<PsiElement, String>()
     val UNIQUENESS_VIOLATION by error1<PsiElement, String>()
     val UNIQUENESS_CFG by info1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val ADT_VIOLATION by error1<PsiElement, String>()
@@ -21,6 +22,7 @@ object PluginErrors : KtDiagnosticsContainer() {
         VIPER_TEXT.name,
         EXP_EMBEDDING.name,
         INTERNAL_ERROR.name,
+        PROVER_NOT_FOUND.name,
         UNIQUENESS_VIOLATION.name,
         UNIQUENESS_CFG.name,
         ADT_VIOLATION.name

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.formver.core.names.SimpleNameResolver
 import org.jetbrains.kotlin.formver.core.shouldVerify
 import org.jetbrains.kotlin.formver.core.viperProgram
 import org.jetbrains.kotlin.formver.plugin.compiler.reporting.reportVerifierError
+import org.jetbrains.kotlin.formver.viper.ProverNotFoundException
 import org.jetbrains.kotlin.formver.viper.SiliconFrontend
 import org.jetbrains.kotlin.formver.viper.ast.Program
 import org.jetbrains.kotlin.formver.viper.ast.registerAllNames
@@ -115,6 +116,8 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
 
         } catch (e: SnaktInternalException) {
             reporter.reportOn(e.source, PluginErrors.INTERNAL_ERROR, e.message)
+        } catch (e: ProverNotFoundException) {
+            reporter.reportOn(declaration.source, PluginErrors.PROVER_NOT_FOUND, e.message ?: "Prover not found")
         } catch (e: Exception) {
             val error = e.message ?: "No message provided"
             reporter.reportOn(declaration.source, PluginErrors.INTERNAL_ERROR, error)

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ProverNotFoundException.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ProverNotFoundException.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.viper
+
+import java.io.File
+
+private const val Z3_EXE_ENV_VAR = "Z3_EXE"
+
+class ProverNotFoundException(message: String) : Exception(message)
+
+/**
+ * Resolves the Z3 executable the same way Silicon does ([Z3_EXE_ENV_VAR], then `PATH`), so the
+ * path named in [checkProverIsUsable]'s diagnostic is the same one Silicon would otherwise have
+ * failed on deep inside its own low-level "not a file" error.
+ */
+private fun resolveZ3Executable(): File {
+    System.getenv(Z3_EXE_ENV_VAR)?.let { return File(it) }
+    val executableName = if (System.getProperty("os.name").lowercase().startsWith("windows")) "z3.exe" else "z3"
+    val searchPath = System.getenv("PATH").orEmpty().split(File.pathSeparatorChar)
+    return searchPath.map { File(it, executableName) }.firstOrNull { it.isFile } ?: File(executableName)
+}
+
+/** Throws [ProverNotFoundException] with a user-facing diagnostic if no usable Z3 executable can be found. */
+fun checkProverIsUsable() {
+    val exe = resolveZ3Executable()
+    val hint = "Set the $Z3_EXE_ENV_VAR environment variable to the path of a z3 binary, or install Z3 " +
+        "(https://github.com/Z3Prover/z3/releases) and add it to PATH."
+    if (!exe.isFile) {
+        throw ProverNotFoundException("Could not find the Z3 prover executable at '${exe.path}'. $hint")
+    }
+    if (!exe.canExecute()) {
+        throw ProverNotFoundException("The Z3 prover at '${exe.path}' is not executable. $hint")
+    }
+}

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SiliconFrontend.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SiliconFrontend.kt
@@ -14,6 +14,7 @@ class SiliconFrontend(commandLineArgs: List<String>) : Closeable {
     private val siliconApi: viper.silicon.SiliconFrontendAPI
 
     init {
+        checkProverIsUsable()
         val args = buildList {
             addAll(commandLineArgs)
             System.getenv("SILICON_PARALLEL_VERIFIERS")?.let {


### PR DESCRIPTION
## Summary

Without a usable `Z3_EXE`, verification currently fails deep inside Silicon
with the low-level `Cannot run prover at location 'z3': not a file`, which
SnaKt's catch-all in `ViperPoweredDeclarationChecker` turns into an
`INTERNAL_ERROR` diagnostic asking the user to file a bug — pointing them
away from the real cause, their own environment.

- `SiliconFrontend.init` now probes for a usable Z3 executable before
  constructing the Silicon API, resolving it the same way Silicon itself
  does (`Z3_EXE` env var, then a `PATH` search), so the diagnostic names the
  same path Silicon would otherwise have failed on.
- If no executable is found, or it isn't executable, it throws
  `ProverNotFoundException` with a message naming the resolved path,
  mentioning `Z3_EXE`, and linking the Z3 releases page.
- `ViperPoweredDeclarationChecker` catches this ahead of the generic
  `Exception` catch-all and reports a new `PROVER_NOT_FOUND` diagnostic
  (added to `PluginErrors`/`FormalVerificationPluginErrorMessages`,
  following the existing `INTERNAL_ERROR` pattern) instead of `INTERNAL_ERROR`.

## Testing

Manually verified with `Z3_EXE=/nonexistent/z3 ./agent-scripts/test.sh --verify empty`:
the test-fixture path (`ViperProgramVerificationFacade`, used by the golden-file
harness) now fails with a clear `ProverNotFoundException` message instead of
Silicon's internal error text. Ran the existing conversion suite
(`./agent-scripts/test.sh`, 168/168) and a verify run with a correctly
configured `Z3_EXE` (`./agent-scripts/test.sh --verify empty`) to confirm no
regression in the working case.

No golden-file test was added for the new `PROVER_NOT_FOUND` diagnostic
itself. In test runs, verification is diagnosed via
`ViperProgramVerificationFacade.transform`, not the FIR checker branch in
`ViperPoweredDeclarationChecker` that reports diagnostics through
`DiagnosticReporter` — the golden-file/marker harness only exercises the
latter. Reaching `PROVER_NOT_FOUND` as an actual `<!PROVER_NOT_FOUND!>`
marker would require the production (non-test) compiler invocation, which
the harness doesn't drive, plus a broken `Z3_EXE` in that invocation's
environment — orthogonal to the golden-file mechanism and in conflict with
CI's environment, which installs a real Z3 for every other test. Flagging
per the task instructions rather than forcing a test that can't express this.

## Note: `./agent-scripts/check-all.sh` in this environment

`gradle check` (inside `check-all.sh`) fails partway through
`:formver.compiler-plugin:test` with `Gradle build daemon has been stopped:
stop command received`. Reproduced identically on unmodified `main` in a
separate worktree — something in this sandbox stops the daemon mid-run,
unrelated to this change. `./agent-scripts/test.sh` (168/168) and
`./agent-scripts/test.sh --verify <pattern>` both ran cleanly outside
`check-all.sh`'s `--no-daemon gradle check` invocation.
