### PR TITLE
Fix setup docs and the internal-error report URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ Once you've published to your local Maven repository, you can use the Gradle
 plugin to enable verification of your project.
 You can see an example setup at [jesyspa/snakt-usage-example](https://github.com/jesyspa/snakt-usage-example).
 
+### JDK
+
+Build and run with a JDK that your Gradle version supports; JDK 21 is a safe
+choice. The Gradle version this repository builds with (8.14.3) does not support
+JDK 25, and the failure is easy to misread: the build aborts with a message that
+is only the version number,
+
+```
+* What went wrong:
+25.0.2
+```
+
+which comes from Gradle's own build-script compiler rejecting the version string
+(`IllegalArgumentException` in `JavaVersion.parse`, visible under
+`--stacktrace`). It happens before any project code runs, so neither this
+repository nor your own build can catch it and report something friendlier. If
+you see it, point `JAVA_HOME` at an older JDK and stop the daemons
+(`./gradlew --stop`).
+
 ### Setup
 
 In your `settings.gradle.kts`, configure your Gradle plugin repositories to allow local plugins:
@@ -35,11 +54,14 @@ In your `settings.gradle.kts`, configure your Gradle plugin repositories to allo
 ```kotlin
 pluginManagement {
     repositories {
-        mavenCentral()
+        gradlePluginPortal()
         mavenLocal()
     }
 }
 ```
+
+Keep `gradlePluginPortal()` in the list: it is where the Kotlin Gradle plugin
+itself comes from, and replacing it outright leaves `kotlin("jvm")` unresolvable.
 
 Then in `build.gradle.kts`, enable the plugin. Make sure that you also enable the Maven
 local repository here: it's necessary to find the compiler plugin for the plugin.
@@ -117,12 +139,25 @@ At the moment we use the text-based interface, meaning you need to:
 - Install the `z3` binary in your path
 - Set the `Z3_EXE` environment variable correctly.
 
-One way to do this is as follows:
+`Z3_EXE` has to be the path to the binary itself, not the directory holding it.
+Any location works as long as it is on your `PATH`; if you can write to a system
+directory, one way to do this is as follows:
 
 ```bash
-export Z3_EXE=/usr/bin/z3 # or a different directory in $PATH
+export Z3_EXE=/usr/local/bin/z3
 sudo cp z3-4.8.7-*/bin/z3 $Z3_EXE
 echo "export Z3_EXE=$Z3_EXE" >> ~/.profile
+```
+
+Without root, install it under your home directory instead:
+
+```bash
+mkdir -p ~/.local/bin
+cp z3-4.8.7-*/bin/z3 ~/.local/bin/z3
+chmod +x ~/.local/bin/z3
+export Z3_EXE=$HOME/.local/bin/z3
+echo "export PATH=\$HOME/.local/bin:\$PATH" >> ~/.profile
+echo "export Z3_EXE=\$HOME/.local/bin/z3" >> ~/.profile
 ```
 
 Make sure that running `$Z3_EXE --version` gives `Z3 version 4.8.7`.
@@ -134,6 +169,10 @@ manager, operating system, etc.
 The Gradle and Kotlin daemons capture `Z3_EXE` at startup, so changing it
 afterwards has no effect until both are stopped (`./gradlew --stop`, plus
 killing the Kotlin daemon).
+
+If `Z3_EXE` is unset or wrong, compilation fails with an internal error whose
+details read `Cannot run prover at location 'z3': not a file`. That one is a
+configuration problem rather than a bug: check `Z3_EXE` before reporting it.
 
 ## Contributing
 

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
@@ -35,7 +35,7 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
         )
         map.put(
             PluginErrors.INTERNAL_ERROR,
-            "An internal error has occurred.\nDetails: {0}\nPlease report this at https://github.com/jesyspa/kotlin",
+            "An internal error has occurred.\nDetails: {0}\nPlease report this at https://github.com/JetBrains/SnaKt/issues",
             CommonRenderers.STRING,
         )
         map.put(

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
@@ -41,4 +41,4 @@ method testInsertedReturn() returns (v_ret_0: Ref)
 
 /empty.kt: error: An internal error has occurred.
 Details: Every statement in invariant block must be a pure boolean invariant.
-Please report this at https://github.com/jesyspa/kotlin
+Please report this at https://github.com/JetBrains/SnaKt/issues


### PR DESCRIPTION
Setting up the plugin from scratch on a clean machine, following the README as
written, and then running the [usage example](https://github.com/jesyspa/snakt-usage-example).
Verification does work end to end; these are the things that pointed the wrong
way on the road there.

### `pluginManagement` snippet is wrong

It lists `mavenCentral()` and `mavenLocal()`, having dropped
`gradlePluginPortal()`. Copied as written, `kotlin("jvm")` no longer resolves,
because the Kotlin Gradle plugin is published to the portal rather than to
Maven Central. The usage example's `settings.gradle.kts` already does this
correctly, so the README was the only wrong copy.

### Z3 instructions assume root

`export Z3_EXE=/usr/bin/z3` + `sudo cp` needs both root and a Debian-ish
layout. Added a `~/.local/bin` variant, and stated that `Z3_EXE` points at the
binary and not at its directory, which the old comment (`or a different
directory in $PATH`) made ambiguous.

### Nothing said which JDK to use

On JDK 25 both this repository and the usage example fail with:

```
* What went wrong:
25.0.2
```

That is the whole message. `--stacktrace` shows an `IllegalArgumentException`
from `JavaVersion.parse` inside Gradle's embedded build-script compiler —
Gradle 8.14.3 does not support JDK 25. Nothing identifies the JDK as the cause,
so it reads like a corrupt install. I looked at guarding it in our build, but
the failure happens while Gradle compiles the build script, before any project
code runs, so there is nowhere to catch it. Documented instead.

### A missing `Z3_EXE` looks like a plugin bug

It reports `An internal error has occurred. Details: Cannot run prover at
location 'z3': not a file. Please report this at ...`, which is a configuration
problem rather than something to file. Noted in the Z3 section. It does at
least fail the build rather than quietly skipping verification.

Separately, `INTERNAL_ERROR` pointed at `https://github.com/jesyspa/kotlin`,
which is not where SnaKt is developed; it now points at this repository's
issue tracker. One golden held that string and was regenerated — the diff is
the URL line only.

## Testing

- `./agent-scripts/check-all.sh` — `gradle check` and `check-testdata.sh` pass.
  `pre-commit` could not be installed on this machine (the proxy blocks PyPI),
  so I ran its three hooks by hand instead: `check-testdata.sh` and
  `agent-scripts/tests/run.sh` pass, and the changed files satisfy
  `end-of-file-fixer`.
- Rebuilt the plugin and reran the usage example against it, confirming
  verification still reports the expected `Function may return a false value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)