### PR TITLE
Build on JDK 25, pin the compile toolchain, and guard the Kotlin version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # The oldest JDK the build supports and the newest. The compile
+        # toolchain is pinned, so what varies here is the JDK the Gradle daemon
+        # and the checks that run inside it see.
+        java-version: [ '21', '25' ]
+
     steps:
       - uses: actions/checkout@v3
       - name: Setup Z3
@@ -35,10 +43,10 @@ jobs:
       - name: Check z3 version
         run: $Z3_EXE --version
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: ${{ matrix.java-version }}
           distribution: 'corretto'
 
       - name: Setup Gradle

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ At present, we do not distribute any part of the plugin through a central reposi
 If you would like to use the plugin, clone it and use the `publishToMavenLocal`
 task to put it in your local repository.
 
+## Kotlin and JDK versions
+
+SnaKt is compiled against Kotlin compiler internals, so the compiler that loads
+it has to be one it was built for. The published plugin is built against Kotlin
+2.3.0 and works with 2.3.x and earlier 2.x releases; a newer Kotlin is refused
+at the start of compilation with a message naming both versions, rather than
+failing later with a linkage error. Moving SnaKt to a newer Kotlin means
+rebuilding it against that release.
+
+Any JDK from 21 to 25 works, both for running the plugin and as the target of
+the code you verify: `jvmToolchain(25)` is supported. Running your own Gradle
+daemon on JDK 25 additionally requires Gradle 9 — Gradle 8 compiles Kotlin
+build scripts with a compiler that rejects JDK 25 outright. Targeting JVM 25
+from a JDK 21 daemon works on Gradle 8.
+
 ## Running the plugin
 
 Once you've published to your local Maven repository, you can use the Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import io.gitlab.arturbosch.detekt.Detekt
+import dev.detekt.gradle.Detekt
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -7,7 +7,7 @@ plugins {
     id("com.github.gmazzo.buildconfig") version "5.6.5"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.16.3" apply false
     id("com.gradle.plugin-publish") version "1.3.1" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.23.7"
+    id("dev.detekt") version "2.0.0-alpha.6"
 }
 
 // The JDK this project compiles against and targets. Pinned rather than
