### PR TITLE
Make the uniqueness checker usable from a Gradle build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ syntax are not supported.
 This repository consists of three published parts:
 
 - `formver.compiler-plugin`: a K2 compiler plugin that performs formal verification.
+  It is published twice: the plain artifact runs against `kotlinc`, while
+  `formver.compiler-plugin-embeddable` runs against `kotlin-compiler-embeddable`,
+  the compiler Gradle builds with.
 - `formver.gradle-plugin`: a Gradle plugin that loads the compiler plugin.
 - `formver.annotations`: definitions that are used for adding specifications
   to your code.
@@ -57,7 +60,7 @@ repositories {
 ```
 
 Additionally, increase the stack size and metaspace of the Kotlin Daemon: the shaded plugin
-jar bundles Silicon and the Scala runtime (~100 MB), and without a larger metaspace the daemon
+jar bundles Silicon and the Scala runtime (~40 MB), and without a larger metaspace the daemon
 dies with `OutOfMemoryError: Metaspace` after roughly a dozen compiles.
 
 ```kotlin

--- a/formver.compiler-plugin/build.gradle.kts
+++ b/formver.compiler-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     kotlin("jvm")
     `java-test-fixtures`
@@ -35,7 +37,10 @@ dependencies {
     implementation(project(":formver.compiler-plugin:plugin")) { isTransitive = false }
     implementation(project(":formver.compiler-plugin:locality")) { isTransitive = false }
     implementation(project(":formver.common")) { isTransitive = false }
-    implementation(kotlin("compiler"))
+    // Provided by whichever compiler runs the plugin. Shading a second copy in would
+    // put compiler classes in the plugin's own class loader next to the ones the
+    // running compiler uses, and the two sets do not interoperate.
+    compileOnly(kotlin("compiler"))
 
     testFixturesApi(kotlin("test-junit5"))
     testFixturesApi(kotlin("compiler-internal-test-framework"))
@@ -157,14 +162,46 @@ fun Test.setLibraryProperty(propName: String, jarName: String) {
     systemProperty(propName, path)
 }
 
+// This project has no sources of its own, and the empty archive collides by name with
+// shadowJar's, leaving whichever ran last in build/libs.
+tasks.jar {
+    enabled = false
+}
+
+// The jar for `kotlinc`, which runs the plugin against the plain compiler.
 tasks.shadowJar {
     archiveClassifier.set("")
+}
+
+// The jar for the Gradle plugin, which runs it against kotlin-compiler-embeddable. That
+// compiler moves the libraries it bundles under its own package prefix, and some of them
+// appear in the compiler API the plugin builds on, so references compiled against the
+// plain compiler have to be rewritten to match.
+//
+// Listed here are the relocated packages the plugin's own classes mention; comparing the
+// package layouts of the two compiler artifacts shows which others are subject to it.
+val embeddableJar by tasks.registering(ShadowJar::class) {
+    archiveBaseName.set("${project.name}-embeddable")
+    archiveClassifier.set("")
+    from(sourceSets.main.map { it.output })
+    configurations.add(project.configurations.runtimeClasspath)
+    relocate("com.intellij", "org.jetbrains.kotlin.com.intellij")
+    relocate("kotlinx.collections.immutable", "org.jetbrains.kotlin.kotlinx.collections.immutable")
+}
+
+// `assemble` picks up shadowJar on its own, but not a hand-registered ShadowJar.
+tasks.assemble {
+    dependsOn(embeddableJar)
 }
 
 publishing {
     publications {
         create<MavenPublication>("maven") {
             artifact(tasks.shadowJar)
+        }
+        create<MavenPublication>("embeddable") {
+            artifactId = "${project.name}-embeddable"
+            artifact(embeddableJar)
         }
     }
 }

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
@@ -49,7 +49,10 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
 
-        if (config.checkLocality) {
+        // The uniqueness checkers resolve the locality of expressions and symbols, and the
+        // resolvers that answer those queries are session components the locality extensions
+        // install. Uniqueness therefore cannot run on its own.
+        if (config.checkLocality || config.checkUniqueness) {
             FirExtensionRegistrarAdapter.registerExtension(LocalityExtensionRegistrar())
         }
 

--- a/formver.gradle-plugin/build.gradle.kts
+++ b/formver.gradle-plugin/build.gradle.kts
@@ -29,7 +29,9 @@ buildConfig {
 
     val pluginProject = project(":formver.compiler-plugin")
     buildConfigField("String", "COMPILER_PLUGIN_GROUP", "\"${pluginProject.group}\"")
-    buildConfigField("String", "COMPILER_PLUGIN_NAME", "\"${pluginProject.name}\"")
+    // Gradle runs the compiler out of kotlin-compiler-embeddable, which needs the
+    // variant of the compiler plugin relocated to match it.
+    buildConfigField("String", "COMPILER_PLUGIN_NAME", "\"${pluginProject.name}-embeddable\"")
     buildConfigField("String", "COMPILER_PLUGIN_VERSION", "\"${pluginProject.version}\"")
 
     val annotationsProject = project(":formver.annotations")


### PR DESCRIPTION
Gradle compiles with kotlin-compiler-embeddable, which moves the libraries it bundles
under its own package prefix. Some of those appear in the compiler API the plugin builds
on, so a plugin jar compiled against the plain compiler asks the embeddable one for
classes it does not have. This publishes a second jar with those references rewritten and
points the Gradle plugin at it.

The plugin jar also shaded in the whole plain compiler, which turned the mismatch into a
cast failure rather than a missing class. It no longer does; the running compiler supplies
those classes.

Uniqueness checking resolves locality facts, which only the locality extensions provide,
so the compiler plugin now enables both together — as the test harness already does.

Supersedes #261. Relocation list checked against the 2.3.0 package layouts: `com.intellij`
and `kotlinx.collections.immutable` are the only relocated prefixes the plugin's own
sources reference.