### PR TITLE
Lower a primary constructor call to an allocation and a fold

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/FirUtils.kt
@@ -105,9 +105,12 @@ val FirBasedSymbol<*>.isBorrowed: Boolean
  *
  * Such a function is never executed, so its arguments are neither consumed nor mutated.
  */
+fun FirFunctionSymbol<*>.isSpecificationFunction(session: FirSession): Boolean =
+    hasAnnotation(annotationId("SpecificationHelper"), session)
+
 context(context: CheckerContext)
 private fun FirFunctionSymbol<*>.isSpecificationFunction(): Boolean =
-    hasAnnotation(annotationId("SpecificationHelper"), context.session)
+    isSpecificationFunction(context.session)
 
 context(context: CheckerContext)
 fun FirStatement.isSpecificationCall(): Boolean =

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SignatureCreation.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/SignatureCreation.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.formver.core.embeddings.callables.*
 import org.jetbrains.kotlin.formver.core.embeddings.expression.EqCmp
 import org.jetbrains.kotlin.formver.core.embeddings.expression.FirVariableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.expression.PlaceholderVariableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.properties.PropertyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.FunctionTypeEmbedding
 import org.jetbrains.kotlin.formver.core.isBorrowed
 import org.jetbrains.kotlin.formver.core.isPure
@@ -161,19 +162,34 @@ fun SignatureWithTarget<NonInlineCallable>.toCompleteSignature(
 }
 
 
+/**
+ * The class a constructor constructs.
+ */
+context(converter: ProgramConversionContext)
+fun FirFunctionSymbol<*>.constructedClassSymbol(): FirRegularClassSymbol =
+    resolvedReturnType.toRegularClassSymbol(converter.session) ?: throw SnaktInternalException(
+        source, "Constructor does not return a regular class"
+    )
+
+/**
+ * The properties of this class that a primary constructor parameter backs, keyed by that parameter.
+ *
+ * Only default-behaving properties are included: an open or custom-accessor property is embedded as an
+ * opaque accessor, and nothing relates it to the parameter it was declared from.
+ */
+context(converter: ProgramConversionContext)
+fun FirRegularClassSymbol.primaryConstructorPropertyMatching(): Map<FirValueParameterSymbol, PropertyEmbedding> =
+    propertySymbols.mapNotNull { propertySymbol ->
+        val name = propertySymbol.embedMemberPropertyName(converter)
+        propertySymbol.withConstructorParam { paramSymbol ->
+            converter.typeResolver.lookupDefaultBehavingProperties(name)?.let { paramSymbol to it }
+        }
+    }.toMap()
+
 context(converter: ProgramConversionContext)
 fun SignatureWithTarget<NonInlineCallable>.toConstructorSignature(symbol: FirFunctionSymbol<*>): SignatureWithTarget<NonInlineFunctionSignature> =
     refineSignature { current ->
-        val constructedClassSymbol =
-            symbol.resolvedReturnType.toRegularClassSymbol(converter.session) ?: throw SnaktInternalException(
-                symbol.source, "Constructor does not return a regular class"
-            )
-        val parameterMatching = constructedClassSymbol.propertySymbols.mapNotNull { propertySymbol ->
-            val name = propertySymbol.embedMemberPropertyName(converter)
-            propertySymbol.withConstructorParam { paramSymbol ->
-                converter.typeResolver.lookupDefaultBehavingProperties(name)?.let { paramSymbol to it }
-            }
-        }.toMap()
+        val parameterMatching = symbol.constructedClassSymbol().primaryConstructorPropertyMatching()
 
         val fieldPostconditions = current.signature.params.mapNotNull { param ->
             require(param is FirVariableEmbedding) { "Constructor parameters must be represented by FirVariableEmbeddings" }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -18,18 +18,24 @@ import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.core.embeddings.FunctionBodyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.LabelEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.core.embeddings.callables.NamedFunctionSignatureWithContract
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
+import org.jetbrains.kotlin.formver.core.embeddings.properties.BackingFieldGetter
 import org.jetbrains.kotlin.formver.core.embeddings.properties.ClassPropertyAccess
 import org.jetbrains.kotlin.formver.core.embeddings.properties.PropertyAccessEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.properties.PropertyEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.properties.asPropertyAccess
+import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.isCustom
 import org.jetbrains.kotlin.formver.core.isInvariantBuilderFunctionNamed
 import org.jetbrains.kotlin.formver.core.linearization.*
 import org.jetbrains.kotlin.formver.viper.SymbolicName
 import org.jetbrains.kotlin.formver.viper.ast.Exp
+import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 import org.jetbrains.kotlin.utils.filterIsInstanceAnd
@@ -216,6 +222,99 @@ fun StmtConversionContext.insertInlineFunctionCall(
         }
     }
 }
+
+/**
+ * Lowers a call to the primary constructor of [symbol]'s class into the statements that build the object
+ * here, rather than a call to the bodyless `con_C` method. Returns null if the constructed type has no
+ * class embedding, and so no unique predicate to establish.
+ *
+ * `con_C` promises `acc(C_unique(ret), write)` and nothing about what is inside it, which leaves the
+ * predicate's snapshot unconstrained: a heap-dependent function reading through a nested predicate is
+ * then unrelated to the values the constructor was given. Allocating the object and folding the
+ * predicate here ties the snapshot to the heap the arguments were written into.
+ *
+ * The predicate also demands facts that no argument establishes: the type of a backing field that no
+ * constructor parameter writes (a Kotlin initializer in the class body is not converted today), and the
+ * unique predicate of a `@Unique` property in the same position. Those are inhaled so the fold goes
+ * through. `con_C` assumed all of this wholesale in its postcondition, so this assumes no more than the
+ * call it replaces.
+ */
+fun StmtConversionContext.insertPrimaryConstructorCall(
+    symbol: FirFunctionSymbol<*>,
+    callable: CallableEmbedding,
+    args: List<ExpEmbedding>,
+): ExpEmbedding? {
+    val classType = embedType(symbol.resolvedReturnType)
+    val pretype = classType.pretype as? ClassTypeEmbedding ?: return null
+    val parameterMatching = with(this) { symbol.constructedClassSymbol().primaryConstructorPropertyMatching() }
+
+    val (declarations, callArgs) = getInlineFunctionCallArgs(args, callable.callableType.formalArgTypes)
+    val valueArgs = callArgs.takeLast(symbol.valueParameterSymbols.size)
+    val obj = freshAnonVar(classType)
+
+    val initialized = mutableSetOf<PropertyEmbedding>()
+    val initializers = symbol.valueParameterSymbols.zip(valueArgs).mapNotNull { (param, arg) ->
+        val property = parameterMatching[param] ?: return@mapNotNull null
+        initialized.add(property)
+        when (val getter = property.getter!!) {
+            is BackingFieldGetter -> InitField(obj, getter.field, arg.withType(getter.field.type))
+            else -> InhaleDirect(EqCmp(getter.getValueSimple(obj, typeResolver), arg))
+        }
+    }
+
+    // Innermost first: folding a predicate consumes the predicates of the supertypes it nests.
+    val foldOrder = typeResolver.uniquePredicateFoldOrder(pretype)
+
+    return Block {
+        addAll(declarations)
+        add(Declare(obj, null))
+        add(AllocateObject(obj, pretype))
+        obj.provenInvariants().forEach { add(InhaleDirect(it)) }
+        addAll(initializers)
+        // The permission part of the type's access invariants comes from the allocation; what remains are
+        // the invariants over the field values, which have to be assumed of the values just written.
+        typeResolver.flatMapUniqueFields(pretype.name) { it.extraAccessInvariantsForParameter() }
+            .fillHoles(obj)
+            .forEach { add(InhaleDirect(it)) }
+        foldOrder.forEach { addAll(residualPredicateAssumptions(it, obj, initialized)) }
+        foldOrder.forEach {
+            add(Fold(PredicateAccessPermissions(it.uniquePredicateName, listOf(obj), PermExp.FullPerm())))
+        }
+        add(obj)
+    }
+}
+
+/**
+ * The conjuncts of the unique predicate of [classType] that a primary constructor call does not establish
+ * from its arguments, as assumptions about [obj].
+ *
+ * [initialized] are the properties a constructor parameter was written into.
+ */
+private fun StmtConversionContext.residualPredicateAssumptions(
+    classType: ClassTypeEmbedding,
+    obj: VariableEmbedding,
+    initialized: Set<PropertyEmbedding>,
+): List<ExpEmbedding> = buildList {
+    for (property in typeResolver.lookupClassProperties(classType.name)) {
+        if (property in initialized) continue
+        val field = (property.getter as? BackingFieldGetter)?.field
+        if (field != null && field.accessPolicy != AccessPolicy.ALWAYS_WRITEABLE) {
+            add(InhaleDirect(field.type.subTypeInvariant().fillHole(PrimitiveFieldAccess(obj, field))))
+        }
+        if (!property.isUnique) continue
+        val value = field?.let { PrimitiveFieldAccess(obj, it) } ?: property.getter?.getValueSimple(obj, typeResolver)
+        value?.let { plain ->
+            property.type.uniquePredicateAccessInvariant(typeResolver)?.fillHole(plain)?.let { add(InhaleDirect(it)) }
+        }
+    }
+}
+
+/**
+ * [classType] and its supertypes, ordered so that every class comes after the supertypes its unique
+ * predicate nests.
+ */
+private fun TypeResolver.uniquePredicateFoldOrder(classType: ClassTypeEmbedding): List<ClassTypeEmbedding> =
+    lookupSuperTypes(classType.name).flatMap { uniquePredicateFoldOrder(it) } + classType
 
 /**
  * Insert `ForAllEmbedding` where `forAll` function call was encountered.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -8,6 +8,7 @@ package org.jetbrains.kotlin.formver.core.conversion
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.contracts.description.LogicOperationKind
 import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.analysis.checkers.isPrimaryConstructor
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.expressions.impl.FirElseIfTrueCondition
@@ -287,11 +288,17 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
 
         val callee = data.embedAnyFunction(symbol)
-        return callee.insertCall(
-            functionCall.functionCallArguments.withVarargsHandled(data, callee),
-            data,
-            data.embedType(functionCall.resolvedType),
-        )
+        val args = functionCall.functionCallArguments.withVarargsHandled(data, callee)
+        val returnType = data.embedType(functionCall.resolvedType)
+        if (symbol.isPrimaryConstructor()) {
+            data.insertPrimaryConstructorCall(symbol, callee, args)?.let { constructed ->
+                return constructed.withNewTypeInvariants(returnType, data.typeResolver) {
+                    access = true
+                    proven = true
+                }
+            }
+        }
+        return callee.insertCall(args, data, returnType)
     }
 
     override fun visitImplicitInvokeCall(

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.fir.visitors.FirVisitor
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.common.UnsupportedFeatureBehaviour
+import org.jetbrains.kotlin.formver.core.isSpecificationFunction
 import org.jetbrains.kotlin.formver.core.embeddings.LabelLink
 import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.callables.insertCall
@@ -290,7 +291,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         val callee = data.embedAnyFunction(symbol)
         val args = functionCall.functionCallArguments.withVarargsHandled(data, callee)
         val returnType = data.embedType(functionCall.resolvedType)
-        if (symbol.isPrimaryConstructor()) {
+        // A specification-DSL constructor such as `UniquePred(x)` denotes a predicate instance rather than an
+        // allocation: `fold` and `unfold` read the predicate back off the method call it converts to.
+        if (symbol.isPrimaryConstructor() && !symbol.isSpecificationFunction(data.session)) {
             data.insertPrimaryConstructorCall(symbol, callee, args)?.let { constructed ->
                 return constructed.withNewTypeInvariants(returnType, data.typeResolver) {
                     access = true

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/ExpVisitor.kt
@@ -68,6 +68,8 @@ interface ExpVisitor<R> {
     fun visitPermissionLit(e: PermissionLit): R
     fun visitFold(e: Fold): R
     fun visitUnfold(e: Unfold): R
+    fun visitAllocateObject(e: AllocateObject): R
+    fun visitInitField(e: InitField): R
 }
 
 /**
@@ -129,4 +131,6 @@ interface DefaultingExpVisitor<R> : ExpVisitor<R> {
     override fun visitPermissionLit(e: PermissionLit): R = visitDefault(e)
     override fun visitFold(e: Fold): R = visitDefault(e)
     override fun visitUnfold(e: Unfold): R = visitDefault(e)
+    override fun visitAllocateObject(e: AllocateObject): R = visitDefault(e)
+    override fun visitInitField(e: InitField): R = visitDefault(e)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/Special.kt
@@ -6,6 +6,8 @@
 package org.jetbrains.kotlin.formver.core.embeddings.expression
 
 import org.jetbrains.kotlin.formver.core.embeddings.ExpVisitor
+import org.jetbrains.kotlin.formver.core.embeddings.properties.FieldEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.buildType
 import org.jetbrains.kotlin.formver.core.purity.PurityContext
@@ -65,4 +67,31 @@ data class Fold(val pred: PredicateAccessPermissions) : ExpEmbedding {
 
     override fun children(): Sequence<ExpEmbedding> = sequenceOf(pred)
     override fun <R> accept(v: ExpVisitor<R>): R = v.visitFold(this)
+}
+
+/**
+ * Allocates a fresh object into [variable], granting write access to every backing field of [classType]
+ * and its supertypes.
+ *
+ * The freshness comes from Viper's allocation, not from a havoc: the reference is distinct from every
+ * reference reachable beforehand, so heap-dependent functions applied to it are unconstrained rather
+ * than conflated with their pre-allocation values.
+ */
+data class AllocateObject(val variable: VariableEmbedding, val classType: ClassTypeEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = buildType { unit() }
+
+    override fun <R> accept(v: ExpVisitor<R>): R = v.visitAllocateObject(this)
+}
+
+/**
+ * Writes [value] into [field] of a freshly allocated [receiver].
+ *
+ * Unlike [FieldModification] this neither unfolds nor havocs: the receiver's predicates are not folded
+ * yet, so the write permission is held directly.
+ */
+data class InitField(val receiver: ExpEmbedding, val field: FieldEmbedding, val value: ExpEmbedding) : ExpEmbedding {
+    override val type: TypeEmbedding = buildType { unit() }
+
+    override fun children(): Sequence<ExpEmbedding> = sequenceOf(receiver, value)
+    override fun <R> accept(v: ExpVisitor<R>): R = v.visitInitField(this)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/debug/DebugTreeViewVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/debug/DebugTreeViewVisitor.kt
@@ -145,6 +145,22 @@ class DebugTreeViewVisitor(private val nameResolver: NameResolver) : DefaultingE
         OperatorNode(e.receiver.tree(), ".", e.field.debugTreeView)
     }
 
