### PR TITLE
Diagnose a missing/unusable Z3 prover instead of reporting an internal error

### DIFF
--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
@@ -39,6 +39,11 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
         )
         map.put(
+            PluginErrors.PROVER_NOT_FOUND,
+            "{0}",
+            CommonRenderers.STRING,
+        )
+        map.put(
             VerificationErrors.UNEXPECTED_RETURNED_VALUE,
             "Function may return a {0} value.",
             CommonRenderers.STRING,

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
@@ -12,6 +12,7 @@ object PluginErrors : KtDiagnosticsContainer() {
     val VIPER_TEXT by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val EXP_EMBEDDING by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val INTERNAL_ERROR by error1<PsiElement, String>()
+    val PROVER_NOT_FOUND by error1<PsiElement, String>()
     val UNIQUENESS_VIOLATION by error1<PsiElement, String>()
     val UNIQUENESS_CFG by info1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
     val ADT_VIOLATION by error1<PsiElement, String>()
@@ -21,6 +22,7 @@ object PluginErrors : KtDiagnosticsContainer() {
         VIPER_TEXT.name,
         EXP_EMBEDDING.name,
         INTERNAL_ERROR.name,
+        PROVER_NOT_FOUND.name,
         UNIQUENESS_VIOLATION.name,
         UNIQUENESS_CFG.name,
         ADT_VIOLATION.name

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.formver.core.names.SimpleNameResolver
 import org.jetbrains.kotlin.formver.core.shouldVerify
 import org.jetbrains.kotlin.formver.core.viperProgram
 import org.jetbrains.kotlin.formver.plugin.compiler.reporting.reportVerifierError
+import org.jetbrains.kotlin.formver.viper.ProverNotFoundException
 import org.jetbrains.kotlin.formver.viper.SiliconFrontend
 import org.jetbrains.kotlin.formver.viper.ast.Program
 import org.jetbrains.kotlin.formver.viper.ast.registerAllNames
@@ -115,6 +116,8 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
 
         } catch (e: SnaktInternalException) {
             reporter.reportOn(e.source, PluginErrors.INTERNAL_ERROR, e.message)
+        } catch (e: ProverNotFoundException) {
+            reporter.reportOn(declaration.source, PluginErrors.PROVER_NOT_FOUND, e.message)
         } catch (e: Exception) {
             val error = e.message ?: "No message provided"
             reporter.reportOn(declaration.source, PluginErrors.INTERNAL_ERROR, error)

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ProverNotFoundException.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ProverNotFoundException.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.viper
+
+import java.io.File
+
+private const val Z3_EXE_ENV_VAR = "Z3_EXE"
+
+class ProverNotFoundException(override val message: String) : Exception(message)
+
+/**
+ * Resolves the Z3 executable exactly as `viper.silicon.Config.z3Exe` does when no `--z3Exe`
+ * argument is passed: [Z3_EXE_ENV_VAR] if set, otherwise the first entry of `PATH` that *contains*
+ * a file or directory of the executable's name, otherwise that bare name.
+ *
+ * Resolving more leniently than Silicon — falling back to `PATH` when [Z3_EXE_ENV_VAR] is set, or
+ * demanding a usable executable of the `PATH` entries — would let a prover through that Silicon
+ * then rejects, or name a path Silicon does not use.
+ */
+private fun resolveZ3Executable(): File {
+    System.getenv(Z3_EXE_ENV_VAR)?.let { return File(it) }
+    val name = if (System.getProperty("os.name").lowercase().startsWith("windows")) "z3.exe" else "z3"
+    val onPath = System.getenv("PATH").orEmpty().split(File.pathSeparatorChar)
+        .map { File(it, name) }
+        .firstOrNull { it.exists() }
+    return onPath ?: File(name)
+}
+
+/** Throws [ProverNotFoundException] with a user-facing diagnostic if no usable Z3 executable can be found. */
+fun checkProverIsUsable() {
+    val exe = resolveZ3Executable()
+    val hint = "Set the $Z3_EXE_ENV_VAR environment variable to the path of a z3 binary, or install Z3 " +
+        "(https://github.com/Z3Prover/z3/releases) and add it to PATH."
+    if (!exe.isFile) {
+        throw ProverNotFoundException("Could not find the Z3 prover executable at '${exe.path}'. $hint")
+    }
+    if (!exe.canExecute()) {
+        throw ProverNotFoundException("The Z3 prover at '${exe.path}' is not executable. $hint")
+    }
+}

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SiliconFrontend.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/SiliconFrontend.kt
@@ -14,6 +14,7 @@ class SiliconFrontend(commandLineArgs: List<String>) : Closeable {
     private val siliconApi: viper.silicon.SiliconFrontendAPI
 
     init {
+        checkProverIsUsable()
         val args = buildList {
             addAll(commandLineArgs)
             System.getenv("SILICON_PARALLEL_VERIFIERS")?.let {


### PR DESCRIPTION
Without a usable Z3, verification fails deep inside Silicon with `Cannot run
prover at location 'z3': not a file`, which SnaKt's catch-all turns into an
`INTERNAL_ERROR` asking the user to file a bug. `SiliconFrontend.init` now
probes for a usable Z3 first and throws `ProverNotFoundException`, reported as
a new `PROVER_NOT_FOUND` diagnostic.

The probe mirrors `viper.silicon.Config.z3Exe`: `Z3_EXE` if set, with no PATH
fallback; otherwise the first PATH entry that contains an entry of the
executable's name (existence, not executability). Checked against the Silicon
build we depend on by running verification with `Z3_EXE` unset and with `Z3_EXE`
broken, probe enabled and disabled — the probe accepts and rejects exactly what
Silicon does. Supersedes #229.

No golden test: in test runs verification goes through
`ViperProgramVerificationFacade`, not the `ViperPoweredDeclarationChecker`
branch that reports diagnostics, so the harness cannot reach the new one.