@@ -33,7 +33,7 @@ allprojects {
 }
 
 subprojects {
-    apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "dev.detekt")
 
     detekt {
         buildUponDefaultConfig = true
@@ -59,9 +59,9 @@ subprojects {
         exclude("**/build/**")
         reports {
             html.required.set(true)
-            xml.required.set(true)
+            checkstyle.required.set(true)
             sarif.required.set(false)
-            md.required.set(false)
+            markdown.required.set(false)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -9,9 +10,20 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version "1.23.7"
 }
 
+// The JDK this project compiles against and targets. Pinned rather than
+// inherited from the launching JVM so the bytecode does not depend on which
+// JDK a developer happens to run Gradle on.
+val jdkVersion = 21
+
 allprojects {
     group = "org.jetbrains.kotlin.formver"
     version = "0.1.0-SNAPSHOT"
+
+    pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+        extensions.configure<KotlinJvmProjectExtension> {
+            jvmToolchain(jdkVersion)
+        }
+    }
 
     tasks.withType<KotlinCompile> {
         compilerOptions {
@@ -30,7 +42,7 @@ subprojects {
     }
 
     tasks.withType<Detekt>().configureEach {
-        jvmTarget = "21"
+        jvmTarget = jdkVersion.toString()
         // Project uses a custom layout (src/ instead of src/main/kotlin) — list the
         // source roots explicitly so detekt scans them. test-gen is not listed: it
         // contains only generated Java test runners (produced by generateTests),

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,7 +1,3 @@
-build:
-  maxIssues: 0
-  excludeCorrectable: false
-
 config:
   validation: true
   warningsAsErrors: false
@@ -13,28 +9,25 @@ processors:
 console-reports:
   active: true
 
-output-reports:
-  active: true
-
 complexity:
   active: true
   LongMethod:
     active: true
-    threshold: 80
+    allowedLines: 80
   LongParameterList:
     active: true
-    functionThreshold: 8
-    constructorThreshold: 8
+    allowedFunctionParameters: 8
+    allowedConstructorParameters: 8
     ignoreDefaultParameters: true
     ignoreDataClasses: true
   TooManyFunctions:
     active: false
   CyclomaticComplexMethod:
     active: true
-    threshold: 35
+    allowedComplexity: 35
   NestedBlockDepth:
     active: true
-    threshold: 5
+    allowedDepth: 5
 
 style:
   active: true
@@ -50,7 +43,7 @@ style:
     active: false
   MaxLineLength:
     active: false
-  UnusedPrivateMember:
+  UnusedPrivateFunction:
     active: true
   UnusedParameter:
     active: true

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -2,6 +2,17 @@
 
 Publishing a new Silicon build: publish-silicon.md.
 
+## Toolchain
+
+The build runs on any JDK from 21 to 25 and compiles with a toolchain pinned to
+21, so the bytecode does not depend on which JDK launched Gradle. The pinned JDK
+is provisioned automatically when it is not installed.
+
+The Gradle version in the wrapper is a floor rather than a preference: Gradle 8
+compiles the Kotlin build scripts with a compiler that rejects JDK 25, and
+detekt below 2.0 embeds a compiler that does the same and runs inside the
+daemon.
+
 ## Tests
 
 We use the test framework built for kotlinc. A test is a `.kt` file under

--- a/formver.compiler-plugin/cli/build.gradle.kts
+++ b/formver.compiler-plugin/cli/build.gradle.kts
@@ -1,5 +1,8 @@
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+
 plugins {
     kotlin("jvm")
+    id("com.github.gmazzo.buildconfig")
 }
 
 dependencies {
@@ -8,6 +11,18 @@ dependencies {
     implementation(project(":formver.compiler-plugin:plugin"))
     implementation(project(":formver.compiler-plugin:locality"))
     implementation(project(":formver.compiler-plugin:uniqueness"))
+}
+
+buildConfig {
+    useKotlinOutput {
+        internalVisibility = true
+    }
+
+    packageName("org.jetbrains.kotlin.formver.cli")
+
+    // The plugin binds to compiler internals, so the compiler that loads it has
+    // to be close enough to the one it was built against.
+    buildConfigField("String", "BUILT_AGAINST_KOTLIN_VERSION", "\"${getKotlinPluginVersion()}\"")
 }
 
 sourceSets {

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
@@ -5,9 +5,13 @@
 
 package org.jetbrains.kotlin.formver.cli
 
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.formver.common.*
 import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
@@ -22,6 +26,8 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
         get() = true
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        if (!reportCompilerVersionSupported(configuration)) return
+
         val logLevel =
             configuration.get(FormalVerificationConfigurationKeys.LOG_LEVEL, LogLevel.Companion.defaultLogLevel())
         val behaviour = configuration.get(
@@ -56,5 +62,39 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
         if (config.checkUniqueness) {
             FirExtensionRegistrarAdapter.registerExtension(UniquenessExtensionRegistrar())
         }
+    }
+
+    /**
+     * Reports whether the compiler loading the plugin is one the plugin can bind to.
+     *
+     * The plugin is compiled against compiler internals that are not binary
+     * compatible across Kotlin feature releases, and registering an extension
+     * against a compiler that has moved on fails with a linkage error naming a
+     * compiler class rather than the plugin. Refusing up front says which
+     * versions the pairing needs instead.
+     */
+    private fun reportCompilerVersionSupported(configuration: CompilerConfiguration): Boolean {
+        val running = KotlinCompilerVersion.getVersion() ?: return true
+        if (featureRelease(running) <= featureRelease(BuildConfig.BUILT_AGAINST_KOTLIN_VERSION)) return true
+
+        configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE).report(
+            CompilerMessageSeverity.ERROR,
+            "This build of SnaKt is compiled against Kotlin ${BuildConfig.BUILT_AGAINST_KOTLIN_VERSION} and " +
+                    "cannot run on Kotlin $running. Compile with Kotlin " +
+                    "${BuildConfig.BUILT_AGAINST_KOTLIN_VERSION} or older, or use a build of SnaKt made " +
+                    "against Kotlin $running."
+        )
+        return false
+    }
+
+    /**
+     * The feature release [version] belongs to, with the patch component dropped:
+     * patch releases keep the internals the plugin binds to.
+     */
+    private fun featureRelease(version: String): KotlinVersion {
+        val parts = version.split('.')
+        val major = parts.getOrNull(0)?.toIntOrNull() ?: 0
+        val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+        return KotlinVersion(major, minor)
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,12 @@ pluginManagement {
     }
 }
 
+// Provisions the JDK the build pins its toolchain to, for developers who do not
+// have it installed.
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()


### PR DESCRIPTION
Makes the build work on JDK 25, stops the published bytecode from depending on
the developer's JDK, and turns the "wrong Kotlin" failure into a message that
says what is wrong.

## What was broken

**The build could not run on JDK 25.** Two things reject the JDK, both for the
same reason: they embed a Kotlin compiler whose bundled IntelliJ
`JavaVersion.parse` throws `IllegalArgumentException: 25.0.4` on feature
versions above 24, and both run inside the Gradle daemon.

- Gradle 8.14.3 compiles the Kotlin build scripts with Kotlin 2.0.21, so the
  build died during script compilation before reaching any task.
- detekt 1.23.7 and 1.23.8 embed the same compiler. Forcing a newer
  `kotlin-compiler-embeddable` onto the `detekt` configuration clears the parse
  failure and is then rejected by detekt's own version guard.

Confirmed directly: `JavaVersion.parse("25.0.4")` throws under
`kotlin-compiler-embeddable` 2.0.21 and returns `25.0.4` under 2.3.0.

**The compile toolchain was whatever JDK launched Gradle.** Nothing pinned it,
so building on JDK 25 produced class file 69 in every published jar, unloadable
on the JDK 21 the project targets. This is not specific to 25 — building on 24
today already ships class file 68.

**A wrong Kotlin failed opaquely.** `kotlinc` 2.4.10 could not load the plugin
at all, failing with `ClassCastException: FirExtensionRegistrarAdapter$Companion
cannot be cast to ProjectExtensionDescriptor`. The message names compiler
classes and gives the user nothing to act on.

## Changes

- Gradle wrapper to 9.7.1, which runs on JDK 25.
- Pin the Kotlin JVM toolchain to 21 for all subprojects, and add the foojay
  resolver so that JDK is provisioned when it is not installed. `jdkVersion` in
  the root build is now the single place the number appears; detekt's
  `jvmTarget` reads it too.
- detekt to 2.0.0-alpha.6 (`dev.detekt`), the first release that runs on a
  JDK 25 daemon. Mechanical migration: plugin id, task type, two report-format
  keys, four renamed threshold properties in `detekt.yml`, and the
  `UnusedPrivateMember` → `UnusedPrivateFunction` rename. Zero findings on all
  ten subprojects on both JDKs.
- A version guard in `FormalVerificationPluginComponentRegistrar`: compare the
  running compiler's feature release against the one the plugin was built
  against, and report an error naming both instead of letting the linkage
  failure happen. The bound is one-sided — older feature releases still load
  and verify, so they are left alone.
- CI runs the matrix `[21, 25]`.
- README gains a Kotlin/JDK section; docs/developing.md gains a toolchain note.

## Verification

`./agent-scripts/check-all.sh` passes on JDK 21 and on JDK 25.

The verification pipeline was additionally run with the test JVM forced to
JDK 25 rather than the pinned toolchain: 139 tests, 0 failures, Silicon and Z3
included.

End to end against `mavenLocal`, with #261 merged in, using a source with a
known verification failure. Every combination reports the expected Viper
diagnostic:

| Path | Daemon JDK | `jvmToolchain` | Result |
|:--|:--|:--|:--|
| Gradle 9.7.1 | 21 | 21 | diagnostic reported |
| Gradle 9.7.1 | 21 | 25 | diagnostic reported |
| Gradle 9.7.1 | 25 | 21 | diagnostic reported |
| Gradle 9.7.1 | 25 | 25 | diagnostic reported, class file 69 |
| Gradle 8.14.3 | 21 | 25 | diagnostic reported, class file 69 |
| Gradle 8.14.3 | 25 | — | fails in script compilation |

`kotlinc` 2.3.0 reports the same diagnostic on JDK 21 and on JDK 25. `kotlinc`
2.4.10 fails on both, identically — the Kotlin axis and the JDK axis are
independent.

The guard was checked against both: `kotlinc` 2.4.10 now exits 1 with
"this build of SnaKt is compiled against Kotlin 2.3.0 and cannot run on Kotlin
2.4.10", and 2.3.0 is unaffected.

## Two things for the reviewer to weigh

**detekt 2.0.0-alpha.6 is an alpha.** It is the only thing standing between this
branch and a JDK 25 daemon, and detekt 1.23 is a dead line for this purpose.
Config errors under it are hard failures at configure time with the allowed keys
named, so a bad migration cannot pass silently. Worth re-pinning once 2.0.0
stable ships.

**The CI matrix doubles the build job**, verification tests included. Dropping
JDK 25 to the fast checks only, or to a scheduled run, is a reasonable trim.

Unrelated but noticed: `config/detekt/baseline.xml` is referenced by
`build.gradle.kts` and has never existed in the repo. Left alone here.