+    override fun visitAllocateObject(e: AllocateObject): TreeView = with(nameResolver) {
+        OperatorNode(
+            e.variable.tree(),
+            " := new ",
+            e.classType.debugTreeView,
+        )
+    }
+
+    override fun visitInitField(e: InitField): TreeView = with(nameResolver) {
+        OperatorNode(
+            OperatorNode(e.receiver.tree(), ".", e.field.debugTreeView),
+            " := ",
+            e.value.tree(),
+        )
+    }
+
     override fun visitFieldModification(e: FieldModification): TreeView = with(nameResolver) {
         OperatorNode(
             OperatorNode(e.receiver.tree(), ".", e.field.debugTreeView),

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -477,6 +477,29 @@ data class LinearizationVisitor(
         }
     }
 
+    override fun visitAllocateObject(e: AllocateObject): Linearizable = object : UnitResultLinearizable(e) {
+        override fun toViperUnusedResult(ctx: LinearizationContext) {
+            val target = e.variable.toViperExp(ctx) as? Exp.LocalVar
+                ?: error("Allocation target must be a local variable")
+            val fields = ctx.typeResolver.flatMapUniqueFields(e.classType.name) { listOf(it.toViper()) }
+            ctx.addStatement { Stmt.New(target, fields, ctx.source.asPosition) }
+        }
+    }
+
+    override fun visitInitField(e: InitField): Linearizable = object : UnitResultLinearizable(e) {
+        override fun toViperUnusedResult(ctx: LinearizationContext) {
+            val receiverViper = e.receiver.linearize().toViper(ctx)
+            val valueViper = e.value.linearize().toViper(ctx)
+            ctx.addStatement {
+                Stmt.FieldAssign(
+                    Exp.FieldAccess(receiverViper, e.field.toViper()),
+                    valueViper,
+                    ctx.source.asPosition
+                )
+            }
+        }
+    }
+
     // endregion
 
     // region Assignment / Declaration

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/purity/ExpPurityVisitor.kt
@@ -70,6 +70,8 @@ internal class ExprPurityVisitor(val declaredVariables: MutableSet<VariableEmbed
     override fun visitAccEmbedding(e: AccEmbedding): Boolean = false
     override fun visitFold(e: Fold): Boolean = false
     override fun visitUnfold(e: Unfold): Boolean = false
+    override fun visitAllocateObject(e: AllocateObject): Boolean = false
+    override fun visitInitField(e: InitField): Boolean = false
 }
 
 private fun ExpEmbedding.allChildrenPure(v: ExprPurityVisitor): Boolean =

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -388,6 +388,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("construction_through_hierarchy.kt")
+      public void testConstruction_through_hierarchy() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/classes/construction_through_hierarchy.kt");
+      }
+
+      @Test
       @TestMetadata("inheritance.kt")
       public void testInheritance() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/classes/inheritance.kt");

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/backing_field_getters.fir.diag.txt
@@ -123,16 +123,20 @@ method nullableReceiverNotNullSafeGet() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var f: Ref
+  var anon_1: Ref
   var anon_0: Ref
   var cond1: Ref
-  var anon_1: Ref
-  anon_0 := con()
-  f := anon_0
+  var anon_2: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), Baz())
+  fold acc(Baz_unique(anon_0), write)
+  anon_1 := anon_0
+  f := anon_1
   if (f != nullValue()) {
-    anon_1 := x(f)
+    anon_2 := x(f)
   } else {
-    anon_1 := nullValue()}
-  cond1 := notBool(boolToRef(anon_1 == nullValue()))
+    anon_2 := nullValue()}
+  cond1 := notBool(boolToRef(anon_2 == nullValue()))
   assert boolFromRef(cond1)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
@@ -186,14 +190,18 @@ method nonNullableReceiverSafeGet() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var f: Ref
+  var anon_0: Ref
   var cond1: Ref
-  var anon: Ref
-  f := con()
+  var anon_1: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), Baz())
+  fold acc(Baz_unique(anon_0), write)
+  f := anon_0
   if (f != nullValue()) {
-    anon := x(f)
+    anon_1 := x(f)
   } else {
-    anon := nullValue()}
-  cond1 := notBool(boolToRef(anon == nullValue()))
+    anon_1 := nullValue()}
+  cond1 := notBool(boolToRef(anon_1 == nullValue()))
   assert boolFromRef(cond1)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
@@ -226,18 +234,34 @@ method checkPrimary(par_x: Ref, par_y: Ref) returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var classI: Ref
+  var anon_0: Ref
   var l0_z: Ref
+  var anon_1: Ref
   var cond1: Ref
   var cond2: Ref
-  var anon: Ref
-  classI := con_ClassI(par_x, par_y)
-  l0_z := con_Z()
+  var anon_3: Ref
+  var anon_2: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), ClassI())
+  inhale intFromRef(g_x(anon_0)) == intFromRef(par_x)
+  inhale intFromRef(g_y(anon_0)) == intFromRef(par_y)
+  fold acc(ClassI_unique(anon_0), write)
+  classI := anon_0
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Z())
+  fold acc(Z_unique(anon_1), write)
+  l0_z := anon_1
   if (!(intFromRef(par_x) == intFromRef(par_y))) {
     cond1 := boolToRef(true)
   } else {
     cond1 := boolToRef(intFromRef(g_x(classI)) == intFromRef(g_y(classI)))}
-  anon := con_ClassII(l0_z)
-  cond2 := boolToRef(ClassII_g_z(anon) == l0_z)
+  anon_2 := new()
+  inhale isSubtype(typeOf(anon_2), ClassII())
+  inhale ClassII_g_z(anon_2) == l0_z
+  fold acc(ClassI_unique(anon_2), write)
+  fold acc(ClassII_unique(anon_2), write)
+  anon_3 := anon_2
+  cond2 := boolToRef(ClassII_g_z(anon_3) == l0_z)
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/custom_list.fir.diag.txt
@@ -72,16 +72,31 @@ method test(n: Ref) returns (v_ret_0: Ref)
 {
   var customList: Ref
   var anon_0: Ref
-  customList := con(n, intToRef(0))
-  anon_0 := isEmpty(customList)
-  if (!boolFromRef(anon_0)) {
-    var anon_1: Ref
-    var anon_2: Ref
+  var anon_1: Ref
+  var anon_2: Ref
+  anon_0 := intToRef(0)
+  anon_1 := new(p_size)
+  inhale isSubtype(typeOf(anon_1), CustomList())
+  anon_1.p_size := n
+  inhale intFromRef(anon_1.p_size) >= 0
+  fold acc(Iterable_unique(anon_1), write)
+  fold acc(Collection_unique(anon_1), write)
+  fold acc(AbstractCollection_unique(anon_1), write)
+  fold acc(Iterable_unique(anon_1), write)
+  fold acc(Collection_unique(anon_1), write)
+  fold acc(List_unique(anon_1), write)
+  fold acc(AbstractList_unique(anon_1), write)
+  fold acc(CustomList_unique(anon_1), write)
+  customList := anon_1
+  anon_2 := isEmpty(customList)
+  if (!boolFromRef(anon_2)) {
     var anon_3: Ref
-    anon_2 := customList.p_size
-    inhale isSubtype(typeOf(anon_2), intType())
-    anon_1 := get(customList, minusInts(anon_2, intToRef(1)))
-    anon_3 := get(customList, intToRef(0))
+    var anon_4: Ref
+    var anon_5: Ref
+    anon_4 := customList.p_size
+    inhale isSubtype(typeOf(anon_4), intType())
+    anon_3 := get(customList, minusInts(anon_4, intToRef(1)))
+    anon_5 := get(customList, intToRef(0))
   }
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/chars.fir.diag.txt
@@ -21,10 +21,17 @@ method testChars(c: Ref) returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var box: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   var charA: Ref
   var cond1: Ref
   var charZ: Ref
-  box := con(charToRef(97))
+  anon_0 := charToRef(97)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), CharBox())
+  inhale charFromRef(g_char(anon_1)) == charFromRef(anon_0)
+  fold acc(CharBox_unique(anon_1), write)
+  box := anon_1
   charA := charToRef(97)
   cond1 := boolToRef(charFromRef(charA) == charFromRef(g_char(box)))
   assert boolFromRef(cond1)

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.fir.diag.txt
@@ -39,13 +39,25 @@ method testType(s: Ref) returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
+  var anon_3: Ref
   var anon_0: Ref
   var cond2: Ref
