### PR TITLE
Add uniqueness checker coverage for linked lists and binary trees

### DIFF
--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -171,6 +171,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("binary_tree.kt")
+    public void testBinary_tree() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt");
+    }
+
+    @Test
     @TestMetadata("break.kt")
     public void testBreak() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt");

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -231,6 +231,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("linked_list.kt")
+    public void testLinked_list() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt");
+    }
+
+    @Test
     @TestMetadata("loop.kt")
     public void testLoop() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/loop.kt");

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.fir.diag.txt
@@ -1,0 +1,5 @@
+/binary_tree.kt: error: Escaping value has moved field: 'pivot.right'.
+
+/binary_tree.kt: error: Attempt to pass the same unique argument 't.left' twice.
+
+/binary_tree.kt: error: Attempt to pass the same unique argument 't.left' twice.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt
@@ -1,0 +1,37 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class Tree(var left: @Unique Tree?, var right: @Unique Tree?)
+
+fun consumeBoth(a: @Unique Tree?, b: @Unique Tree?) {}
+
+fun `insert leaf into an empty child slot`(t: @Unique Tree, leaf: @Unique Tree) {
+    if (t.left == null) {
+        t.left = leaf
+    } else {
+        t.right = leaf
+    }
+}
+
+// `root.left` is nullable, so the pivot has to be dereferenced through `?.`. The
+// checker does not see `pivot?.right = root` as restoring `pivot.right`, so the
+// pivot still has a moved field when it escapes through the return. The same
+// rotation written on a non-null pivot, with `pivot.right = root`, checks clean,
+// which places the gap in the safe-call assignment rather than in the rotation.
+fun `rotate right around the root`(root: @Unique Tree): @Unique Tree? {
+    val pivot: @Unique Tree? = root.left
+    root.left = pivot?.right
+    pivot?.right = root
+    return <!ESCAPE_UNIQUENESS_INCONSISTENCY!>pivot<!>
+}
+
+fun `swap the children through a temporary`(t: @Unique Tree) {
+    val tmp: @Unique Tree? = t.left
+    t.left = t.right
+    t.right = tmp
+}
+
+fun `pass the same child as two unique arguments`(t: @Unique Tree) {
+    consumeBoth(<!INVALID_DUPLICATE_UNIQUE_ARGUMENT!>t.left<!>, <!INVALID_DUPLICATE_UNIQUE_ARGUMENT!>t.left<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
@@ -5,3 +5,7 @@
 /linked_list.kt: error: Invalid access to moved reference.
 
 /linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.
+
+/linked_list.kt: error: Invalid access to moved reference.
+
+/linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
@@ -1,0 +1,7 @@
+/linked_list.kt: error: Invalid access to moved reference.
+
+/linked_list.kt: error: Escaping value has moved field: 'head.next'.
+
+/linked_list.kt: error: Invalid access to moved reference.
+
+/linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -57,6 +57,64 @@ fun `traverse then consume list`(head: @Unique Node) {
     consume(head)
 }
 
+// Traversing recursively through a borrowed parameter
+//
+// The same walk the loop above cannot express. Each call borrows the node it is
+// handed and restores it at exit, so nothing is left moved and the caller's list
+// survives the traversal. What the loop loses is lost in the join at the loop
+// head, not in the borrow.
+
+fun length(n: @Borrowed Node?): Int = if (n == null) 0 else 1 + length(n.next)
+
+fun contains(n: @Borrowed Node?, v: Int): Boolean =
+    if (n == null) false else if (n.value == v) true else contains(n.next, v)
+
+fun `use list after recursive length`(head: @Unique Node) {
+    val len = length(head)
+    consume(head)
+}
+
+fun `use list after recursive search`(head: @Unique Node) {
+    val found = contains(head, 3)
+    consume(head)
+}
+
+// A spine that cannot be reassigned
+//
+// `next` is a `val` here, so the chain is fixed once built and only the payload
+// is mutable. That buys nothing for the cursor: the loop form is rejected the
+// same way it is for a `var` spine, while the recursive form checks clean and
+// may write through the spine it walks.
+
+class RoNode(var value: Int, val next: @Unique RoNode?)
+
+fun consumeRo(n: @Unique RoNode?) {}
+
+fun `sum a readonly spine in a loop`(head: @Borrowed RoNode?): Int {
+    var current: @Borrowed RoNode? = head
+    var total = 0
+    while (current != null) {
+        total = total + current.value
+        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+    }
+    <!EXIT_UNIQUENESS_INCONSISTENCY!>return total<!>
+}
+
+fun `sum a readonly spine recursively`(n: @Borrowed RoNode?): Int =
+    if (n == null) 0 else n.value + `sum a readonly spine recursively`(n.next)
+
+fun `bump a readonly spine recursively`(n: @Borrowed RoNode?) {
+    if (n == null) return
+    n.value = n.value + 1
+    `bump a readonly spine recursively`(n.next)
+}
+
+fun `use readonly spine list after recursion`(head: @Unique RoNode) {
+    val total = `sum a readonly spine recursively`(head)
+    `bump a readonly spine recursively`(head)
+    consumeRo(head)
+}
+
 // Iterative reversal
 //
 // Commented out: the uniqueness checker does not terminate on this function.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -1,0 +1,77 @@
+// FULL_JDK
+// WITH_STDLIB
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class Node(var value: Int, var next: @Unique Node?)
+
+fun consume(n: @Unique Node?) {}
+
+fun borrow(n: @Borrowed Node?) {}
+
+// Push front
+
+fun `push front`(head: @Unique Node?): @Unique Node {
+    return Node(0, head)
+}
+
+fun `use old head after push front`(head: @Unique Node?) {
+    val fresh: @Unique Node = Node(0, head)
+    consume(fresh)
+    consume(<!INVALID_MOVED_ACCESS!>head<!>)
+}
+
+// Detach
+
+fun `detach tail`(head: @Unique Node): @Unique Node? {
+    return head.next
+}
+
+fun `return node after detaching tail`(head: @Unique Node): @Unique Node {
+    val tail: @Unique Node? = head.next
+    consume(tail)
+    return <!ESCAPE_UNIQUENESS_INCONSISTENCY!>head<!>
+}
+
+// Borrowed traversal
+
+// Advancing the cursor reads the unique `next` field out of the node the cursor
+// points at, so the cursor's own `next` is moved on the way round the loop. The
+// checker keeps that moved field in the state joined at the loop head, which
+// makes the next read of `current.next` an access to a moved reference and
+// leaves the borrowed cursor with a moved field at exit.
+fun `sum values`(head: @Borrowed Node?): Int {
+    var current: @Borrowed Node? = head
+    var total = 0
+    while (current != null) {
+        total = total + current.value
+        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+    }
+    <!EXIT_UNIQUENESS_INCONSISTENCY!>return total<!>
+}
+
+fun `traverse then consume list`(head: @Unique Node) {
+    val total = `sum values`(head)
+    consume(head)
+}
+
+// Iterative reversal
+//
+// Commented out: the uniqueness checker does not terminate on this function.
+// A run of `./agent-scripts/test.sh linked_list` with the body below live was
+// still burning CPU inside the check after 40 minutes and produced no
+// diagnostics, so the scenario cannot be recorded as a golden.
+//
+// fun `reverse in place`(head: @Unique Node?): @Unique Node? {
+//     var prev: @Unique Node? = null
+//     var current: @Unique Node? = head
+//     while (current != null) {
+//         val next: @Unique Node? = current.next
+//         current.next = prev
+//         prev = current
+//         current = next
+//     }
+//     return prev
+// }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -60,9 +60,14 @@ fun `traverse then consume list`(head: @Unique Node) {
 // Iterative reversal
 //
 // Commented out: the uniqueness checker does not terminate on this function.
-// A run of `./agent-scripts/test.sh linked_list` with the body below live was
-// still burning CPU inside the check after 40 minutes and produced no
-// diagnostics, so the scenario cannot be recorded as a golden.
+// A run with the body below live was still burning CPU inside the check after
+// 40 minutes and produced no diagnostics, so there is no golden to record.
+//
+// The loop is not on its own what costs. Advancing a unique cursor with
+// `current = current.next` and nothing else checks in seconds, and so does
+// advancing while writing `null` into the field just read. What those two
+// leave out, and what the body below adds, is writing a unique local carried
+// over from the previous iteration back into the field.
 //
 // fun `reverse in place`(head: @Unique Node?): @Unique Node? {
 //     var prev: @Unique Node? = null


### PR DESCRIPTION
Adds `linked_list.kt` and `binary_tree.kt` to `testData/diagnostics/uniqueness_checker/`, exercising the uniqueness checker on recursive data structures (`Node` with `@Unique next`, `Tree` with `@Unique left/right`).

Seven scenarios behave as intended: push-front, use-after-move of the old head, tail detach, escape with a moved field, leaf insert, child swap via a temporary, and duplicate-unique-argument detection on a property path (previously only covered for bare locals).

Three gaps are documented in-file rather than fixed:
- Borrowed traversal of a `@Unique` next chain is impossible: advancing the cursor moves the cursor's own `next`, and the loop-head join keeps it moved.
- Safe-call assignment (`pivot?.right = root`) is not recognized as restoring a moved field, so a rotation on a nullable pivot gets a spurious escape diagnostic; the non-null and smart-cast forms check clean.
- Iterative list reversal makes the analysis hang (committed commented out, with a comment narrowing the trigger to writing back a unique local carried over from the previous iteration).

Note for reviewers: the inline `<!DIAG!>` markers in this suite are not asserted — `AbstractPhasedDiagnosticTest` compares only the offset-free `.fir.diag.txt` golden. The markers here were verified by hand against emitted offsets.

`./agent-scripts/check-all.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)