### PR TITLE
Consume uniqueness and locality results in verification

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -15,8 +15,12 @@ diagnostics, alongside golden files holding the diagnostic text:
 The test runners are generated from the testData tree as part of
 `compileTestKotlin`, so a new file is picked up on the next build.
 
-The pipeline splits into conversion (uniqueness checking, conversion, purity
-checking) and verification (Viper consistency checking and verification):
+Locality and uniqueness checking happens in FIR checkers that run in every task
+below and report into `.fir.diag.txt`; the plugin's `check_locality` and
+`check_uniqueness` options switch those diagnostics off, and tests leave them on.
+`@Unique` and `@Borrowed` reach conversion as type attributes either way. Past
+that the pipeline splits into conversion (conversion proper and purity checking)
+and verification (Viper consistency checking and verification):
 
 | Task                       | Conversion | Verification                |
 |:---------------------------|:-----------|:----------------------------|
@@ -43,11 +47,11 @@ Which checks run:
 
 - `NEVER_VALIDATE` — convert but do not verify. Consistency checking still runs.
   This is how a test that is not meant to reach the verifier says so.
-- `UNIQUE_CHECK_ONLY` — uniqueness checking, with locality first. No conversion.
-- `LOCALITY_CHECK_ONLY` — locality checking alone, uniqueness off. No conversion.
-- `ALWAYS_VALIDATE` — verify every target. Verification is already the default,
-  so this changes nothing on its own; it earns its place by overriding the two
-  `*_CHECK_ONLY` directives above.
+- `UNIQUE_CHECK_ONLY`, `LOCALITY_CHECK_ONLY` — neither convert nor verify, so the
+  goldens hold the locality and uniqueness diagnostics alone. The two have the
+  same effect; both checkers run either way.
+- `ALWAYS_VALIDATE` — verify every target. Tests verify every target already, so
+  this changes nothing on its own.
 
 What the diagnostic contains:
 

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Annotations.kt
@@ -10,17 +10,10 @@ annotation class NeverVerify
 annotation class AlwaysVerify
 annotation class DumpExpEmbeddings
 
-// We annotate the function to indicate that the return value is unique
-@Target(
-    AnnotationTarget.LOCAL_VARIABLE,
-    AnnotationTarget.VALUE_PARAMETER,
-    AnnotationTarget.FUNCTION,
-    AnnotationTarget.PROPERTY,
-    AnnotationTarget.TYPE,
-)
+@Target(AnnotationTarget.TYPE)
 annotation class Unique
 
-@Target(AnnotationTarget.LOCAL_VARIABLE, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE)
+@Target(AnnotationTarget.TYPE)
 annotation class Borrowed
 
 @Target(AnnotationTarget.FUNCTION)

--- a/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
+++ b/formver.annotations/src/org/jetbrains/kotlin/formver/plugin/Builtins.kt
@@ -5,6 +5,9 @@
 
 package org.jetbrains.kotlin.formver.plugin
 
+@Target(AnnotationTarget.CONSTRUCTOR, AnnotationTarget.FUNCTION)
+internal annotation class SpecificationHelper
+
 private class FormverFunctionCalledInRuntimeException(offendingFunction: String) :
     RuntimeException("Function `$offendingFunction` should never be called in runtime.")
 
@@ -13,22 +16,26 @@ private class FormverFunctionCalledInRuntimeException(offendingFunction: String)
  * This function hooks-in in the `formver` plugin, its invocation in a Kotlin
  * program does not do anything.
  */
+@SpecificationHelper
 fun verify(@Suppress("UNUSED_PARAMETER") vararg predicates: Boolean) = Unit
 
 infix fun Boolean.implies(other: Boolean) = !this || other
 
-fun loopInvariants(@Suppress("UNUSED_PARAMETER") body: () -> Unit) = Unit
+@SpecificationHelper
+fun loopInvariants(@Suppress("UNUSED_PARAMETER") body: @Borrowed () -> Unit) = Unit
 
-fun preconditions(@Suppress("UNUSED_PARAMETER") body: () -> Unit) = Unit
+@SpecificationHelper
+fun preconditions(@Suppress("UNUSED_PARAMETER") body: @Borrowed () -> Unit) = Unit
 
-fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: (T) -> Unit) = Unit
+@SpecificationHelper
+fun <T> postconditions(@Suppress("UNUSED_PARAMETER") body: @Borrowed (T) -> Unit) = Unit
 
-
-fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: InvariantBuilder.(T) -> Unit): Boolean =
+@SpecificationHelper
+fun <T> forAll(@Suppress("UNUSED_PARAMETER") body: @Borrowed InvariantBuilder.(T) -> Unit): Boolean =
     throw FormverFunctionCalledInRuntimeException("forAll")
 
-
-fun <T> old(@Suppress("UNUSED_PARAMETER") body: T): T =
+@SpecificationHelper
+fun <T> old(@Suppress("UNUSED_PARAMETER") body: @Borrowed T): T =
     throw FormverFunctionCalledInRuntimeException("old")
 
 
@@ -39,6 +46,7 @@ fun <T> old(@Suppress("UNUSED_PARAMETER") body: T): T =
  * permission is requested; use [write] for full (the default) or [read] for a read-only
  * (wildcard) fraction.
  */