+  var anon_4: Ref
   var anon_1: Ref
-  anon_0 := con(s)
-  cond1 := boolToRef(stringFromRef(g_str(anon_0)) == stringFromRef(s))
-  anon_1 := con(stringToRef(Seq(115, 116, 114)))
-  cond2 := boolToRef(stringFromRef(g_str(anon_1)) == Seq(115, 116, 114))
+  var anon_2: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), StringBox())
+  inhale stringFromRef(g_str(anon_0)) == stringFromRef(s)
+  fold acc(StringBox_unique(anon_0), write)
+  anon_3 := anon_0
+  cond1 := boolToRef(stringFromRef(g_str(anon_3)) == stringFromRef(s))
+  anon_1 := stringToRef(Seq(115, 116, 114))
+  anon_2 := new()
+  inhale isSubtype(typeOf(anon_2), StringBox())
+  inhale stringFromRef(g_str(anon_2)) == stringFromRef(anon_1)
+  fold acc(StringBox_unique(anon_2), write)
+  anon_4 := anon_2
+  cond2 := boolToRef(stringFromRef(g_str(anon_4)) == Seq(115, 116, 114))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
   label lbl_ret_0
@@ -94,10 +106,17 @@ method testLengthField(s: Ref) returns (v_ret_0: Ref)
 {
   var len: Ref
   var cond1: Ref
-  var anon: Ref
+  var anon_2: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   len := stringLength(s)
-  anon := con(stringToRef(Seq(115, 116, 114)))
-  cond1 := boolToRef(|stringFromRef(g_str(anon))| == 3)
+  anon_0 := stringToRef(Seq(115, 116, 114))
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), StringBox())
+  inhale stringFromRef(g_str(anon_1)) == stringFromRef(anon_0)
+  fold acc(StringBox_unique(anon_1), write)
+  anon_2 := anon_1
+  cond1 := boolToRef(|stringFromRef(g_str(anon_2))| == 3)
   assert boolFromRef(cond1)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/construction_through_hierarchy.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/construction_through_hierarchy.fir.diag.txt
@@ -1,0 +1,88 @@
+/construction_through_hierarchy.kt: info: Generated Viper text for buildDerived:
+field bf_own: Ref
+
+field inherited: Ref
+
+predicate DerivedWithVar_unique(this: Ref) {
+  isSubtype(typeOf(this), DerivedWithVar()) && acc(this.bf_own, write) &&
+  isSubtype(typeOf(this.bf_own), intType()) &&
+  acc(WithInheritedVar_unique(this), write)
+}
+
+predicate WithInheritedVar_unique(this: Ref) {
+  isSubtype(typeOf(this), WithInheritedVar()) && acc(this.inherited, write) &&
+  isSubtype(typeOf(this.inherited), intType())
+}
+
+method buildDerived() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), WithInheritedVar())
+{
+  var anon_2: Ref
+  var anon_0: Ref
+  var anon_1: Ref
+  anon_0 := intToRef(7)
+  anon_1 := new(bf_own, inherited)
+  inhale isSubtype(typeOf(anon_1), DerivedWithVar())
+  anon_1.bf_own := anon_0
+  inhale isSubtype(typeOf(anon_1.inherited), intType())
+  fold acc(WithInheritedVar_unique(anon_1), write)
+  fold acc(DerivedWithVar_unique(anon_1), write)
+  anon_2 := anon_1
+  v_ret_0 := anon_2
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+method con(par_own: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_own), intType())
+  ensures isSubtype(typeOf(ret_1), DerivedWithVar())
+  ensures acc(DerivedWithVar_unique(ret_1), write)
+  ensures intFromRef((unfolding acc(DerivedWithVar_unique(ret_1), write) in
+      ret_1.bf_own)) ==
+    intFromRef(par_own)
+
+
+/construction_through_hierarchy.kt: info: Generated Viper text for buildDiamond:
+predicate Apex_unique(this: Ref) {
+  isSubtype(typeOf(this), Apex())
+}
+
+predicate Diamond_unique(this: Ref) {
+  isSubtype(typeOf(this), Diamond()) && acc(LeftBranch_unique(this), write) &&
+  acc(RightBranch_unique(this), write)
+}
+
+predicate LeftBranch_unique(this: Ref) {
+  isSubtype(typeOf(this), LeftBranch()) && acc(Apex_unique(this), write)
+}
+
+predicate RightBranch_unique(this: Ref) {
+  isSubtype(typeOf(this), RightBranch()) && acc(Apex_unique(this), write)
+}
+
+method buildDiamond() returns (v_ret_1: Ref)
+  ensures isSubtype(typeOf(v_ret_1), Apex())
+{
+  var anon_1: Ref
+  var anon_0: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), Diamond())
+  fold acc(Apex_unique(anon_0), write)
+  fold acc(LeftBranch_unique(anon_0), write)
+  fold acc(Apex_unique(anon_0), write)
+  fold acc(RightBranch_unique(anon_0), write)
+  fold acc(Diamond_unique(anon_0), write)
+  anon_1 := anon_0
+  v_ret_1 := anon_1
+  goto lbl_ret_1
+  label lbl_ret_1
+}
+
+method con() returns (ret_2: Ref)
+  ensures isSubtype(typeOf(ret_2), Diamond())
+  ensures acc(Diamond_unique(ret_2), write)
+
+
+method tag(this: Ref) returns (ret_0: Ref)
+  requires isSubtype(typeOf(this), anyType())
+  ensures isSubtype(typeOf(ret_0), nullable(anyType()))

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/construction_through_hierarchy.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/construction_through_hierarchy.kt
@@ -1,0 +1,26 @@
+// FULL_JDK
+// RENDER_PREDICATES
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+
+open class WithInheritedVar {
+    var inherited: Int = 0
+}
+
+class DerivedWithVar(var own: Int) : WithInheritedVar()
+
+interface Apex {
+    val tag: Int
+        get() = 0
+}
+
+interface LeftBranch : Apex
+
+abstract class RightBranch : Apex
+
+class Diamond : LeftBranch, RightBranch()
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>buildDerived<!>(): WithInheritedVar = DerivedWithVar(7)
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>buildDiamond<!>(): Apex = Diamond()

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/inheritance_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/inheritance_fields.fir.diag.txt
@@ -19,14 +19,24 @@ method createB() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var fieldB: Ref
+  var anon_0: Ref
   var b: Ref
+  var anon_1: Ref
   var l0_fieldOverride: Ref
-  var anon: Ref
+  var anon_2: Ref
   var l0_fieldNotOverride: Ref
-  fieldB := con_FieldB()
-  b := con_B(fieldB)
-  anon := g_fieldOverride(b)
-  l0_fieldOverride := anon
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), FieldB())
+  fold acc(FieldA_unique(anon_0), write)
+  fold acc(FieldB_unique(anon_0), write)
+  fieldB := anon_0
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), B())
+  fold acc(A_unique(anon_1), write)
+  fold acc(B_unique(anon_1), write)
+  b := anon_1
+  anon_2 := g_fieldOverride(b)
+  l0_fieldOverride := anon_2
   inhale isSubtype(typeOf(l0_fieldOverride), FieldB())
   l0_fieldNotOverride := g_fieldNotOverride(b)
   label lbl_ret_0
@@ -66,22 +76,41 @@ method createBFsAndNoBF() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var fbf: Ref
-  var fbfx: Ref
   var anon_0: Ref
+  var fbfx: Ref
+  var anon_4: Ref
   var nbf: Ref
-  var nbfx: Ref
   var anon_1: Ref
+  var nbfx: Ref
+  var anon_5: Ref
   var sbf: Ref
+  var anon_2: Ref
+  var anon_3: Ref
   var sbfx: Ref
-  fbf := con_FirstBackingFieldClass()
-  anon_0 := public_g_x(fbf)
-  fbfx := anon_0
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), FirstBackingFieldClass())
+  fold acc(FirstBackingFieldClass_unique(anon_0), write)
+  fbf := anon_0
+  anon_4 := public_g_x(fbf)
+  fbfx := anon_4
   inhale isSubtype(typeOf(fbfx), intType())
-  nbf := con_NoBackingFieldClass()
-  anon_1 := public_g_x(nbf)
-  nbfx := anon_1
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), NoBackingFieldClass())
+  fold acc(FirstBackingFieldClass_unique(anon_1), write)
+  fold acc(NoBackingFieldClass_unique(anon_1), write)
+  nbf := anon_1
+  anon_5 := public_g_x(nbf)
+  nbfx := anon_5
   inhale isSubtype(typeOf(nbfx), intType())
-  sbf := con_SecondBackingFieldClass(intToRef(10))
+  anon_2 := intToRef(10)
+  anon_3 := new()
+  inhale isSubtype(typeOf(anon_3), SecondBackingFieldClass())
+  inhale intFromRef(SecondBackingFieldClass_g_x(anon_3)) ==
+    intFromRef(anon_2)
+  fold acc(FirstBackingFieldClass_unique(anon_3), write)
+  fold acc(NoBackingFieldClass_unique(anon_3), write)
+  fold acc(SecondBackingFieldClass_unique(anon_3), write)
+  sbf := anon_3
   sbfx := SecondBackingFieldClass_g_x(sbf)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
@@ -108,8 +137,15 @@ method createY() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var y: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   var ya: Ref
-  y := con(intToRef(10))
+  anon_0 := intToRef(10)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Y())
+  fold acc(X_unique(anon_1), write)
+  fold acc(Y_unique(anon_1), write)
+  y := anon_1
   ya := g_a(y)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/interfaces.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/interfaces.fir.diag.txt
@@ -54,8 +54,17 @@ method createImpl() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var impl: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   var implField: Ref
-  impl := con(intToRef(-1))
+  anon_0 := intToRef(-1)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Impl())
+  inhale intFromRef(Impl_g_number(anon_1)) == intFromRef(anon_0)
+  fold acc(First_unique(anon_1), write)
+  fold acc(Second_unique(anon_1), write)
+  fold acc(Impl_unique(anon_1), write)
+  impl := anon_1
   implField := Impl_g_number(impl)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
@@ -191,64 +200,95 @@ method createImpls() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var impl12: Ref
-  var start12: Ref
   var anon_0: Ref
-  var anon_1: Ref
-  var impl23: Ref
-  var start23: Ref
-  var anon_2: Ref
-  var anon_3: Ref
-  var impl3: Ref
-  var start3: Ref
-  var anon_4: Ref
-  var impl24: Ref
-  var start24: Ref
+  var start12: Ref
   var anon_5: Ref
   var anon_6: Ref
