### PR TITLE
Report ignored preconditions/postconditions/loopInvariants blocks

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.kotlin.formver.core.conversion
 
+import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
@@ -22,9 +23,36 @@ fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Bo
     return formverInvariantsArgument.anonymousFunction
 }
 
-fun extractLoopInvariants(parentBlock: FirBlock): FirBlock? {
-    val firstStmt = parentBlock.statements.firstOrNull() ?: return null
-    return firstStmt.extractFormverFirBlock { isFormverFunctionNamed("loopInvariants") }?.body
+private fun FirStatement.isFormverCallNamed(name: String): Boolean {
+    if (this !is FirFunctionCall) return false
+    val firFunction = toResolvedCallableSymbol() as? FirFunctionSymbol<*> ?: return false
+    return firFunction.isFormverFunctionNamed(name)
+}
+
+/**
+ * Conversion only ever looks for [name] at [usedIndex] (or nowhere, if [usedIndex] is -1); any other
+ * occurrence in [statements] is silently no-op'd by the special-function machinery instead of being
+ * picked up as part of the specification. Report each such occurrence via [report] so it isn't silently
+ * ignored.
+ */
+private fun reportMisplacedSpecBlocks(
+    statements: List<FirStatement>,
+    name: String,
+    usedIndex: Int,
+    report: (String, KtSourceElement?) -> Unit,
+) {
+    for ((index, stmt) in statements.withIndex()) {
+        if (index != usedIndex && stmt.isFormverCallNamed(name)) report(name, stmt.source)
+    }
+}
+
+fun extractLoopInvariants(parentBlock: FirBlock, reportMisplaced: (KtSourceElement?) -> Unit): FirBlock? {
+    val statements = parentBlock.statements
+    val invariants = statements.firstOrNull()?.extractFormverFirBlock { isFormverFunctionNamed("loopInvariants") }
+    reportMisplacedSpecBlocks(statements, "loopInvariants", usedIndex = if (invariants != null) 0 else -1) { _, source ->
+        reportMisplaced(source)
+    }
+    return invariants?.body
 }
 
 data class FirSpecification(val precond: FirBlock?, val postcond: FirBlock?, val returnVar: FirValueParameterSymbol?) {
@@ -38,16 +66,37 @@ private fun FirAnonymousFunction.extractFormverReturnVar(returnType: ConeKotlinT
     return param.symbol
 }
 
-fun extractFirSpecification(parentBlock: FirBlock, returnType: ConeKotlinType): FirSpecification {
-    val firstStmt = parentBlock.statements.firstOrNull() ?: return FirSpecification()
+/**
+ * Picks out the `preconditions{}`/`postconditions{}` blocks that head [parentBlock]: `preconditions` must
+ * be the first statement, and `postconditions` must be the first statement (if there is no `preconditions`)
+ * or the second (right after `preconditions`). Any occurrence outside that position is invisible to the
+ * rest of conversion, which no-ops such calls wherever they appear rather than erroring — so [reportMisplaced]
+ * is called for each one instead of letting it disappear silently.
+ */
+fun extractFirSpecification(
+    parentBlock: FirBlock,
+    returnType: ConeKotlinType,
+    reportMisplaced: (String, KtSourceElement?) -> Unit,
+): FirSpecification {
+    val statements = parentBlock.statements
+    val firstStmt = statements.firstOrNull() ?: return FirSpecification()
 
-    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }?.let { lambda ->
-        return FirSpecification(null, lambda.body, lambda.extractFormverReturnVar(returnType))
+    val leadingPostcond = firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
+    if (leadingPostcond != null) {
+        reportMisplacedSpecBlocks(statements, "preconditions", usedIndex = -1, reportMisplaced)
+        reportMisplacedSpecBlocks(statements, "postconditions", usedIndex = 0, reportMisplaced)
+        return FirSpecification(null, leadingPostcond.body, leadingPostcond.extractFormverReturnVar(returnType))
     }
 
     val precond = firstStmt.extractFormverFirBlock { isFormverFunctionNamed("preconditions") }
-        ?: return FirSpecification()
-    val postcond =
-        parentBlock.statements.getOrNull(1)?.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
+    if (precond == null) {
+        reportMisplacedSpecBlocks(statements, "preconditions", usedIndex = -1, reportMisplaced)
+        reportMisplacedSpecBlocks(statements, "postconditions", usedIndex = -1, reportMisplaced)
+        return FirSpecification()
+    }
+    reportMisplacedSpecBlocks(statements, "preconditions", usedIndex = 0, reportMisplaced)
+
+    val postcond = statements.getOrNull(1)?.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
+    reportMisplacedSpecBlocks(statements, "postconditions", usedIndex = if (postcond != null) 1 else -1, reportMisplaced)
     return FirSpecification(precond.body, postcond?.body, postcond?.extractFormverReturnVar(returnType))
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -79,6 +79,9 @@ class ProgramConverter(
     override fun reportMinorInternalError(msg: String) =
         emit(currentDeclarationSource, ConversionErrors.MINOR_INTERNAL_ERROR, msg)
 
+    override fun reportIgnoredSpecBlock(source: KtSourceElement?, msg: String) =
+        emit(source, ConversionErrors.IGNORED_SPEC_BLOCK, msg)
+
     private fun reportVerificationSkipped(source: KtSourceElement?, msg: String) {
         context(diagnosticContext) {
             reporter.reportOn(source, ConversionErrors.VERIFICATION_SKIPPED, msg)
@@ -376,8 +379,14 @@ class ProgramConverter(
             return Pair(emptyList(), emptyList())
         }
 
-        val firSpec = extractFirSpecification(body, declaration.symbol.resolvedReturnType)
-
+        val firSpec = extractFirSpecification(body, declaration.symbol.resolvedReturnType) { name, source ->
+            reportIgnoredSpecBlock(
+                source,
+                "This `$name` block is ignored: `preconditions` must be the first statement of the function " +
+                    "body, and `postconditions` must immediately follow it (or be first, if there is no " +
+                    "`preconditions` block)."
+            )
+        }
 
         val (preconditionContext, postconditionContext) = createContractConversionContext(
             symbol, signature, firSpec, returnTarget

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -337,7 +337,12 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             data.retrievePropertiesAndParameters().forEach {
                 addAll(it.provenInvariants())
             }
-            extractLoopInvariants(whileLoop.block)?.let {
+            extractLoopInvariants(whileLoop.block) { source ->
+                data.reportIgnoredSpecBlock(
+                    source,
+                    "This `loopInvariants` block is ignored: it must be the first statement of the loop body."
+                )
+            }?.let {
                 addAll(data.withScopeImpl(ScopeIndex.NoScope) { data.collectInvariants(it) })
             }
         }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrorMessages.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrorMessages.kt
@@ -26,5 +26,10 @@ object ConversionErrorMessages : BaseDiagnosticRendererFactory() {
             "{0}",
             CommonRenderers.STRING,
         )
+        map.put(
+            ConversionErrors.IGNORED_SPEC_BLOCK,
+            "{0}",
+            CommonRenderers.STRING,
+        )
     }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrors.kt
@@ -20,6 +20,9 @@ object ConversionErrors : KtDiagnosticsContainer() {
     val PURITY_VIOLATION by error1<PsiElement, String>()
     val MINOR_INTERNAL_ERROR by error1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
 
+    /** A `preconditions`/`postconditions`/`loopInvariants` block sits in a position where the conversion never looks for it. */
+    val IGNORED_SPEC_BLOCK by error1<PsiElement, String>()
+
     /**
      * Per-function summary fired by `ProgramConverter.validateAll` whenever a registered declaration's
      * pipeline (signature embedding, body conversion, or validation) produced any blocking errors.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ErrorCollectionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ErrorCollectionContext.kt
@@ -18,4 +18,7 @@ interface ErrorCollectionContext {
 
     /** Report a minor internal error; the source is supplied by the implementation. */
     fun reportMinorInternalError(msg: String)
+
+    /** Report a spec block (`preconditions`/`postconditions`/`loopInvariants`) at [source] that will be ignored. */
+    fun reportIgnoredSpecBlock(source: KtSourceElement?, msg: String)
 }

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -888,6 +888,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("misplaced_spec_blocks.kt")
+      public void testMisplaced_spec_blocks() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.kt");
+      }
+
+      @Test
       @TestMetadata("simple_forall.kt")
       public void testSimple_forall() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/simple_forall.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.fir.diag.txt
@@ -1,0 +1,11 @@
+/misplaced_spec_blocks.kt: error: Function 'preconditionsAfterPostconditions' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `preconditions` block is ignored: `preconditions` must be the first statement of the function body, and `postconditions` must immediately follow it (or be first, if there is no `preconditions` block).
+
+/misplaced_spec_blocks.kt: error: Function 'postconditionsNotImmediatelyAfterPreconditions' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `postconditions` block is ignored: `preconditions` must be the first statement of the function body, and `postconditions` must immediately follow it (or be first, if there is no `preconditions` block).
+
+/misplaced_spec_blocks.kt: error: Function 'loopInvariantsNotFirstInLoop' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `loopInvariants` block is ignored: it must be the first statement of the loop body.

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.kt
@@ -1,0 +1,35 @@
+// FULL_JDK
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.preconditions
+import org.jetbrains.kotlin.formver.plugin.postconditions
+import org.jetbrains.kotlin.formver.plugin.loopInvariants
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>preconditionsAfterPostconditions<!>(arg: Boolean): Boolean {
+    postconditions<Boolean> { ret -> ret == arg }
+    <!IGNORED_SPEC_BLOCK!>preconditions {
+        arg == true
+    }<!>
+    return arg
+}
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>postconditionsNotImmediatelyAfterPreconditions<!>(arg: Boolean): Boolean {
+    preconditions {
+        arg == true
+    }
+    val unrelated = arg
+    <!IGNORED_SPEC_BLOCK!>postconditions<Boolean> { ret -> ret == arg }<!>
+    return unrelated
+}
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>loopInvariantsNotFirstInLoop<!>() {
+    var i = 0
+    while (i < 10) {
+        i = i + 1
+        <!IGNORED_SPEC_BLOCK!>loopInvariants {
+            i <= 10
+        }<!>
+    }
+}


### PR DESCRIPTION
## Summary

Spec-block extraction (\`extractFirSpecification\`/\`extractLoopInvariants\` in \`FormverFirBlock.kt\`) only ever looks at fixed statement positions: \`preconditions\` must be the first statement of a function body, \`postconditions\` must be first (if there's no preconditions) or immediately after it, and \`loopInvariants\` must be the first statement of a loop body. Meanwhile the rest of body conversion resolves these calls by name *anywhere* they appear in the block and silently turns them into no-ops (they're registered as no-op special functions). A spec block outside its required position was therefore dropped with no diagnostic — same source, opposite verification outcome.

- Added \`ConversionErrors.IGNORED_SPEC_BLOCK\`, following the existing \`PURITY_VIOLATION\`/\`MINOR_INTERNAL_ERROR\` pattern in that file.
- \`extractFirSpecification\`/\`extractLoopInvariants\` now take a \`reportMisplaced\` callback and scan the full statement list for any spec-block call outside the position that's actually used, reporting it at its exact source.
- Wired into \`ProgramConverter.embedFormverContract\` and \`StmtConversionVisitor.visitWhileLoop\`.
- Added a golden diagnostics test (\`testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.kt\`) covering preconditions-after-postconditions, postconditions-not-immediately-after-preconditions, and loopInvariants-not-first-in-loop.

## Test plan

- [x] \`./agent-scripts/test.sh --verify user_invariants\` — 13/13 passed
- [x] \`./agent-scripts/test.sh --verify\` (full suite) — 169/169 passed
- [x] \`./agent-scripts/check-all.sh\` — passed