### PR TITLE
Make the uniqueness checker usable from a Gradle build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ syntax are not supported.
 This repository consists of three published parts:
 
 - `formver.compiler-plugin`: a K2 compiler plugin that performs formal verification.
+  It is published twice: the plain artifact runs against `kotlinc`, while
+  `formver.compiler-plugin-embeddable` runs against `kotlin-compiler-embeddable`,
+  the compiler Gradle builds with.
 - `formver.gradle-plugin`: a Gradle plugin that loads the compiler plugin.
 - `formver.annotations`: definitions that are used for adding specifications
   to your code.
@@ -57,7 +60,7 @@ repositories {
 ```
 
 Additionally, increase the stack size and metaspace of the Kotlin Daemon: the shaded plugin
-jar bundles Silicon and the Scala runtime (~100 MB), and without a larger metaspace the daemon
+jar bundles Silicon and the Scala runtime (~40 MB), and without a larger metaspace the daemon
 dies with `OutOfMemoryError: Metaspace` after roughly a dozen compiles.
 
 ```kotlin

--- a/formver.compiler-plugin/build.gradle.kts
+++ b/formver.compiler-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     kotlin("jvm")
     `java-test-fixtures`
@@ -35,7 +37,10 @@ dependencies {
     implementation(project(":formver.compiler-plugin:plugin")) { isTransitive = false }
     implementation(project(":formver.compiler-plugin:locality")) { isTransitive = false }
     implementation(project(":formver.common")) { isTransitive = false }
-    implementation(kotlin("compiler"))
+    // Provided by whichever compiler runs the plugin. Shading a second copy in would
+    // put compiler classes in the plugin's own class loader next to the ones the
+    // running compiler uses, and the two sets do not interoperate.
+    compileOnly(kotlin("compiler"))
 
     testFixturesApi(kotlin("test-junit5"))
     testFixturesApi(kotlin("compiler-internal-test-framework"))
@@ -157,14 +162,46 @@ fun Test.setLibraryProperty(propName: String, jarName: String) {
     systemProperty(propName, path)
 }
 
+// This project has no sources of its own, so the plain jar task has nothing to put in
+// its archive — and it names that archive exactly what shadowJar names its own, which
+// leaves whichever ran last in build/libs.
+tasks.jar {
+    enabled = false
+}
+
+// The jar for `kotlinc`, which runs the plugin against the plain compiler.
 tasks.shadowJar {
     archiveClassifier.set("")
+}
+
+// The jar for the Gradle plugin, which runs it against kotlin-compiler-embeddable.
+//
+// The embeddable compiler moves the libraries it bundles under its own package prefix,
+// and some of them show up in the compiler API the plugin builds on: PSI elements in
+// diagnostic factories, persistent maps in the control-flow signatures the plugin
+// overrides. References compiled against the plain compiler have to be rewritten to
+// match, or the plugin looks for classes the running compiler does not have.
+//
+// This list covers the relocated packages the plugin's own classes mention. Comparing
+// the package layouts of kotlin-compiler and kotlin-compiler-embeddable shows which
+// packages are subject to it, should the plugin come to depend on more of them.
+val embeddableJar by tasks.registering(ShadowJar::class) {
+    archiveBaseName.set("${project.name}-embeddable")
+    archiveClassifier.set("")
+    from(sourceSets.main.map { it.output })
+    configurations.add(project.configurations.runtimeClasspath)
+    relocate("com.intellij", "org.jetbrains.kotlin.com.intellij")
+    relocate("kotlinx.collections.immutable", "org.jetbrains.kotlin.kotlinx.collections.immutable")
 }
 
 publishing {
     publications {
         create<MavenPublication>("maven") {
             artifact(tasks.shadowJar)
+        }
+        create<MavenPublication>("embeddable") {
+            artifactId = "${project.name}-embeddable"
+            artifact(embeddableJar)
         }
     }
 }

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
@@ -49,7 +49,10 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
 
-        if (config.checkLocality) {
+        // The uniqueness checkers resolve the locality of expressions and symbols, and the
+        // resolvers that answer those queries are session components the locality extensions
+        // install. Uniqueness therefore cannot run on its own.
+        if (config.checkLocality || config.checkUniqueness) {
             FirExtensionRegistrarAdapter.registerExtension(LocalityExtensionRegistrar())
         }
 

--- a/formver.gradle-plugin/build.gradle.kts
+++ b/formver.gradle-plugin/build.gradle.kts
@@ -29,7 +29,9 @@ buildConfig {
 
     val pluginProject = project(":formver.compiler-plugin")
     buildConfigField("String", "COMPILER_PLUGIN_GROUP", "\"${pluginProject.group}\"")
-    buildConfigField("String", "COMPILER_PLUGIN_NAME", "\"${pluginProject.name}\"")
+    // Gradle runs the compiler out of kotlin-compiler-embeddable, which needs the
+    // variant of the compiler plugin relocated to match it.
+    buildConfigField("String", "COMPILER_PLUGIN_NAME", "\"${pluginProject.name}-embeddable\"")
     buildConfigField("String", "COMPILER_PLUGIN_VERSION", "\"${pluginProject.version}\"")
 
     val annotationsProject = project(":formver.annotations")


### PR DESCRIPTION
`formver { checkUniqueness(true) }` in a Gradle build died with an internal
compiler error on any source, including trivial ones with no `@Unique` anywhere:

    ClassCastException: org.jetbrains.kotlin.kotlinx...PersistentOrderedMap
    cannot be cast to kotlinx.collections.immutable.PersistentMap
      at GraphUniquenessStatesAnalyzer.visitNode

## Cause

Gradle runs the compiler out of `kotlin-compiler-embeddable`, which relocates the
libraries it bundles under `org.jetbrains.kotlin.*` — among them
`kotlinx.collections.immutable` and `com.intellij`. Both surface in the compiler
API this plugin builds on: FIR's control-flow visitors take `PersistentMap`
directly in the signatures the uniqueness analyzer overrides, and the diagnostic
factories mention `PsiElement`. Compiled against the plain compiler, the plugin
names classes the embeddable one does not have.

The shadow jar also shaded in the entire plain compiler (104 MB), which is what
made the mismatch a cast failure rather than a missing class: with the plugin's
own class loader supplying a second, unrelocated copy of those packages, the
plugin loaded its own `PersistentMap` and was handed the compiler's.

`checkLocality(true)` survived only because nothing on its path crosses one of
those types.

## Changes

- Publish `formver.compiler-plugin-embeddable`, a second shadow jar with those
  two packages rewritten to match the embeddable compiler, and resolve that
  artifact from the Gradle plugin. The plain artifact still targets `kotlinc`.
- Stop shading the compiler into the plugin jar — whichever compiler runs the
  plugin supplies it. Both jars drop from 104 MB to 41 MB.
- Disable the aggregator's plain `jar` task. It has no sources, so it produced an
  empty archive under the same name as `shadowJar`, leaving whichever ran last in
  `build/libs` — which can mean publishing an empty jar.

A second defect surfaced once the first was fixed: uniqueness checking resolves
the locality of expressions and symbols, but those resolvers are session
components only the locality extensions install, so `checkUniqueness` alone threw
`IllegalStateException: No ExpressionLocalityResolver in array owner` on the
first declaration that consults one. A trivial source never reaches that path.
The test harness already enables both checkers together and says so; the
compiler plugin now matches. Note the user-visible consequence: `checkUniqueness`
also reports locality diagnostics.

## Verification

`./agent-scripts/check-all.sh` passes.

End to end against `mavenLocal` in a scratch Gradle project, `--no-daemon`, clean
build each run, with a non-trivial source (`testData/diagnostics/uniqueness_checker/aliasing.kt`
with its diagnostic markers stripped): `checkUniqueness` alone, `checkLocality`
alone, and both together all compile without an internal error and report the
uniqueness diagnostics the golden file expects.

The `kotlinc` path was checked separately against the 2.3.0 compiler and reports
the same diagnostics. (The `kotlinc` on this machine is 2.4.10 and cannot load
the plugin at all — `FirExtensionRegistrarAdapter` changed supertype since 2.3.0.
That is unrelated to this change and predates it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)