+  var impl23: Ref
+  var anon_1: Ref
+  var start23: Ref
   var anon_7: Ref
   var anon_8: Ref
-  var impl14: Ref
-  var start14: Ref
+  var impl3: Ref
+  var anon_2: Ref
+  var start3: Ref
   var anon_9: Ref
+  var impl24: Ref
+  var anon_3: Ref
+  var start24: Ref
   var anon_10: Ref
-  var impl6: Ref
-  var start6: Ref
   var anon_11: Ref
   var anon_12: Ref
+  var anon_13: Ref
+  var impl14: Ref
+  var anon_4: Ref
+  var start14: Ref
+  var anon_14: Ref
+  var anon_15: Ref
+  var impl6: Ref
+  var start6: Ref
+  var anon_16: Ref
+  var anon_17: Ref
   var cond1: Ref
   var cond2: Ref
   var cond3: Ref
   var cond4: Ref
   var cond5: Ref
-  impl12 := con_Impl12()
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), Impl12())
+  fold acc(InterfaceWithImplementation1_unique(anon_0), write)
+  fold acc(InterfaceWithoutImplementation2_unique(anon_0), write)
+  fold acc(Impl12_unique(anon_0), write)
+  impl12 := anon_0
   start12 := minusInts(plusInts(Impl12_g_field(impl12), intToRef(1)), intToRef(1))
-  anon_0 := take1(impl12)
-  anon_1 := take2(impl12)
-  impl23 := con_Impl23()
+  anon_5 := take1(impl12)
+  anon_6 := take2(impl12)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Impl23())
+  fold acc(AnyInterfaceWithoutImplementation5_unique(anon_1), write)
+  fold acc(InterfaceWithoutImplementation2_unique(anon_1), write)
+  fold acc(InheritingInterfaceWithoutImplementation6_unique(anon_1), write)
+  fold acc(AbstractWithFinalImplementation3_unique(anon_1), write)
+  fold acc(Impl23_unique(anon_1), write)
+  impl23 := anon_1
   start23 := minusInts(plusInts(AbstractWithFinalImplementation3_g_field(impl23),
     intToRef(1)), intToRef(1))
-  anon_2 := take2(impl23)
-  anon_3 := take3(impl23)
-  impl3 := con_Impl3()
+  anon_7 := take2(impl23)
+  anon_8 := take3(impl23)
+  anon_2 := new()
+  inhale isSubtype(typeOf(anon_2), Impl3())
+  fold acc(AbstractWithFinalImplementation3_unique(anon_2), write)
+  fold acc(Impl3_unique(anon_2), write)
+  impl3 := anon_2
   start3 := minusInts(plusInts(AbstractWithFinalImplementation3_g_field(impl3),
     intToRef(1)), intToRef(1))
-  anon_4 := take3(impl3)
-  impl24 := con_Impl24()
-  anon_6 := public_g_field(impl24)
-  anon_5 := anon_6
-  inhale isSubtype(typeOf(anon_5), intType())
-  start24 := minusInts(plusInts(anon_5, intToRef(1)), intToRef(1))
-  anon_7 := take2(impl24)
-  anon_8 := take4(impl24)
-  impl14 := con_Impl14()
+  anon_9 := take3(impl3)
+  anon_3 := new()
+  inhale isSubtype(typeOf(anon_3), Impl24())
+  fold acc(InterfaceWithoutImplementation2_unique(anon_3), write)
+  fold acc(AbstractWithOpenImplementation4_unique(anon_3), write)
+  fold acc(Impl24_unique(anon_3), write)
+  impl24 := anon_3
+  anon_11 := public_g_field(impl24)
+  anon_10 := anon_11
+  inhale isSubtype(typeOf(anon_10), intType())
+  start24 := minusInts(plusInts(anon_10, intToRef(1)), intToRef(1))
+  anon_12 := take2(impl24)
+  anon_13 := take4(impl24)
+  anon_4 := new()
+  inhale isSubtype(typeOf(anon_4), Impl14())
+  fold acc(InterfaceWithImplementation1_unique(anon_4), write)
+  fold acc(AbstractWithOpenImplementation4_unique(anon_4), write)
+  fold acc(Impl14_unique(anon_4), write)
+  impl14 := anon_4
   start14 := minusInts(plusInts(Impl14_g_field(impl14), intToRef(1)), intToRef(1))
-  anon_9 := take1(impl14)
-  anon_10 := take4(impl14)
+  anon_14 := take1(impl14)
+  anon_15 := take4(impl14)
   impl6 := create6()
-  anon_12 := public_g_field(impl6)
-  anon_11 := anon_12
-  inhale isSubtype(typeOf(anon_11), intType())
-  start6 := minusInts(plusInts(anon_11, intToRef(1)), intToRef(1))
+  anon_17 := public_g_field(impl6)
+  anon_16 := anon_17
+  inhale isSubtype(typeOf(anon_16), intType())
+  start6 := minusInts(plusInts(anon_16, intToRef(1)), intToRef(1))
   cond1 := boolToRef(intFromRef(start12) ==
     intFromRef(Impl12_g_field(impl12)))
   cond2 := boolToRef(intFromRef(start23) ==
@@ -306,11 +346,19 @@ method g_field(this: Ref) returns (ret_1: Ref)
 method testDiamond() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), intType())
 {
-  var anon_0: Ref
   var anon_1: Ref
-  anon_1 := con()
-  anon_0 := g_field(anon_1)
-  v_ret_0 := anon_0
+  var anon_2: Ref
+  var anon_0: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), D())
+  fold acc(A_unique(anon_0), write)
+  fold acc(B_unique(anon_0), write)
+  fold acc(A_unique(anon_0), write)
+  fold acc(C_unique(anon_0), write)
+  fold acc(D_unique(anon_0), write)
+  anon_2 := anon_0
+  anon_1 := g_field(anon_2)
+  v_ret_0 := anon_1
   inhale isSubtype(typeOf(v_ret_0), intType())
   goto lbl_ret_0
   label lbl_ret_0
@@ -343,22 +391,34 @@ method testVarVal() returns (v_ret_0: Ref)
 {
   var g: Ref
   var anon_0: Ref
-  var anon_1: Ref
   var anon_2: Ref
-  var i: Ref
   var anon_3: Ref
   var anon_4: Ref
+  var i: Ref
+  var anon_1: Ref
   var anon_5: Ref
-  g := con_G()
-  anon_1 := g_field(g)
-  anon_0 := anon_1
-  inhale isSubtype(typeOf(anon_0), intType())
-  anon_2 := s_field(g, intToRef(1))
-  i := con_I()
-  anon_4 := g_field(i)
-  anon_3 := anon_4
-  inhale isSubtype(typeOf(anon_3), intType())
-  anon_5 := s_field(i, intToRef(1))
+  var anon_6: Ref
+  var anon_7: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), G())
+  fold acc(E_unique(anon_0), write)
+  fold acc(F_unique(anon_0), write)
+  fold acc(G_unique(anon_0), write)
+  g := anon_0
+  anon_3 := g_field(g)
+  anon_2 := anon_3
+  inhale isSubtype(typeOf(anon_2), intType())
+  anon_4 := s_field(g, intToRef(1))
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), I())
+  fold acc(E_unique(anon_1), write)
+  fold acc(H_unique(anon_1), write)
+  fold acc(I_unique(anon_1), write)
+  i := anon_1
+  anon_6 := g_field(i)
+  anon_5 := anon_6
+  inhale isSubtype(typeOf(anon_5), intType())
+  anon_7 := s_field(i, intToRef(1))
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/predicates.fir.diag.txt
@@ -230,7 +230,11 @@ method unique_result() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), T())
   ensures acc(T_unique(v_ret_0), write)
 {
-  v_ret_0 := con()
+  var anon: Ref
+  anon := new()
+  inhale isSubtype(typeOf(anon), T())
+  fold acc(T_unique(anon), write)
+  v_ret_0 := anon
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/primary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/primary_constructors.fir.diag.txt
@@ -21,7 +21,17 @@ method con(par_a: Ref, par_b: Ref) returns (ret_1: Ref)
 method createPrimitiveFields() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), PrimitiveFields())
 {
-  v_ret_0 := con(intToRef(10), intToRef(20))
+  var anon_0: Ref
+  var anon_1: Ref
+  var anon_2: Ref
+  anon_0 := intToRef(10)
+  anon_1 := intToRef(20)
+  anon_2 := new()
+  inhale isSubtype(typeOf(anon_2), PrimitiveFields())
+  inhale intFromRef(g_a(anon_2)) == intFromRef(anon_0)
+  inhale intFromRef(g_b(anon_2)) == intFromRef(anon_1)
+  fold acc(PrimitiveFields_unique(anon_2), write)
+  v_ret_0 := anon_2
   goto lbl_ret_0
   label lbl_ret_0
 }
@@ -42,7 +52,15 @@ method con(par_a: Ref) returns (ret_1: Ref)
 method createRecursive() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), Recursive())
 {
-  v_ret_0 := con(nullValue())
+  var anon_0: Ref
+  var anon_1: Ref
+  anon_0 := nullValue()
+  inhale isSubtype(typeOf(anon_0), nullable(Recursive()))
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Recursive())
+  inhale g_a(anon_1) == anon_0
+  fold acc(Recursive_unique(anon_1), write)
+  v_ret_0 := anon_1
   goto lbl_ret_0
   label lbl_ret_0
 }
@@ -68,7 +86,14 @@ method con(par_c: Ref) returns (ret_1: Ref)
 method createFieldInBody() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), FieldInBody())
 {
-  v_ret_0 := con(intToRef(10))
+  var anon_0: Ref
+  var anon_1: Ref
+  anon_0 := intToRef(10)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), FieldInBody())
+  inhale intFromRef(g_c(anon_1)) == intFromRef(anon_0)
+  fold acc(FieldInBody_unique(anon_1), write)
+  v_ret_0 := anon_1
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/private_properties.fir.diag.txt
@@ -80,15 +80,26 @@ method extractPublic() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var cond1: Ref
-  var anon_0: Ref
-  var anon_1: Ref
-  var cond2: Ref
   var anon_2: Ref
-  anon_1 := con_C()
-  anon_0 := havoc(intType())
-  cond1 := boolToRef(isSubtype(typeOf(anon_0), intType()))
-  anon_2 := con_D()
-  cond2 := boolToRef(isSubtype(typeOf(D_g_field(anon_2)), intType()))
+  var anon_0: Ref
+  var cond2: Ref
+  var anon_3: Ref
+  var anon_1: Ref
+  anon_0 := new(bf_field)
+  inhale isSubtype(typeOf(anon_0), C())
+  inhale isSubtype(typeOf(anon_0.bf_field), intType())
+  fold acc(A_unique(anon_0), write)
+  fold acc(B_unique(anon_0), write)
+  fold acc(C_unique(anon_0), write)
+  anon_2 := havoc(intType())
+  cond1 := boolToRef(isSubtype(typeOf(anon_2), intType()))
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), D())
+  fold acc(A_unique(anon_1), write)
+  fold acc(B_unique(anon_1), write)
+  fold acc(D_unique(anon_1), write)
+  anon_3 := anon_1
+  cond2 := boolToRef(isSubtype(typeOf(D_g_field(anon_3)), intType()))
   assert boolFromRef(cond1)
   assert boolFromRef(cond2)
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/property_accessors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/property_accessors.fir.diag.txt
@@ -198,10 +198,14 @@ method testReferencePropertySetter(rp: Ref) returns (v_ret_0: Ref)
   requires isSubtype(typeOf(rp), ReferenceProperty())
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var anon_0: Ref
   var anon_1: Ref
