### PR TITLE
Pass an argument for every parameter of a call

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -149,6 +149,17 @@ fun StmtConversionContext.embedPropertyAccess(accessExpression: FirPropertyAcces
     }
 
 
+/**
+ * A value about which nothing is known beyond its type.
+ *
+ * Access permissions are deliberately left out: inhaling them would conjure permission to a
+ * reference nobody handed us.
+ */
+fun StmtConversionContext.unconstrainedValue(type: TypeEmbedding): Pair<Declare, ExpEmbedding> {
+    val declaration = declareAnonVar(type, null)
+    return declaration to declaration.variable.withInvariants(typeResolver) { proven = true }
+}
+
 fun StmtConversionContext.argumentDeclaration(
     arg: ExpEmbedding,
     callType: TypeEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -23,6 +23,8 @@ import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.common.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.formver.core.embeddings.LabelLink
 import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.callables.InlineNamedFunction
+import org.jetbrains.kotlin.formver.core.embeddings.callables.NonInlineCallable
 import org.jetbrains.kotlin.formver.core.embeddings.callables.insertCall
 import org.jetbrains.kotlin.formver.core.embeddings.callables.isVerifyFunction
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
@@ -282,16 +284,52 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             }
         }
 
+    /**
+     * The call's value arguments in the order the callee declares its parameters, `null` where
+     * the call leaves a parameter to its default value.
+     *
+     * `null` when the mapping is unavailable, in which case the arguments have to be taken as
+     * they come.
+     */
+    private fun FirFunctionCall.argumentsPerParameter(symbol: FirFunctionSymbol<*>): List<FirExpression?>? {
+        val mapping = resolvedArgumentMapping ?: return null
+        val byParameter = mapping.entries.associate { (argument, parameter) -> parameter.symbol to argument }
+        return symbol.valueParameterSymbols.map { byParameter[it] }
+    }
+
     override fun visitFunctionCall(functionCall: FirFunctionCall, data: StmtConversionContext): ExpEmbedding {
         val symbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
             ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
 
         val callee = data.embedAnyFunction(symbol)
-        return callee.insertCall(
-            functionCall.functionCallArguments.withVarargsHandled(data, callee),
-            data,
-            data.embedType(functionCall.resolvedType),
-        )
+        val returnType = data.embedType(functionCall.resolvedType)
+        // Only a call that matches its arguments against the callee's own parameters needs this;
+        // the plugin's specification functions interpret the arguments they were given themselves.
+        val matchesParameters = callee is NonInlineCallable || callee is InlineNamedFunction
+        val arguments = if (matchesParameters) functionCall.argumentsPerParameter(symbol) else null
+        if (arguments == null || arguments.none { it == null }) {
+            return callee.insertCall(
+                functionCall.functionCallArguments.withVarargsHandled(data, callee),
+                data,
+                returnType,
+            )
+        }
+
+        // A default value is not available at the call site, and a Viper call that simply omits the
+        // argument leaves the callee's formal unbound, which makes the verification state
+        // inconsistent and proves anything afterwards. Pass a value of the parameter's type instead
+        // and assume nothing else about it: that loses what the default would have told us, but
+        // only that.
+        val declarations = mutableListOf<Declare>()
+        val receivers = listOfNotNull(functionCall.dispatchReceiver, functionCall.extensionReceiver)
+        val args = receivers.map { data.convert(it) } +
+                arguments.zip(symbol.valueParameterSymbols) { argument, parameter ->
+                    if (argument != null) return@zip data.convert(argument)
+                    val (declaration, value) = data.unconstrainedValue(data.embedType(parameter.resolvedReturnType))
+                    declarations.add(declaration)
+                    value
+                }
+        return (declarations + callee.insertCall(args, data, returnType)).toBlock()
     }
 
     override fun visitImplicitInvokeCall(

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -130,6 +130,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("prefix_suffix.kt")
+      public void testPrefix_suffix() {
+        runTest("formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.kt");
+      }
+
+      @Test
       @TestMetadata("strings.kt")
       public void testStrings() {
         runTest("formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.kt");
@@ -292,6 +298,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     @TestMetadata("basic.kt")
     public void testBasic() {
       runTest("formver.compiler-plugin/testData/diagnostics/verification/basic.kt");
+    }
+
+    @Test
+    @TestMetadata("default_arguments.kt")
+    public void testDefault_arguments() {
+      runTest("formver.compiler-plugin/testData/diagnostics/verification/default_arguments.kt");
     }
 
     @Test

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.fir.diag.txt
@@ -1,0 +1,56 @@
+/prefix_suffix.kt: info: Generated Viper text for startsWithKeepsStateConsistent:
+function size(v_this: Ref): Ref
+  requires isSubtype(typeOf(v_this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method startsWith(v_this_extension: Ref, prefix: Ref, ignoreCase: Ref)
+  returns (ret_1: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
+  requires isSubtype(typeOf(prefix), stringType())
+  requires isSubtype(typeOf(ignoreCase), boolType())
+  ensures isSubtype(typeOf(ret_1), boolType())
+
+
+method startsWithKeepsStateConsistent(a: Ref, b: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), stringType())
+  requires isSubtype(typeOf(b), stringType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), boolType())
+  anon_1 := startsWith(a, b, anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/prefix_suffix.kt: info: Generated Viper text for endsWithKeepsStateConsistent:
+function size(v_this: Ref): Ref
+  requires isSubtype(typeOf(v_this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method endsWith(v_this_extension: Ref, suffix: Ref, ignoreCase: Ref)
+  returns (ret_1: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
+  requires isSubtype(typeOf(suffix), stringType())
+  requires isSubtype(typeOf(ignoreCase), boolType())
+  ensures isSubtype(typeOf(ret_1), boolType())
+
+
+method endsWithKeepsStateConsistent(a: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), stringType())
+  requires isSubtype(typeOf(b), stringType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), boolType())
+  anon_1 := endsWith(a, b, anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.kt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.kt
@@ -1,0 +1,18 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.verify
+
+// A prefix/suffix query is a pure observation: it may not make the verification
+// state inconsistent, so `false` has to stay unprovable after one.
+@AlwaysVerify
+fun <!VIPER_TEXT!>startsWithKeepsStateConsistent<!>(a: String, b: String) {
+    a.startsWith(b)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>endsWithKeepsStateConsistent<!>(a: String, b: String) {
+    a.endsWith(b)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.viper.diag.txt
@@ -1,0 +1,3 @@
+/prefix_suffix.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/prefix_suffix.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.

--- a/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.fir.diag.txt
@@ -1,0 +1,187 @@
+/default_arguments.kt: info: Generated Viper text for trailingDefault:
+method trailingDefault(a: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := plusInts(a, b)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for pureTrailingDefault:
+function pureTrailingDefault(a: Ref, b: Ref): Ref
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(result), intType())
+{
+  plusInts(a, b)
+}
+
+/default_arguments.kt: info: Generated Viper text for inlineTrailingDefault:
+method inlineTrailingDefault(a: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := plusInts(a, b)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for defaultInTheMiddle:
+method defaultInTheMiddle(a: Ref, skipped: Ref, c: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(skipped), intType())
+  requires isSubtype(typeOf(c), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := plusInts(plusInts(a, skipped), c)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedTrailingDefault:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method omittedTrailingDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), intType())
+  anon_1 := trailingDefault(intToRef(1), anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+method trailingDefault(a: Ref, b: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+/default_arguments.kt: info: Generated Viper text for omittedDefaultInTheMiddle:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method defaultInTheMiddle(a: Ref, skipped: Ref, c: Ref)
+  returns (ret_1: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(skipped), intType())
+  requires isSubtype(typeOf(c), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+method omittedDefaultInTheMiddle() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), intType())
+  anon_1 := defaultInTheMiddle(intToRef(1), anon_0, intToRef(2))
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedInlineDefault:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method inlineTrailingDefault(a: Ref, b: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+method omittedInlineDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var v_ret_2: Ref
+  var anon_1: Ref
+  anon_1 := intToRef(1)
+  inhale isSubtype(typeOf(anon_0), intType())
+  v_ret_2 := plusInts(anon_1, anon_0)
+  goto lbl_ret_2
+  label lbl_ret_2
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedConstructorDefault:
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method con(par_a: Ref, par_b: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_b), intType())
+  ensures isSubtype(typeOf(ret_1), Boxed())
+  ensures acc(Boxed_unique(ret_1), write)
+  ensures intFromRef(g_a(ret_1)) == intFromRef(par_a)
+  ensures intFromRef(g_b(ret_1)) == intFromRef(par_b)
+
+
+method omittedConstructorDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), intType())
+  anon_1 := con(intToRef(1), anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for defaultValueIsNotAssumed:
+function pureTrailingDefault(a: Ref, b: Ref): Ref
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(result), intType())
+{
+  plusInts(a, b)
+}
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method defaultValueIsNotAssumed() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var defaulted: Ref
+  var anon: Ref
+  var given: Ref
+  inhale isSubtype(typeOf(anon), intType())
+  defaulted := pureTrailingDefault(intToRef(1), anon)
+  given := pureTrailingDefault(intToRef(1), intToRef(0))
+  assert intFromRef(given) == 1
+  assert intFromRef(defaulted) == 1
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.kt
@@ -1,0 +1,53 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.Pure
+import org.jetbrains.kotlin.formver.plugin.verify
+
+fun <!VIPER_TEXT!>trailingDefault<!>(a: Int, b: Int = 0): Int = a + b
+
+@Pure
+fun <!VIPER_TEXT!>pureTrailingDefault<!>(a: Int, b: Int = 0): Int = a + b
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <!VIPER_TEXT!>inlineTrailingDefault<!>(a: Int, b: Int = 0): Int = a + b
+
+fun <!VIPER_TEXT!>defaultInTheMiddle<!>(a: Int, skipped: Int = 0, c: Int): Int = a + skipped + c
+
+class Boxed(val a: Int, val b: Int = 0)
+
+// A parameter left at its default tells the caller nothing, but the call still may not
+// make the verification state inconsistent.
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedTrailingDefault<!>() {
+    trailingDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedDefaultInTheMiddle<!>() {
+    defaultInTheMiddle(1, c = 2)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedInlineDefault<!>() {
+    inlineTrailingDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedConstructorDefault<!>() {
+    Boxed(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+// Nothing is assumed about the omitted argument, so the default value itself does not
+// reach the caller.
+@AlwaysVerify
+fun <!VIPER_TEXT!>defaultValueIsNotAssumed<!>() {
+    val defaulted = pureTrailingDefault(1)
+    val given = pureTrailingDefault(1, 0)
+    verify(given == 1)
+    verify(<!VIPER_VERIFICATION_ERROR!>defaulted == 1<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.viper.diag.txt
@@ -1,0 +1,9 @@
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion intFromRef(defaulted) == 1 might not hold.


### PR DESCRIPTION
Reported as a string bug: after `a.startsWith(b)`, `verify(false)` was accepted, so
everything downstream of such a call was vacuously proved on a green build.

## Root cause

Not the string model — `startsWith`/`endsWith` have no model at all, and neither does
any other unmodelled stdlib function. They are emitted as body-less Viper methods whose
only contract is the type invariants of their arguments and result, which is sound.

The hole is in how a call passes its arguments. `String.startsWith` is
`startsWith(prefix: String, ignoreCase: Boolean = false)`, and conversion took the call's
arguments straight from the FIR argument list, which does not contain an argument for a
parameter left at its default. The emitted call was therefore

    method startsWith(v_this_extension: Ref, prefix: Ref, ignoreCase: Ref) returns (ret_1: Ref)
      requires isSubtype(typeOf(ignoreCase), boolType())
      ...
    anon := startsWith(a, b)          // two arguments, three formals

Silicon neither rejects this nor treats it as a consistency error; it leaves the third
formal unbound and the state after the call is inconsistent, so `assert false` succeeds.

Nothing about this is string-specific. It fires for any call that omits a defaulted
argument — a plain user function, a `@Pure` function, a constructor, and a parameter
skipped in the middle via named arguments all reproduce it.

## The fix

`StmtConversionVisitor.visitFunctionCall` now lines the call's arguments up against the
callee's value parameters via `resolvedArgumentMapping`, and fills a parameter left at
its default with a fresh value constrained only by the parameter's type:

    var anon_0: Ref
    inhale isSubtype(typeOf(anon_0), boolType())
    anon_1 := startsWith(a, b, anon_0)

That is a sound under-approximation: the caller learns nothing the default would have
told it, and the callee's precondition on that parameter has to hold for an arbitrary
value of its type, so a call can now fail to verify where it previously "verified"
vacuously. Access permissions are deliberately not inhaled for the fresh value —
that would conjure permission to a reference nobody handed us.

Only callees that match arguments against their own parameters go through this —
`NonInlineCallable` and `InlineNamedFunction`. The plugin's own specification functions
(`acc`, `unfold`, …) interpret their arguments themselves and must keep receiving them as
written; filling a gap for those put a variable declaration inside a precondition.

## Tests

- `testData/diagnostics/stdlib/string/prefix_suffix.kt` — the reported case:
  `verify(false)` after `startsWith`/`endsWith` must fail. Fails on `main`.
- `testData/diagnostics/verification/default_arguments.kt` — the general case: a trailing
  default, a default skipped in the middle by a named argument, an inline function, a
  constructor default, and a `@Pure` function showing that the default value itself is not
  assumed.

## Audit — other models, and what is still suspect

- The collection models in `StdLibConverter.kt` (`get`, `subList`, `isEmpty`, `emptyList`,
  `add`) are internally consistent: sizes are related to `old(size)` or to the arguments,
  and no two conditions contradict. None of those functions has a defaulted parameter, so
  none was hit by this bug.
- Inline functions take a different path (`insertInlineFunctionCall` → `getInlineFunctionCallArgs`,
  which `zip`s arguments against formals and so also truncates). There the omitted parameter
  left the substitution map short rather than producing a malformed Viper call, so it failed
  loudly with `INTERNAL_ERROR` instead of verifying vacuously. Filling the gap before the call
  fixes that path too, and the new test covers it.
- `ViperPoweredDeclarationChecker.check` reports an internal exception with
  `reporter.reportOn(e.source, …)`. When the exception carries no source this throws
  `IllegalArgumentException: source must not be null` out of the declaration checker, so an
  internal error surfaces as a compiler crash rather than a diagnostic. Pre-existing and not
  touched here; `e.source ?: declaration.source` would fix it.
- Worth a follow-up: using the parameter's actual default value where FIR exposes it would
  recover the precision this trades away. It is not a drop-in — a default expression may
  reference other parameters, so it cannot simply be converted in the caller's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
