### PR TITLE
Make recursive @Pure functions over @Unique structures verify

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -46,6 +46,8 @@ fun abs(x: Int): Int {
 ```
 
 Multiple conditions are implicitly conjoined. The postconditions block receives the return value as its parameter.
+Its type argument spells the return type without `@Unique` or `@Borrowed`, which the parameter inherits from the
+function's signature.
 
 ## Loop Invariants
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
@@ -6,11 +6,16 @@
 package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.withAttributes
 import org.jetbrains.kotlin.formver.core.isFormverFunctionNamed
+import org.jetbrains.kotlin.formver.locality.plugin.LocalityAttribute
+import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessAttribute
 
 fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Boolean): FirAnonymousFunction? {
     if (this !is FirFunctionCall) return null
@@ -31,23 +36,50 @@ data class FirSpecification(val precond: FirBlock?, val postcond: FirBlock?, val
     constructor() : this(null, null, null)
 }
 
+/**
+ * Drops the attributes that a specification binder inherits rather than restates.
+ *
+ * `@Unique` and `@Borrowed` are rejected on a type argument, so a `postconditions` binder cannot spell out the
+ * uniqueness and locality of the value it stands for; it takes them from the signature instead.
+ */
+private fun ConeKotlinType.withoutInheritedAttributes(): ConeKotlinType =
+    withAttributes(attributes.remove(UniquenessAttribute).remove(LocalityAttribute))
+
 private fun FirAnonymousFunction.extractFormverReturnVar(returnType: ConeKotlinType): FirValueParameterSymbol {
     val param = valueParameters.first()
-    if (param.symbol.resolvedReturnType != returnType)
-        error("Expected type ${returnType} based on signature, got ${param.symbol.resolvedReturnType}")
+    val declaredType = param.symbol.resolvedReturnType
+    if (declaredType.withoutInheritedAttributes() != returnType.withoutInheritedAttributes())
+        error("Expected type ${returnType} based on signature, got ${declaredType}")
     return param.symbol
+}
+
+/**
+ * The lambda of the `postconditions` block of [this] body, if it has one.
+ */
+private fun FirBlock.extractPostconditionsLambda(): FirAnonymousFunction? {
+    val firstStmt = statements.firstOrNull() ?: return null
+
+    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }?.let { return it }
+    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("preconditions") } ?: return null
+
+    return statements.getOrNull(1)?.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
+}
+
+/**
+ * The parameter that the `postconditions` block of [this] function binds its return value to, if it has one.
+ */
+@OptIn(SymbolInternals::class)
+fun FirFunctionSymbol<*>.extractPostconditionsReturnVar(): FirValueParameterSymbol? {
+    val body = (fir as? FirSimpleFunction)?.body ?: return null
+    return body.extractPostconditionsLambda()?.valueParameters?.firstOrNull()?.symbol
 }
 
 fun extractFirSpecification(parentBlock: FirBlock, returnType: ConeKotlinType): FirSpecification {
     val firstStmt = parentBlock.statements.firstOrNull() ?: return FirSpecification()
 
-    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }?.let { lambda ->
-        return FirSpecification(null, lambda.body, lambda.extractFormverReturnVar(returnType))
-    }
-
     val precond = firstStmt.extractFormverFirBlock { isFormverFunctionNamed("preconditions") }
-        ?: return FirSpecification()
-    val postcond =
-        parentBlock.statements.getOrNull(1)?.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
-    return FirSpecification(precond.body, postcond?.body, postcond?.extractFormverReturnVar(returnType))
+    val postcond = parentBlock.extractPostconditionsLambda()
+    if (precond == null && postcond == null) return FirSpecification()
+
+    return FirSpecification(precond?.body, postcond?.body, postcond?.extractFormverReturnVar(returnType))
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/FieldAccessLowering.kt
@@ -15,16 +15,15 @@ import org.jetbrains.kotlin.formver.viper.ast.PermExp
 import org.jetbrains.kotlin.formver.viper.ast.Stmt
 
 /**
- * The unique-predicate access on [classOnPath] that must be unfolded to reach a field on a superclass
- * through [receiver].
+ * Full-permission access to the unique predicate of [classType] on [receiver].
  */
-fun hierarchyPredicateAccess(
+fun uniquePredicateAccess(
     receiver: Exp,
-    classOnPath: ClassTypeEmbedding,
+    classType: ClassTypeEmbedding,
     source: KtSourceElement?,
 ): Exp.PredicateAccess =
     Exp.PredicateAccess(
-        classOnPath.uniquePredicateName,
+        classType.uniquePredicateName,
         listOf(receiver),
         PermExp.FullPerm(),
         source.asPosition,
@@ -40,7 +39,7 @@ fun LinearizationContext.hierarchyPredicateAccesses(
     field: FieldEmbedding,
 ): Sequence<Exp.PredicateAccess> =
     typeResolver.hierarchyPathTo(receiverType.pretype, field)
-        .map { hierarchyPredicateAccess(receiver, it, source) }
+        .map { uniquePredicateAccess(receiver, it, source) }
 
 /**
  * Emits a `Stmt.Unfold` for each unique-predicate on the hierarchy path from [receiverType]

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -11,9 +11,11 @@ import org.jetbrains.kotlin.formver.core.conversion.AccessPolicy
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain
 import org.jetbrains.kotlin.formver.core.domains.RuntimeTypeDomain.Companion.isOf
 import org.jetbrains.kotlin.formver.core.embeddings.*
+import org.jetbrains.kotlin.formver.core.embeddings.callables.NonInlineCallable
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toFuncApp
 import org.jetbrains.kotlin.formver.core.embeddings.callables.toMethodCall
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
+import org.jetbrains.kotlin.formver.core.embeddings.properties.CustomGetter
 import org.jetbrains.kotlin.formver.core.embeddings.types.ClassTypeEmbedding
 import org.jetbrains.kotlin.formver.core.embeddings.types.fillHoles
 import org.jetbrains.kotlin.formver.core.embeddings.types.injection
@@ -116,10 +118,17 @@ data class LinearizationVisitor(
     }
 
     override fun visitFunctionCall(e: FunctionCall): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
-        override fun toViper(ctx: LinearizationContext): Exp = e.function.toFuncApp(
-            e.args.map { it.linearize().toViper(ctx) },
-            ctx.source.asPosition
-        )
+        override fun toViper(ctx: LinearizationContext): Exp {
+            val argExps = e.args.map { it.linearize().toViper(ctx) }
+            var result: Exp = e.function.toFuncApp(argExps, ctx.source.asPosition)
+            for ((formal, arg) in e.function.formalArgs.zip(e.args.zip(argExps))) {
+                val (argEmbedding, argExp) = arg
+                if (formal.isUnique) {
+                    result = ctx.unfoldingUniqueReads(argEmbedding, argExp, result)
+                }
+            }
+            return result
+        }
     }
 
     override fun visitInvokeFunctionObject(e: InvokeFunctionObject): Linearizable = object : DirectResultLinearizable(e, this@LinearizationVisitor) {
@@ -605,4 +614,42 @@ data class LinearizationVisitor(
     }
 
     // endregion
+}
+
+/**
+ * The class whose unique predicate holds the permissions for the value [callable] reads, if [callable]
+ * is the getter of a `@Unique` property that its class embeds as a function rather than as a field.
+ */
+private fun LinearizationContext.uniqueReadOwner(callable: NonInlineCallable): ClassTypeEmbedding? {
+    val owner = callable.callableType.dispatchReceiverType?.pretype as? ClassTypeEmbedding ?: return null
+    val property = typeResolver.lookupClassDefaultBehavingProperties(owner.name).firstOrNull {
+        (it.getter as? CustomGetter)?.getterMethod?.name == callable.name
+    } ?: return null
+    return owner.takeIf { property.isUnique }
+}
+
+/**
+ * [body], wrapped in the unfoldings that expose the permissions carried by the value [arg] reads.
+ *
+ * A `@Unique` property with no backing field is embedded as a permission-free function, so the
+ * permissions of the value it holds sit inside the unique predicate of the receiver it is read from.
+ * A chain of such reads needs one unfolding per link, with the receiver end outermost: unfolding one
+ * link is what grants access to the predicate of the next.
+ *
+ * [argExp] must be the Viper form of [arg]. The two are walked in lockstep, and the wrapping stops as
+ * soon as they cease to correspond, since only [argExp] may be reused: linearizing [arg] again would
+ * emit its statements a second time.
+ */
+private fun LinearizationContext.unfoldingUniqueReads(arg: ExpEmbedding, argExp: Exp, body: Exp): Exp {
+    val read = arg.ignoringCastsAndMetaNodes() as? FunctionCall ?: return body
+    val owner = uniqueReadOwner(read.function) ?: return body
+    val call = argExp as? Exp.FuncApp ?: return body
+    if (call.functionName != read.function.name) return body
+    val receiver = read.args.singleOrNull() ?: return body
+    val receiverExp = call.args.singleOrNull() ?: return body
+    return unfoldingUniqueReads(
+        receiver,
+        receiverExp,
+        Exp.Unfolding(uniquePredicateAccess(receiverExp, owner, source), body, source.asPosition),
+    )
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginExtensionRegistrar.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginExtensionRegistrar.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.formver.locality.plugin.LocalityErrors
 import org.jetbrains.kotlin.formver.uniqueness.plugin.ExpressionAccessStateResolver
 import org.jetbrains.kotlin.formver.uniqueness.plugin.ExpressionUniquenessResolver
 import org.jetbrains.kotlin.formver.uniqueness.plugin.GraphUniquenessStatesResolver
+import org.jetbrains.kotlin.formver.uniqueness.plugin.SymbolUniquenessResolver
 import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessAttributeExtension
 import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessErrors
 
@@ -41,6 +42,7 @@ class FormalVerificationPluginExtensionRegistrar(private val config: PluginConfi
         +ExpressionAccessStateResolver.getFactory()
         +ExpressionUniquenessResolver.getFactory()
         +GraphUniquenessStatesResolver.getFactory { it.isSpecificationCall() }
+        +SymbolUniquenessResolver.getFactory { it.resolveSpecificationBinderUniqueness() }
         +UniquenessAttributeExtension.getFactory()
 
         if (config.checkLocality) {

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/SpecificationBinderUniqueness.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/SpecificationBinderUniqueness.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.plugin.compiler
+
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
+import org.jetbrains.kotlin.formver.core.conversion.extractPostconditionsReturnVar
+import org.jetbrains.kotlin.formver.uniqueness.plugin.Uniqueness
+import org.jetbrains.kotlin.formver.uniqueness.plugin.scopeUniqueness
+
+/**
+ * The uniqueness [this] takes from the function it specifies, when it binds the return value of a `postconditions`
+ * block, and `null` otherwise.
+ *
+ * The binder stands for the value the function returns, so it is as unique as the declared return type. It cannot say
+ * so itself: `@Unique` is rejected on the type argument of `postconditions`.
+ */
+context(context: CheckerContext)
+fun FirVariableSymbol<*>.resolveSpecificationBinderUniqueness(): Uniqueness? {
+    if (this !is FirValueParameterSymbol) return null
+
+    val specifiedFunction = context.containingDeclarations
+        .lastOrNull { it is FirNamedFunctionSymbol } as? FirNamedFunctionSymbol
+        ?: return null
+    if (specifiedFunction.extractPostconditionsReturnVar() != this) return null
+
+    return specifiedFunction.resolvedReturnType.scopeUniqueness
+}

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -855,6 +855,22 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/uniqueness")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Uniqueness {
+      @Test
+      public void testAllFilesPresentInUniqueness() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/verification/uniqueness"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("pure_recursion.kt")
+      public void testPure_recursion() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/user_invariants")
     @TestDataPath("$PROJECT_ROOT")
     public class User_invariants {

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.fir.diag.txt
@@ -11,7 +11,8 @@ function length(l: Ref): Ref
     ((l == nullValue() ? intToRef(0) : null)) in
     (let anon_2_0 ==
       ((!(l == nullValue()) ?
-        plusInts(intToRef(1), length(next(l))) :
+        plusInts(intToRef(1), (unfolding acc(Link_unique(l), write) in
+          length(next(l)))) :
         null)) in
       (let anon_0_0 ==
         ((l == nullValue() ? anon_1_0 : anon_2_0)) in
@@ -27,4 +28,123 @@ predicate Link_unique(this: Ref) {
   isSubtype(typeOf(this), Link()) && acc(this.data, write) &&
   isSubtype(typeOf(this.data), intType()) &&
   (next(this) != nullValue() ==> acc(Link_unique(next(this)), write))
+}
+
+/pure_recursion.kt: info: Generated Viper text for callLength:
+field data: Ref
+
+function length(l: Ref): Ref
+  requires isSubtype(typeOf(l), nullable(Link()))
+  requires l != nullValue() ==> acc(Link_unique(l), write)
+  ensures isSubtype(typeOf(result), intType())
+  ensures intFromRef(result) >= 0
+{
+  (let anon_1_0 ==
+    ((l == nullValue() ? intToRef(0) : null)) in
+    (let anon_2_0 ==
+      ((!(l == nullValue()) ?
+        plusInts(intToRef(1), (unfolding acc(Link_unique(l), write) in
+          length(next(l)))) :
+        null)) in
+      (let anon_0_0 ==
+        ((l == nullValue() ? anon_1_0 : anon_2_0)) in
+        anon_0_0)))
+}
+
+function next(this: Ref): Ref
+  requires isSubtype(typeOf(this), Link())
+  ensures isSubtype(typeOf(result), nullable(Link()))
+
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+predicate BooleanArray_unique(this: Ref) {
+  isSubtype(typeOf(this), BooleanArray()) &&
+  acc(Cloneable_unique(this), write) &&
+  acc(Serializable_unique(this), write)
+}
+
+predicate Cloneable_unique(this: Ref) {
+  isSubtype(typeOf(this), Cloneable())
+}
+
+predicate Link_unique(this: Ref) {
+  isSubtype(typeOf(this), Link()) && acc(this.data, write) &&
+  isSubtype(typeOf(this.data), intType()) &&
+  (next(this) != nullValue() ==> acc(Link_unique(next(this)), write))
+}
+
+predicate Serializable_unique(this: Ref) {
+  isSubtype(typeOf(this), Serializable())
+}
+
+method callLength(l: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(l), nullable(Link()))
+  requires l != nullValue() ==> acc(Link_unique(l), write)
+  ensures l != nullValue() ==> acc(Link_unique(l), write)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  assert intFromRef(length(l)) == intFromRef(length(l))
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/pure_recursion.kt: info: Generated Viper text for pushFront:
+field bf_data: Ref
+
+function g_next(this: Ref): Ref
+  requires isSubtype(typeOf(this), Link())
+  ensures isSubtype(typeOf(result), nullable(Link()))
+
+
+function length(l: Ref): Ref
+  requires isSubtype(typeOf(l), nullable(Link()))
+  requires l != nullValue() ==> acc(Link_unique(l), write)
+  ensures isSubtype(typeOf(result), intType())
+  ensures intFromRef(result) >= 0
+{
+  (let anon_1_0 ==
+    ((l == nullValue() ? intToRef(0) : null)) in
+    (let anon_2_0 ==
+      ((!(l == nullValue()) ?
+        plusInts(intToRef(1), (unfolding acc(Link_unique(l), write) in
+          length(g_next(l)))) :
+        null)) in
+      (let anon_0_0 ==
+        ((l == nullValue() ? anon_1_0 : anon_2_0)) in
+        anon_0_0)))
+}
+
+predicate Link_unique(this: Ref) {
+  isSubtype(typeOf(this), Link()) && acc(this.bf_data, write) &&
+  isSubtype(typeOf(this.bf_data), intType()) &&
+  (g_next(this) != nullValue() ==> acc(Link_unique(g_next(this)), write))
+}
+
+method con(par_data: Ref, par_next: Ref) returns (ret_3: Ref)
+  requires isSubtype(typeOf(par_data), intType())
+  requires isSubtype(typeOf(par_next), nullable(Link()))
+  requires par_next != nullValue() ==> acc(Link_unique(par_next), write)
+  ensures isSubtype(typeOf(ret_3), Link())
+  ensures acc(Link_unique(ret_3), write)
+  ensures intFromRef((unfolding acc(Link_unique(ret_3), write) in
+      ret_3.bf_data)) ==
+    intFromRef(par_data)
+  ensures g_next(ret_3) == par_next
+
+
+method pushFront(tail: Ref, d: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(tail), nullable(Link()))
+  requires tail != nullValue() ==> acc(Link_unique(tail), write)
+  requires isSubtype(typeOf(d), intType())
+  ensures isSubtype(typeOf(v_ret_0), Link())
+  ensures acc(Link_unique(v_ret_0), write)
+  ensures intFromRef(length(v_ret_0)) == old(intFromRef(length(tail))) + 1
+{
+  v_ret_0 := con(d, tail)
+  goto lbl_ret_0
+  label lbl_ret_0
 }

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.fir.diag.txt
@@ -1,0 +1,30 @@
+/pure_recursion.kt: info: Generated Viper text for length:
+field data: Ref
+
+function length(l: Ref): Ref
+  requires isSubtype(typeOf(l), nullable(Link()))
+  requires l != nullValue() ==> acc(Link_unique(l), write)
+  ensures isSubtype(typeOf(result), intType())
+  ensures intFromRef(result) >= 0
+{
+  (let anon_1_0 ==
+    ((l == nullValue() ? intToRef(0) : null)) in
+    (let anon_2_0 ==
+      ((!(l == nullValue()) ?
+        plusInts(intToRef(1), length(next(l))) :
+        null)) in
+      (let anon_0_0 ==
+        ((l == nullValue() ? anon_1_0 : anon_2_0)) in
+        anon_0_0)))
+}
+
+function next(this: Ref): Ref
+  requires isSubtype(typeOf(this), Link())
+  ensures isSubtype(typeOf(result), nullable(Link()))
+
+
+predicate Link_unique(this: Ref) {
+  isSubtype(typeOf(this), Link()) && acc(this.data, write) &&
+  isSubtype(typeOf(this.data), intType()) &&
+  (next(this) != nullValue() ==> acc(Link_unique(next(this)), write))
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.kt
@@ -16,8 +16,8 @@ fun <!VIPER_TEXT!>callLength<!>(l: @Unique @Borrowed Link?) {
     verify(length(l) == length(l))
 }
 
-@AlwaysVerify
-fun <!VIPER_TEXT!>pushFront<!>(old: @Unique Link?, d: Int): @Unique Link {
-    postconditions<Link> { new -> length(new) == length(old) + 1 }
-    return Link(d, old)
-}
+<!VIPER_VERIFICATION_ERROR!>@AlwaysVerify
+fun <!VIPER_TEXT!>pushFront<!>(tail: @Unique Link?, d: Int): @Unique Link {
+    postconditions<Link> { new -> length(new) == old(length(tail)) + 1 }
+    return Link(d, tail)
+}<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.kt
@@ -1,0 +1,23 @@
+// FULL_JDK
+// RENDER_PREDICATES
+import org.jetbrains.kotlin.formver.plugin.*
+
+class Link(var data: Int, val next: @Unique Link?)
+
+@AlwaysVerify
+@Pure
+fun <!VIPER_TEXT!>length<!>(l: @Unique @Borrowed Link?): Int {
+    postconditions<Int> { res -> res >= 0 }
+    return if (l == null) 0 else 1 + length(l.next)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>callLength<!>(l: @Unique @Borrowed Link?) {
+    verify(length(l) == length(l))
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>pushFront<!>(old: @Unique Link?, d: Int): @Unique Link {
+    postconditions<Link> { new -> length(new) == length(old) + 1 }
+    return Link(d, old)
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.viper.diag.txt
@@ -1,0 +1,1 @@
+/pure_recursion.kt: warning: Viper verification error: Precondition of function length might not hold. There might be insufficient permission to access Link_unique(next(l))

--- a/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/uniqueness/pure_recursion.viper.diag.txt
@@ -1,1 +1,1 @@
-/pure_recursion.kt: warning: Viper verification error: Precondition of function length might not hold. There might be insufficient permission to access Link_unique(next(l))
+/pure_recursion.kt: warning: Viper verification error: Postcondition of pushFront might not hold. Assertion intFromRef(length(v_ret_0)) == old(intFromRef(length(tail))) + 1 might not hold.

--- a/formver.compiler-plugin/uniqueness/README.md
+++ b/formver.compiler-plugin/uniqueness/README.md
@@ -50,6 +50,10 @@ The checker tracks two kinds of uniqueness:
 - `@Unique` applies to types only (`AnnotationTarget.TYPE`). `TypeRefUniquenessAttributeChecker.kt` narrows
   that further to the type positions the analysis understands: value parameters, receiver parameters,
   properties, function return types, and implicit type arguments.
+- A `postconditions` binder is typed by an explicit type argument, a position that checker rejects `@Unique`
+  on, so it takes its uniqueness from the declared return type of the function it specifies.
+  `SymbolUniquenessResolver.kt` asks an `InheritedUniquenessResolver` for that before reading a symbol's own
+  type; the plugin supplies `resolveSpecificationBinderUniqueness`.
 
 ### Path models
 

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/SymbolUniquenessResolver.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/SymbolUniquenessResolver.kt
@@ -6,7 +6,9 @@
 package org.jetbrains.kotlin.formver.uniqueness.plugin
 
 import org.jetbrains.kotlin.KtFakeSourceElementKind
+import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirReceiverParameterSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
@@ -14,12 +16,43 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirVariableSymbol
 import org.jetbrains.kotlin.fir.types.ConeErrorType
 import org.jetbrains.kotlin.formver.type.plugin.SymbolTypeFactResolver
 
+/**
+ * Resolves the uniqueness a symbol takes from the declaration it stands for, rather than from its own type.
+ *
+ * A binder of a specification block is such a symbol: its type is a type argument, which `@Unique` may not be written
+ * on, so its uniqueness has to come from the signature the block specifies.
+ */
+fun interface InheritedUniquenessResolver {
+    context(context: CheckerContext)
+    fun resolveInheritedUniquenessOf(symbol: FirVariableSymbol<*>): Uniqueness?
+}
+
+/**
+ * Session component that carries the [InheritedUniquenessResolver] declared uniqueness consults first.
+ */
+class SymbolUniquenessResolver(
+    val inheritedUniquenessResolver: InheritedUniquenessResolver,
+    session: FirSession
+) : FirExtensionSessionComponent(session) {
+    companion object {
+        fun getFactory(inheritedUniquenessResolver: InheritedUniquenessResolver = { null }): Factory {
+            return Factory { session -> SymbolUniquenessResolver(inheritedUniquenessResolver, session) }
+        }
+    }
+}
+
+private val FirSession.symbolUniquenessResolver: SymbolUniquenessResolver
+        by FirSession.sessionComponentAccessor()
+
 fun FirReceiverParameterSymbol.resolveUniqueness(): Uniqueness =
     resolvedType.scopeUniqueness
 
 context(context: CheckerContext)
 fun FirVariableSymbol<*>.resolveUniqueness(): Uniqueness {
     if (resolvedReturnType is ConeErrorType) return Uniqueness.Shared
+
+    context.session.symbolUniquenessResolver.inheritedUniquenessResolver
+        .resolveInheritedUniquenessOf(this)?.let { return it }
 
     if (resolvedReturnTypeRef.source?.kind !is KtFakeSourceElementKind.ImplicitTypeRef) {
         return resolvedReturnType.scopeUniqueness

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessExtensionRegistrar.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessExtensionRegistrar.kt
@@ -18,6 +18,7 @@ class UniquenessExtensionRegistrar(
         +ExpressionAccessStateResolver.getFactory()
         +ExpressionUniquenessResolver.getFactory()
         +GraphUniquenessStatesResolver.getFactory()
+        +SymbolUniquenessResolver.getFactory()
         +UniquenessAdditionalCheckers.getFactory()
         +UniquenessAttributeExtension.getFactory(uniquenessAnnotationId)
     }


### PR DESCRIPTION
Stacked on #260. Two changes that together let a recursive `@Pure` function over a uniquely-owned recursive structure reach Viper and verify.

## Unfold the framing predicate for a `@Unique` property read

A `val @Unique` property is embedded as a permission-free function, so `Link_unique(this)` nests `acc(Link_unique(next(this)))` behind a null guard. Passing `l.next` to a parameter that needs that predicate therefore requires an `unfolding`, which was never emitted — so a recursive pure function failed its own recursive call with "insufficient permission to access `Link_unique(next(l))`".

`visitFunctionCall` now wraps the emitted `FuncApp` in `Exp.Unfolding` for each `@Unique` formal whose argument is a `@Unique` property read, innermost receiver outermost — the only sound order, since unfolding `A_unique(a)` is what grants `acc(B_unique(b(a)))`. The `unfolding` lands inside whatever branch the user's own null check already guards, so no synthesised guards are needed and failures surface against the user's code.

Not handled: a `@Unique` property declared on a supertype, which needs `hierarchyPathTo` treatment. `PropertyEmbedding` carries no declaring class, so such a call gets no unfolding — exactly as before, no regression.

## Let a function returning `@Unique` have postconditions

Pre-existing bug, found while writing the test. `extractFormverReturnVar` compared the `postconditions` binder's type to the declared return type with `!=`, which includes the uniqueness and locality attributes. The declared type carries `@Unique`; the binder cannot, because `@Unique` on a type argument is rejected as an invalid target. So *any* function returning `@Unique T` failed with an internal error.

The binder denotes the return value, so it now inherits those attributes rather than restating them: types are compared modulo them, and a session component supplies the binder's uniqueness from the signature. That second half is load-bearing and was verified by registering the no-op default and watching `expected 'unique', actual 'shared'` return.

## Soundness note

Modelling a closed `val` as a permission-free uninterpreted function is sound: the path is taken only for `(property final || class final) && no custom accessor`, so the backing field is written once in the constructor and `next(x)` really is time-invariant. Open `val`s and custom getters fall through to impure methods, closing the override-`val`-with-`var` hole. Accessor names are class-qualified, so two unrelated classes with a same-named `val` do not collide. The remaining gap is incompleteness, not unsoundness: a body-declared `val a = 5` gets no constraint tying it to `5`.

## Test

`testData/diagnostics/verification/uniqueness/pure_recursion.kt`. `length` and `callLength` verify. `pushFront` still fails here on a separate constructor-snapshot problem, fixed in #265.