-  anon_1 := con()
-  anon_0 := s_ppProp(rp, anon_1)
+  var anon_2: Ref
+  var anon_0: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), PrimitiveProperty())
+  fold acc(PrimitiveProperty_unique(anon_0), write)
+  anon_2 := anon_0
+  anon_1 := s_ppProp(rp, anon_2)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/secondary_constructors.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/secondary_constructors.fir.diag.txt
@@ -51,8 +51,15 @@ method primaryAndSecondConstructor() returns (v_ret_0: Ref)
 {
   var bc1: Ref
   var bc2: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   bc1 := con_c_BothConstructors_args_Boolean(boolToRef(false))
-  bc2 := con_c_BothConstructors_args_Int(intToRef(42))
+  anon_0 := intToRef(42)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), c_BothConstructors())
+  inhale intFromRef(g_a(anon_1)) == intFromRef(anon_0)
+  fold acc(c_BothConstructors_unique(anon_1), write)
+  bc2 := anon_1
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/classes/unique_fields.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/classes/unique_fields.fir.diag.txt
@@ -270,16 +270,28 @@ method testReferenceFieldSetterUnique(rf: Ref) returns (v_ret_0: Ref)
   var anon_7: Ref
   var anon_8: Ref
   var anon_9: Ref
+  anon_0 := con_Any()
   anon_1 := con_Any()
   anon_2 := con_Any()
   anon_3 := con_Any()
-  anon_4 := con_Any()
-  anon_0 := con_UniqueContainer(anon_1, anon_2, anon_3, anon_4)
+  anon_4 := new(bf_sharedVar, bf_uniqueVar)
+  inhale isSubtype(typeOf(anon_4), UniqueContainer())
+  inhale UniqueContainer_g_sharedVal(anon_4) == anon_0
+  anon_4.bf_sharedVar := anon_1
+  inhale UniqueContainer_g_uniqueVal(anon_4) == anon_2
+  anon_4.bf_uniqueVar := anon_3
+  fold acc(UniqueContainer_unique(anon_4), write)
+  anon_5 := con_Any()
   anon_6 := con_Any()
   anon_7 := con_Any()
   anon_8 := con_Any()
-  anon_9 := con_Any()
-  anon_5 := con_UniqueContainer(anon_6, anon_7, anon_8, anon_9)
+  anon_9 := new(bf_sharedVar, bf_uniqueVar)
+  inhale isSubtype(typeOf(anon_9), UniqueContainer())
+  inhale UniqueContainer_g_sharedVal(anon_9) == anon_5
+  anon_9.bf_sharedVar := anon_6
+  inhale UniqueContainer_g_uniqueVal(anon_9) == anon_7
+  anon_9.bf_uniqueVar := anon_8
+  fold acc(UniqueContainer_unique(anon_9), write)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -346,16 +358,28 @@ method testReferenceFieldSetterShared(rf: Ref) returns (v_ret_0: Ref)
   var anon_7: Ref
   var anon_8: Ref
   var anon_9: Ref
+  anon_0 := con_Any()
   anon_1 := con_Any()
   anon_2 := con_Any()
   anon_3 := con_Any()
-  anon_4 := con_Any()
-  anon_0 := con_UniqueContainer(anon_1, anon_2, anon_3, anon_4)
+  anon_4 := new(bf_sharedVar, bf_uniqueVar)
+  inhale isSubtype(typeOf(anon_4), UniqueContainer())
+  inhale UniqueContainer_g_sharedVal(anon_4) == anon_0
+  anon_4.bf_sharedVar := anon_1
+  inhale UniqueContainer_g_uniqueVal(anon_4) == anon_2
+  anon_4.bf_uniqueVar := anon_3
+  fold acc(UniqueContainer_unique(anon_4), write)
+  anon_5 := con_Any()
   anon_6 := con_Any()
   anon_7 := con_Any()
   anon_8 := con_Any()
-  anon_9 := con_Any()
-  anon_5 := con_UniqueContainer(anon_6, anon_7, anon_8, anon_9)
+  anon_9 := new(bf_sharedVar, bf_uniqueVar)
+  inhale isSubtype(typeOf(anon_9), UniqueContainer())
+  inhale UniqueContainer_g_sharedVal(anon_9) == anon_5
+  anon_9.bf_sharedVar := anon_6
+  inhale UniqueContainer_g_uniqueVal(anon_9) == anon_7
+  anon_9.bf_uniqueVar := anon_8
+  fold acc(UniqueContainer_unique(anon_9), write)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/contracts/positive/is_type_contract.fir.diag.txt
@@ -47,9 +47,13 @@ method constructorReturnType() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), boolType())
   ensures boolFromRef(v_ret_0) == true
 {
-  var anon: Ref
-  anon := con()
-  v_ret_0 := boolToRef(isSubtype(typeOf(anon), Foo()))
+  var anon_1: Ref
+  var anon_0: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), Foo())
+  fold acc(Foo_unique(anon_0), write)
+  anon_1 := anon_0
+  v_ret_0 := boolToRef(isSubtype(typeOf(anon_1), Foo()))
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/full_viper_dump.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/full_viper_dump.fir.diag.txt
@@ -1,7 +1,21 @@
 /full_viper_dump.kt: info: Generated ExpEmbedding for pkg$f$f$args$t$ret$Unit:
 Function(
     name = pkg$f$f$args$t$ret$Unit,
-    { Declare(Var(l0$foo), pkg$c$Foo, MethodCall(callee = pkg$c$Foo$con$pkg$c$Foo$args$Int, Int(0))) },
+    {
+        Declare(
+            Var(l0$foo),
+            pkg$c$Foo,
+            {
+                Declare(Var(v$anon$0), Int, Int(0));
+                Declare(Var(v$anon$1), pkg$c$Foo);
+                Var(v$anon$1) := new pkg$c$Foo;
+                InhaleDirect(Is(Var(v$anon$1), type = pkg$c$Foo));
+                InhaleDirect(EqCmp(FunctionCall(Var(v$anon$1)), Var(v$anon$0)));
+                Fold(PredicateAccess(pkg$c$Foo$unique, Var(v$anon$1)));
+                Var(v$anon$1);
+            },
+        );
+    },
     return = lbl$ret$0,
 )
 
@@ -401,7 +415,14 @@ method f() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var foo: Ref
-  foo := con(intToRef(0))
+  var anon_0: Ref
+  var anon_1: Ref
+  anon_0 := intToRef(0)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Foo())
+  inhale intFromRef(g_x(anon_1)) == intFromRef(anon_0)
+  fold acc(Foo_unique(anon_1), write)
+  foo := anon_1
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/function_overloading.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/function_overloading.fir.diag.txt
@@ -106,18 +106,26 @@ method f_fakePrint_args_Int_ret_Unit(value: Ref) returns (ret_1: Ref)
 method testGlobalScopeOverloading() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var anon_0: Ref
-  var anon_1: Ref
   var anon_2: Ref
   var anon_3: Ref
   var anon_4: Ref
   var anon_5: Ref
-  anon_0 := f_fakePrint_args_Int_ret_Unit(intToRef(42))
-  anon_1 := f_fakePrint_args_Boolean_ret_Unit(boolToRef(true))
-  anon_3 := con_Foo()
-  anon_2 := f_fakePrint_args_Foo_ret_Unit(anon_3)
-  anon_5 := con_Bar()
-  anon_4 := f_fakePrint_args_Bar_ret_Unit(anon_5)
+  var anon_0: Ref
+  var anon_6: Ref
+  var anon_7: Ref
+  var anon_1: Ref
+  anon_2 := f_fakePrint_args_Int_ret_Unit(intToRef(42))
+  anon_3 := f_fakePrint_args_Boolean_ret_Unit(boolToRef(true))
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), Foo())
+  fold acc(Foo_unique(anon_0), write)
+  anon_5 := anon_0
+  anon_4 := f_fakePrint_args_Foo_ret_Unit(anon_5)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Bar())
+  fold acc(Bar_unique(anon_1), write)
+  anon_7 := anon_1
+  anon_6 := f_fakePrint_args_Bar_ret_Unit(anon_7)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
@@ -152,14 +160,26 @@ method testClassFunctionOverloading() returns (v_ret_0: Ref)
 {
   var l0_b: Ref
   var anon_0: Ref
-  var anon_1: Ref
-  var anon_2: Ref
   var anon_3: Ref
-  l0_b := con_c_Bar()
-  anon_1 := con_Foo()
-  anon_0 := c_Bar_f_baz_args_c_Bar_Foo_ret_Unit(l0_b, anon_1)
-  anon_3 := con_c_Bar()
-  anon_2 := c_Bar_f_baz_args_c_Bar_c_Bar_ret_Unit(l0_b, anon_3)
+  var anon_4: Ref
+  var anon_1: Ref
+  var anon_5: Ref
+  var anon_6: Ref
+  var anon_2: Ref
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), c_Bar())
+  fold acc(c_Bar_unique(anon_0), write)
+  l0_b := anon_0
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), Foo())
+  fold acc(Foo_unique(anon_1), write)
+  anon_4 := anon_1
+  anon_3 := c_Bar_f_baz_args_c_Bar_Foo_ret_Unit(l0_b, anon_4)
+  anon_2 := new()
+  inhale isSubtype(typeOf(anon_2), c_Bar())
+  fold acc(c_Bar_unique(anon_2), write)
+  anon_6 := anon_2
+  anon_5 := c_Bar_f_baz_args_c_Bar_c_Bar_ret_Unit(l0_b, anon_6)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/custom_run_functions.fir.diag.txt
@@ -709,41 +709,45 @@ method testCustomClass() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var custom: Ref
-  var cond1: Ref
   var anon_0: Ref
+  var cond1: Ref
   var anon_1: Ref
-  var v_ret_4: Ref
   var anon_2: Ref
-  var v_ret_5: Ref
+  var v_ret_4: Ref
   var anon_3: Ref
+  var v_ret_5: Ref
   var anon_4: Ref
-  var v_ret_8: Ref
   var anon_5: Ref
+  var v_ret_8: Ref
+  var anon_6: Ref
   var v_ret_9: Ref
-  custom := con()
+  anon_0 := new()
+  inhale isSubtype(typeOf(anon_0), CustomClass())
+  fold acc(CustomClass_unique(anon_0), write)
+  custom := anon_0
   v_ret_5 := member(custom)
   goto lbl_ret_5
   label lbl_ret_5
-  anon_2 := v_ret_5
-  v_ret_4 := anon_2
+  anon_3 := v_ret_5
+  v_ret_4 := anon_3
   inhale isSubtype(typeOf(v_ret_4), nullable(anyType()))
   goto lbl_ret_4
   label lbl_ret_4
