### PR TITLE
Make the default test dump dir per-checkout, not just per-user

### DIFF
--- a/agent-scripts/lib.sh
+++ b/agent-scripts/lib.sh
@@ -93,10 +93,13 @@ count_xml_results() {
 }
 
 # Where DumpAssertionDiffExtension writes its dumps (see docs/agents-dev.md).
-# Per-user, because callers glob and clear this directory and a shared /tmp
-# would hand them someone else's files.
+# Per-user and per-checkout, because callers glob and clear this directory and
+# a shared /tmp would hand them another user's or another worktree's files.
 dump_dir_default() {
-    printf '%s' "${SNAKT_TEST_DUMP_DIR:-${TMPDIR:-/tmp}/snakt-test-diff-$(id -u)}"
+    local repo_root repo_tag
+    repo_root="$(dirname "$LIB_DIR")"
+    repo_tag="$(printf '%s' "$repo_root" | cksum | cut -d' ' -f1)"
+    printf '%s' "${SNAKT_TEST_DUMP_DIR:-${TMPDIR:-/tmp}/snakt-test-diff-$(id -u)-$repo_tag}"
 }
 
 # Replace source-position offsets like ":(23,31):" with ":(_,_):", so a method


### PR DESCRIPTION
## Summary
- `dump_dir_default()` in `agent-scripts/lib.sh` derived the test-assertion-dump directory from just `$(id -u)`, so two sessions running `test.sh` in sibling worktrees of the same repo shared one directory. `test.sh` clears that directory at the start of every run, so concurrent worktrees deleted each other's assertion diffs and could read the other's diffs as their own.
- The default now also tags the path with a checksum of the repo root (derived from `lib.sh`'s own location, so it doesn't depend on the caller's cwd), giving each checkout a distinct directory. An explicit `SNAKT_TEST_DUMP_DIR` still overrides the default unchanged.
- Checked all consumers of the variable in `agent-scripts/`: only `lib.sh` computes the default and only `test.sh` uses it (exporting it for `DumpAssertionDiffExtension.kt` to read) — both now agree.

## Test plan
- [x] `./agent-scripts/tests/run.sh` — passes
- [x] `./agent-scripts/check-all.sh` — passes (gradle check, check-testdata.sh, pre-commit)
- [x] Manually verified `dump_dir_default` produces different paths for two different repo-root locations, and that an exported `SNAKT_TEST_DUMP_DIR` still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)