### PR TITLE
Check loop-carried unique state

### DIFF
--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -171,6 +171,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("binary_tree.kt")
+    public void testBinary_tree() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt");
+    }
+
+    @Test
     @TestMetadata("break.kt")
     public void testBreak() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt");

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -231,6 +231,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("linked_list.kt")
+    public void testLinked_list() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt");
+    }
+
+    @Test
     @TestMetadata("loop.kt")
     public void testLoop() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/loop.kt");

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.fir.diag.txt
@@ -1,0 +1,5 @@
+/binary_tree.kt: error: Escaping value has moved field: 'pivot.right'.
+
+/binary_tree.kt: error: Attempt to pass the same unique argument 't.left' twice.
+
+/binary_tree.kt: error: Attempt to pass the same unique argument 't.left' twice.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt
@@ -1,0 +1,37 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class Tree(var left: @Unique Tree?, var right: @Unique Tree?)
+
+fun consumeBoth(a: @Unique Tree?, b: @Unique Tree?) {}
+
+fun `insert leaf into an empty child slot`(t: @Unique Tree, leaf: @Unique Tree) {
+    if (t.left == null) {
+        t.left = leaf
+    } else {
+        t.right = leaf
+    }
+}
+
+// `root.left` is nullable, so the pivot has to be dereferenced through `?.`. The
+// checker does not see `pivot?.right = root` as restoring `pivot.right`, so the
+// pivot still has a moved field when it escapes through the return. The same
+// rotation written on a non-null pivot, with `pivot.right = root`, checks clean,
+// which places the gap in the safe-call assignment rather than in the rotation.
+fun `rotate right around the root`(root: @Unique Tree): @Unique Tree? {
+    val pivot: @Unique Tree? = root.left
+    root.left = pivot?.right
+    pivot?.right = root
+    return <!ESCAPE_UNIQUENESS_INCONSISTENCY!>pivot<!>
+}
+
+fun `swap the children through a temporary`(t: @Unique Tree) {
+    val tmp: @Unique Tree? = t.left
+    t.left = t.right
+    t.right = tmp
+}
+
+fun `pass the same child as two unique arguments`(t: @Unique Tree) {
+    consumeBoth(<!INVALID_DUPLICATE_UNIQUE_ARGUMENT!>t.left<!>, <!INVALID_DUPLICATE_UNIQUE_ARGUMENT!>t.left<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
@@ -5,3 +5,7 @@
 /linked_list.kt: error: Invalid access to moved reference.
 
 /linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.
+
+/linked_list.kt: error: Invalid access to moved reference.
+
+/linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
@@ -3,9 +3,3 @@
 /linked_list.kt: error: Escaping value has moved field: 'head.next'.
 
 /linked_list.kt: error: Invalid access to moved reference.
-
-/linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.
-
-/linked_list.kt: error: Invalid access to moved reference.
-
-/linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
@@ -1,0 +1,7 @@
+/linked_list.kt: error: Invalid access to moved reference.
+
+/linked_list.kt: error: Escaping value has moved field: 'head.next'.
+
+/linked_list.kt: error: Invalid access to moved reference.
+
+/linked_list.kt: error: Borrowed local value has moved field at exit: 'current.next'.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -128,24 +128,20 @@ fun `drop the tail in a loop`(head: @Unique Node?) {
 
 // Iterative reversal
 //
-// Commented out: the uniqueness checker does not terminate on this function.
-// A run with the body below live was still burning CPU inside the check after
-// 40 minutes and produced no diagnostics, so there is no golden to record.
-//
-// The loop is not on its own what costs. Advancing a unique cursor with
-// `current = current.next` and nothing else checks in seconds, and so does
-// advancing while writing `null` into the field just read. What those two
-// leave out, and what the body below adds, is writing a unique local carried
-// over from the previous iteration back into the field.
-//
-// fun `reverse in place`(head: @Unique Node?): @Unique Node? {
-//     var prev: @Unique Node? = null
-//     var current: @Unique Node? = head
-//     while (current != null) {
-//         val next: @Unique Node? = current.next
-//         current.next = prev
-//         prev = current
-//         current = next
-//     }
-//     return prev
-// }
+// Writing a unique local carried over from the previous iteration back into the
+// field is what deepens the tracked paths: `prev` gains the spine of the node it
+// was just assigned, and that spine is written into `current.next` next time
+// round. Summarizing a path where a symbol comes round a second time bounds the
+// depth, so the states stabilize and the reversal checks.
+
+fun `reverse in place`(head: @Unique Node?): @Unique Node? {
+    var prev: @Unique Node? = null
+    var current: @Unique Node? = head
+    while (current != null) {
+        val next: @Unique Node? = current.next
+        current.next = prev
+        prev = current
+        current = next
+    }
+    return prev
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -57,6 +57,64 @@ fun `traverse then consume list`(head: @Unique Node) {
     consume(head)
 }
 
+// Traversing recursively through a borrowed parameter
+//
+// The same walk the loop above cannot express. Each call borrows the node it is
+// handed and restores it at exit, so nothing is left moved and the caller's list
+// survives the traversal. What the loop loses is lost in the join at the loop
+// head, not in the borrow.
+
+fun length(n: @Borrowed Node?): Int = if (n == null) 0 else 1 + length(n.next)
+
+fun contains(n: @Borrowed Node?, v: Int): Boolean =
+    if (n == null) false else if (n.value == v) true else contains(n.next, v)
+
+fun `use list after recursive length`(head: @Unique Node) {
+    val len = length(head)
+    consume(head)
+}
+
+fun `use list after recursive search`(head: @Unique Node) {
+    val found = contains(head, 3)
+    consume(head)
+}
+
+// A spine that cannot be reassigned
+//
+// `next` is a `val` here, so the chain is fixed once built and only the payload
+// is mutable. That buys nothing for the cursor: the loop form is rejected the
+// same way it is for a `var` spine, while the recursive form checks clean and
+// may write through the spine it walks.
+
+class RoNode(var value: Int, val next: @Unique RoNode?)
+
+fun consumeRo(n: @Unique RoNode?) {}
+
+fun `sum a readonly spine in a loop`(head: @Borrowed RoNode?): Int {
+    var current: @Borrowed RoNode? = head
+    var total = 0
+    while (current != null) {
+        total = total + current.value
+        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+    }
+    <!EXIT_UNIQUENESS_INCONSISTENCY!>return total<!>
+}
+
+fun `sum a readonly spine recursively`(n: @Borrowed RoNode?): Int =
+    if (n == null) 0 else n.value + `sum a readonly spine recursively`(n.next)
+
+fun `bump a readonly spine recursively`(n: @Borrowed RoNode?) {
+    if (n == null) return
+    n.value = n.value + 1
+    `bump a readonly spine recursively`(n.next)
+}
+
+fun `use readonly spine list after recursion`(head: @Unique RoNode) {
+    val total = `sum a readonly spine recursively`(head)
+    `bump a readonly spine recursively`(head)
+    consumeRo(head)
+}
+
 // Iterative reversal
 //
 // Commented out: the uniqueness checker does not terminate on this function.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -38,18 +38,17 @@ fun `return node after detaching tail`(head: @Unique Node): @Unique Node {
 // Borrowed traversal
 
 // Advancing the cursor reads the unique `next` field out of the node the cursor
-// points at, so the cursor's own `next` is moved on the way round the loop. The
-// checker keeps that moved field in the state joined at the loop head, which
-// makes the next read of `current.next` an access to a moved reference and
-// leaves the borrowed cursor with a moved field at exit.
+// points at. That read moves the field, but the same assignment points the
+// cursor at what it read, so the moved field is no longer reachable through the
+// cursor and the loop head has nothing to carry round.
 fun `sum values`(head: @Borrowed Node?): Int {
     var current: @Borrowed Node? = head
     var total = 0
     while (current != null) {
         total = total + current.value
-        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+        current = current.next
     }
-    <!EXIT_UNIQUENESS_INCONSISTENCY!>return total<!>
+    return total
 }
 
 fun `traverse then consume list`(head: @Unique Node) {
@@ -59,10 +58,9 @@ fun `traverse then consume list`(head: @Unique Node) {
 
 // Traversing recursively through a borrowed parameter
 //
-// The same walk the loop above cannot express. Each call borrows the node it is
-// handed and restores it at exit, so nothing is left moved and the caller's list
-// survives the traversal. What the loop loses is lost in the join at the loop
-// head, not in the borrow.
+// The same walk, written the other way. Each call borrows the node it is handed
+// and restores it at exit, so nothing is left moved and the caller's list
+// survives the traversal.
 
 fun length(n: @Borrowed Node?): Int = if (n == null) 0 else 1 + length(n.next)
 
@@ -82,9 +80,8 @@ fun `use list after recursive search`(head: @Unique Node) {
 // A spine that cannot be reassigned
 //
 // `next` is a `val` here, so the chain is fixed once built and only the payload
-// is mutable. That buys nothing for the cursor: the loop form is rejected the
-// same way it is for a `var` spine, while the recursive form checks clean and
-// may write through the spine it walks.
+// is mutable. Both the loop and the recursion walk it without disturbing it, and
+// the recursive form may write through the spine as it goes.
 
 class RoNode(var value: Int, val next: @Unique RoNode?)
 
@@ -95,9 +92,9 @@ fun `sum a readonly spine in a loop`(head: @Borrowed RoNode?): Int {
     var total = 0
     while (current != null) {
         total = total + current.value
-        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+        current = current.next
     }
-    <!EXIT_UNIQUENESS_INCONSISTENCY!>return total<!>
+    return total
 }
 
 fun `sum a readonly spine recursively`(n: @Borrowed RoNode?): Int =
@@ -113,6 +110,20 @@ fun `use readonly spine list after recursion`(head: @Unique RoNode) {
     val total = `sum a readonly spine recursively`(head)
     `bump a readonly spine recursively`(head)
     consumeRo(head)
+}
+
+// A cursor whose field is taken by someone else
+//
+// Overwriting the cursor only drops the moved mark because the assignment is
+// what reads the field. Here the field goes to `consume` first, so the read that
+// advances the cursor is a read of a reference already handed away.
+
+fun `drop the tail in a loop`(head: @Unique Node?) {
+    var current: @Unique Node? = head
+    while (current != null) {
+        consume(current.next)
+        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+    }
 }
 
 // Iterative reversal

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -1,0 +1,77 @@
+// FULL_JDK
+// WITH_STDLIB
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class Node(var value: Int, var next: @Unique Node?)
+
+fun consume(n: @Unique Node?) {}
+
+fun borrow(n: @Borrowed Node?) {}
+
+// Push front
+
+fun `push front`(head: @Unique Node?): @Unique Node {
+    return Node(0, head)
+}
+
+fun `use old head after push front`(head: @Unique Node?) {
+    val fresh: @Unique Node = Node(0, head)
+    consume(fresh)
+    consume(<!INVALID_MOVED_ACCESS!>head<!>)
+}
+
+// Detach
+
+fun `detach tail`(head: @Unique Node): @Unique Node? {
+    return head.next
+}
+
+fun `return node after detaching tail`(head: @Unique Node): @Unique Node {
+    val tail: @Unique Node? = head.next
+    consume(tail)
+    return <!ESCAPE_UNIQUENESS_INCONSISTENCY!>head<!>
+}
+
+// Borrowed traversal
+
+// Advancing the cursor reads the unique `next` field out of the node the cursor
+// points at, so the cursor's own `next` is moved on the way round the loop. The
+// checker keeps that moved field in the state joined at the loop head, which
+// makes the next read of `current.next` an access to a moved reference and
+// leaves the borrowed cursor with a moved field at exit.
+fun `sum values`(head: @Borrowed Node?): Int {
+    var current: @Borrowed Node? = head
+    var total = 0
+    while (current != null) {
+        total = total + current.value
+        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+    }
+    <!EXIT_UNIQUENESS_INCONSISTENCY!>return total<!>
+}
+
+fun `traverse then consume list`(head: @Unique Node) {
+    val total = `sum values`(head)
+    consume(head)
+}
+
+// Iterative reversal
+//
+// Commented out: the uniqueness checker does not terminate on this function.
+// A run of `./agent-scripts/test.sh linked_list` with the body below live was
+// still burning CPU inside the check after 40 minutes and produced no
+// diagnostics, so the scenario cannot be recorded as a golden.
+//
+// fun `reverse in place`(head: @Unique Node?): @Unique Node? {
+//     var prev: @Unique Node? = null
+//     var current: @Unique Node? = head
+//     while (current != null) {
+//         val next: @Unique Node? = current.next
+//         current.next = prev
+//         prev = current
+//         current = next
+//     }
+//     return prev
+// }

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -60,9 +60,14 @@ fun `traverse then consume list`(head: @Unique Node) {
 // Iterative reversal
 //
 // Commented out: the uniqueness checker does not terminate on this function.
-// A run of `./agent-scripts/test.sh linked_list` with the body below live was
-// still burning CPU inside the check after 40 minutes and produced no
-// diagnostics, so the scenario cannot be recorded as a golden.
+// A run with the body below live was still burning CPU inside the check after
+// 40 minutes and produced no diagnostics, so there is no golden to record.
+//
+// The loop is not on its own what costs. Advancing a unique cursor with
+// `current = current.next` and nothing else checks in seconds, and so does
+// advancing while writing `null` into the field just read. What those two
+// leave out, and what the body below adds, is writing a unique local carried
+// over from the previous iteration back into the field.
 //
 // fun `reverse in place`(head: @Unique Node?): @Unique Node? {
 //     var prev: @Unique Node? = null

--- a/formver.compiler-plugin/uniqueness/README.md
+++ b/formver.compiler-plugin/uniqueness/README.md
@@ -40,10 +40,11 @@ The checker tracks two kinds of uniqueness:
   - `AccessState = PathTrie<Access>`
   - `UniquenessState = PathTrie<Uniqueness>`
 - `ExpressionAccessStateResolver.kt` extracts the paths touched by each expression.
+- A trie node can be a **summary node**: a leaf whose value is the join of everything that would otherwise be below it, standing for both its own prefix and every path under it. A lookup or update that would descend past a summary node lands on the node itself instead. `UniquenessState.summarizeRecursivePaths` collapses any path that revisits a symbol into a summary, which bounds the trie's depth by the number of distinct symbols a function mentions — the mechanism that keeps recursive types from growing the trie without bound.
 
 ### CFG uniqueness state analysis
 
-`GraphUniquenessStatesAnalyzer.kt` computes a fixed point over the following CFG nodes:
+`GraphUniquenessStatesAnalyzer.kt` computes a fixed point over the following CFG nodes. The outgoing state of every node is normalized by `UniquenessState.summarizeRecursivePaths` before it is recorded, so recursion through a symbol never deepens the trie past a summary node — this is what makes the fixed point terminate over recursive types.
 
 - **Initialization**
   - The initial state contains the uniqueness information of the function's parameters.
@@ -119,4 +120,7 @@ Known limitations in current code/tests:
 
 - **Interaction with closures** 
   - The current `GraphUniquenessStatesAnalyzer.kt` visits the lambda subgraphs as if they were part of the local control flows, which can result in unexpected behavior.
+
+- **Summary nodes are approximate**
+  - A summary node stands for a whole region of paths rather than one path, so operations that reach past it apply to that entire region. An access past a summary lands on the summary itself, so a read there is treated as touching everything it covers. Restoring a borrow through a summary likewise restores the whole summarized region, not just the one path that was borrowed.
   

--- a/formver.compiler-plugin/uniqueness/README.md
+++ b/formver.compiler-plugin/uniqueness/README.md
@@ -49,9 +49,11 @@ The checker tracks two kinds of uniqueness:
   - The initial state contains the uniqueness information of the function's parameters.
 
 - **Variable declaration/assignment**
-  - Project RHS' uniqueness substate into LHS' path.
+  - Project RHS' uniqueness substate against the incoming state.
+  - Move RHS access paths, also against the incoming state.
+  - Insert the projected substate into LHS' path.
   - Initialize LHS path to declared uniqueness.
-  - Move RHS access paths.
+  - The order matters when the LHS is a prefix of an RHS path: advancing a cursor with `current = current.next` moves the field out of the node the cursor is leaving, and overwriting `current` then drops that mark, because it describes a location the cursor no longer reaches.
 
 - **Function-call enter**
   - Move all receivers (including context receivers) and value arguments.
@@ -95,6 +97,7 @@ Current scenarios include:
 - return/throw escape consistency
 - loops, `when`, `try/catch`, nullable flows
 - constructor/operator cases
+- recursive data structures: linked lists and binary trees, walked both by loop and by recursion
 
 ## Current Limitations / Untested Behavior
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/AccessState.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/AccessState.kt
@@ -97,12 +97,19 @@ fun AccessState.append(other: AccessState): AccessState {
  * If any of the intermediate path components is not resolved within [uniquenessState], the uniqueness of those
  * components is automatically inferred to be the join between the declared uniqueness of the component's symbol and the
  * uniqueness of the parent.
+ *
+ * An access that reaches past a summary node lands on the summary itself, which is the only node standing for the path
+ * it names. The transform then applies to the whole region the summary covers rather than to one path in it.
  */
 context(context: CheckerContext)
 fun AccessState.transformOnTerminals(
     uniquenessState: UniquenessState,
     transform: (FirBasedSymbol<*>, UniquenessState) -> UniquenessState
 ): UniquenessState {
+    if (uniquenessState.summarizesDescendants) {
+        return children.keys.fold(uniquenessState) { state, symbol -> transform(symbol, state) }
+    }
+
     var newUniquenessState = uniquenessState
 
     for ((symbol, accessChild) in children) {

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStateRenderer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStateRenderer.kt
@@ -18,7 +18,9 @@ private fun UniquenessState?.renderOrNull(): String =
 private fun UniquenessState.render(): String? =
     children.takeIf { it.isNotEmpty() }?.entries
         ?.flatMap { (symbol, state) ->
-            val current = "${symbol.render()} ${UniquenessRenderer.render(state.data)}"
+            // A summary node covers everything below it, so its line has to say so: it has no children to render.
+            val descendants = if (state.summarizesDescendants) " (and below)" else ""
+            val current = "${symbol.render()} ${UniquenessRenderer.render(state.data)}$descendants"
             val children = state.render()?.prependIndent("    ")
             listOfNotNull(current, children)
         }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
@@ -83,6 +83,16 @@ class GraphUniquenessStatesAnalyzer(
     private fun UniquenessStateFlow.getOrInitialize(): UniquenessState =
         this[Unit] ?: initialState
 
+    /**
+     * Records [state] as the outcome of a node, summarized so that no path in it revisits a symbol.
+     *
+     * Normalizing at every node, rather than only where control flow merges, keeps the bound on the state space
+     * independent of which nodes the traversal happens to merge at, so the fixed point is reached whatever shape the
+     * graph has.
+     */
+    private fun UniquenessStateFlow.putSummarized(state: UniquenessState): UniquenessStateFlow =
+        put(Unit, state.summarizeRecursivePaths())
+
     override fun visitSubGraph(node: CFGNodeWithSubgraphs<*>, graph: ControlFlowGraph): Boolean {
         return node.extendsLocalFlow
     }
@@ -91,7 +101,7 @@ class GraphUniquenessStatesAnalyzer(
         node: CFGNode<*>,
         data: PathAwareUniquenessStateFlow
     ): PathAwareUniquenessStateFlow {
-        return data.transformValues { data -> data.put(Unit, data.getOrInitialize()) }
+        return data.transformValues { data -> data.putSummarized(data.getOrInitialize()) }
     }
 
     override fun visitVariableDeclarationNode(
@@ -124,7 +134,7 @@ class GraphUniquenessStatesAnalyzer(
 
                 newUniquenessState = leftAccessState.initialize(newUniquenessState)
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -159,7 +169,7 @@ class GraphUniquenessStatesAnalyzer(
 
                 newUniquenessState = leftAccessState.initialize(newUniquenessState)
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -183,7 +193,7 @@ class GraphUniquenessStatesAnalyzer(
                     newUniquenessState = argument.resolveAccessState().move(newUniquenessState)
                 }
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -210,7 +220,7 @@ class GraphUniquenessStatesAnalyzer(
                     newUniquenessState = argument.resolveAccessState().initialize(newUniquenessState)
                 }
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -231,7 +241,7 @@ class GraphUniquenessStatesAnalyzer(
                 val defaultValueUniquenessState = defaultValueAccessState.projectTerminalUniquenessState(newUniquenessState)
                 newUniquenessState = newUniquenessState.insert(valueParameterPath, defaultValueUniquenessState)
                 newUniquenessState = defaultValueAccessState.move(newUniquenessState)
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -248,7 +258,7 @@ class GraphUniquenessStatesAnalyzer(
                         val resultAccessState = jumpExpression.result.resolveAccessState()
                         newUniquenessState = resultAccessState.move(newUniquenessState)
 
-                        data.put(Unit, newUniquenessState)
+                        data.putSummarized(newUniquenessState)
                     }
                 }
             }
@@ -268,7 +278,7 @@ class GraphUniquenessStatesAnalyzer(
                 val exceptionAccessState = throwExpression.exception.resolveAccessState()
                 newUniquenessState = exceptionAccessState.move(newUniquenessState)
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
@@ -111,19 +111,18 @@ class GraphUniquenessStatesAnalyzer(
 
             return data.transformValues { data ->
                 val uniquenessState = data.getOrInitialize()
+                val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(uniquenessState)
                 var newUniquenessState = uniquenessState
-
-                if (initializer != null) {
-                    val rightAccessState = initializer.resolveAccessState()
-                    val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(uniquenessState)
-                    newUniquenessState = newUniquenessState.insert(listOf(leftSymbol), rightUniquenessState)
-                }
-
-                newUniquenessState = leftAccessState.initialize(newUniquenessState)
 
                 if (leftSymbol.source?.kind != KtFakeSourceElementKind.WhenGeneratedSubject) {
                     newUniquenessState = rightAccessState.move(newUniquenessState)
                 }
+
+                if (initializer != null) {
+                    newUniquenessState = newUniquenessState.insert(listOf(leftSymbol), rightUniquenessState)
+                }
+
+                newUniquenessState = leftAccessState.initialize(newUniquenessState)
 
                 data.put(Unit, newUniquenessState)
             }
@@ -142,18 +141,23 @@ class GraphUniquenessStatesAnalyzer(
             val leftAccessState = leftValue.resolveAccessState()
 
             return data.transformValues { data ->
-                var newUniquenessState = data.getOrInitialize()
+                val uniquenessState = data.getOrInitialize()
                 val leftAccessPaths = leftAccessState.enumeratePaths()
                 val rightAccessState = rightValue.resolveAccessState()
 
+                // The right-hand side is read before the assignment takes effect, so both what it projects and the move
+                // of the paths it reads are computed against the incoming state, and the move is applied first. That
+                // ordering matters when the left-hand side is a prefix of what was read: advancing a cursor with
+                // `current = current.next` moves the field out of the node the cursor is leaving, and overwriting
+                // `current` then drops that mark, because it described a location the cursor no longer reaches.
+                val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(uniquenessState)
+                var newUniquenessState = rightAccessState.move(uniquenessState)
+
                 if (leftAccessPaths.count() == 1) {
-                    val leftPath = leftAccessPaths.first()
-                    val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(newUniquenessState)
-                    newUniquenessState = newUniquenessState.insert(leftPath, rightUniquenessState)
+                    newUniquenessState = newUniquenessState.insert(leftAccessPaths.first(), rightUniquenessState)
                 }
 
                 newUniquenessState = leftAccessState.initialize(newUniquenessState)
-                newUniquenessState = rightAccessState.move(newUniquenessState)
 
                 data.put(Unit, newUniquenessState)
             }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/PathTrie.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/PathTrie.kt
@@ -20,12 +20,19 @@ import org.jetbrains.kotlin.formver.type.plugin.TypeFactUnifier
  * For example, for a FIR access path like `a.b.c`, the trie contains:
  * `children[a] -> children[b] -> children[c]`.
  *
- * @property data value attached to the current path prefix.
- * @property children map keyed by the next symbol component.
+ * A node may instead stand for a whole region of the path space: when [summarizesDescendants] is set, [data] is the
+ * join of the values of every path under the node, the node carries no children, and a lookup that would descend past
+ * it lands on the node itself. Summary nodes are what keeps the trie finite over recursive types; see
+ * [UniquenessState.summarizeRecursivePaths].
+ *
+ * @property data value attached to the current path prefix, and to everything below it when [summarizesDescendants].
+ * @property children map keyed by the next symbol component; empty when [summarizesDescendants].
+ * @property summarizesDescendants whether this node stands for every path below it as well as for its own prefix.
  */
 data class PathTrie<Type>(
     val data: Type,
     val children: PersistentMap<FirBasedSymbol<*>, PathTrie<Type>> = persistentMapOf(),
+    val summarizesDescendants: Boolean = false,
 )
 
 fun <Type> PathTrie<Type>.putChild(symbol: FirBasedSymbol<*>, child: PathTrie<Type>): PathTrie<Type> =
@@ -34,7 +41,23 @@ fun <Type> PathTrie<Type>.putChild(symbol: FirBasedSymbol<*>, child: PathTrie<Ty
 val PathTrie<*>.symbols: Sequence<FirBasedSymbol<*>>
     get() = children.keys.asSequence() + children.values.flatMap { it.symbols }
 
+/**
+ * Replaces this subtrie by a single summary node covering it: a leaf whose value is the join of every value in the
+ * subtrie, standing for the node's own prefix and for all paths below it.
+ */
+fun <Type> PathTrie<Type>.summarizeDescendants(typeUnifier: TypeFactUnifier<Type>): PathTrie<Type> =
+    if (summarizesDescendants) this else PathTrie(joinChildren(typeUnifier), summarizesDescendants = true)
+
 fun <Type> PathTrie<Type>.join(other: PathTrie<Type>, typeUnifier: TypeFactUnifier<Type>): PathTrie<Type> {
+    // A summary on either side absorbs the other side's children: the result has to stand for every path that either
+    // input stands for, and only a summary can do that for the paths the summary itself no longer spells out.
+    if (summarizesDescendants || other.summarizesDescendants) {
+        return PathTrie(
+            typeUnifier.join(joinChildren(typeUnifier), other.joinChildren(typeUnifier)),
+            summarizesDescendants = true,
+        )
+    }
+
     var joinedChildren = children
 
     for ((symbol, otherChild) in other.children) {
@@ -77,13 +100,10 @@ fun <Type> PathTrie<Type>.joinChildren(typeUnifier: TypeFactUnifier<Type>): Type
 }
 
 fun <Type> PathTrie<Type>.find(path: List<FirBasedSymbol<*>>): PathTrie<Type>? {
-    val head = path.firstOrNull()
+    val head = path.firstOrNull() ?: return this
+    val child = children[head] ?: return this.takeIf { summarizesDescendants }
 
-    return if (head != null) {
-        children[head]?.find(path.drop(1))
-    } else {
-        this
-    }
+    return child.find(path.drop(1))
 }
 
 fun <Type> PathTrie<Type>.enumerate(isTerminal: PathTrie<Type>.() -> Boolean): Sequence<List<FirBasedSymbol<*>>> =

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessState.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessState.kt
@@ -28,13 +28,53 @@ fun UniquenessState.enumerateInconsistentPaths(): Sequence<Path> =
 
 /**
  * Replaces the substate at [path] with [child].
+ *
+ * Writing into a summary node cannot single out one path out of the region the summary stands for, so the write is
+ * weak there: the summary absorbs [child] instead of replacing anything.
  */
 fun UniquenessState.insert(path: Path, child: UniquenessState): UniquenessState =
-    if (path.isEmpty()) {
-        child
-    } else {
-        val head = path.first()
-        copy(
-            children = children.put(head, (children[head] ?: EmptyUniquenessState).insert(path.drop(1), child))
-        )
+    when {
+        path.isEmpty() -> child
+        summarizesDescendants -> copy(data = data.join(child.joinChildren(UniquenessUnifier)))
+        else -> {
+            val head = path.first()
+            copy(
+                children = children.put(head, (children[head] ?: EmptyUniquenessState).insert(path.drop(1), child))
+            )
+        }
     }
+
+/**
+ * Collapses every path that revisits a symbol into a summary of the region below the repeat.
+ *
+ * Assignment projects the substate of the right-hand side under the path of the left-hand side, so a loop over a
+ * recursive type can deepen the trie once per iteration - `prev.next`, then `prev.next.next`, and so on - and the
+ * chain of states never stabilizes. Cutting the trie wherever a symbol comes round a second time bounds its depth by
+ * the number of distinct symbols the function mentions, which makes the state space finite and the fixed point
+ * reachable. Any growth that is unbounded has to repeat a symbol, because a loop body can only ever append the finitely
+ * many components its own syntax spells out; paths over non-recursive data are therefore left exactly as they are.
+ */
+fun UniquenessState.summarizeRecursivePaths(): UniquenessState =
+    summarizeRecursivePaths(emptySet())
+
+private fun UniquenessState.summarizeRecursivePaths(seen: Set<FirBasedSymbol<*>>): UniquenessState {
+    if (summarizesDescendants || children.isEmpty()) return this
+
+    var newChildren = children
+
+    for ((symbol, child) in children) {
+        // States are normalized at every node, so most of the time there is nothing to collapse: keep the subtries
+        // that come back unchanged rather than rebuilding the trie on each visit.
+        val newChild = if (symbol in seen) {
+            child.summarizeDescendants(UniquenessUnifier)
+        } else {
+            child.summarizeRecursivePaths(seen + symbol)
+        }
+
+        if (newChild !== child) {
+            newChildren = newChildren.put(symbol, newChild)
+        }
+    }
+
+    return if (newChildren === children) this else copy(children = newChildren)
+}


### PR DESCRIPTION
Loop-carried unique state was mishandled in two connected ways. Both are fixed here.

Stacked on #259, which supplies the tests; the first four commits are that branch. Review from `Read an assignment's right-hand side against the state it enters with` onwards, or rebase once #259 lands.

## Advancing a cursor left a moved field behind

The transfer function for a declaration or assignment projected the RHS substate into the LHS path and only then moved the paths the RHS had read. By that point the LHS was already overwritten, so the move landed on whatever the target now pointed at rather than on what was read.

`current = current.next` therefore marked the `next` field of the node the cursor had just moved *to*. The loop head carried the mark round, the next read of `current.next` was an access to a moved reference, and the borrowed cursor was left with a moved field at exit — on a list the traversal never disturbed.

Project and move against the incoming state, and apply the move before the insert. Overwriting a variable then drops the moved marks under it, which is right when they describe a location the variable no longer reaches.

This is a narrow change: it only alters the outcome when the LHS is a prefix of an RHS path. Everywhere else the two orders commute, which is why no existing golden moved. The move still bites when someone else takes the field first — `drop the tail in a loop` passes `current.next` to `consume` before advancing, and the advance is still reported.

Note what it does *not* fix: the checker is alias-insensitive, so if another variable still reaches the node the cursor left, the field really is moved and nothing says so. That gap predates this change — moving `current.next` never marked `head.next` either.

## The fixed point did not terminate over recursive types

Assignment projects the RHS substate under the LHS path, so a loop over a recursive type deepens the trie once per iteration: `prev` picks up the spine of the node assigned to it, and that spine goes into `current.next` on the way round. `PathTrie.join` unions children, so the states grow without bound and the fixed point is never reached. In-place list reversal was the case that showed it; #259 had to leave it commented out because the check did not come back.

### The choice

Two directions were on the table: depth k-limiting, or widening at loop heads. I took a third that is really k-limiting with the bound chosen structurally rather than numerically — **collapse a path wherever a symbol comes round a second time.**

A fixed depth k is a number with no meaning in the domain: it truncates `a.b.c.d` in straight-line non-recursive code for the same reason it truncates `prev.next.next`, and picking k trades one against the other. Repetition is the thing that actually distinguishes them. Unbounded growth *has* to repeat a symbol, because a loop body can only ever append the finitely many components its own syntax spells out — so cutting at repeats bounds depth by the number of distinct symbols a function mentions, which is finite, while leaving every path over non-recursive data exactly as it was. That is why this lands with no golden churn outside the file under test.

Widening at loop heads would be more precise inside loop bodies, but it makes termination depend on every CFG cycle passing through a node the traversal merges at. Normalizing at every node costs a little precision at depth and buys a bound that holds whatever shape the graph has.

### The mechanism

A `PathTrie` node may now be a **summary node**: a leaf whose value is the join of everything that would otherwise be below it, standing for both its own prefix and every path under it. `join` lets a summary absorb the other side's children; `find` descending past one lands on the summary; `insert` into one is a weak update. `UniquenessState.summarizeRecursivePaths` collapses repeats, and the analyzer normalizes every state it records.

Summaries are approximate, and the README says so: a read past one is treated as touching everything it covers, and restoring a borrow through one restores the whole region rather than the one path borrowed. Neither is reachable without source that spells out a path of length three or more into a recursive spine.

## Result

- `reverse in place` is un-commented and checks with no diagnostics, in seconds.
- `sum values` and `sum a readonly spine in a loop` check clean — the priority case, a unique readonly spine with mutable values walked in idiomatic loop code, now costs nothing that the recursive form does not.
- `drop the tail in a loop` is new, guarding that the reorder did not blunt move detection.
- `./agent-scripts/check-all.sh` passes.