-  anon_1 := v_ret_4
-  anon_0 := anon_1
-  inhale isSubtype(typeOf(anon_0), intType())
+  anon_2 := v_ret_4
+  anon_1 := anon_2
+  inhale isSubtype(typeOf(anon_1), intType())
   v_ret_9 := member(custom)
   goto lbl_ret_9
   label lbl_ret_9
-  anon_5 := v_ret_9
-  v_ret_8 := anon_5
+  anon_6 := v_ret_9
+  v_ret_8 := anon_6
   inhale isSubtype(typeOf(v_ret_8), nullable(anyType()))
   goto lbl_ret_8
   label lbl_ret_8
-  anon_4 := v_ret_8
-  anon_3 := anon_4
-  inhale isSubtype(typeOf(anon_3), intType())
-  cond1 := boolToRef(intFromRef(anon_0) == intFromRef(anon_3))
+  anon_5 := v_ret_8
+  anon_4 := anon_5
+  inhale isSubtype(typeOf(anon_4), intType())
+  cond1 := boolToRef(intFromRef(anon_1) == intFromRef(anon_4))
   assert boolFromRef(cond1)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/inlining/viper_casts_while_inlining.fir.diag.txt
@@ -19,45 +19,52 @@ method checkMemberAccess() returns (v_ret_0: Ref)
   ensures boolFromRef(v_ret_0) == true
 {
   var obj: Ref
-  var anon_1: Ref
-  var anon_2: Ref
-  var v_ret_5: Ref
-  var anon_3: Ref
-  var v_ret_7: Ref
   var anon_0: Ref
+  var anon_1: Ref
+  var anon_3: Ref
   var anon_4: Ref
+  var v_ret_5: Ref
   var anon_5: Ref
+  var v_ret_7: Ref
+  var anon_2: Ref
   var anon_6: Ref
-  var v_ret_10: Ref
   var anon_7: Ref
+  var anon_8: Ref
+  var v_ret_10: Ref
+  var anon_9: Ref
   var v_ret_11: Ref
-  obj := con(intToRef(42))
+  anon_0 := intToRef(42)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), ClassWithMember())
+  inhale intFromRef(g_member(anon_1)) == intFromRef(anon_0)
+  fold acc(ClassWithMember_unique(anon_1), write)
+  obj := anon_1
   inhale isSubtype(typeOf(obj), nullable(anyType()))
-  anon_4 := idFun(obj)
-  anon_0 := anon_4
-  inhale isSubtype(typeOf(anon_0), ClassWithMember())
-  v_ret_7 := g_member(anon_0)
+  anon_6 := idFun(obj)
+  anon_2 := anon_6
+  inhale isSubtype(typeOf(anon_2), ClassWithMember())
+  v_ret_7 := g_member(anon_2)
   goto lbl_ret_7
   label lbl_ret_7
-  anon_3 := v_ret_7
-  v_ret_5 := anon_3
+  anon_5 := v_ret_7
+  v_ret_5 := anon_5
   inhale isSubtype(typeOf(v_ret_5), nullable(anyType()))
   goto lbl_ret_5
   label lbl_ret_5
-  anon_2 := v_ret_5
-  anon_1 := anon_2
-  inhale isSubtype(typeOf(anon_1), intType())
+  anon_4 := v_ret_5
+  anon_3 := anon_4
+  inhale isSubtype(typeOf(anon_3), intType())
   v_ret_0 := boolToRef(intFromRef(g_member(obj)) == 42)
   goto lbl_ret_0
   label lbl_ret_11
-  anon_7 := v_ret_11
-  v_ret_10 := anon_7
+  anon_9 := v_ret_11
+  v_ret_10 := anon_9
   inhale isSubtype(typeOf(v_ret_10), nullable(anyType()))
   goto lbl_ret_10
   label lbl_ret_10
-  anon_6 := v_ret_10
-  anon_5 := anon_6
-  inhale isSubtype(typeOf(anon_5), nothingType())
+  anon_8 := v_ret_10
+  anon_7 := anon_8
+  inhale isSubtype(typeOf(anon_7), nothingType())
   label lbl_ret_0
 }
 
@@ -99,17 +106,19 @@ method checkGenericMemberAccess(box: Ref) returns (v_ret_0: Ref)
   var v_ret_4: Ref
   var v_ret_6: Ref
   var anon_0: Ref
-  var anon_2: Ref
-  var anon_3: Ref
   var anon_4: Ref
-  var v_ret_10: Ref
-  var anon_1: Ref
   var anon_5: Ref
   var anon_6: Ref
+  var v_ret_10: Ref
+  var anon_3: Ref
+  var anon_7: Ref
+  var anon_1: Ref
+  var anon_2: Ref
+  var anon_8: Ref
   var v_ret_11: Ref
   inhale isSubtype(typeOf(box), nullable(anyType()))
-  anon_2 := idFun(box)
-  anon_0 := anon_2
+  anon_4 := idFun(box)
+  anon_0 := anon_4
   inhale isSubtype(typeOf(anon_0), Box())
   v_ret_6 := g_wrapped(anon_0)
   goto lbl_ret_6
@@ -117,21 +126,26 @@ method checkGenericMemberAccess(box: Ref) returns (v_ret_0: Ref)
   v_ret_4 := v_ret_6
   goto lbl_ret_4
   label lbl_ret_4
-  anon_5 := con(g_wrapped(box))
-  anon_1 := anon_5
-  inhale isSubtype(typeOf(anon_1), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_1), Box())
-  v_ret_0 := boolToRef(g_wrapped(anon_1) == g_wrapped(box))
+  anon_1 := g_wrapped(box)
+  anon_2 := new()
+  inhale isSubtype(typeOf(anon_2), Box())
+  inhale g_wrapped(anon_2) == anon_1
+  fold acc(Box_unique(anon_2), write)
+  anon_7 := anon_2
+  anon_3 := anon_7
+  inhale isSubtype(typeOf(anon_3), nullable(anyType()))
+  inhale isSubtype(typeOf(anon_3), Box())
+  v_ret_0 := boolToRef(g_wrapped(anon_3) == g_wrapped(box))
   goto lbl_ret_0
   label lbl_ret_11
-  anon_6 := v_ret_11
-  v_ret_10 := anon_6
+  anon_8 := v_ret_11
+  v_ret_10 := anon_8
   inhale isSubtype(typeOf(v_ret_10), nullable(anyType()))
   goto lbl_ret_10
   label lbl_ret_10
-  anon_4 := v_ret_10
-  anon_3 := anon_4
-  inhale isSubtype(typeOf(anon_3), nothingType())
+  anon_6 := v_ret_10
+  anon_5 := anon_6
+  inhale isSubtype(typeOf(anon_5), nothingType())
   label lbl_ret_0
 }
 

--- a/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/manualFolding.fir.diag.txt
@@ -123,17 +123,26 @@ method combine(par_left: Ref, par_right: Ref) returns (v_ret_0: Ref)
   ensures acc(Tree_unique(v_ret_0), write)
 {
   var l0_data: Ref
-  var anon_0: Ref
   var anon_1: Ref
+  var anon_2: Ref
   var res: Ref
+  var anon_0: Ref
   unfold acc(Tree_unique(par_left), write)
   unfold acc(Tree_unique(par_right), write)
-  anon_0 := par_left.bf_data
-  anon_1 := par_right.bf_data
-  l0_data := plusInts(anon_0, anon_1)
+  anon_1 := par_left.bf_data
+  anon_2 := par_right.bf_data
+  l0_data := plusInts(anon_1, anon_2)
   fold acc(Tree_unique(par_left), write)
   fold acc(Tree_unique(par_right), write)
-  res := con_Tree(par_left, par_right, l0_data)
+  anon_0 := new(bf_left, bf_right, bf_data)
+  inhale isSubtype(typeOf(anon_0), Tree())
+  inhale isSubtype(typeOf(par_left), nullable(Tree()))
+  anon_0.bf_left := par_left
+  inhale isSubtype(typeOf(par_right), nullable(Tree()))
+  anon_0.bf_right := par_right
+  anon_0.bf_data := l0_data
+  fold acc(Tree_unique(anon_0), write)
+  res := anon_0
   v_ret_0 := res
   goto lbl_ret_0
   label lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/multiple_receivers.fir.diag.txt
@@ -81,45 +81,52 @@ method applyInlineDelta(v_this: Ref, v_this_extension: Ref)
 method checkClassWithExtension() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
-  var anon_2: Ref
-  var anon_3: Ref
-  var v_ret_4: Ref
-  var anon_0: Ref
   var anon_4: Ref
   var anon_5: Ref
-  var v_ret_5: Ref
+  var v_ret_4: Ref
+  var anon_2: Ref
   var anon_6: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   var anon_7: Ref
+  var v_ret_5: Ref
   var anon_8: Ref
   var anon_9: Ref
+  var anon_10: Ref
+  var anon_11: Ref
   var v_ret_10: Ref
-  var anon_1: Ref
-  anon_4 := con(intToRef(42))
-  anon_0 := anon_4
-  inhale isSubtype(typeOf(anon_0), nullable(anyType()))
-  inhale isSubtype(typeOf(anon_0), ClassWithExtension())
-  anon_6 := applyDelta(anon_0, intToRef(42))
-  inhale isSubtype(typeOf(anon_0), ClassWithExtension())
-  anon_7 := returnDelta(anon_0)
-  inhale isSubtype(typeOf(anon_0), ClassWithExtension())
-  anon_8 := extensionReturnDelta(anon_0)
-  anon_1 := intToRef(42)
-  inhale isSubtype(typeOf(anon_0), ClassWithExtension())
-  v_ret_10 := plusInts(anon_1, g_delta(anon_0))
+  var anon_3: Ref
+  anon_0 := intToRef(42)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), ClassWithExtension())
+  inhale intFromRef(g_delta(anon_1)) == intFromRef(anon_0)
+  fold acc(ClassWithExtension_unique(anon_1), write)
+  anon_6 := anon_1
+  anon_2 := anon_6
+  inhale isSubtype(typeOf(anon_2), nullable(anyType()))
+  inhale isSubtype(typeOf(anon_2), ClassWithExtension())
+  anon_8 := applyDelta(anon_2, intToRef(42))
+  inhale isSubtype(typeOf(anon_2), ClassWithExtension())
+  anon_9 := returnDelta(anon_2)
+  inhale isSubtype(typeOf(anon_2), ClassWithExtension())
+  anon_10 := extensionReturnDelta(anon_2)
+  anon_3 := intToRef(42)
+  inhale isSubtype(typeOf(anon_2), ClassWithExtension())
+  v_ret_10 := plusInts(anon_3, g_delta(anon_2))
   goto lbl_ret_10
   label lbl_ret_10
-  anon_9 := v_ret_10
-  assert intFromRef(anon_9) == 84
+  anon_11 := v_ret_10
+  assert intFromRef(anon_11) == 84
   label lbl_ret_5
   inhale isSubtype(typeOf(v_ret_5), unitType())
-  anon_5 := v_ret_5
-  v_ret_4 := anon_5
+  anon_7 := v_ret_5
+  v_ret_4 := anon_7
   inhale isSubtype(typeOf(v_ret_4), nullable(anyType()))
   goto lbl_ret_4
   label lbl_ret_4
