### PR TITLE
Treat a SnaKt spec block as a contract for target selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ The plugin accepts a number of command line options which can be passed via
   `only_warnings`).
 - Option `error_style`: permitted values `user_friendly`, `original_viper` and `both` (default: `user_friendly`).
 - Options `conversion_targets_selection` and `verification_targets_selection`: permitted values `no_targets`,
-  `targets_with_contract`, `all_targets` (default: `targets_with_contract`).
+  `targets_with_contract`, `all_targets` (default: `targets_with_contract`). A function counts as having a
+  contract if it has a Kotlin `contract { }` block or a SnaKt `preconditions`/`postconditions` block.
 - Option `unsupported_feature_behaviour`: permitted values `throw_exception`, `assume_unreachable` (default:
   `throw_exception`).
 

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -4,17 +4,25 @@ SnaKt translates Kotlin code with formal specifications to [Viper](https://www.p
 
 ## Verification Control
 
-By default, SnaKt only verifies functions with Kotlin `contract { }` blocks. To verify functions with SnaKt specifications:
+By default, SnaKt verifies the functions that have a contract: a Kotlin `contract { }` block, or a
+SnaKt `preconditions { }` or `postconditions<T> { }` block. Everything else is left alone:
 
 ```kotlin
 import org.jetbrains.kotlin.formver.plugin.*
 
-@AlwaysVerify  // Enables verification for this function
 fun divide(numerator: Int, denominator: Int): Int {
-    preconditions { denominator != 0 }
+    preconditions { denominator != 0 }   // enough on its own to make this a target
     return numerator / denominator
 }
+
+@AlwaysVerify  // verify this one too, though it specifies nothing
+fun half(x: Int) = divide(x, 2)
 ```
+
+Callers of a specified function may assume its postconditions, so a function that carries a
+specification is verified against it rather than believed. Suppressing that — with `@NeverVerify`,
+or by setting the selection to `no_targets` — turns the specification into an assumption that
+nothing checks.
 
 **Annotations:**
 - `@AlwaysVerify` — verify this function regardless of plugin settings
@@ -25,7 +33,7 @@ fun divide(numerator: Int, denominator: Int): Int {
 ```kotlin
 formver {
     verificationTargetsSelection("all_targets")  // Verify all functions
-    // or "targets_with_contract" (default) — only Kotlin contract { } blocks
+    // or "targets_with_contract" (default) — only functions carrying a contract
     // or "no_targets" — disable verification
 }
 ```

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -48,6 +48,9 @@ Which checks run:
 - `ALWAYS_VALIDATE` — verify every target. Verification is already the default,
   so this changes nothing on its own; it earns its place by overriding the two
   `*_CHECK_ONLY` directives above.
+- `DEFAULT_SELECTION` — pick targets the way an unconfigured plugin does, rather
+  than taking every function in the file. For tests about which functions get
+  selected at all; elsewhere it only hides code from the verifier.
 
 What the diagnostic contains:
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
@@ -38,6 +38,24 @@ private fun FirAnonymousFunction.extractFormverReturnVar(returnType: ConeKotlinT
     return param.symbol
 }
 
+private fun FirStatement.isFormverCallNamed(name: String): Boolean {
+    if (this !is FirFunctionCall) return false
+    val firFunction = toResolvedCallableSymbol() as? FirFunctionSymbol<*> ?: return false
+    return firFunction.isFormverFunctionNamed(name)
+}
+
+/**
+ * Whether [parentBlock] opens with a specification block, that is, whether
+ * [extractFirSpecification] would find anything in it.
+ *
+ * Answers the question without touching the lambdas, so it is safe to ask about a body that
+ * conversion may yet reject.
+ */
+fun hasFirSpecification(parentBlock: FirBlock): Boolean {
+    val firstStmt = parentBlock.statements.firstOrNull() ?: return false
+    return firstStmt.isFormverCallNamed("postconditions") || firstStmt.isFormverCallNamed("preconditions")
+}
+
 fun extractFirSpecification(parentBlock: FirBlock, returnType: ConeKotlinType): FirSpecification {
     val firstStmt = parentBlock.statements.firstOrNull() ?: return FirSpecification()
 

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.common.TargetsSelection
 import org.jetbrains.kotlin.formver.core.conversion.ProgramConverter
+import org.jetbrains.kotlin.formver.core.conversion.hasFirSpecification
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.print
 import org.jetbrains.kotlin.formver.core.names.SimpleNameResolver
 import org.jetbrains.kotlin.formver.core.shouldVerify
@@ -36,11 +37,23 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-private val FirContractDescriptionOwner.hasContract: Boolean
+private val FirContractDescriptionOwner.hasKotlinContract: Boolean
     get() = when (val description = contractDescription) {
         is FirResolvedContractDescription -> description.effects.isNotEmpty()
         else -> false
     }
+
+private val FirSimpleFunction.hasSnaktSpecification: Boolean
+    get() = body?.let { hasFirSpecification(it) } == true
+
+/**
+ * Whether callers of [this] may assume anything about it that its own body has to establish.
+ *
+ * Both a Kotlin `contract { }` and a SnaKt specification block qualify: a callee that is not a
+ * target is never checked against the conditions its callers assume of it.
+ */
+private val FirSimpleFunction.hasContract: Boolean
+    get() = hasKotlinContract || hasSnaktSpecification
 
 private fun TargetsSelection.applicable(declaration: FirSimpleFunction): Boolean = when (this) {
     TargetsSelection.ALL_TARGETS -> true

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.formver.common.*
 import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.ALWAYS_VALIDATE
+import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DEFAULT_SELECTION
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DUMP_UNIQUENESS_CFG
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.FULL_VIPER_DUMP
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.LOCALITY_CHECK_ONLY
@@ -51,14 +52,17 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
         val uniquenessOnly = UNIQUE_CHECK_ONLY in module.directives
         val localityOnly = LOCALITY_CHECK_ONLY in module.directives
         val dumpUniquenessCFG = DUMP_UNIQUENESS_CFG in module.directives
+        val defaultSelection = DEFAULT_SELECTION in module.directives
         val verificationSelection = when {
             conversionOnly -> TargetsSelection.FORCE_DISABLE
             ALWAYS_VALIDATE in module.directives -> TargetsSelection.ALL_TARGETS
             uniquenessOnly || localityOnly -> TargetsSelection.NO_TARGETS
+            defaultSelection -> TargetsSelection.defaultBehaviour()
             else -> TargetsSelection.ALL_TARGETS
         }
         val conversionSelection = when {
             uniquenessOnly || localityOnly -> TargetsSelection.NO_TARGETS
+            defaultSelection -> TargetsSelection.defaultBehaviour()
             else -> TargetsSelection.ALL_TARGETS
         }
         val checkUniqueness = uniquenessOnly
@@ -116,6 +120,10 @@ object FormVerDirectives : SimpleDirectivesContainer() {
 
     val NEVER_VALIDATE by directive(
         description = "Run in conversion-only mode: skip verification, keep consistency checking"
+    )
+
+    val DEFAULT_SELECTION by directive(
+        description = "Select targets the way an unconfigured plugin does, rather than taking every function"
     )
 }
 

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -815,6 +815,22 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/target_selection")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Target_selection {
+      @Test
+      public void testAllFilesPresentInTarget_selection() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/verification/target_selection"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("spec_block_is_a_contract.kt")
+      public void testSpec_block_is_a_contract() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/types")
     @TestDataPath("$PROJECT_ROOT")
     public class Types {

--- a/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.fir.diag.txt
@@ -1,0 +1,56 @@
+/spec_block_is_a_contract.kt: info: Generated Viper text for alwaysPositive:
+method alwaysPositive(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) > 0
+{
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/spec_block_is_a_contract.kt: info: Generated Viper text for atLeastTen:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method atLeastTen(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
+  requires intFromRef(x) >= 10
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  assert intFromRef(x) > 100
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/spec_block_is_a_contract.kt: info: Generated Viper text for caller:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method alwaysPositive(x: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+  ensures intFromRef(ret_1) > 0
+
+
+method atLeastTen(x: Ref) returns (ret_2: Ref)
+  requires isSubtype(typeOf(x), intType())
+  requires intFromRef(x) >= 10
+  ensures isSubtype(typeOf(ret_2), intType())
+
+
+method caller() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var positive: Ref
+  positive := alwaysPositive(intToRef(-1))
+  assert intFromRef(positive) > 0
+  v_ret_0 := atLeastTen(intToRef(20))
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.kt
@@ -1,0 +1,32 @@
+// FULL_JDK
+// DEFAULT_SELECTION
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+// A specification block is the only thing marking these two functions as worth verifying.
+// Callers may assume what they promise, so their bodies have to be checked against it.
+
+<!VIPER_VERIFICATION_ERROR!>fun <!VIPER_TEXT!>alwaysPositive<!>(x: Int): Int {
+    postconditions<Int> {
+        it > 0
+    }
+    return x
+}<!>
+
+fun <!VIPER_TEXT!>atLeastTen<!>(x: Int): Int {
+    preconditions {
+        x >= 10
+    }
+    verify(<!VIPER_VERIFICATION_ERROR!>x > 100<!>)
+    return x
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>caller<!>(): Int {
+    val positive = alwaysPositive(-1)
+    verify(positive > 0)
+    return atLeastTen(20)
+}
+
+// Neither specified nor annotated: not a target, and nothing is assumed of it.
+fun unspecified(x: Int): Int = x + 1

--- a/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.viper.diag.txt
@@ -1,0 +1,3 @@
+/spec_block_is_a_contract.kt: warning: Viper verification error: Postcondition of alwaysPositive might not hold. Assertion intFromRef(v_ret_0) > 0 might not hold.
+
+/spec_block_is_a_contract.kt: warning: Viper verification error: Assert might fail. Assertion intFromRef(x) > 100 might not hold.


### PR DESCRIPTION
## The gap

Under the default `targets_with_contract` selection, "contract" meant a Kotlin `contract { }` block
with resolved effects and nothing else. A function whose only specification was a SnaKt spec block
was therefore not a target — but its callers still got its postconditions, because `embedContract`
extracts a callee's spec whether or not the callee is itself verified.

So this compiled green:

```kotlin
fun alwaysPositive(x: Int): Int {
    postconditions<Int> { it > 0 }
    return x                        // never checked against the postcondition
}

@AlwaysVerify
fun caller() {
    val positive = alwaysPositive(-1)
    verify(positive > 0)            // proved, from the lie
}
```

Adding `@AlwaysVerify` to `alwaysPositive` made it fail as it should. Without the annotation every
spec block was an axiom nothing checked.

## The fix

`TARGETS_WITH_CONTRACT` now selects a function if it has a Kotlin contract **or** a SnaKt
specification block. The semantics: *a function has a contract when callers may assume something of
it that its own body has to establish.* That is what the selection is for, and the
Kotlin-contract-only reading was narrower both than the option's name and than its purpose.

Detection mirrors `extractFirSpecification` exactly — `hasFirSpecification` sits next to it so the
two stay in sync. The body's first statement being a `preconditions` or `postconditions` call is
precisely when conversion finds a spec, so selection and semantics cannot drift apart. It does not
touch the lambdas, so it is safe to ask about a body conversion may yet reject.

A `preconditions`-only function is selected too. It promises callers nothing, but its own body still
has to hold up under the precondition it declares, and nothing was checking that either.

`loopInvariants` and `verify` deliberately do not select: neither is visible to callers.

## Other entry points for the same trap

Checked against the plugin rather than guessed at; both confirmed by probe.

- **`@NeverConvert` is a live hole, and this PR does not close it.** The annotation stops the
  function being converted as a target, but `embedAnyFunction` reads it only to decide whether to
  inline a *pure* function's body — the callee's signature, postcondition included, is still
  embedded into the caller's program. A `@NeverConvert` helper with a false postcondition still
  hands that postcondition to its callers, with nothing anywhere checking it. Unlike the default
  selection this is at least explicitly asked for, but it is asked for with an annotation whose
  documented meaning is "skip Viper conversion entirely", not "trust me".
- **`@NeverVerify` is the same shape, but only inside the test harness.** The production checker
  verifies everything it converts and never reads `shouldVerify`; only `VerificationFacade` does. So
  `@NeverVerify` — and `verification_targets_selection` with it — has no effect on a real compile
  today. In a test run the callee is converted, left unverified, and its postcondition assumed by
  callers. Worth deciding deliberately if that flag is ever wired up in production.
- **Cross-module callees.** `embedFormverContract` bails when the body is not visible, so a spec
  from another module is neither assumed nor honoured. Not a hole; a known limitation.
- **`verify(...)` in an unselected function** is silently never checked. Not unsound for callers,
  but the same flavour of false assurance. Left alone here.

The shared root is that assuming a callee's spec and checking that callee are decided independently.
A diagnostic at the point where a spec is assumed of a function nothing verifies would cover all of
these at once; that seems the right follow-up rather than patching each entry point.

## Test

`testData/diagnostics/verification/target_selection/spec_block_is_a_contract.kt`, under a new
`DEFAULT_SELECTION` directive — the existing suite runs everything at `all_targets`, so no test
could see this. On `main` it fails all three goldens. Here `alwaysPositive` reports its postcondition
violation and `atLeastTen` its failing body assertion, while the unspecified function is still left
alone.

No existing golden changed: nothing else in the suite uses `targets_with_contract`.

## Docs

`SPECIFICATIONS.md` said the default verifies "only Kotlin `contract { }` blocks" and presented
`@AlwaysVerify` as the way to get a spec block verified at all; both updated, with a note that
suppressing verification of a specified function turns its spec into an unchecked assumption.
`README.md` says what counts as a contract for the CLI option. `docs/developing.md` documents the
new directive.