+@SpecificationHelper
 fun acc(
     @Suppress("UNUSED_PARAMETER") path: Any?,
     @Suppress("UNUSED_PARAMETER") permission: Permission? = null
@@ -58,25 +66,28 @@ abstract class Predicate(val exp: Any)
 /**
  * Denotes a read-only (wildcard) permission amount. Only meaningful as the second argument of [acc].
  */
+@SpecificationHelper
 fun read(): Permission =
     throw FormverFunctionCalledInRuntimeException("read")
 
 /**
  * Denotes a full (write) permission amount. Only meaningful as the second argument of [acc].
  */
+@SpecificationHelper
 fun write(): Permission =
     throw FormverFunctionCalledInRuntimeException("write")
 
 /**
  * The uniqueness predicate of [data]: exclusive access to [data] and its fields.
  */
-data class UniquePred(val data: Any) : Predicate(data)
+data class UniquePred @SpecificationHelper constructor(val data: @Borrowed Any) : Predicate(data)
 
 /**
  * Exchanges [exp] for access to its body, exposing the underlying fields. The inverse of [fold].
  *
  * [permission] is the amount of the predicate to unfold, defaulting to full ([write]).
  */
+@SpecificationHelper
 fun unfold(
     @Suppress("UNUSED_PARAMETER") exp: Predicate,
     @Suppress("UNUSED_PARAMETER") permission: Permission? = null
@@ -88,17 +99,19 @@ fun unfold(
  *
  * [permission] is the amount of the predicate to fold, defaulting to full ([write]).
  */
+@SpecificationHelper
 fun fold(
     @Suppress("UNUSED_PARAMETER") exp: Predicate,
     @Suppress("UNUSED_PARAMETER") permission: Permission? = null
 ): Unit = throw FormverFunctionCalledInRuntimeException("fold")
 
-class InvariantBuilder {
+class InvariantBuilder @SpecificationHelper constructor() {
     /**
      * Specifies trigger expressions for quantifiers.
      * This function should be called within a `forAll` block to provide user-defined triggers
      * for SMT solver guidance.
      */
+    @SpecificationHelper
     fun triggers(@Suppress("UNUSED_PARAMETER") vararg expressions: Any?): Unit =
         throw FormverFunctionCalledInRuntimeException("triggers")
 }

--- a/formver.common/src/org/jetbrains/kotlin/formver/common/PluginConfiguration.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/PluginConfiguration.kt
@@ -11,10 +11,17 @@ data class PluginConfiguration(
     val behaviour: UnsupportedFeatureBehaviour,
     val conversionSelection: TargetsSelection,
     val verificationSelection: TargetsSelection,
-    val checkLocality: Boolean,
-    val checkUniqueness: Boolean,
-    val dumpUniquenessCFG: Boolean,
+    val checkLocality: Boolean = DEFAULT_CHECK_LOCALITY,
+    val checkUniqueness: Boolean = DEFAULT_CHECK_UNIQUENESS,
+    val dumpUniquenessCFG: Boolean = false,
 ) {
+    // The Viper encoding reads `@Unique` and `@Borrowed` off types whether or not the checkers run, so leaving them
+    // off gives a program whose annotations nothing validates.
+    companion object {
+        const val DEFAULT_CHECK_LOCALITY = true
+        const val DEFAULT_CHECK_UNIQUENESS = true
+    }
+
     init {
         require(conversionSelection >= verificationSelection) {
             "Conversion options may not be stricter than verification options; converting $conversionSelection but verifying $verificationSelection."

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
@@ -10,9 +10,7 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.common.*
-import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
-import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessExtensionRegistrar
 
 @OptIn(ExperimentalCompilerApi::class)
 class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
@@ -40,21 +38,19 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
             FormalVerificationConfigurationKeys.VERIFICATION_TARGETS_SELECTION,
             TargetsSelection.Companion.defaultBehaviour()
         )
-        val checkUniqueness = configuration.get(FormalVerificationConfigurationKeys.CHECK_UNIQUENESS, false)
-        val checkLocality = configuration.get(FormalVerificationConfigurationKeys.CHECK_LOCALITY, false)
+        val checkUniqueness = configuration.get(
+            FormalVerificationConfigurationKeys.CHECK_UNIQUENESS,
+            PluginConfiguration.DEFAULT_CHECK_UNIQUENESS
+        )
+        val checkLocality = configuration.get(
+            FormalVerificationConfigurationKeys.CHECK_LOCALITY,
+            PluginConfiguration.DEFAULT_CHECK_LOCALITY
+        )
         val dumpUniquenessCFG = configuration.get(FormalVerificationConfigurationKeys.DUMP_UNIQUENESS_CFG, false)
         val config = PluginConfiguration(
             logLevel, errorStyle, behaviour, conversionSelection, verificationSelection,
             checkLocality, checkUniqueness, dumpUniquenessCFG
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
-
-        if (config.checkLocality) {
-            FirExtensionRegistrarAdapter.registerExtension(LocalityExtensionRegistrar())
-        }
-
-        if (config.checkUniqueness) {
-            FirExtensionRegistrarAdapter.registerExtension(UniquenessExtensionRegistrar())
-        }
     }
 }

--- a/formver.compiler-plugin/core/build.gradle.kts
+++ b/formver.compiler-plugin/core/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     compileOnly(project(":formver.common"))
     compileOnly(project(":formver.compiler-plugin:viper"))
+    compileOnly(project(":formver.compiler-plugin:locality"))
+    compileOnly(project(":formver.compiler-plugin:uniqueness"))
     compileOnly(kotlin("compiler"))
 
     // TODO: figure out how to avoid this dependency

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
@@ -6,8 +6,8 @@
 package org.jetbrains.kotlin.formver.core
 
 import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.fir.FirAnnotationContainer
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.contracts.FirEffectDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationDataKey
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationDataRegistry
@@ -18,13 +18,21 @@ import org.jetbrains.kotlin.fir.declarations.impl.FirDefaultPropertySetter
 import org.jetbrains.kotlin.fir.declarations.utils.isInline
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirStatement
+import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirReceiverParameterSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
 import org.jetbrains.kotlin.formver.core.names.SpecialPackages
+import org.jetbrains.kotlin.formver.locality.plugin.Locality
+import org.jetbrains.kotlin.formver.locality.plugin.locality
+import org.jetbrains.kotlin.formver.uniqueness.plugin.Uniqueness
+import org.jetbrains.kotlin.formver.uniqueness.plugin.scopeUniqueness
 import org.jetbrains.kotlin.formver.viper.ast.Position
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -72,17 +80,44 @@ fun formverCallableId(className: String?, name: String): CallableId =
 
 fun kotlinCallableId(className: String?, name: String): CallableId = callableId(SpecialPackages.kotlin, className, name)
 
-fun FirBasedSymbol<*>.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
+/*
+ * Conversion has no `CheckerContext`, so it cannot call the uniqueness and locality modules' symbol resolvers and
+ * reads the type attributes those modules install directly instead. That covers explicitly typed declarations only,
+ * which is all conversion sees.
+ */
 
-fun FirBasedSymbol<*>.isBorrowed(session: FirSession) = hasAnnotation(annotationId("Borrowed"), session)
+val FirBasedSymbol<*>.isUnique: Boolean
+    get() = when (this) {
+        is FirReceiverParameterSymbol -> resolvedType.scopeUniqueness == Uniqueness.Unique
+        is FirCallableSymbol<*> -> resolvedReturnType.scopeUniqueness == Uniqueness.Unique
+        else -> false
+    }
+
+val FirBasedSymbol<*>.isBorrowed: Boolean
+    get() = when (this) {
+        is FirReceiverParameterSymbol -> resolvedType.locality == Locality.Local
+        is FirCallableSymbol<*> -> resolvedReturnType.locality == Locality.Local
+        else -> false
+    }
+
+/**
+ * Returns `true` if [this] function is part of the specification DSL, that is, if it carries `@SpecificationHelper`.
+ *
+ * Such a function is never executed, so its arguments are neither consumed nor mutated.
+ */
+context(context: CheckerContext)
+private fun FirFunctionSymbol<*>.isSpecificationFunction(): Boolean =
+    hasAnnotation(annotationId("SpecificationHelper"), context.session)
+
+context(context: CheckerContext)
+fun FirStatement.isSpecificationCall(): Boolean =
+    ((this as? FirFunctionCall)
+        ?.toResolvedCallableSymbol() as? FirFunctionSymbol<*>)
+        ?.isSpecificationFunction() ?: false
 
 fun FirBasedSymbol<*>.isPure(session: FirSession) = hasAnnotation(annotationId("Pure"), session)
 
 fun FirBasedSymbol<*>.isManual(session: FirSession) = hasAnnotation(annotationId("Manual"), session)
-
-fun FirAnnotationContainer.isUnique(session: FirSession) = hasAnnotation(annotationId("Unique"), session)
-
-fun FirAnnotationContainer.isBorrowed(session: FirSession) = hasAnnotation(annotationId("Borrowed"), session)
 
 fun FirFunctionSymbol<*>.neverConvert(session: FirSession) = hasAnnotation(annotationId("NeverConvert"), session)
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -440,7 +440,7 @@ class ProgramConverter(
                 val isDefaultProperty = isGuaranteedDefaultProperty(symbol)
                 val isImmutable = symbol.isVal
                 val isManual = symbol.isManual(session)
-                val isUnique = symbol.isUnique(session)
+                val isUnique = symbol.isUnique
 
                 val returnType = embedType(symbol.resolvedReturnType)
 
@@ -512,7 +512,7 @@ class ProgramConverter(
             scopedName,
             embedType(symbol.resolvedReturnType),
             symbol,
-            symbol.isUnique(session),
+            symbol.isUnique,
             embedding,
             symbol.isManual(session)
         )
@@ -666,7 +666,7 @@ class ProgramConverter(
             }
         }
         withReturnType { embedTypeWithBuilder(symbol.resolvedReturnType) }
-        returnsUnique = symbol.isUnique(session) || symbol is FirConstructorSymbol
+        returnsUnique = symbol.isUnique || symbol is FirConstructorSymbol
     }
 
     private fun TypeBuilder.unimplementedTypeEmbedding(type: ConeKotlinType): PretypeBuilder = when (config.behaviour) {

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SignatureCreation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SignatureCreation.kt
@@ -78,8 +78,8 @@ fun FirFunctionSymbol<*>.toFunctionSignature(): SignatureWithTarget<FunctionSign
         PlaceholderVariableEmbedding(
             ExtensionReceiverName,
             converter.embedType(it),
-            this.receiverParameterSymbol?.isUnique(converter.session) ?: false,
-            this.receiverParameterSymbol?.isBorrowed(converter.session) ?: false,
+            this.receiverParameterSymbol?.isUnique ?: false,
+            this.receiverParameterSymbol?.isBorrowed ?: false,
         )
     }
 
@@ -88,8 +88,8 @@ fun FirFunctionSymbol<*>.toFunctionSignature(): SignatureWithTarget<FunctionSign
             it.embedName(),
             converter.embedType(it.resolvedReturnType),
             it,
-            it.isUnique(converter.session),
-            it.isBorrowed(converter.session)
+            it.isUnique,
+            it.isBorrowed
         )
     }
 

--- a/formver.compiler-plugin/locality/src/org/jetbrains/kotlin/formver/locality/plugin/LocalityAttributeExtension.kt
+++ b/formver.compiler-plugin/locality/src/org/jetbrains/kotlin/formver/locality/plugin/LocalityAttributeExtension.kt
@@ -11,13 +11,21 @@ import org.jetbrains.kotlin.fir.extensions.FirTypeAttributeExtension
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.types.ConeAttribute
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+val defaultLocalityAnnotationId =
+    ClassId(
+        FqName("org.jetbrains.kotlin.formver.plugin"),
+        Name.identifier("Borrowed")
+    )
 
 class LocalityAttributeExtension(
     session: FirSession,
     private val annotationId: ClassId
 ) : FirTypeAttributeExtension(session) {
     companion object {
-        fun getFactory(annotationId: ClassId): Factory {
+        fun getFactory(annotationId: ClassId = defaultLocalityAnnotationId): Factory {
             return Factory { session -> LocalityAttributeExtension(session, annotationId) }
         }
     }

--- a/formver.compiler-plugin/locality/src/org/jetbrains/kotlin/formver/locality/plugin/LocalityExtensionRegistrar.kt
+++ b/formver.compiler-plugin/locality/src/org/jetbrains/kotlin/formver/locality/plugin/LocalityExtensionRegistrar.kt
@@ -13,12 +13,6 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-private val defaultLocalityAnnotationId =
-    ClassId(
-        FqName("org.jetbrains.kotlin.formver.plugin"),
-        Name.identifier("Borrowed")
-    )
-
 class LocalityExtensionRegistrar(
     private val localityAnnotationId: ClassId = defaultLocalityAnnotationId
 ) : FirExtensionRegistrar() {

--- a/formver.compiler-plugin/locality/testData/diagnostics/invalid.kt
+++ b/formver.compiler-plugin/locality/testData/diagnostics/invalid.kt
@@ -2,7 +2,7 @@
 
 import org.jetbrains.kotlin.formver.plugin.Borrowed
 
-fun `allow locality attribute on extension receiver type`(@Borrowed x: Any) {
+fun `allow locality attribute on extension receiver type`(x: @Borrowed Any) {
     fun @Borrowed Any.localReceiver() {}
     x.localReceiver()
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginExtensionRegistrar.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginExtensionRegistrar.kt
@@ -8,12 +8,50 @@ package org.jetbrains.kotlin.formver.plugin.compiler
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.core.diagnostics.ConversionErrors
+import org.jetbrains.kotlin.formver.core.isSpecificationCall
+import org.jetbrains.kotlin.formver.locality.contract.plugin.ExpressionLocalityContractResolver
+import org.jetbrains.kotlin.formver.locality.contract.plugin.LocalityContractErrors
+import org.jetbrains.kotlin.formver.locality.plugin.ExpressionLocalityResolver
+import org.jetbrains.kotlin.formver.locality.plugin.GraphCapturedSymbolsResolver
+import org.jetbrains.kotlin.formver.locality.plugin.GraphDeclaredSymbolsResolver
+import org.jetbrains.kotlin.formver.locality.plugin.GraphScopeLocalityResolver
+import org.jetbrains.kotlin.formver.locality.plugin.LocalityAttributeExtension
+import org.jetbrains.kotlin.formver.locality.plugin.LocalityErrors
+import org.jetbrains.kotlin.formver.uniqueness.plugin.ExpressionAccessStateResolver
+import org.jetbrains.kotlin.formver.uniqueness.plugin.ExpressionUniquenessResolver
+import org.jetbrains.kotlin.formver.uniqueness.plugin.GraphUniquenessStatesResolver
+import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessAttributeExtension
+import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessErrors
 
 class FormalVerificationPluginExtensionRegistrar(private val config: PluginConfiguration) : FirExtensionRegistrar() {
     override fun ExtensionRegistrarContext.configurePlugin() {
         registerDiagnosticContainers(PluginErrors)
         registerDiagnosticContainers(VerificationErrors)
         registerDiagnosticContainers(ConversionErrors)
+
+        // Locality resolvers
+        +ExpressionLocalityContractResolver.getFactory()
+        +ExpressionLocalityResolver.getFactory()
+        +GraphCapturedSymbolsResolver.getFactory()
+        +GraphDeclaredSymbolsResolver.getFactory()
+        +GraphScopeLocalityResolver.getFactory()
+        +LocalityAttributeExtension.getFactory()
+
+        // Uniqueness resolvers
+        +ExpressionAccessStateResolver.getFactory()
+        +ExpressionUniquenessResolver.getFactory()
+        +GraphUniquenessStatesResolver.getFactory { it.isSpecificationCall() }
+        +UniquenessAttributeExtension.getFactory()
+
+        if (config.checkLocality) {
+            registerDiagnosticContainers(LocalityErrors)
+            registerDiagnosticContainers(LocalityContractErrors)
+        }
+
+        if (config.checkUniqueness) {
+            registerDiagnosticContainers(UniquenessErrors)
+        }
+
         +PluginAdditionalCheckers.getFactory(config)
     }
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FunctionUniquenessStateRenderingChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FunctionUniquenessStateRenderingChecker.kt
@@ -13,20 +13,15 @@ import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionC
 import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.resolve.dfa.controlFlowGraph
-import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.uniqueness.plugin.render
 import org.jetbrains.kotlin.formver.uniqueness.plugin.resolveUniquenessStateFlows
 
 /**
  * Stub checker for emitting the rendered representation of a graph along with the uniqueness state information.
  */
-class FunctionUniquenessStateRenderingChecker(
-    private val config: PluginConfiguration
-) : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+object FunctionUniquenessStateRenderingChecker : FirSimpleFunctionChecker(MppCheckerKind.Common) {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirSimpleFunction) {
-        if (!config.checkUniqueness || !config.dumpUniquenessCFG) return
-
         if (declaration.origin != FirDeclarationOrigin.Source) return
 
         val graph = declaration.controlFlowGraphReference?.controlFlowGraph

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginAdditionalCheckers.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginAdditionalCheckers.kt
@@ -6,11 +6,51 @@
 package org.jetbrains.kotlin.formver.plugin.compiler
 
 import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.analysis.checkers.cfa.FirControlFlowChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirPropertyChecker
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirValueParameterChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.ExpressionCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirCallChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirFunctionCallChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirPropertyAccessExpressionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirQualifiedAccessExpressionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirReturnExpressionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirThrowExpressionChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirVariableAssignmentChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.type.FirResolvedTypeRefChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.type.TypeCheckers
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 import org.jetbrains.kotlin.formver.common.PluginConfiguration
+import org.jetbrains.kotlin.formver.locality.contract.plugin.AssignmentLocalityContractChecker
+import org.jetbrains.kotlin.formver.locality.contract.plugin.CallLocalityContractChecker
+import org.jetbrains.kotlin.formver.locality.contract.plugin.PropertyLocalityContractChecker
+import org.jetbrains.kotlin.formver.locality.contract.plugin.QualifiedAccessLocalityContractChecker
+import org.jetbrains.kotlin.formver.locality.contract.plugin.ReturnLocalityContractChecker
+import org.jetbrains.kotlin.formver.locality.contract.plugin.ValueParameterLocalityContractChecker
+import org.jetbrains.kotlin.formver.locality.plugin.AssignmentLocalityChecker
+import org.jetbrains.kotlin.formver.locality.plugin.CallLocalityChecker
+import org.jetbrains.kotlin.formver.locality.plugin.PropertyAccessLocalityChecker
+import org.jetbrains.kotlin.formver.locality.plugin.PropertyLocalityChecker
+import org.jetbrains.kotlin.formver.locality.plugin.QualifiedAccessLocalityChecker
+import org.jetbrains.kotlin.formver.locality.plugin.ReturnLocalityChecker
+import org.jetbrains.kotlin.formver.locality.plugin.ThrowLocalityChecker
+import org.jetbrains.kotlin.formver.locality.plugin.TypeRefLocalityAttributeChecker
+import org.jetbrains.kotlin.formver.locality.plugin.ValueParameterLocalityChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.AssignmentUniquenessChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.CallUniquenessChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.FunctionCallArgumentUniquenessCollisionChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.FunctionEscapeUniquenessConsistencyChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.FunctionExitUniquenessConsistencyChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.FunctionUseAfterMoveChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.PropertyUniquenessChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.QualifiedAccessArgumentUniquenessCollisionChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.QualifiedAccessUniquenessChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.ReturnUniquenessChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.ThrowUniquenessChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.TypeRefUniquenessAttributeChecker
+import org.jetbrains.kotlin.formver.uniqueness.plugin.ValueParameterUniquenessChecker
 
 class PluginAdditionalCheckers(session: FirSession, config: PluginConfiguration) :
     FirAdditionalCheckersExtension(session) {
@@ -22,9 +62,125 @@ class PluginAdditionalCheckers(session: FirSession, config: PluginConfiguration)
 
     override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
         override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker>
-            get() = setOf(
-                ViperPoweredDeclarationChecker(session, config),
-                FunctionUniquenessStateRenderingChecker(config)
-            )
+            get() = buildSet {
+                add(ViperPoweredDeclarationChecker(session, config))
+
+                if (config.dumpUniquenessCFG) {
+                    add(FunctionUniquenessStateRenderingChecker)
+                }
+            }
+
+        override val functionCheckers: Set<FirFunctionChecker> = buildSet {
+            if (config.checkUniqueness) {
+                // A specification body never runs, so there is no flow through it to check.
+                add(FunctionEscapeUniquenessConsistencyChecker.asSpecificationAware())
+                add(FunctionExitUniquenessConsistencyChecker.asSpecificationAware())
+                add(FunctionUseAfterMoveChecker.asSpecificationAware())
+            }
+        }
+
+        override val propertyCheckers: Set<FirPropertyChecker> = buildSet {
+            if (config.checkLocality) {
+                add(PropertyLocalityChecker)
+                add(PropertyLocalityContractChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(PropertyUniquenessChecker)
+            }
+        }
+
+        override val valueParameterCheckers: Set<FirValueParameterChecker> = buildSet {
+            if (config.checkLocality) {
+                add(ValueParameterLocalityChecker)
+                add(ValueParameterLocalityContractChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(ValueParameterUniquenessChecker)
+            }
+        }
+    }
+
+    override val expressionCheckers: ExpressionCheckers = object : ExpressionCheckers() {
+        override val variableAssignmentCheckers: Set<FirVariableAssignmentChecker> = buildSet {
+            if (config.checkLocality) {
+                add(AssignmentLocalityChecker)
+                add(AssignmentLocalityContractChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(AssignmentUniquenessChecker)
+            }
+        }
+
+        override val callCheckers: Set<FirCallChecker> = buildSet {
+            if (config.checkLocality) {
+                add(CallLocalityChecker)
+                add(CallLocalityContractChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(CallUniquenessChecker)
+            }
+        }
+
+        override val functionCallCheckers: Set<FirFunctionCallChecker> = buildSet {
+            if (config.checkUniqueness) {
+                add(FunctionCallArgumentUniquenessCollisionChecker)
+            }
+        }
+
+        override val qualifiedAccessExpressionCheckers: Set<FirQualifiedAccessExpressionChecker> = buildSet {
+            if (config.checkLocality) {
+                add(QualifiedAccessLocalityChecker)
+                add(QualifiedAccessLocalityContractChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(QualifiedAccessUniquenessChecker)
+                add(QualifiedAccessArgumentUniquenessCollisionChecker)
+            }
+        }
+
+        override val propertyAccessExpressionCheckers: Set<FirPropertyAccessExpressionChecker> = buildSet {
+            if (config.checkLocality) {
+                // A specification block never runs, so it may capture a variable of any locality.
+                add(PropertyAccessLocalityChecker.asSpecificationAware())
+            }
+        }
+
+        override val returnExpressionCheckers: Set<FirReturnExpressionChecker> = buildSet {
+            if (config.checkLocality) {
+                add(ReturnLocalityChecker)
+                add(ReturnLocalityContractChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(ReturnUniquenessChecker)
+            }
+        }
+
+        override val throwExpressionCheckers: Set<FirThrowExpressionChecker> = buildSet {
+            if (config.checkLocality) {
+                add(ThrowLocalityChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(ThrowUniquenessChecker)
+            }
+        }
+    }
+
+    override val typeCheckers: TypeCheckers = object : TypeCheckers() {
+        override val resolvedTypeRefCheckers: Set<FirResolvedTypeRefChecker> = buildSet {
+            if (config.checkLocality) {
+                add(TypeRefLocalityAttributeChecker)
+            }
+
+            if (config.checkUniqueness) {
+                add(TypeRefUniquenessAttributeChecker)
+            }
+        }
     }
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/SpecificationAwareChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/SpecificationAwareChecker.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.plugin.compiler
+
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirDeclarationChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.expression.FirExpressionChecker
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.expressions.FirStatement
+import org.jetbrains.kotlin.formver.core.isSpecificationCall
+
+/**
+ * Returns `true` if [this] context is in an argument position for a specification function.
+ */
+private fun CheckerContext.isInSpecificationContext(): Boolean =
+    callsOrAssignments.any { statement ->
+        statement.isSpecificationCall()
+    }
+
+/**
+ * Wraps a declaration [checker] into a checker that only executes if not in a specification context.
+ *
+ * @see [CheckerContext.isInSpecificationContext]
+ */
+class SpecificationAwareDeclarationChecker<Declaration : FirDeclaration>(
+    private val checker: FirDeclarationChecker<Declaration>
+) : FirDeclarationChecker<Declaration>(checker.mppKind) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: Declaration) {
+        if (context.isInSpecificationContext()) return
+
+        checker.check(declaration)
+    }
+}
+
+/**
+ * Wraps [this] checker into a [SpecificationAwareDeclarationChecker].
+ */
+fun <Declaration : FirDeclaration> FirDeclarationChecker<Declaration>.asSpecificationAware(): FirDeclarationChecker<Declaration> =
+    SpecificationAwareDeclarationChecker(this)
+
+/**
+ * Wraps an expression [checker] into a checker that only executes if not in a specification context.
+ *
+ * @see [CheckerContext.isInSpecificationContext]
+ */
+class SpecificationAwareExpressionChecker<Expression : FirStatement>(
+    private val checker: FirExpressionChecker<Expression>
+) : FirExpressionChecker<Expression>(checker.mppKind) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(expression: Expression) {
+        if (context.isInSpecificationContext()) return
+
+        checker.check(expression)
+    }
+}
+
+/**
+ * Wraps [this] checker into a [SpecificationAwareExpressionChecker].
+ */
+fun <Expression : FirStatement> FirExpressionChecker<Expression>.asSpecificationAware(): FirExpressionChecker<Expression> =
+    SpecificationAwareExpressionChecker(this)

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar.ExtensionSto
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.common.*
-import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.ALWAYS_VALIDATE
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DUMP_UNIQUENESS_CFG
@@ -19,7 +18,6 @@ import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.NEVER_VALI
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.RENDER_PREDICATES
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.REPLACE_STDLIB_EXTENSIONS
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.UNIQUE_CHECK_ONLY
-import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessExtensionRegistrar
 import org.jetbrains.kotlin.test.directives.model.DirectivesContainer
 import org.jetbrains.kotlin.test.directives.model.RegisteredDirectives
 import org.jetbrains.kotlin.test.directives.model.SimpleDirectivesContainer
@@ -61,27 +59,16 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
             uniquenessOnly || localityOnly -> TargetsSelection.NO_TARGETS
             else -> TargetsSelection.ALL_TARGETS
         }
-        val checkUniqueness = uniquenessOnly
-        // Locality must run before uniqueness in tests.
-        // UNIQUE_CHECK_ONLY enables both checkers (in this order), while LOCALITY_CHECK_ONLY keeps uniqueness off.
-        val checkLocality = localityOnly || checkUniqueness
+
         val config = PluginConfiguration(
             logLevel,
             errorStyle,
             UnsupportedFeatureBehaviour.THROW_EXCEPTION,
             conversionSelection = conversionSelection,
             verificationSelection = verificationSelection,
-            checkUniqueness = checkUniqueness,
-            dumpUniquenessCFG = dumpUniquenessCFG,
-            checkLocality = checkLocality,
+            dumpUniquenessCFG = dumpUniquenessCFG
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
-        if (config.checkLocality) {
-            FirExtensionRegistrarAdapter.registerExtension(LocalityExtensionRegistrar())
-        }
-        if (config.checkUniqueness) {
-            FirExtensionRegistrarAdapter.registerExtension(UniquenessExtensionRegistrar())
-        }
     }
 }
 
@@ -98,12 +85,15 @@ object FormVerDirectives : SimpleDirectivesContainer() {
         description = "Always validate functions"
     )
 
+    // The uniqueness and locality checkers run in every test; these two only take conversion and verification out of
+    // the way, so a test can be about the checker diagnostics alone. They are synonyms, kept apart to say which
+    // checker the test is about.
     val UNIQUE_CHECK_ONLY by directive(
-        description = "Do uniqueness checking (and run locality first)"
+        description = "Report checker diagnostics only; do not convert or verify"
     )
 
     val LOCALITY_CHECK_ONLY by directive(
-        description = "Do locality checking"
+        description = "Report checker diagnostics only; do not convert or verify"
     )
 
     val DUMP_UNIQUENESS_CFG by directive(

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -261,6 +261,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("specification.kt")
+    public void testSpecification() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/specification.kt");
+    }
+
+    @Test
     @TestMetadata("throw.kt")
     public void testThrow() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/throw.kt");

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/specification.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/specification.fir.diag.txt
@@ -1,0 +1,15 @@
+/specification.kt: error: Invalid access to moved reference.
+
+/specification.kt: error: Invalid access to moved reference.
+
+/specification.kt: error: Invalid access to moved reference.
+
+/specification.kt: error: Invalid access to moved reference.
+
+/specification.kt: error: Invalid access to moved reference.
+
+/specification.kt: error: Invalid access to moved reference.
+
+/specification.kt: error: Invalid access to moved reference.
+
+/specification.kt: error: Invalid access to moved reference.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/specification.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/specification.kt
@@ -1,0 +1,128 @@
+// FULL_JDK
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+class A {
+    var n: Int = 0
+    var x: @Unique Any = Any()
+}
+
+class B {
+    var y: @Unique A = A()
+}
+
+fun consume(a: @Unique Any) {}
+
+fun consumeA(a: @Unique A) {}
+
+// Specification blocks do not move what they mention
+
+fun `consume unique after verifying it`(a: @Unique A) {
+    verify(a.n == 0)
+    consumeA(a)
+}
+
+fun `consume unique subproperty after verifying the parent`(a: @Unique B) {
+    verify(a.y.n == 0)
+    consume(a.y)
+}
+
+fun `consume unique after requesting access to its field`(a: @Unique A) {
+    verify(acc(a.x))
+    consumeA(a)
+}
+
+fun `consume unique after requesting read access to its field`(a: @Unique A) {
+    verify(acc(a.x, read()))
+    consumeA(a)
+}
+
+fun `consume unique after taking its old value`(a: @Unique A) {
+    verify(old(a) === a)
+    consumeA(a)
+}
+
+fun `consume unique after taking the old value of its field`(a: @Unique A) {
+    verify(old(a.n) == a.n)
+    consumeA(a)
+}
+
+fun `consume unique after naming it in a uniqueness predicate`(a: @Unique A) {
+    unfold(UniquePred(a))
+    fold(UniquePred(a))
+    consumeA(a)
+}
+
+fun `consume unique after naming it in a uniqueness predicate with permissions`(a: @Unique A) {
+    unfold(UniquePred(a), write())
+    fold(UniquePred(a), write())
+    consumeA(a)
+}
+
+fun `consume unique after mentioning it in preconditions`(a: @Unique A) {
+    preconditions {
+        a.n == 0
+    }
+    consumeA(a)
+}
+
+fun `consume unique after mentioning it in postconditions`(a: @Unique A) {
+    postconditions<Unit> {
+        a.n == 0
+    }
+    consumeA(a)
+}
+
+fun `consume unique after mentioning it in loop invariants`(a: @Unique A) {
+    var i = 0
+    while (i < 10) {
+        loopInvariants {
+            a.n == 0
+        }
+        i = i + 1
+    }
+    consumeA(a)
+}
+
+fun `consume unique after mentioning it in a quantifier`(a: @Unique A) {
+    verify(forAll<Int> { i ->
+        triggers(i)
+        a.n == i
+    })
+    consumeA(a)
+}
+
+// Specification blocks do not restore what was moved before them
+
+fun `consume moved unique after an unrelated specification`(a: @Unique A, b: @Unique A) {
+    consumeA(a)
+    verify(b.n == 0)
+    consumeA(<!INVALID_MOVED_ACCESS!>a<!>)
+}
+
+fun `consume moved unique after verifying it`(a: @Unique A, b: @Unique A) {
+    consumeA(a)
+    verify(<!INVALID_MOVED_ACCESS!>a<!> === b)
+    consumeA(<!INVALID_MOVED_ACCESS!>a<!>)
+}
+
+fun `consume moved unique after taking its old value`(a: @Unique A, b: @Unique A) {
+    consumeA(a)
+    verify(old(<!INVALID_MOVED_ACCESS!>a<!>) === b)
+    consumeA(<!INVALID_MOVED_ACCESS!>a<!>)
+}
+
+fun `consume moved unique after naming it in a uniqueness predicate`(a: @Unique A) {
+    consumeA(a)
+    unfold(UniquePred(<!INVALID_MOVED_ACCESS!>a<!>))
+    consumeA(<!INVALID_MOVED_ACCESS!>a<!>)
+}
+
+fun `consume moved unique after mentioning it in preconditions`(a: @Unique A) {
+    consumeA(a)
+    preconditions {
+        a.n == 0
+    }
+    consumeA(<!INVALID_MOVED_ACCESS!>a<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates.kt
@@ -28,20 +28,18 @@ class T()
 
 open class S()
 
-class Foo(val w: Int, var x: Int, @property:Unique val y: T, @property:Unique var z: T) : S()
+class Foo(val w: Int, var x: Int, val y: @Unique T, var z: @Unique T) : S()
 
-fun <!VIPER_TEXT!>unique_foo_arg<!>(@Unique foo: Foo) {}
+fun <!VIPER_TEXT!>unique_foo_arg<!>(foo: @Unique Foo) {}
 
-fun <!VIPER_TEXT!>nullable_unique_arg<!>(@Unique t: T?) {}
+fun <!VIPER_TEXT!>nullable_unique_arg<!>(t: @Unique T?) {}
 
-fun <!VIPER_TEXT!>borrowed_unique_arg<!>(@Unique @Borrowed t: T) {}
+fun <!VIPER_TEXT!>borrowed_unique_arg<!>(t: @Unique @Borrowed T) {}
 
-fun @receiver:Unique T.<!VIPER_TEXT!>unique_receiver<!>() {}
+fun (@Unique T).<!VIPER_TEXT!>unique_receiver<!>() {}
 
-fun @receiver:Unique @receiver:Borrowed T.<!VIPER_TEXT!>borrowed_unique_receiver<!>() {}
+fun (@Unique @Borrowed T).<!VIPER_TEXT!>borrowed_unique_receiver<!>() {}
 
-@Unique
-fun <!VIPER_TEXT!>unique_result<!>() : T { return T() }
+fun <!VIPER_TEXT!>unique_result<!>() : @Unique T { return T() }
 
-@Unique
-fun <!VIPER_TEXT!>unique_nullable_result<!>() : T? { return null }
+fun <!VIPER_TEXT!>unique_nullable_result<!>() : @Unique T? { return null }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/unique_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/unique_fields.fir.diag.txt
@@ -4,18 +4,18 @@ field bf_sharedVar: Ref
 field bf_uniqueVar: Ref
 
 function g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
 function g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
 method testPrimitiveFieldGetterUnique(pf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(pf), UniquePrimitiveFields())
-  requires acc(UniquePrimitiveFields_unique(pf), write)
+  requires isSubtype(typeOf(pf), UniqueContainer())
+  requires acc(UniqueContainer_unique(pf), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
@@ -23,9 +23,9 @@ method testPrimitiveFieldGetterUnique(pf: Ref) returns (v_ret_0: Ref)
   var l0_uniqueVal: Ref
   var l0_uniqueVar: Ref
   l0_sharedVal := g_sharedVal(pf)
-  l0_sharedVar := havoc(intType())
+  l0_sharedVar := havoc(anyType())
   l0_uniqueVal := g_uniqueVal(pf)
-  l0_uniqueVar := havoc(intType())
+  l0_uniqueVar := havoc(anyType())
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -36,17 +36,17 @@ field bf_sharedVar: Ref
 field bf_uniqueVar: Ref
 
 function g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
 function g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
 method testPrimitiveFieldGetterShared(pf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(pf), UniquePrimitiveFields())
+  requires isSubtype(typeOf(pf), UniqueContainer())
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
@@ -54,9 +54,9 @@ method testPrimitiveFieldGetterShared(pf: Ref) returns (v_ret_0: Ref)
   var l0_uniqueVal: Ref
   var l0_uniqueVar: Ref
   l0_sharedVal := g_sharedVal(pf)
-  l0_sharedVar := havoc(intType())
+  l0_sharedVar := havoc(anyType())
   l0_uniqueVal := g_uniqueVal(pf)
-  l0_uniqueVar := havoc(intType())
+  l0_uniqueVar := havoc(anyType())
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -67,20 +67,28 @@ field sharedVar: Ref
 field uniqueVar: Ref
 
 function sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
 function uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), anyType())
 
 
 method testPrimitiveFieldSetterUnique(pf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(pf), UniquePrimitiveFields())
-  requires acc(UniquePrimitiveFields_unique(pf), write)
+  requires isSubtype(typeOf(pf), UniqueContainer())
+  requires acc(UniqueContainer_unique(pf), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
+  var anon_0: Ref
+  var anon_1: Ref
+  anon_0 := con()
+  anon_1 := con()
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -91,19 +99,27 @@ field sharedVar: Ref
 field uniqueVar: Ref
 
 function sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
 function uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
+
+
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), anyType())
 
 
 method testPrimitiveFieldSetterShared(pf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(pf), UniquePrimitiveFields())
+  requires isSubtype(typeOf(pf), UniqueContainer())
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
+  var anon_0: Ref
+  var anon_1: Ref
+  anon_0 := con()
+  anon_1 := con()
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -113,39 +129,39 @@ field bf_sharedVar: Ref
 
 field bf_uniqueVar: Ref
 
-function UniquePrimitiveFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniquePrimitiveFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniqueReferenceFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
-function UniqueReferenceFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
 method testReferenceFieldGetterUnique(rf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(rf), UniqueReferenceFields())
-  requires acc(UniqueReferenceFields_unique(rf), write)
+  requires isSubtype(typeOf(rf), UniqueNestedContainer())
+  requires acc(UniqueNestedContainer_unique(rf), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
   var l0_uniqueVal: Ref
   var l0_uniqueVar: Ref
-  l0_sharedVal := UniqueReferenceFields_g_sharedVal(rf)
-  l0_sharedVar := havoc(UniquePrimitiveFields())
-  l0_uniqueVal := UniqueReferenceFields_g_uniqueVal(rf)
-  l0_uniqueVar := havoc(UniquePrimitiveFields())
+  l0_sharedVal := UniqueNestedContainer_g_sharedVal(rf)
+  l0_sharedVar := havoc(UniqueContainer())
+  l0_uniqueVal := UniqueNestedContainer_g_uniqueVal(rf)
+  l0_uniqueVar := havoc(UniqueContainer())
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -155,38 +171,38 @@ field bf_sharedVar: Ref
 
 field bf_uniqueVar: Ref
 
-function UniquePrimitiveFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniquePrimitiveFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniqueReferenceFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
-function UniqueReferenceFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
 method testReferenceFieldGetterShared(rf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(rf), UniqueReferenceFields())
+  requires isSubtype(typeOf(rf), UniqueNestedContainer())
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l0_sharedVal: Ref
   var l0_sharedVar: Ref
   var l0_uniqueVal: Ref
   var l0_uniqueVar: Ref
-  l0_sharedVal := UniqueReferenceFields_g_sharedVal(rf)
-  l0_sharedVar := havoc(UniquePrimitiveFields())
-  l0_uniqueVal := UniqueReferenceFields_g_uniqueVal(rf)
-  l0_uniqueVar := havoc(UniquePrimitiveFields())
+  l0_sharedVal := UniqueNestedContainer_g_sharedVal(rf)
+  l0_sharedVar := havoc(UniqueContainer())
+  l0_uniqueVal := UniqueNestedContainer_g_uniqueVal(rf)
+  l0_uniqueVar := havoc(UniqueContainer())
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -196,55 +212,74 @@ field bf_sharedVar: Ref
 
 field bf_uniqueVar: Ref
 
-function UniquePrimitiveFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniquePrimitiveFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniqueReferenceFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
-function UniqueReferenceFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
-method con(par_sharedVal: Ref, par_sharedVar: Ref, par_uniqueVal: Ref, par_uniqueVar: Ref)
+method con_Any() returns (ret_2: Ref)
+  ensures isSubtype(typeOf(ret_2), anyType())
+
+
+method con_UniqueContainer(par_sharedVal: Ref, par_sharedVar: Ref, par_uniqueVal: Ref,
+  par_uniqueVar: Ref)
   returns (ret_1: Ref)
-  requires isSubtype(typeOf(par_sharedVal), intType())
-  requires isSubtype(typeOf(par_sharedVar), intType())
-  requires isSubtype(typeOf(par_uniqueVal), intType())
-  requires isSubtype(typeOf(par_uniqueVar), intType())
-  ensures isSubtype(typeOf(ret_1), UniquePrimitiveFields())
-  ensures acc(UniquePrimitiveFields_unique(ret_1), write)
-  ensures intFromRef(UniquePrimitiveFields_g_sharedVal(ret_1)) ==
-    intFromRef(par_sharedVal)
-  ensures intFromRef((unfolding acc(UniquePrimitiveFields_unique(ret_1), write) in
-      ret_1.bf_sharedVar)) ==
-    intFromRef(par_sharedVar)
-  ensures intFromRef(UniquePrimitiveFields_g_uniqueVal(ret_1)) ==
-    intFromRef(par_uniqueVal)
-  ensures intFromRef((unfolding acc(UniquePrimitiveFields_unique(ret_1), write) in
-      ret_1.bf_uniqueVar)) ==
-    intFromRef(par_uniqueVar)
+  requires isSubtype(typeOf(par_sharedVal), anyType())
+  requires isSubtype(typeOf(par_sharedVar), anyType())
+  requires isSubtype(typeOf(par_uniqueVal), anyType())
+  requires isSubtype(typeOf(par_uniqueVar), anyType())
+  ensures isSubtype(typeOf(ret_1), UniqueContainer())
+  ensures acc(UniqueContainer_unique(ret_1), write)
+  ensures UniqueContainer_g_sharedVal(ret_1) == par_sharedVal
+  ensures (unfolding acc(UniqueContainer_unique(ret_1), write) in
+      ret_1.bf_sharedVar) ==
+    par_sharedVar
+  ensures UniqueContainer_g_uniqueVal(ret_1) == par_uniqueVal
+  ensures (unfolding acc(UniqueContainer_unique(ret_1), write) in
+      ret_1.bf_uniqueVar) ==
+    par_uniqueVar
 
 
 method testReferenceFieldSetterUnique(rf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(rf), UniqueReferenceFields())
-  requires acc(UniqueReferenceFields_unique(rf), write)
+  requires isSubtype(typeOf(rf), UniqueNestedContainer())
+  requires acc(UniqueNestedContainer_unique(rf), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
-  anon_0 := con(intToRef(5), intToRef(6), intToRef(7), intToRef(8))
-  anon_1 := con(intToRef(9), intToRef(10), intToRef(11), intToRef(12))
+  var anon_2: Ref
+  var anon_3: Ref
+  var anon_4: Ref
+  var anon_5: Ref
+  var anon_6: Ref
+  var anon_7: Ref
+  var anon_8: Ref
+  var anon_9: Ref
+  anon_1 := con_Any()
+  anon_2 := con_Any()
+  anon_3 := con_Any()
+  anon_4 := con_Any()
+  anon_0 := con_UniqueContainer(anon_1, anon_2, anon_3, anon_4)
+  anon_6 := con_Any()
+  anon_7 := con_Any()
+  anon_8 := con_Any()
+  anon_9 := con_Any()
+  anon_5 := con_UniqueContainer(anon_6, anon_7, anon_8, anon_9)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -254,54 +289,73 @@ field bf_sharedVar: Ref
 
 field bf_uniqueVar: Ref
 
-function UniquePrimitiveFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniquePrimitiveFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniquePrimitiveFields())
-  ensures isSubtype(typeOf(result), intType())
+function UniqueContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueContainer())
+  ensures isSubtype(typeOf(result), anyType())
 
 
-function UniqueReferenceFields_g_sharedVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_sharedVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
-function UniqueReferenceFields_g_uniqueVal(this: Ref): Ref
-  requires isSubtype(typeOf(this), UniqueReferenceFields())
-  ensures isSubtype(typeOf(result), UniquePrimitiveFields())
+function UniqueNestedContainer_g_uniqueVal(this: Ref): Ref
+  requires isSubtype(typeOf(this), UniqueNestedContainer())
+  ensures isSubtype(typeOf(result), UniqueContainer())
 
 
-method con(par_sharedVal: Ref, par_sharedVar: Ref, par_uniqueVal: Ref, par_uniqueVar: Ref)
+method con_Any() returns (ret_2: Ref)
+  ensures isSubtype(typeOf(ret_2), anyType())
+
+
+method con_UniqueContainer(par_sharedVal: Ref, par_sharedVar: Ref, par_uniqueVal: Ref,
+  par_uniqueVar: Ref)
   returns (ret_1: Ref)
-  requires isSubtype(typeOf(par_sharedVal), intType())
-  requires isSubtype(typeOf(par_sharedVar), intType())
-  requires isSubtype(typeOf(par_uniqueVal), intType())
-  requires isSubtype(typeOf(par_uniqueVar), intType())
-  ensures isSubtype(typeOf(ret_1), UniquePrimitiveFields())
-  ensures acc(UniquePrimitiveFields_unique(ret_1), write)
-  ensures intFromRef(UniquePrimitiveFields_g_sharedVal(ret_1)) ==
-    intFromRef(par_sharedVal)
-  ensures intFromRef((unfolding acc(UniquePrimitiveFields_unique(ret_1), write) in
-      ret_1.bf_sharedVar)) ==
-    intFromRef(par_sharedVar)
-  ensures intFromRef(UniquePrimitiveFields_g_uniqueVal(ret_1)) ==
-    intFromRef(par_uniqueVal)
-  ensures intFromRef((unfolding acc(UniquePrimitiveFields_unique(ret_1), write) in
-      ret_1.bf_uniqueVar)) ==
-    intFromRef(par_uniqueVar)
+  requires isSubtype(typeOf(par_sharedVal), anyType())
+  requires isSubtype(typeOf(par_sharedVar), anyType())
+  requires isSubtype(typeOf(par_uniqueVal), anyType())
+  requires isSubtype(typeOf(par_uniqueVar), anyType())
+  ensures isSubtype(typeOf(ret_1), UniqueContainer())
+  ensures acc(UniqueContainer_unique(ret_1), write)
+  ensures UniqueContainer_g_sharedVal(ret_1) == par_sharedVal
+  ensures (unfolding acc(UniqueContainer_unique(ret_1), write) in
+      ret_1.bf_sharedVar) ==
+    par_sharedVar
+  ensures UniqueContainer_g_uniqueVal(ret_1) == par_uniqueVal
+  ensures (unfolding acc(UniqueContainer_unique(ret_1), write) in
+      ret_1.bf_uniqueVar) ==
+    par_uniqueVar
 
 
 method testReferenceFieldSetterShared(rf: Ref) returns (v_ret_0: Ref)
-  requires isSubtype(typeOf(rf), UniqueReferenceFields())
+  requires isSubtype(typeOf(rf), UniqueNestedContainer())
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var anon_0: Ref
   var anon_1: Ref
-  anon_0 := con(intToRef(13), intToRef(14), intToRef(15), intToRef(16))
-  anon_1 := con(intToRef(17), intToRef(18), intToRef(19), intToRef(20))
+  var anon_2: Ref
+  var anon_3: Ref
+  var anon_4: Ref
+  var anon_5: Ref
+  var anon_6: Ref
+  var anon_7: Ref
+  var anon_8: Ref
+  var anon_9: Ref
+  anon_1 := con_Any()
+  anon_2 := con_Any()
+  anon_3 := con_Any()
+  anon_4 := con_Any()
+  anon_0 := con_UniqueContainer(anon_1, anon_2, anon_3, anon_4)
+  anon_6 := con_Any()
+  anon_7 := con_Any()
+  anon_8 := con_Any()
+  anon_9 := con_Any()
+  anon_5 := con_UniqueContainer(anon_6, anon_7, anon_8, anon_9)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/unique_fields.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/unique_fields.kt
@@ -1,63 +1,63 @@
 import org.jetbrains.kotlin.formver.plugin.Unique
 
-class UniquePrimitiveFields(
-    val sharedVal: Int,
-    var sharedVar: Int,
-    @Unique val uniqueVal: Int,
-    @Unique var uniqueVar: Int
+class UniqueContainer(
+    val sharedVal: Any,
+    var sharedVar: Any,
+    val uniqueVal: @Unique Any,
+    var uniqueVar: @Unique Any
 )
 
-fun <!VIPER_TEXT!>testPrimitiveFieldGetterUnique<!>(@Unique pf: UniquePrimitiveFields) {
+fun <!VIPER_TEXT!>testPrimitiveFieldGetterUnique<!>(pf: @Unique UniqueContainer) {
     val sharedVal = pf.sharedVal
     var sharedVar = pf.sharedVar
     val uniqueVal = pf.uniqueVal
     var uniqueVar = pf.uniqueVar
 }
 
-fun <!VIPER_TEXT!>testPrimitiveFieldGetterShared<!>(pf: UniquePrimitiveFields) {
+fun <!VIPER_TEXT!>testPrimitiveFieldGetterShared<!>(pf: UniqueContainer) {
     val sharedVal = pf.sharedVal
     var sharedVar = pf.sharedVar
     val uniqueVal = pf.uniqueVal
     var uniqueVar = pf.uniqueVar
 }
 
-fun <!VIPER_TEXT!>testPrimitiveFieldSetterUnique<!>(@Unique pf: UniquePrimitiveFields) {
-    pf.sharedVar = 1
-    pf.uniqueVar = 2
+fun <!VIPER_TEXT!>testPrimitiveFieldSetterUnique<!>(pf: @Unique UniqueContainer) {
+    pf.sharedVar = Any()
+    pf.uniqueVar = Any()
 }
 
-fun <!VIPER_TEXT!>testPrimitiveFieldSetterShared<!>(pf: UniquePrimitiveFields) {
-    pf.sharedVar = 3
-    pf.uniqueVar = 4
+fun <!VIPER_TEXT!>testPrimitiveFieldSetterShared<!>(pf: UniqueContainer) {
+    pf.sharedVar = Any()
+    pf.uniqueVar = Any()
 }
 
-class UniqueReferenceFields(
-    val sharedVal: UniquePrimitiveFields,
-    var sharedVar: UniquePrimitiveFields,
-    @Unique val uniqueVal: UniquePrimitiveFields,
-    @Unique var uniqueVar: UniquePrimitiveFields
+class UniqueNestedContainer(
+    val sharedVal: UniqueContainer,
+    var sharedVar: UniqueContainer,
+    val uniqueVal: @Unique UniqueContainer,
+    var uniqueVar: @Unique UniqueContainer
 )
 
-fun <!VIPER_TEXT!>testReferenceFieldGetterUnique<!>(@Unique rf: UniqueReferenceFields) {
+fun <!VIPER_TEXT!>testReferenceFieldGetterUnique<!>(rf: @Unique UniqueNestedContainer) {
     val sharedVal = rf.sharedVal
     var sharedVar = rf.sharedVar
     val uniqueVal = rf.uniqueVal
     var uniqueVar = rf.uniqueVar
 }
 
-fun <!VIPER_TEXT!>testReferenceFieldGetterShared<!>(rf: UniqueReferenceFields) {
+fun <!VIPER_TEXT!>testReferenceFieldGetterShared<!>(rf: UniqueNestedContainer) {
     val sharedVal = rf.sharedVal
     var sharedVar = rf.sharedVar
     val uniqueVal = rf.uniqueVal
     var uniqueVar = rf.uniqueVar
 }
 
-fun <!VIPER_TEXT!>testReferenceFieldSetterUnique<!>(@Unique rf: UniqueReferenceFields) {
-    rf.sharedVar = UniquePrimitiveFields(5, 6, 7, 8)
-    rf.uniqueVar = UniquePrimitiveFields(9, 10, 11, 12)
+fun <!VIPER_TEXT!>testReferenceFieldSetterUnique<!>(rf: @Unique UniqueNestedContainer) {
+    rf.sharedVar = UniqueContainer(Any(), Any(), Any(), Any())
+    rf.uniqueVar = UniqueContainer(Any(), Any(), Any(), Any())
 }
 
-fun <!VIPER_TEXT!>testReferenceFieldSetterShared<!>(rf: UniqueReferenceFields) {
-    rf.sharedVar = UniquePrimitiveFields(13, 14, 15, 16)
-    rf.uniqueVar = UniquePrimitiveFields(17, 18, 19, 20)
+fun <!VIPER_TEXT!>testReferenceFieldSetterShared<!>(rf: UniqueNestedContainer) {
+    rf.sharedVar = UniqueContainer(Any(), Any(), Any(), Any())
+    rf.uniqueVar = UniqueContainer(Any(), Any(), Any(), Any())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.fir.diag.txt
@@ -11,7 +11,11 @@ function g_data(this: Ref): Ref
   ensures isSubtype(typeOf(result), anyType())
 
 
-method con(par_data: Ref) returns (ret_1: Ref)
+method con_Any() returns (ret_2: Ref)
+  ensures isSubtype(typeOf(ret_2), anyType())
+
+
+method con_UniquePred(par_data: Ref) returns (ret_1: Ref)
   requires isSubtype(typeOf(par_data), anyType())
   ensures isSubtype(typeOf(ret_1), UniquePred())
   ensures acc(UniquePred_unique(ret_1), write)
@@ -22,9 +26,11 @@ method test(p: Ref) returns (v_ret_0: Ref)
   requires acc(Test_unique(p), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
+  var anon: Ref
   unfold acc(Test_unique(p), write)
   unfold acc(Super_unique(p), write)
-  p.x := intToRef(5)
+  anon := con_Any()
+  p.x := anon
   fold acc(Super_unique(p), write)
   fold acc(Test_unique(p), write)
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.kt
@@ -3,18 +3,18 @@
 import org.jetbrains.kotlin.formver.plugin.*
 
 abstract class Super(
-    @Unique var x: Int
+    var x: @Unique Any
 )
 
 @Manual
 class Test(
-    x: Int
+    x: @Unique Any
 ) : Super(x)
 
-fun <!VIPER_TEXT!>test<!>(@Unique p: Test) {
+fun <!VIPER_TEXT!>test<!>(p: @Unique Test) {
     unfold(UniquePred(p))
     unfold(UniquePred(p as Super))
-    p.x = 5
+    p.x = Any()
     fold(UniquePred(p as Super))
     fold(UniquePred(p))
 }
@@ -22,13 +22,13 @@ fun <!VIPER_TEXT!>test<!>(@Unique p: Test) {
 
 @Manual
 class Tree(
-    @Unique var left: Tree?,
-    @Unique var right: Tree?,
-    @Unique var data: Int,
+    var left: @Unique Tree?,
+    var right: @Unique Tree?,
+    var data: Int,
 )
 
 
-fun <!VIPER_TEXT!>contains<!>(@Unique @Borrowed tree: Tree?, search: Int) : Boolean {
+fun <!VIPER_TEXT!>contains<!>(tree: @Unique @Borrowed Tree?, search: Int) : Boolean {
     if (tree == null) return false
     unfold(UniquePred(tree))
     if (tree.data == search) {
@@ -41,13 +41,12 @@ fun <!VIPER_TEXT!>contains<!>(@Unique @Borrowed tree: Tree?, search: Int) : Bool
 }
 
 
-@Unique
-fun <!VIPER_TEXT!>combine<!>(@Unique left: Tree, @Unique right: Tree) : Tree {
+fun <!VIPER_TEXT!>combine<!>(left: @Unique Tree, right: @Unique Tree) : @Unique Tree {
     unfold(UniquePred(left))
     unfold(UniquePred(right))
     val data = left.data + right.data
     fold(UniquePred(left))
     fold(UniquePred(right))
-    val res = Tree(left, right, data)
+    val res: @Unique Tree = Tree(left, right, data)
     return res
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.fir.diag.txt
@@ -1,12 +1,18 @@
 /manualFoldingNegative.kt: info: Generated Viper text for writeWithoutUnfold:
 field value: Ref
 
+method con() returns (ret_1: Ref)
+  ensures isSubtype(typeOf(ret_1), anyType())
+
+
 method writeWithoutUnfold(c: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(c), Cell())
   requires acc(Cell_unique(c), write)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  c.value := intToRef(5)
+  var anon: Ref
+  anon := con()
+  c.value := anon
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFoldingNegative.kt
@@ -4,17 +4,17 @@ import org.jetbrains.kotlin.formver.plugin.*
 
 @Manual
 class Cell(
-    @Unique var value: Int
+    var value: @Unique Any
 )
 
 // Writing a field of a @Manual class without unfolding its predicate must fail:
 // the permission to the field is still held inside the folded predicate.
-fun <!VIPER_TEXT!>writeWithoutUnfold<!>(@Unique c: Cell) {
-    <!VIPER_VERIFICATION_ERROR!>c.value = 5<!>
+fun <!VIPER_TEXT!>writeWithoutUnfold<!>(c: @Unique Cell) {
+    <!VIPER_VERIFICATION_ERROR!>c.value = Any()<!>
 }
 
 // Unfolding the predicate and returning without folding it back must fail:
 // the borrowed parameter's predicate is not re-established for the caller.
-<!VIPER_VERIFICATION_ERROR!>fun <!VIPER_TEXT!>unfoldWithoutRefold<!>(@Unique @Borrowed c: Cell) {
+<!VIPER_VERIFICATION_ERROR!>fun <!VIPER_TEXT!>unfoldWithoutRefold<!>(c: @Unique @Borrowed Cell) {
     unfold(UniquePred(c))
 }<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/negative/binary_tree.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/negative/binary_tree.kt
@@ -5,9 +5,9 @@ import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
 import org.jetbrains.kotlin.formver.plugin.Unique
 import org.jetbrains.kotlin.formver.plugin.verify
 
-class Node(var data: Int, @Unique val left: Node?, @Unique val right: Node?)
+class Node(var data: Int, val left: @Unique Node?, val right: @Unique Node?)
 
-fun <!VIPER_TEXT!>get_left_val<!>(@Unique n: Node): Int? {
+fun <!VIPER_TEXT!>get_left_val<!>(n: @Unique Node): Int? {
     return n.left?.data
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/negative/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/negative/linked_list.kt
@@ -5,10 +5,10 @@ import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
 import org.jetbrains.kotlin.formver.plugin.Unique
 import org.jetbrains.kotlin.formver.plugin.verify
 
-class Link(var data: Int, @Unique val next: Link?)
+class Link(var data: Int, val next: @Unique Link?)
 
 @AlwaysVerify
-fun <!VIPER_TEXT!>getVal<!>(@Unique l: Link): Int? {
+fun <!VIPER_TEXT!>getVal<!>(l: @Unique Link): Int? {
     return l.next?.data
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/old.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/old.kt
@@ -4,10 +4,10 @@ import org.jetbrains.kotlin.formver.plugin.*
 
 
 class C(
-    @Unique var field: Int
+    var field: Int
 )
 
-fun <!VIPER_TEXT!>test<!>(@Unique @Borrowed c: C) {
+fun <!VIPER_TEXT!>test<!>(c: @Unique @Borrowed C) {
     preconditions {
         c.field == 42
     }
@@ -20,7 +20,7 @@ fun <!VIPER_TEXT!>test<!>(@Unique @Borrowed c: C) {
 
 // TODO: Remove the @NeverConvert once we have uniqueness information.
 @NeverConvert
-fun inc(@Unique @Borrowed c: C) {
+fun inc(c: @Unique @Borrowed C) {
     postconditions<Unit> {
         c.field == old(c.field) + 1
     }

--- a/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/pure_functions/pure_function_with_heap_dependent_expressions.kt
@@ -90,4 +90,4 @@ fun <!VIPER_TEXT!>getNextValueUsingId<!>(node: Node): Int {
 }
 
 @Pure
-fun <!VIPER_TEXT!>testBorrowed<!>(@Unique @Borrowed node: Node): Unit = Unit
+fun <!VIPER_TEXT!>testBorrowed<!>(node: @Unique @Borrowed Node): Unit = Unit

--- a/formver.compiler-plugin/uniqueness/README.md
+++ b/formver.compiler-plugin/uniqueness/README.md
@@ -12,6 +12,18 @@ The module is responsible for:
 
 `@Borrowed` behavior is provided by the locality module and consumed here to restore borrowed values after calls.
 
+## Wiring
+
+`FormalVerificationPluginExtensionRegistrar` registers `UniquenessAttributeExtension` and this module's
+resolvers unconditionally, so a `@Unique` type carries `UniquenessAttribute` in every run of the plugin.
+Conversion relies on that: `ProgramConverter` and `SignatureCreation` ask a symbol's type for its
+`scopeUniqueness` — and for its `locality`, in the case of `@Borrowed` — rather than reading the annotations
+themselves.
+
+The diagnostics are separate and on by default. `PluginAdditionalCheckers` adds the checkers below only when
+`PluginConfiguration.checkUniqueness` is set, which the `check_uniqueness` compiler option controls; unsetting
+it leaves `@Unique` in the Viper encoding with nothing validating it.
+
 ## Strategy
 
 The checker tracks two kinds of uniqueness:
@@ -31,7 +43,13 @@ The checker tracks two kinds of uniqueness:
 - `UniquenessAttributeExtension.kt` maps the `@Unique` annotation to `UniquenessAttribute`.
 - `Uniqueness.kt` defines the actual uniqueness lattice:
   - `Unique < Unknown < Shared < Moved`
-- `TypeRefUniquenessAttributeChecker.kt` restricts valid annotation targets to local variables and function parameters.
+- `Uniqueness.kt` also reads a type's attributes into that lattice:
+  - `scopeUniqueness` — what a value of the type is assumed to be: `Unique` for `@Unique`, `Unknown` for
+    `@Borrowed`, `Shared` otherwise.
+  - `parameterUniqueness` — what a parameter declared with the type requires.
+- `@Unique` applies to types only (`AnnotationTarget.TYPE`). `TypeRefUniquenessAttributeChecker.kt` narrows
+  that further to the type positions the analysis understands: value parameters, receiver parameters,
+  properties, function return types, and implicit type arguments.
 
 ### Path models
 
@@ -65,6 +83,12 @@ The checker tracks two kinds of uniqueness:
 - **Merges**
   - Join incoming states path-wise.
 
+Both call nodes are skipped for a call the analyzer's `UniquenessNeutralCallPredicate` accepts, leaving the
+state untouched. The plugin supplies `isSpecificationCall`, which holds for the `@SpecificationHelper`
+specification DSL (`verify`, `preconditions`, `old`, `fold`, `UniquePred`, and the rest), so a specification
+neither moves nor mutates what it mentions. Those functions take their arguments `@Borrowed`, so what a
+specification mentions does not escape either.
+
 ### Diagnostics
 
 Checkers consume the above analyses:
@@ -79,6 +103,10 @@ Checkers consume the above analyses:
   - reports moved subpaths left in borrowed locals at function exit
 - `ExpressionArgumentUniquenessCollisionChecker.kt`
   - reports duplicate/overlapping unique arguments in one call
+
+The three flow-sensitive function checkers are registered through `asSpecificationAware()`
+(`SpecificationAwareChecker.kt`, in the plugin module), which suppresses them inside the arguments of a
+specification call.
 
 ## Current Test Coverage
 
@@ -116,4 +144,9 @@ Known limitations in current code/tests:
 
 - **Interaction with closures** 
   - The current `GraphUniquenessStatesAnalyzer.kt` visits the lambda subgraphs as if they were part of the local control flows, which can result in unexpected behavior.
-  
+
+- **Reading a moved value inside a specification**
+  - Whether this is reported depends on the shape of the DSL entry point. `verify(a === b)` evaluates its
+    argument in the enclosing function's flow, so a moved `a` is reported; `preconditions { a.n == 0 }` puts it
+    in a lambda that `asSpecificationAware()` stands the checker down on, so nothing is reported.
+  - Both behaviours are pinned by `uniqueness_checker/specification.kt`.

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
@@ -70,6 +70,7 @@ class GraphUniquenessStatesAnalyzer(
     private val initialState: UniquenessState,
     private val context: CheckerContext,
     private val callArgumentLocalitiesMapper: CallArgumentTypeFactsMapper<Locality>,
+    private val uniquenessNeutralCallPredicate: UniquenessNeutralCallPredicate
 ) : PathAwareControlFlowGraphVisitor<Unit, UniquenessState>() {
     override fun mergeInfo(
         a: UniquenessStateFlow,
@@ -167,6 +168,8 @@ class GraphUniquenessStatesAnalyzer(
         val call = node.fir
 
         with(context) {
+            if (uniquenessNeutralCallPredicate.accepts(call)) return data
+
             return data.transformValues { data ->
                 var newUniquenessState = data.getOrInitialize()
 
@@ -191,6 +194,8 @@ class GraphUniquenessStatesAnalyzer(
         val call = node.fir
 
         with(context) {
+            if (uniquenessNeutralCallPredicate.accepts(call)) return data
+
             return data.transformValues { data ->
                 var newUniquenessState = data.getOrInitialize()
                 val explicitReceiver = call.explicitReceiver

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesResolver.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesResolver.kt
@@ -11,18 +11,33 @@ import org.jetbrains.kotlin.fir.analysis.cfa.util.traverseToFixedPoint
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.declarations.FirFunction
+import org.jetbrains.kotlin.fir.expressions.FirCall
 import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.CFGNode
 import org.jetbrains.kotlin.fir.resolve.dfa.cfg.ControlFlowGraph
 import org.jetbrains.kotlin.formver.locality.plugin.CallArgumentLocalitiesMapper
 
 /**
- * Session component that caches uniqueness-state flow analysis for control-flow graphs.
+ * Checks whether a call doesn't modify the uniqueness state (i.e. it is uniqueness-neutral).
  */
-class GraphUniquenessStatesResolver(session: FirSession) : FirExtensionSessionComponent(session) {
+fun interface UniquenessNeutralCallPredicate {
+    context(context: CheckerContext)
+    fun accepts(call: FirCall): Boolean
+}
+
+/**
+ * Session component that caches uniqueness-state flow analysis for control-flow graphs.
+ *
+ * @param uniquenessNeutralCallPredicate Is a predicate returning `true` if a call does not change the uniqueness state,
+ *  `false` otherwise.
+ */
+class GraphUniquenessStatesResolver(
+    private val uniquenessNeutralCallPredicate: UniquenessNeutralCallPredicate,
+    session: FirSession
+) : FirExtensionSessionComponent(session) {
     companion object {
-        fun getFactory(): Factory {
-            return Factory { session -> GraphUniquenessStatesResolver(session) }
+        fun getFactory(uniquenessNeutralCallPredicate: UniquenessNeutralCallPredicate = { false }): Factory {
+            return Factory { session -> GraphUniquenessStatesResolver(uniquenessNeutralCallPredicate, session) }
         }
     }
 
@@ -69,7 +84,8 @@ class GraphUniquenessStatesResolver(session: FirSession) : FirExtensionSessionCo
         val analyzer = GraphUniquenessStatesAnalyzer(
             initialState,
             context,
-            CallArgumentLocalitiesMapper
+            CallArgumentLocalitiesMapper,
+            uniquenessNeutralCallPredicate
         )
 
         return graph.traverseToFixedPoint(analyzer)

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessAttributeExtension.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessAttributeExtension.kt
@@ -11,13 +11,21 @@ import org.jetbrains.kotlin.fir.extensions.FirTypeAttributeExtension
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.types.ConeAttribute
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+val defaultUniquenessAnnotationId =
+    ClassId(
+        FqName("org.jetbrains.kotlin.formver.plugin"),
+        Name.identifier("Unique")
+    )
 
 class UniquenessAttributeExtension(
     session: FirSession,
     private val annotationId: ClassId
 ) : FirTypeAttributeExtension(session) {
     companion object {
-        fun getFactory(annotationId: ClassId): Factory {
+        fun getFactory(annotationId: ClassId = defaultUniquenessAnnotationId): Factory {
             return Factory { session -> UniquenessAttributeExtension(session, annotationId) }
         }
     }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessExtensionRegistrar.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessExtensionRegistrar.kt
@@ -10,12 +10,6 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-private val defaultUniquenessAnnotationId =
-    ClassId(
-        FqName("org.jetbrains.kotlin.formver.plugin"),
-        Name.identifier("Unique")
-    )
-
 class UniquenessExtensionRegistrar(
     private val uniquenessAnnotationId: ClassId = defaultUniquenessAnnotationId
 ) : FirExtensionRegistrar() {


### PR DESCRIPTION
The uniqueness and locality checkers ran as an opt-in side channel: the verification
plugin never registered them, and conversion read `@Unique`/`@Borrowed` off
annotations of its own rather than off what the checkers compute. Verification could
therefore encode an annotation that nothing had validated. This makes verification
consume them.

Built from the abandoned `marco/add-uniqueness-locality-checkers-to-viper-plugin-checkers`
(40 commits, 17 unsquashed fixups), rebased onto `main` and reworked where noted below.

## What changed

**Registration.** `FormalVerificationPluginExtensionRegistrar` now registers the FIR
type-attribute extensions and the uniqueness/locality resolvers unconditionally, so
`@Unique`/`@Borrowed` on a type always reach conversion. The separate registration
from the CLI registrar and from the compiler-plugin test fixture is gone.

**Conversion reads results, not annotations.** `ProgramConverter` and
`SignatureCreation` read `resolvedType.scopeUniqueness` and `.locality`.

**`@Unique`/`@Borrowed` are type-position-only**, which is what a type attribute can
see. The verification testData moves to that form, and off `Int` — the annotation on
a primitive never produced a meaningful predicate. The `uniqueness_checker` testData
was already written this way on `main`.

**Specification calls are uniqueness-neutral.** A `verify` or `preconditions` block
never executes, so it must neither consume nor mutate what it mentions, but the CFG
analysis saw a call and moved the arguments. Specification DSL entry points now carry
`@SpecificationHelper`; the analysis skips calls a `UniquenessNeutralCallPredicate`
accepts, at both call-enter and call-exit, so a neutral call can neither move a path
nor restore one. `asSpecificationAware()` additionally stands the flow-sensitive
checkers down inside a specification argument.

**New test.** `uniqueness_checker/specification.kt` pins all of that: a unique value
named in `verify`, `acc`, `old`, `UniquePred`/`fold`/`unfold`, `preconditions`,
`postconditions`, `loopInvariants` and `forAll` stays usable afterwards, and a value
moved *before* a specification call is still `INVALID_MOVED_ACCESS` after it. Dropping
the neutrality predicate makes it fail, which I checked. The case that carries the
guard is `acc(a.x)`: it is the only DSL entry point in the file that takes the unique
value itself and is not `@Borrowed`, so without the guard `a.x` stays moved and the
following use reports an escaping moved field.

## Decisions I made that the source branch left open

- **`checkUniqueness`/`checkLocality` default to `true`**, in one place
  (`PluginConfiguration`) that the CLI registrar reads. The source branch had them at
  `true` in `PluginConfiguration` but still `false` at the CLI registrar, so tests ran
  with the checkers on and real compilations ran with them off. On is the right
  default: the encoding consumes the annotations whether or not the checkers run, so
  off-by-default leaves them unvalidated. No existing verification golden gained a
  diagnostic from the switch.
- **Dropped the `UniquePred` DSL TODO.** `fold`/`unfold` take `Predicate`, and the
  converter matches a predicate *constructor* call; turning `UniquePred` into a
  function would remove the extension point `Predicate` exists to be.
- **Dropped two commits that cancelled out** (an import removed and re-added) and one
  whitespace-only change to an untouched file.
- Checker registration is duplicated between `PluginAdditionalCheckers` and the
  modules' own `UniquenessAdditionalCheckers`/`LocalityAdditionalCheckers`. That is
  deliberate: the plugin's copy wraps some checkers in `asSpecificationAware()`, which
  the modules cannot do.

## Things a reviewer may want to overrule

- `UniquenessExtensionRegistrar` and `UniquenessAdditionalCheckers` now have no
  in-tree caller. I left them; locality keeps its equivalents for its own tests.
- `UNIQUE_CHECK_ONLY` and `LOCALITY_CHECK_ONLY` are now synonyms — both only take
  conversion and verification out of the way, since both checkers always run. I
  updated their stale descriptions rather than collapsing them into one directive.
- Reading a *moved* value inside a specification is reported for `verify(a === b)` but
  not for `preconditions { a.n == 0 }`: the lambda body is a separate declaration that
  `asSpecificationAware()` covers. Both behaviours are asserted by the new test and
  the asymmetry is written up in the uniqueness README's limitations.

## Testing

`./agent-scripts/check-all.sh` green, including `./agent-scripts/test.sh --verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