-  anon_3 := v_ret_4
-  anon_2 := anon_3
-  inhale isSubtype(typeOf(anon_2), unitType())
+  anon_5 := v_ret_4
+  anon_4 := anon_5
+  inhale isSubtype(typeOf(anon_4), unitType())
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/negative/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/negative/binary_tree.fir.diag.txt
@@ -92,29 +92,104 @@ method test() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var n: Ref
+  var anon_16: Ref
+  var anon_17: Ref
+  var anon_20: Ref
   var anon_0: Ref
   var anon_1: Ref
   var anon_2: Ref
   var anon_3: Ref
-  var expr1: Ref
+  var anon_18: Ref
+  var anon_21: Ref
+  var anon_12: Ref
+  var anon_13: Ref
+  var anon_22: Ref
   var anon_4: Ref
-  var expr2: Ref
   var anon_5: Ref
-  anon_0 := con(intToRef(4), nullValue(), nullValue())
-  anon_2 := con(intToRef(2), nullValue(), nullValue())
-  anon_3 := con(intToRef(1), nullValue(), nullValue())
-  anon_1 := con(intToRef(3), anon_2, anon_3)
-  n := con(intToRef(5), anon_0, anon_1)
-  anon_4 := havoc(intType())
-  expr1 := boolToRef(intFromRef(anon_4) == 5)
+  var anon_6: Ref
+  var anon_7: Ref
+  var anon_14: Ref
+  var anon_23: Ref
+  var anon_8: Ref
+  var anon_9: Ref
+  var anon_10: Ref
+  var anon_11: Ref
+  var anon_15: Ref
+  var anon_19: Ref
+  var expr1: Ref
+  var anon_24: Ref
+  var expr2: Ref
+  var anon_25: Ref
+  anon_16 := intToRef(5)
+  anon_0 := intToRef(4)
+  anon_1 := nullValue()
+  inhale isSubtype(typeOf(anon_1), nullable(Node()))
+  anon_2 := nullValue()
+  inhale isSubtype(typeOf(anon_2), nullable(Node()))
+  anon_3 := new(bf_data)
+  inhale isSubtype(typeOf(anon_3), Node())
+  anon_3.bf_data := anon_0
+  inhale g_left(anon_3) == anon_1
+  inhale g_right(anon_3) == anon_2
+  fold acc(Node_unique(anon_3), write)
+  anon_20 := anon_3
+  anon_17 := anon_20
+  inhale isSubtype(typeOf(anon_17), nullable(Node()))
+  anon_12 := intToRef(3)
+  anon_4 := intToRef(2)
+  anon_5 := nullValue()
+  inhale isSubtype(typeOf(anon_5), nullable(Node()))
+  anon_6 := nullValue()
+  inhale isSubtype(typeOf(anon_6), nullable(Node()))
+  anon_7 := new(bf_data)
+  inhale isSubtype(typeOf(anon_7), Node())
+  anon_7.bf_data := anon_4
+  inhale g_left(anon_7) == anon_5
+  inhale g_right(anon_7) == anon_6
+  fold acc(Node_unique(anon_7), write)
+  anon_22 := anon_7
+  anon_13 := anon_22
+  inhale isSubtype(typeOf(anon_13), nullable(Node()))
+  anon_8 := intToRef(1)
+  anon_9 := nullValue()
+  inhale isSubtype(typeOf(anon_9), nullable(Node()))
+  anon_10 := nullValue()
+  inhale isSubtype(typeOf(anon_10), nullable(Node()))
+  anon_11 := new(bf_data)
+  inhale isSubtype(typeOf(anon_11), Node())
+  anon_11.bf_data := anon_8
+  inhale g_left(anon_11) == anon_9
+  inhale g_right(anon_11) == anon_10
+  fold acc(Node_unique(anon_11), write)
+  anon_23 := anon_11
+  anon_14 := anon_23
+  inhale isSubtype(typeOf(anon_14), nullable(Node()))
+  anon_15 := new(bf_data)
+  inhale isSubtype(typeOf(anon_15), Node())
+  anon_15.bf_data := anon_12
+  inhale g_left(anon_15) == anon_13
+  inhale g_right(anon_15) == anon_14
+  fold acc(Node_unique(anon_15), write)
+  anon_21 := anon_15
+  anon_18 := anon_21
+  inhale isSubtype(typeOf(anon_18), nullable(Node()))
+  anon_19 := new(bf_data)
+  inhale isSubtype(typeOf(anon_19), Node())
+  anon_19.bf_data := anon_16
+  inhale g_left(anon_19) == anon_17
+  inhale g_right(anon_19) == anon_18
+  fold acc(Node_unique(anon_19), write)
+  n := anon_19
+  anon_24 := havoc(intType())
+  expr1 := boolToRef(intFromRef(anon_24) == 5)
   assert boolFromRef(expr1)
   if (g_left(n) != nullValue()) {
-    var anon_6: Ref
-    anon_6 := havoc(intType())
-    anon_5 := anon_6
+    var anon_26: Ref
+    anon_26 := havoc(intType())
+    anon_25 := anon_26
   } else {
-    anon_5 := nullValue()}
-  expr2 := boolToRef(anon_5 == intToRef(4))
+    anon_25 := nullValue()}
+  expr2 := boolToRef(anon_25 == intToRef(4))
   assert boolFromRef(expr2)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/negative/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/negative/linked_list.fir.diag.txt
@@ -76,23 +76,45 @@ method test() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var l: Ref
+  var anon_3: Ref
+  var anon_4: Ref
+  var anon_6: Ref
   var anon_0: Ref
-  var expr1: Ref
   var anon_1: Ref
-  var expr2: Ref
   var anon_2: Ref
-  anon_0 := con(intToRef(3), nullValue())
-  l := con(intToRef(5), anon_0)
-  anon_1 := havoc(intType())
-  expr1 := boolToRef(intFromRef(anon_1) == 5)
+  var anon_5: Ref
+  var expr1: Ref
+  var anon_7: Ref
+  var expr2: Ref
+  var anon_8: Ref
+  anon_3 := intToRef(5)
+  anon_0 := intToRef(3)
+  anon_1 := nullValue()
+  inhale isSubtype(typeOf(anon_1), nullable(Link()))
+  anon_2 := new(bf_data)
+  inhale isSubtype(typeOf(anon_2), Link())
+  anon_2.bf_data := anon_0
+  inhale g_next(anon_2) == anon_1
+  fold acc(Link_unique(anon_2), write)
+  anon_6 := anon_2
+  anon_4 := anon_6
+  inhale isSubtype(typeOf(anon_4), nullable(Link()))
+  anon_5 := new(bf_data)
+  inhale isSubtype(typeOf(anon_5), Link())
+  anon_5.bf_data := anon_3
+  inhale g_next(anon_5) == anon_4
+  fold acc(Link_unique(anon_5), write)
+  l := anon_5
+  anon_7 := havoc(intType())
+  expr1 := boolToRef(intFromRef(anon_7) == 5)
   assert boolFromRef(expr1)
   if (g_next(l) != nullValue()) {
-    var anon_3: Ref
-    anon_3 := havoc(intType())
-    anon_2 := anon_3
+    var anon_9: Ref
+    anon_9 := havoc(intType())
+    anon_8 := anon_9
   } else {
-    anon_2 := nullValue()}
-  expr2 := boolToRef(anon_2 == intToRef(3))
+    anon_8 := nullValue()}
+  expr2 := boolToRef(anon_8 == intToRef(3))
   assert boolFromRef(expr2)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())

--- a/formver.compiler-plugin/testData/diagnostics/verification/types/generics.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/types/generics.fir.diag.txt
@@ -25,17 +25,33 @@ method createBox() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), intType())
 {
   var boolBox: Ref
-  var b: Ref
   var anon_0: Ref
-  var intBox: Ref
   var anon_1: Ref
-  boolBox := con(boolToRef(true))
-  anon_0 := havoc(nullable(anyType()))
-  b := anon_0
+  var b: Ref
+  var anon_4: Ref
+  var intBox: Ref
+  var anon_2: Ref
+  var anon_3: Ref
+  var anon_5: Ref
+  anon_0 := boolToRef(true)
+  inhale isSubtype(typeOf(anon_0), nullable(anyType()))
+  anon_1 := new(bf_t)
+  inhale isSubtype(typeOf(anon_1), Box())
+  anon_1.bf_t := anon_0
+  fold acc(Box_unique(anon_1), write)
+  boolBox := anon_1
+  anon_4 := havoc(nullable(anyType()))
+  b := anon_4
   inhale isSubtype(typeOf(b), boolType())
-  intBox := con(intToRef(2))
-  anon_1 := havoc(nullable(anyType()))
-  v_ret_0 := anon_1
+  anon_2 := intToRef(2)
+  inhale isSubtype(typeOf(anon_2), nullable(anyType()))
+  anon_3 := new(bf_t)
+  inhale isSubtype(typeOf(anon_3), Box())
+  anon_3.bf_t := anon_2
+  fold acc(Box_unique(anon_3), write)
+  intBox := anon_3
+  anon_5 := havoc(nullable(anyType()))
+  v_ret_0 := anon_5
   inhale isSubtype(typeOf(v_ret_0), intType())
   goto lbl_ret_0
   label lbl_ret_0
@@ -55,7 +71,15 @@ method setGenericField() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var box: Ref
-  box := con(intToRef(3))
+  var anon_0: Ref
+  var anon_1: Ref
+  anon_0 := intToRef(3)
+  inhale isSubtype(typeOf(anon_0), nullable(anyType()))
+  anon_1 := new(bf_t)
+  inhale isSubtype(typeOf(anon_1), Box())
+  anon_1.bf_t := anon_0
+  fold acc(Box_unique(anon_1), write)
+  box := anon_1
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.fir.diag.txt
@@ -106,16 +106,16 @@ function length(l: Ref): Ref
   ensures isSubtype(typeOf(result), intType())
   ensures intFromRef(result) >= 0
 {
-  (let anon_1_0 ==
+  (let anon_2_0 ==
     ((l == nullValue() ? intToRef(0) : null)) in
-    (let anon_2_0 ==
+    (let anon_3_0 ==
       ((!(l == nullValue()) ?
         plusInts(intToRef(1), (unfolding acc(Link_unique(l), write) in
           length(g_next(l)))) :
         null)) in
-      (let anon_0_0 ==
-        ((l == nullValue() ? anon_1_0 : anon_2_0)) in
-        anon_0_0)))
+      (let anon_1_0 ==
+        ((l == nullValue() ? anon_2_0 : anon_3_0)) in
+        anon_1_0)))
 }
 
 predicate Link_unique(this: Ref) {
@@ -144,7 +144,13 @@ method pushFront(tail: Ref, d: Ref) returns (v_ret_0: Ref)
   ensures acc(Link_unique(v_ret_0), write)
   ensures intFromRef(length(v_ret_0)) == old(intFromRef(length(tail))) + 1
 {
-  v_ret_0 := con(d, tail)
+  var anon_0: Ref
+  anon_0 := new(bf_data)
+  inhale isSubtype(typeOf(anon_0), Link())
+  anon_0.bf_data := d
+  inhale g_next(anon_0) == tail
+  fold acc(Link_unique(anon_0), write)
+  v_ret_0 := anon_0
   goto lbl_ret_0
   label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.kt
@@ -16,8 +16,8 @@ fun <!VIPER_TEXT!>callLength<!>(l: @Unique @Borrowed Link?) {
     verify(length(l) == length(l))
 }
 
-<!VIPER_VERIFICATION_ERROR!>@AlwaysVerify
+@AlwaysVerify
 fun <!VIPER_TEXT!>pushFront<!>(tail: @Unique Link?, d: Int): @Unique Link {
     postconditions<Link> { new -> length(new) == old(length(tail)) + 1 }
     return Link(d, tail)
-}<!>
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.viper.diag.txt
@@ -1,1 +1,0 @@
-/pure_recursion.kt: warning: Viper verification error: Postcondition of pushFront might not hold. Assertion intFromRef(length(v_ret_0)) == old(intFromRef(length(tail))) + 1 might not hold.

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/loops.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/loops.fir.diag.txt
@@ -152,15 +152,22 @@ method test_boolean_postcondition() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var withVar: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   var boolean: Ref
-  var anon: Ref
-  withVar := con(intToRef(42))
+  var anon_2: Ref
+  anon_0 := intToRef(42)
+  anon_1 := new(bf_e)
+  inhale isSubtype(typeOf(anon_1), WithVar())
+  anon_1.bf_e := anon_0
+  fold acc(WithVar_unique(anon_1), write)
+  withVar := anon_1
   boolean := boolToRef(true)
   label cont
     invariant isSubtype(typeOf(withVar), WithVar())
     invariant isSubtype(typeOf(boolean), boolType())
-  anon := boolean
-  if (boolFromRef(anon)) {
+  anon_2 := boolean
+  if (boolFromRef(anon_2)) {
     boolean := doSomething(withVar)
     goto cont
   }
@@ -195,12 +202,19 @@ method test_while(param: Ref) returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var c: Ref
+  var anon_0: Ref
+  var anon_1: Ref
   var initParamField: Ref
   var iteration: Ref
-  var anon: Ref
+  var anon_2: Ref
   var cond1: Ref
   var cond2: Ref
-  c := con(intToRef(13))
+  anon_0 := intToRef(13)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), ClassWithField())
+  inhale intFromRef(g_field(anon_1)) == intFromRef(anon_0)
+  fold acc(ClassWithField_unique(anon_1), write)
+  c := anon_1
   initParamField := g_field(param)
   if (intFromRef(initParamField) > 0) {
     iteration := intToRef(0)
@@ -214,8 +228,8 @@ method test_while(param: Ref) returns (v_ret_0: Ref)
     invariant isSubtype(typeOf(initParamField), intType())
     invariant isSubtype(typeOf(iteration), intType())
     invariant isSubtype(typeOf(param), ClassWithField())
-  anon := ltInts(iteration, intToRef(10))
-  if (boolFromRef(anon)) {
+  anon_2 := ltInts(iteration, intToRef(10))
+  if (boolFromRef(anon_2)) {
     var l4_field: Ref
     var paramField: Ref
     l4_field := g_field(c)
@@ -266,55 +280,69 @@ method test_while_with_inlining(param: Ref) returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), unitType())
 {
   var local: Ref
-  var anon_1: Ref
-  var anon_2: Ref
-  var v_ret_4: Ref
   var anon_0: Ref
-  var anon_3: Ref
+  var anon_1: Ref
+  var anon_5: Ref
+  var anon_6: Ref
+  var v_ret_4: Ref
   var anon_4: Ref
+  var anon_7: Ref
+  var anon_2: Ref
+  var anon_3: Ref
+  var anon_8: Ref
   var v_ret_5: Ref
   var iteration: Ref
-  var anon_5: Ref
-  local := con(intToRef(13))
-  anon_3 := con(intToRef(42))
-  anon_0 := anon_3
-  inhale isSubtype(typeOf(anon_0), nullable(anyType()))
+  var anon_9: Ref
+  anon_0 := intToRef(13)
+  anon_1 := new()
+  inhale isSubtype(typeOf(anon_1), ClassWithField())
+  inhale intFromRef(g_field(anon_1)) == intFromRef(anon_0)
+  fold acc(ClassWithField_unique(anon_1), write)
+  local := anon_1
+  anon_2 := intToRef(42)
+  anon_3 := new()
+  inhale isSubtype(typeOf(anon_3), ClassWithField())
+  inhale intFromRef(g_field(anon_3)) == intFromRef(anon_2)
+  fold acc(ClassWithField_unique(anon_3), write)
+  anon_7 := anon_3
+  anon_4 := anon_7
+  inhale isSubtype(typeOf(anon_4), nullable(anyType()))
   iteration := intToRef(0)
   label cont
     invariant isSubtype(typeOf(iteration), intType())
-    invariant isSubtype(typeOf(anon_0), nullable(anyType()))
+    invariant isSubtype(typeOf(anon_4), nullable(anyType()))
     invariant isSubtype(typeOf(local), ClassWithField())
     invariant isSubtype(typeOf(param), ClassWithField())
-  anon_5 := ltInts(iteration, intToRef(10))
-  if (boolFromRef(anon_5)) {
+  anon_9 := ltInts(iteration, intToRef(10))
+  if (boolFromRef(anon_9)) {
     var paramField: Ref
     var localField: Ref
     var thisField: Ref
     paramField := g_field(param)
     localField := g_field(local)
-    inhale isSubtype(typeOf(anon_0), ClassWithField())
-    thisField := g_field(anon_0)
+    inhale isSubtype(typeOf(anon_4), ClassWithField())
+    thisField := g_field(anon_4)
     iteration := plusInts(iteration, intToRef(1))
     goto cont
   }
   label break
   assert isSubtype(typeOf(iteration), intType())
-  assert isSubtype(typeOf(anon_0), nullable(anyType()))
+  assert isSubtype(typeOf(anon_4), nullable(anyType()))
   assert isSubtype(typeOf(local), ClassWithField())
   assert isSubtype(typeOf(param), ClassWithField())
-  inhale isSubtype(typeOf(anon_0), ClassWithField())
-  assert intFromRef(g_field(anon_0)) == 42
+  inhale isSubtype(typeOf(anon_4), ClassWithField())
+  assert intFromRef(g_field(anon_4)) == 42
   assert intFromRef(g_field(local)) == 13
   label lbl_ret_5
   inhale isSubtype(typeOf(v_ret_5), unitType())
-  anon_4 := v_ret_5
-  v_ret_4 := anon_4
+  anon_8 := v_ret_5
+  v_ret_4 := anon_8
   inhale isSubtype(typeOf(v_ret_4), nullable(anyType()))
   goto lbl_ret_4
   label lbl_ret_4
-  anon_2 := v_ret_4
-  anon_1 := anon_2
-  inhale isSubtype(typeOf(anon_1), unitType())
+  anon_6 := v_ret_4
+  anon_5 := anon_6
+  inhale isSubtype(typeOf(anon_5), unitType())
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Stmt.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Stmt.kt
@@ -277,6 +277,35 @@ sealed interface Stmt : WithSilverMetadata, IntoSilver<viper.silver.ast.Stmt> {
         }
     }
 
+    /**
+     * Allocates a fresh reference into [lhs] and grants write permission to each of [fields] on it.
+     *
+     * The freshness is what makes this usable in place of a havoc: the allocated reference is
+     * distinct from every reference reachable beforehand, so heap-dependent functions applied to
+     * it cannot be conflated with their pre-allocation values.
+     */
+    data class New(
+        val lhs: Exp.LocalVar,
+        val fields: List<Field>,
+        override val pos: Position = Position.NoPosition,
+        override val info: Info = Info.NoInfo,
+    ) : Stmt {
+        context(nameResolver: NameResolver)
+        override fun toSilver(): viper.silver.ast.NewStmt = viper.silver.ast.NewStmt(
+            lhs.toSilver(),
+            fields.toSilver().toScalaSeq(),
+            pos.toSilver(),
+            info.toSilver(),
+            silverNoTrafos
+        )
+
+        context(nameResolver: NameResolver)
+        override fun registerNames() {
+            nameResolver.register(lhs.name)
+            fields.forEach { nameResolver.register(it.name) }
+        }
+    }
+
     data class Fold(
         val acc: Exp.PredicateAccess,
         override val pos: Position = Position.NoPosition,


### PR DESCRIPTION
A constructor was a bodyless Viper method whose postcondition promised `acc(C_unique(ret), write)` and nothing about what the predicate contains. Silicon gives such an inhaled predicate an unconstrained snapshot, so a heap-dependent function reading through a nested predicate is unrelated to the values the constructor was given. `length(new) == old(length(tail)) + 1` on a linked-list push was unprovable — not because it is false, but because the contract could not express it.

A primary constructor call now builds the object at the call site: allocate with Silver's `NewStmt`, whose reference is genuinely fresh; write the parameters that back properties; fold the class predicate, which ties its snapshot to the heap just written.

`pure_recursion` verifies clean as a result — `pure_recursion.viper.diag.txt` regenerated empty and was removed.

## Shape

```
obj := new(<every backing field of C and its supertypes>)
inhale isSubtype(typeOf(obj), C())
obj.bf_x := arg          // parameter backing a `var`
inhale g_y(obj) == arg   // parameter backing a `val` (permission-free accessor)
<residual assumptions>
fold acc(S_unique(obj), write)   // each supertype, innermost first
fold acc(C_unique(obj), write)
```

## What this assumes

Folding forces the predicate body to be *proven*, where the opaque method merely assumed it. Two conjuncts no argument establishes are inhaled so the fold goes through:

- the type of a backing field no parameter writes, since a Kotlin initializer in the class body is not converted today;
- the unique predicate of a `@Unique` property in the same position — emitted, but no test exercises it.

`con_C` assumed all of this wholesale in its postcondition, so this assumes no more than the call it replaces.

## Notes for review

- **Specification constructors are exempt.** `UniquePred(x)` is itself a primary constructor call, and `fold`/`unfold` pattern-match the method call it converts to. Constructors carrying `@SpecificationHelper` keep the call form.
- **The diamond's shared predicate is folded once per path, and that is required, not incidental.** `Diamond_unique` nests `LeftBranch_unique` and `RightBranch_unique`; each nests its own `Apex_unique`. Two instances are consumed, so one fold would leave the second branch short. It succeeds because a shared apex is necessarily an interface, and an interface predicate carries no permission — `Apex_unique(this)` is `isSubtype(typeOf(this), Apex())` alone. `construction_through_hierarchy.kt` renders these bodies so the claim is checkable by reading the golden.
- **Superclass constructors are still not run.** `B(fieldB) : A(C())` allocates and folds `A_unique` without evaluating `A(C())`, so `g_fieldNotOverride(b)` stays unconstrained. Identical to the opaque path — no regression — but the gap is now visible in the emitted Viper instead of hidden behind an assumed postcondition.
- **`con_C` is still emitted** although nothing calls it now. Removing it is a separate change.
- Most of the golden churn is anon-var renumbering: the block's result is a variable, so callers emit one extra hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)