### PR TITLE
Make the severity of failed proofs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ formver {
 However, keep in mind that the Viper is dump is provided as an info message: this message will not be shown
 unless you run `gradle` with the `--info` flag.
 
+By default a failed proof is reported as a warning, so adopting the plugin cannot break an
+existing build. Set `verificationErrorSeverity("error")` to fail compilation on a failed proof
+instead.
+
 ### Annotations
 
 The plugin provides a number of annotations to add specifications to your code.
@@ -104,6 +108,8 @@ The plugin accepts a number of command line options which can be passed via
   `targets_with_contract`, `all_targets` (default: `targets_with_contract`).
 - Option `unsupported_feature_behaviour`: permitted values `throw_exception`, `assume_unreachable` (default:
   `throw_exception`).
+- Option `verification_error_severity`: permitted values `warning` and `error` (default: `warning`, so that
+  adopting the plugin cannot break an existing build).
 
 ### Z3
 

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -117,5 +117,10 @@ formver {
     errorStyle("user_friendly")  // or "original_viper", "both"
     logLevel("only_warnings")    // or "short_viper_dump", "full_viper_dump"
     unsupportedFeatureBehaviour("throw_exception")  // or "assume_unreachable"
+    verificationErrorSeverity("warning")  // or "error"
 }
 ```
+
+`verificationErrorSeverity` defaults to `"warning"`, so a failed proof leaves the build green
+and adopting the plugin cannot break an existing build. Set it to `"error"` to fail compilation
+on a failed proof instead.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -48,6 +48,8 @@ Which checks run:
 - `ALWAYS_VALIDATE` — verify every target. Verification is already the default,
   so this changes nothing on its own; it earns its place by overriding the two
   `*_CHECK_ONLY` directives above.
+- `FAIL_ON_VERIFICATION_ERROR` — report failed proofs as errors rather than
+  warnings, matching `verificationErrorSeverity("error")`.
 
 What the diagnostic contains:
 

--- a/formver.common/src/org/jetbrains/kotlin/formver/common/FormalVerificationPluginNames.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/FormalVerificationPluginNames.kt
@@ -15,4 +15,5 @@ object FormalVerificationPluginNames {
     const val CHECK_UNIQUENESS_OPTION_NAME = "check_uniqueness"
     const val CHECK_LOCALITY_OPTION_NAME = "check_locality"
     const val DUMP_UNIQUENESS_CFG_OPTION_NAME = "dump_uniqueness_cfg"
+    const val VERIFICATION_ERROR_SEVERITY_OPTION_NAME = "verification_error_severity"
 }

--- a/formver.common/src/org/jetbrains/kotlin/formver/common/PluginConfiguration.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/PluginConfiguration.kt
@@ -14,6 +14,7 @@ data class PluginConfiguration(
     val checkLocality: Boolean,
     val checkUniqueness: Boolean,
     val dumpUniquenessCFG: Boolean,
+    val verificationErrorSeverity: VerificationErrorSeverity,
 ) {
     init {
         require(conversionSelection >= verificationSelection) {

--- a/formver.common/src/org/jetbrains/kotlin/formver/common/VerificationErrorSeverity.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/VerificationErrorSeverity.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.formver.common
+
+/**
+ * Severity at which a failed proof is reported.
+ *
+ * At [WARNING] a failed proof leaves the build green, so that adopting the plugin
+ * cannot break an existing build; at [ERROR] it fails compilation like any other
+ * compiler error.
+ */
+enum class VerificationErrorSeverity {
+    WARNING,
+    ERROR;
+
+    companion object {
+        @JvmStatic
+        fun defaultBehaviour(): VerificationErrorSeverity = WARNING
+    }
+}

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationCommandLineProcessor.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationCommandLineProcessor.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.formver.cli.FormalVerificationConfigurationKeys.DUMP
 import org.jetbrains.kotlin.formver.cli.FormalVerificationConfigurationKeys.ERROR_STYLE
 import org.jetbrains.kotlin.formver.cli.FormalVerificationConfigurationKeys.LOG_LEVEL
 import org.jetbrains.kotlin.formver.cli.FormalVerificationConfigurationKeys.UNSUPPORTED_FEATURE_BEHAVIOUR
+import org.jetbrains.kotlin.formver.cli.FormalVerificationConfigurationKeys.VERIFICATION_ERROR_SEVERITY
 import org.jetbrains.kotlin.formver.cli.FormalVerificationConfigurationKeys.VERIFICATION_TARGETS_SELECTION
 import org.jetbrains.kotlin.formver.common.*
 import org.jetbrains.kotlin.formver.common.FormalVerificationPluginNames.CHECK_LOCALITY_OPTION_NAME
@@ -24,6 +25,7 @@ import org.jetbrains.kotlin.formver.common.FormalVerificationPluginNames.DUMP_UN
 import org.jetbrains.kotlin.formver.common.FormalVerificationPluginNames.ERROR_STYLE_NAME
 import org.jetbrains.kotlin.formver.common.FormalVerificationPluginNames.LOG_LEVEL_OPTION_NAME
 import org.jetbrains.kotlin.formver.common.FormalVerificationPluginNames.UNSUPPORTED_FEATURE_BEHAVIOUR_OPTION_NAME
+import org.jetbrains.kotlin.formver.common.FormalVerificationPluginNames.VERIFICATION_ERROR_SEVERITY_OPTION_NAME
 import org.jetbrains.kotlin.formver.common.FormalVerificationPluginNames.VERIFICATION_TARGETS_SELECTION_OPTION_NAME
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.toUpperCaseAsciiOnly
 
@@ -42,6 +44,8 @@ object FormalVerificationConfigurationKeys {
         CompilerConfigurationKey.create("check locality")
     val DUMP_UNIQUENESS_CFG: CompilerConfigurationKey<Boolean> =
         CompilerConfigurationKey.create("dump uniqueness CFG")
+    val VERIFICATION_ERROR_SEVERITY: CompilerConfigurationKey<VerificationErrorSeverity> =
+        CompilerConfigurationKey.create("verification error severity")
 }
 
 @OptIn(ExperimentalCompilerApi::class)
@@ -97,6 +101,13 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
             required = false,
             allowMultipleOccurrences = false
         )
+        val VERIFICATION_ERROR_SEVERITY_OPTION = CliOption(
+            VERIFICATION_ERROR_SEVERITY_OPTION_NAME,
+            "<verification_error_severity>",
+            "Severity at which a failed proof is reported",
+            required = false,
+            allowMultipleOccurrences = false
+        )
     }
 
     override val pluginId: String = FormalVerificationPluginNames.PLUGIN_ID
@@ -109,6 +120,7 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
         CHECK_UNIQUENESS_OPTION,
         CHECK_LOCALITY_OPTION,
         DUMP_UNIQUENESS_CFG_OPTION,
+        VERIFICATION_ERROR_SEVERITY_OPTION,
     )
 
     override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) =
@@ -144,6 +156,12 @@ class FormalVerificationCommandLineProcessor : CommandLineProcessor {
 
                 DUMP_UNIQUENESS_CFG_OPTION ->
                     configuration.put(DUMP_UNIQUENESS_CFG, value.toBooleanStrict())
+
+                VERIFICATION_ERROR_SEVERITY_OPTION ->
+                    configuration.put(
+                        VERIFICATION_ERROR_SEVERITY,
+                        VerificationErrorSeverity.valueOf(value.toUpperCaseAsciiOnly())
+                    )
 
                 else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
             }

--- a/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
+++ b/formver.compiler-plugin/cli/src/org/jetbrains/kotlin/formver/cli/FormalVerificationPluginComponentRegistrar.kt
@@ -43,9 +43,13 @@ class FormalVerificationPluginComponentRegistrar : CompilerPluginRegistrar() {
         val checkUniqueness = configuration.get(FormalVerificationConfigurationKeys.CHECK_UNIQUENESS, false)
         val checkLocality = configuration.get(FormalVerificationConfigurationKeys.CHECK_LOCALITY, false)
         val dumpUniquenessCFG = configuration.get(FormalVerificationConfigurationKeys.DUMP_UNIQUENESS_CFG, false)
+        val verificationErrorSeverity = configuration.get(
+            FormalVerificationConfigurationKeys.VERIFICATION_ERROR_SEVERITY,
+            VerificationErrorSeverity.Companion.defaultBehaviour()
+        )
         val config = PluginConfiguration(
             logLevel, errorStyle, behaviour, conversionSelection, verificationSelection,
-            checkLocality, checkUniqueness, dumpUniquenessCFG
+            checkLocality, checkUniqueness, dumpUniquenessCFG, verificationErrorSeverity
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
 

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
@@ -9,6 +9,37 @@ import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
 
+private fun KtDiagnosticFactoryToRendererMap.putVerificationDiagnostics(diagnostics: VerificationDiagnostics) {
+    put(
+        diagnostics.VIPER_VERIFICATION_ERROR,
+        "Viper verification error: {0}",
+        CommonRenderers.STRING,
+    )
+    put(
+        diagnostics.UNEXPECTED_RETURNED_VALUE,
+        "Function may return a {0} value.",
+        CommonRenderers.STRING,
+    )
+    put(
+        diagnostics.CONDITIONAL_EFFECT_ERROR,
+        "Cannot verify that if {0} then {1}.",
+        CommonRenderers.STRING,
+        CommonRenderers.STRING,
+    )
+    put(
+        diagnostics.POSSIBLE_INDEX_OUT_OF_BOUND,
+        "Invalid index for {0}, the index may be {1}.",
+        CommonRenderers.STRING,
+        CommonRenderers.STRING,
+    )
+    put(
+        diagnostics.INVALID_SUBLIST_RANGE,
+        "Invalid sub-list range for {0}, the range may be {1}.",
+        CommonRenderers.STRING,
+        CommonRenderers.STRING,
+    )
+}
+
 object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
     override val MAP: KtDiagnosticFactoryToRendererMap by KtDiagnosticFactoryToRendererMap("FormalVerification") { map ->
         map.put(
@@ -23,11 +54,8 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
             CommonRenderers.STRING,
         )
-        map.put(
-            VerificationErrors.VIPER_VERIFICATION_ERROR,
-            "Viper verification error: {0}",
-            CommonRenderers.STRING,
-        )
+        map.putVerificationDiagnostics(VerificationErrors)
+        map.putVerificationDiagnostics(StrictVerificationErrors)
         map.put(
             VerificationErrors.CONSISTENCY,
             "Viper consistency error: {0}",
@@ -36,29 +64,6 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
         map.put(
             PluginErrors.INTERNAL_ERROR,
             "An internal error has occurred.\nDetails: {0}\nPlease report this at https://github.com/jesyspa/kotlin",
-            CommonRenderers.STRING,
-        )
-        map.put(
-            VerificationErrors.UNEXPECTED_RETURNED_VALUE,
-            "Function may return a {0} value.",
-            CommonRenderers.STRING,
-        )
-        map.put(
-            VerificationErrors.CONDITIONAL_EFFECT_ERROR,
-            "Cannot verify that if {0} then {1}.",
-            CommonRenderers.STRING,
-            CommonRenderers.STRING,
-        )
-        map.put(
-            VerificationErrors.POSSIBLE_INDEX_OUT_OF_BOUND,
-            "Invalid index for {0}, the index may be {1}.",
-            CommonRenderers.STRING,
-            CommonRenderers.STRING,
-        )
-        map.put(
-            VerificationErrors.INVALID_SUBLIST_RANGE,
-            "Invalid sub-list range for {0}, the range may be {1}.",
-            CommonRenderers.STRING,
             CommonRenderers.STRING,
         )
         map.put(

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/FormalVerificationPluginErrorMessages.kt
@@ -8,32 +8,33 @@ package org.jetbrains.kotlin.formver.plugin.compiler
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.diagnostics.rendering.CommonRenderers
+import org.jetbrains.kotlin.formver.common.VerificationErrorSeverity
 
 private fun KtDiagnosticFactoryToRendererMap.putVerificationDiagnostics(diagnostics: VerificationDiagnostics) {
     put(
-        diagnostics.VIPER_VERIFICATION_ERROR,
+        diagnostics.viperVerificationError,
         "Viper verification error: {0}",
         CommonRenderers.STRING,
     )
     put(
-        diagnostics.UNEXPECTED_RETURNED_VALUE,
+        diagnostics.unexpectedReturnedValue,
         "Function may return a {0} value.",
         CommonRenderers.STRING,
     )
     put(
-        diagnostics.CONDITIONAL_EFFECT_ERROR,
+        diagnostics.conditionalEffectError,
         "Cannot verify that if {0} then {1}.",
         CommonRenderers.STRING,
         CommonRenderers.STRING,
     )
     put(
-        diagnostics.POSSIBLE_INDEX_OUT_OF_BOUND,
+        diagnostics.possibleIndexOutOfBound,
         "Invalid index for {0}, the index may be {1}.",
         CommonRenderers.STRING,
         CommonRenderers.STRING,
     )
     put(
-        diagnostics.INVALID_SUBLIST_RANGE,
+        diagnostics.invalidSublistRange,
         "Invalid sub-list range for {0}, the range may be {1}.",
         CommonRenderers.STRING,
         CommonRenderers.STRING,
@@ -54,8 +55,7 @@ object FormalVerificationPluginErrorMessages : BaseDiagnosticRendererFactory() {
             CommonRenderers.STRING,
             CommonRenderers.STRING,
         )
-        map.putVerificationDiagnostics(VerificationErrors)
-        map.putVerificationDiagnostics(StrictVerificationErrors)
+        VerificationErrorSeverity.entries.forEach { map.putVerificationDiagnostics(VerificationDiagnostics.of(it)) }
         map.put(
             VerificationErrors.CONSISTENCY,
             "Viper consistency error: {0}",

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
@@ -7,6 +7,7 @@ package org.jetbrains.kotlin.formver.plugin.compiler
 
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.*
+import org.jetbrains.kotlin.formver.common.VerificationErrorSeverity
 
 object PluginErrors : KtDiagnosticsContainer() {
     val VIPER_TEXT by info2<PsiElement, String, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
@@ -27,13 +28,39 @@ object PluginErrors : KtDiagnosticsContainer() {
     )
 }
 
+/**
+ * The diagnostics a failed proof is reported through.
+ *
+ * The Kotlin diagnostic API fixes a severity per factory, so reporting a failed
+ * proof at a configurable severity takes one set of factories per severity.
+ * The two sets carry the same diagnostic names, so which one is in use is
+ * invisible to anything that refers to a diagnostic by name — a `@Suppress`, an
+ * `-Xwarning-level`, a test's expected tags.
+ */
+// The property names are the diagnostic names: the delegates in the
+// implementing containers derive one from the other.
+@Suppress("VariableNaming")
+sealed interface VerificationDiagnostics {
+    val CONDITIONAL_EFFECT_ERROR: KtDiagnosticFactory2<String, String>
+    val VIPER_VERIFICATION_ERROR: KtDiagnosticFactory1<String>
+    val POSSIBLE_INDEX_OUT_OF_BOUND: KtDiagnosticFactory2<String, String>
+    val UNEXPECTED_RETURNED_VALUE: KtDiagnosticFactory1<String>
+    val INVALID_SUBLIST_RANGE: KtDiagnosticFactory2<String, String>
 
-object VerificationErrors : KtDiagnosticsContainer() {
-    val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
-    val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
-    val POSSIBLE_INDEX_OUT_OF_BOUND by warning2<PsiElement, String, String>()
-    val UNEXPECTED_RETURNED_VALUE by warning1<PsiElement, String>()
-    val INVALID_SUBLIST_RANGE by warning2<PsiElement, String, String>()
+    companion object {
+        fun of(severity: VerificationErrorSeverity): VerificationDiagnostics = when (severity) {
+            VerificationErrorSeverity.WARNING -> VerificationErrors
+            VerificationErrorSeverity.ERROR -> StrictVerificationErrors
+        }
+    }
+}
+
+object VerificationErrors : KtDiagnosticsContainer(), VerificationDiagnostics {
+    override val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
+    override val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
+    override val POSSIBLE_INDEX_OUT_OF_BOUND by warning2<PsiElement, String, String>()
+    override val UNEXPECTED_RETURNED_VALUE by warning1<PsiElement, String>()
+    override val INVALID_SUBLIST_RANGE by warning2<PsiElement, String, String>()
     val CONSISTENCY by error1<PsiElement, String>()
     override fun getRendererFactory() = FormalVerificationPluginErrorMessages
     fun tags() = listOf(
@@ -44,4 +71,13 @@ object VerificationErrors : KtDiagnosticsContainer() {
         INVALID_SUBLIST_RANGE.name,
         CONSISTENCY.name
     )
+}
+
+object StrictVerificationErrors : KtDiagnosticsContainer(), VerificationDiagnostics {
+    override val CONDITIONAL_EFFECT_ERROR by error2<PsiElement, String, String>()
+    override val VIPER_VERIFICATION_ERROR by error1<PsiElement, String>()
+    override val POSSIBLE_INDEX_OUT_OF_BOUND by error2<PsiElement, String, String>()
+    override val UNEXPECTED_RETURNED_VALUE by error1<PsiElement, String>()
+    override val INVALID_SUBLIST_RANGE by error2<PsiElement, String, String>()
+    override fun getRendererFactory() = FormalVerificationPluginErrorMessages
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/PluginErrors.kt
@@ -29,38 +29,54 @@ object PluginErrors : KtDiagnosticsContainer() {
 }
 
 /**
- * The diagnostics a failed proof is reported through.
+ * The factories a failed proof is reported through, at one severity.
  *
- * The Kotlin diagnostic API fixes a severity per factory, so reporting a failed
- * proof at a configurable severity takes one set of factories per severity.
- * The two sets carry the same diagnostic names, so which one is in use is
- * invisible to anything that refers to a diagnostic by name — a `@Suppress`, an
+ * The Kotlin diagnostic API fixes a severity per factory, so a configurable
+ * severity takes one set of factories per severity. Both sets use the same
+ * property names, and a factory's name is its property name, so which set is in
+ * use is invisible to anything naming a diagnostic: a `@Suppress`, an
  * `-Xwarning-level`, a test's expected tags.
+ *
+ * Every parameter is required, so a diagnostic added at one severity does not
+ * compile until it is added at the other.
  */
-// The property names are the diagnostic names: the delegates in the
-// implementing containers derive one from the other.
-@Suppress("VariableNaming")
-sealed interface VerificationDiagnostics {
-    val CONDITIONAL_EFFECT_ERROR: KtDiagnosticFactory2<String, String>
-    val VIPER_VERIFICATION_ERROR: KtDiagnosticFactory1<String>
-    val POSSIBLE_INDEX_OUT_OF_BOUND: KtDiagnosticFactory2<String, String>
-    val UNEXPECTED_RETURNED_VALUE: KtDiagnosticFactory1<String>
-    val INVALID_SUBLIST_RANGE: KtDiagnosticFactory2<String, String>
-
+data class VerificationDiagnostics(
+    val conditionalEffectError: KtDiagnosticFactory2<String, String>,
+    val viperVerificationError: KtDiagnosticFactory1<String>,
+    val possibleIndexOutOfBound: KtDiagnosticFactory2<String, String>,
+    val unexpectedReturnedValue: KtDiagnosticFactory1<String>,
+    val invalidSublistRange: KtDiagnosticFactory2<String, String>,
+) {
     companion object {
+        private val warnings = VerificationDiagnostics(
+            conditionalEffectError = VerificationErrors.CONDITIONAL_EFFECT_ERROR,
+            viperVerificationError = VerificationErrors.VIPER_VERIFICATION_ERROR,
+            possibleIndexOutOfBound = VerificationErrors.POSSIBLE_INDEX_OUT_OF_BOUND,
+            unexpectedReturnedValue = VerificationErrors.UNEXPECTED_RETURNED_VALUE,
+            invalidSublistRange = VerificationErrors.INVALID_SUBLIST_RANGE,
+        )
+
+        private val errors = VerificationDiagnostics(
+            conditionalEffectError = StrictVerificationErrors.CONDITIONAL_EFFECT_ERROR,
+            viperVerificationError = StrictVerificationErrors.VIPER_VERIFICATION_ERROR,
+            possibleIndexOutOfBound = StrictVerificationErrors.POSSIBLE_INDEX_OUT_OF_BOUND,
+            unexpectedReturnedValue = StrictVerificationErrors.UNEXPECTED_RETURNED_VALUE,
+            invalidSublistRange = StrictVerificationErrors.INVALID_SUBLIST_RANGE,
+        )
+
         fun of(severity: VerificationErrorSeverity): VerificationDiagnostics = when (severity) {
-            VerificationErrorSeverity.WARNING -> VerificationErrors
-            VerificationErrorSeverity.ERROR -> StrictVerificationErrors
+            VerificationErrorSeverity.WARNING -> warnings
+            VerificationErrorSeverity.ERROR -> errors
         }
     }
 }
 
-object VerificationErrors : KtDiagnosticsContainer(), VerificationDiagnostics {
-    override val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
-    override val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
-    override val POSSIBLE_INDEX_OUT_OF_BOUND by warning2<PsiElement, String, String>()
-    override val UNEXPECTED_RETURNED_VALUE by warning1<PsiElement, String>()
-    override val INVALID_SUBLIST_RANGE by warning2<PsiElement, String, String>()
+object VerificationErrors : KtDiagnosticsContainer() {
+    val CONDITIONAL_EFFECT_ERROR by warning2<PsiElement, String, String>()
+    val VIPER_VERIFICATION_ERROR by warning1<PsiElement, String>()
+    val POSSIBLE_INDEX_OUT_OF_BOUND by warning2<PsiElement, String, String>()
+    val UNEXPECTED_RETURNED_VALUE by warning1<PsiElement, String>()
+    val INVALID_SUBLIST_RANGE by warning2<PsiElement, String, String>()
     val CONSISTENCY by error1<PsiElement, String>()
     override fun getRendererFactory() = FormalVerificationPluginErrorMessages
     fun tags() = listOf(
@@ -73,11 +89,13 @@ object VerificationErrors : KtDiagnosticsContainer(), VerificationDiagnostics {
     )
 }
 
-object StrictVerificationErrors : KtDiagnosticsContainer(), VerificationDiagnostics {
-    override val CONDITIONAL_EFFECT_ERROR by error2<PsiElement, String, String>()
-    override val VIPER_VERIFICATION_ERROR by error1<PsiElement, String>()
-    override val POSSIBLE_INDEX_OUT_OF_BOUND by error2<PsiElement, String, String>()
-    override val UNEXPECTED_RETURNED_VALUE by error1<PsiElement, String>()
-    override val INVALID_SUBLIST_RANGE by error2<PsiElement, String, String>()
+// Not registered as a diagnostic container: its renderers live in the factory
+// VerificationErrors registers, which is enough for them to be found.
+object StrictVerificationErrors : KtDiagnosticsContainer() {
+    val CONDITIONAL_EFFECT_ERROR by error2<PsiElement, String, String>()
+    val VIPER_VERIFICATION_ERROR by error1<PsiElement, String>()
+    val POSSIBLE_INDEX_OUT_OF_BOUND by error2<PsiElement, String, String>()
+    val UNEXPECTED_RETURNED_VALUE by error1<PsiElement, String>()
+    val INVALID_SUBLIST_RANGE by error2<PsiElement, String, String>()
     override fun getRendererFactory() = FormalVerificationPluginErrorMessages
 }

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -106,7 +106,7 @@ class ViperPoweredDeclarationChecker(private val session: FirSession, private va
 
                 val onFailure = { err: VerifierError ->
                     val source = err.position.unwrapOr { declaration.source }
-                    reporter.reportVerifierError(source, err, config.errorStyle)
+                    reporter.reportVerifierError(source, err, config)
                 }
 
                 val verifier = SiliconFrontend(emptyList())

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/reporting/FormattedError.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/reporting/FormattedError.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.diagnostics.FirDiagnosticRenderers
 import org.jetbrains.kotlin.formver.core.embeddings.SourceRole
-import org.jetbrains.kotlin.formver.plugin.compiler.VerificationErrors
+import org.jetbrains.kotlin.formver.plugin.compiler.VerificationDiagnostics
 import org.jetbrains.kotlin.formver.plugin.compiler.reporting.SourceRoleConditionPrettyPrinter.prettyPrint
 import org.jetbrains.kotlin.formver.viper.ast.info
 import org.jetbrains.kotlin.formver.viper.ast.unwrapOr
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.formver.viper.errors.VerificationError
 
 sealed interface FormattedError {
     context(context: CheckerContext, reporter: DiagnosticReporter)
-    fun report(source: KtSourceElement?)
+    fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics)
 }
 
 class ReturnsEffectError(private val sourceRole: SourceRole.ReturnsEffect) : FormattedError {
@@ -31,8 +31,8 @@ class ReturnsEffectError(private val sourceRole: SourceRole.ReturnsEffect) : For
         }
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
-    override fun report(source: KtSourceElement?) {
-        reporter.reportOn(source, VerificationErrors.UNEXPECTED_RETURNED_VALUE, msg())
+    override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
+        reporter.reportOn(source, diagnostics.UNEXPECTED_RETURNED_VALUE, msg())
     }
 
     fun msg(): String = sourceRole.asUserFriendlyMessage
@@ -46,9 +46,9 @@ class ConditionalEffectError(private val sourceRole: SourceRole.ConditionalEffec
         }
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
-    override fun report(source: KtSourceElement?) {
+    override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
         val (returnEffectMsg, conditionPrettyPrinted) = msg()
-        reporter.reportOn(source, VerificationErrors.CONDITIONAL_EFFECT_ERROR, returnEffectMsg, conditionPrettyPrinted)
+        reporter.reportOn(source, diagnostics.CONDITIONAL_EFFECT_ERROR, returnEffectMsg, conditionPrettyPrinted)
     }
 
     fun msg(): Pair<String, String> = sourceRole.let { (returnEffect, condition) ->
@@ -58,8 +58,8 @@ class ConditionalEffectError(private val sourceRole: SourceRole.ConditionalEffec
 
 class DefaultError(private val error: VerificationError) : FormattedError {
     context(context: CheckerContext, reporter: DiagnosticReporter)
-    override fun report(source: KtSourceElement?) {
-        reporter.reportOn(source, VerificationErrors.VIPER_VERIFICATION_ERROR, msg())
+    override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
+        reporter.reportOn(source, diagnostics.VIPER_VERIFICATION_ERROR, msg())
     }
 
     fun msg(): String = error.msg
@@ -78,7 +78,7 @@ class IndexOutOfBoundError(
         }
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
-    override fun report(source: KtSourceElement?) {
+    override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
         /**
          * When we are dealing with inlined expressions returning a list, we do not have access to any list symbol.
          * Therefore, we do not report any name since the compiler would highlight the sub-expression causing the problem.
@@ -86,7 +86,7 @@ class IndexOutOfBoundError(
         val (targetInfo, userFriendlyMessage) = msg()
         reporter.reportOn(
             source,
-            VerificationErrors.POSSIBLE_INDEX_OUT_OF_BOUND,
+            diagnostics.POSSIBLE_INDEX_OUT_OF_BOUND,
             targetInfo,
             userFriendlyMessage,
         )
@@ -110,11 +110,11 @@ class InvalidSubListRangeError(
         }
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
-    override fun report(source: KtSourceElement?) {
+    override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
         val (targetInfo, userFriendlyMessage) = msg()
         reporter.reportOn(
             source,
-            VerificationErrors.INVALID_SUBLIST_RANGE,
+            diagnostics.INVALID_SUBLIST_RANGE,
             targetInfo,
             userFriendlyMessage,
         )

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/reporting/FormattedError.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/reporting/FormattedError.kt
@@ -32,7 +32,7 @@ class ReturnsEffectError(private val sourceRole: SourceRole.ReturnsEffect) : For
 
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
-        reporter.reportOn(source, diagnostics.UNEXPECTED_RETURNED_VALUE, msg())
+        reporter.reportOn(source, diagnostics.unexpectedReturnedValue, msg())
     }
 
     fun msg(): String = sourceRole.asUserFriendlyMessage
@@ -48,7 +48,7 @@ class ConditionalEffectError(private val sourceRole: SourceRole.ConditionalEffec
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
         val (returnEffectMsg, conditionPrettyPrinted) = msg()
-        reporter.reportOn(source, diagnostics.CONDITIONAL_EFFECT_ERROR, returnEffectMsg, conditionPrettyPrinted)
+        reporter.reportOn(source, diagnostics.conditionalEffectError, returnEffectMsg, conditionPrettyPrinted)
     }
 
     fun msg(): Pair<String, String> = sourceRole.let { (returnEffect, condition) ->
@@ -59,7 +59,7 @@ class ConditionalEffectError(private val sourceRole: SourceRole.ConditionalEffec
 class DefaultError(private val error: VerificationError) : FormattedError {
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun report(source: KtSourceElement?, diagnostics: VerificationDiagnostics) {
-        reporter.reportOn(source, diagnostics.VIPER_VERIFICATION_ERROR, msg())
+        reporter.reportOn(source, diagnostics.viperVerificationError, msg())
     }
 
     fun msg(): String = error.msg
@@ -86,7 +86,7 @@ class IndexOutOfBoundError(
         val (targetInfo, userFriendlyMessage) = msg()
         reporter.reportOn(
             source,
-            diagnostics.POSSIBLE_INDEX_OUT_OF_BOUND,
+            diagnostics.possibleIndexOutOfBound,
             targetInfo,
             userFriendlyMessage,
         )
@@ -114,7 +114,7 @@ class InvalidSubListRangeError(
         val (targetInfo, userFriendlyMessage) = msg()
         reporter.reportOn(
             source,
-            diagnostics.INVALID_SUBLIST_RANGE,
+            diagnostics.invalidSublistRange,
             targetInfo,
             userFriendlyMessage,
         )

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/reporting/VerifierErrorInterpreter.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/reporting/VerifierErrorInterpreter.kt
@@ -12,7 +12,9 @@ import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.formver.common.ErrorStyle
+import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.plugin.compiler.PluginErrors
+import org.jetbrains.kotlin.formver.plugin.compiler.VerificationDiagnostics
 import org.jetbrains.kotlin.formver.viper.errors.ConsistencyError
 import org.jetbrains.kotlin.formver.viper.errors.VerificationError
 import org.jetbrains.kotlin.formver.viper.errors.VerifierError
@@ -27,8 +29,11 @@ context(context: CheckerContext)
 private fun DiagnosticReporter.reportVerificationError(
     source: KtSourceElement?,
     error: VerificationError,
-    errorStyle: ErrorStyle,
-) = error.formatByErrorStyle(errorStyle).forEach { it.report(source) }
+    config: PluginConfiguration,
+) {
+    val diagnostics = VerificationDiagnostics.of(config.verificationErrorSeverity)
+    error.formatByErrorStyle(config.errorStyle).forEach { it.report(source, diagnostics) }
+}
 
 context(context: CheckerContext)
 private fun DiagnosticReporter.reportConsistencyError(source: KtSourceElement?, error: ConsistencyError) {
@@ -44,8 +49,8 @@ context(context: CheckerContext)
 fun DiagnosticReporter.reportVerifierError(
     source: KtSourceElement?,
     error: VerifierError,
-    errorStyle: ErrorStyle,
+    config: PluginConfiguration,
 ) = when (error) {
     is ConsistencyError -> reportConsistencyError(source, error)
-    is VerificationError -> reportVerificationError(source, error, errorStyle)
+    is VerificationError -> reportVerificationError(source, error, config)
 }

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.ALWAYS_VALIDATE
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DUMP_UNIQUENESS_CFG
+import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.FAIL_ON_VERIFICATION_ERROR
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.FULL_VIPER_DUMP
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.LOCALITY_CHECK_ONLY
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.NEVER_VALIDATE
@@ -74,6 +75,7 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
             checkUniqueness = checkUniqueness,
             dumpUniquenessCFG = dumpUniquenessCFG,
             checkLocality = checkLocality,
+            verificationErrorSeverity = module.verificationErrorSeverity,
         )
         FirExtensionRegistrarAdapter.registerExtension(FormalVerificationPluginExtensionRegistrar(config))
         if (config.checkLocality) {
@@ -117,7 +119,23 @@ object FormVerDirectives : SimpleDirectivesContainer() {
     val NEVER_VALIDATE by directive(
         description = "Run in conversion-only mode: skip verification, keep consistency checking"
     )
+
+    val FAIL_ON_VERIFICATION_ERROR by directive(
+        description = "Report failed proofs as errors rather than warnings"
+    )
 }
+
+/**
+ * The severity failed proofs are reported at in this module.
+ *
+ * Both the plugin's own reporting and the test harness's verification phase read
+ * it, so that a test exercises the option rather than one of its two callers.
+ */
+val TestModule.verificationErrorSeverity: VerificationErrorSeverity
+    get() = when (FAIL_ON_VERIFICATION_ERROR in directives) {
+        true -> VerificationErrorSeverity.ERROR
+        false -> VerificationErrorSeverity.WARNING
+    }
 
 class StdlibReplacementsProvider(testServices: TestServices, baseDir: String = ".") :
     AdditionalSourceProvider(testServices) {

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/VerificationFacade.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/VerificationFacade.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitorVoid
 import org.jetbrains.kotlin.formver.common.services.runChecks
 import org.jetbrains.kotlin.formver.core.shouldVerify
 import org.jetbrains.kotlin.formver.core.viperProgram
+import org.jetbrains.kotlin.formver.plugin.compiler.VerificationDiagnostics
 import org.jetbrains.kotlin.formver.plugin.compiler.VerificationErrors
 import org.jetbrains.kotlin.formver.plugin.compiler.reporting.*
 import org.jetbrains.kotlin.formver.plugin.runners.*
@@ -116,10 +117,11 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
         module: TestModule
     ): KtDiagnostic {
         val source = err.position.unwrapOr { decl.source }!!
+        val diagnostics = VerificationDiagnostics.of(module.verificationErrorSeverity)
         val diagnostic = when (val formattedError = err.formatUserFriendly()) {
             is ConditionalEffectError -> {
                 val msg = formattedError.msg()
-                VerificationErrors.CONDITIONAL_EFFECT_ERROR.on(
+                diagnostics.CONDITIONAL_EFFECT_ERROR.on(
                     source, msg.first, msg.second,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -128,7 +130,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is DefaultError -> {
                 val msg = formattedError.msg()
-                VerificationErrors.VIPER_VERIFICATION_ERROR.on(
+                diagnostics.VIPER_VERIFICATION_ERROR.on(
                     source, msg,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -137,7 +139,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is IndexOutOfBoundError -> {
                 val msg = formattedError.msg()
-                VerificationErrors.POSSIBLE_INDEX_OUT_OF_BOUND.on(
+                diagnostics.POSSIBLE_INDEX_OUT_OF_BOUND.on(
                     source, msg.first, msg.second,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -146,7 +148,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is InvalidSubListRangeError -> {
                 val msg = formattedError.msg()
-                VerificationErrors.INVALID_SUBLIST_RANGE.on(
+                diagnostics.INVALID_SUBLIST_RANGE.on(
                     source, msg.first, msg.second,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -155,7 +157,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is ReturnsEffectError -> {
                 val msg = formattedError.msg()
-                VerificationErrors.UNEXPECTED_RETURNED_VALUE.on(
+                diagnostics.UNEXPECTED_RETURNED_VALUE.on(
                     source, msg,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -163,7 +165,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
             }
 
             null -> {
-                VerificationErrors.VIPER_VERIFICATION_ERROR.on(
+                diagnostics.VIPER_VERIFICATION_ERROR.on(
                     source, err.msg, positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
                 )

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/VerificationFacade.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/VerificationFacade.kt
@@ -121,7 +121,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
         val diagnostic = when (val formattedError = err.formatUserFriendly()) {
             is ConditionalEffectError -> {
                 val msg = formattedError.msg()
-                diagnostics.CONDITIONAL_EFFECT_ERROR.on(
+                diagnostics.conditionalEffectError.on(
                     source, msg.first, msg.second,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -130,7 +130,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is DefaultError -> {
                 val msg = formattedError.msg()
-                diagnostics.VIPER_VERIFICATION_ERROR.on(
+                diagnostics.viperVerificationError.on(
                     source, msg,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -139,7 +139,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is IndexOutOfBoundError -> {
                 val msg = formattedError.msg()
-                diagnostics.POSSIBLE_INDEX_OUT_OF_BOUND.on(
+                diagnostics.possibleIndexOutOfBound.on(
                     source, msg.first, msg.second,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -148,7 +148,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is InvalidSubListRangeError -> {
                 val msg = formattedError.msg()
-                diagnostics.INVALID_SUBLIST_RANGE.on(
+                diagnostics.invalidSublistRange.on(
                     source, msg.first, msg.second,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -157,7 +157,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
 
             is ReturnsEffectError -> {
                 val msg = formattedError.msg()
-                diagnostics.UNEXPECTED_RETURNED_VALUE.on(
+                diagnostics.unexpectedReturnedValue.on(
                     source, msg,
                     positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
@@ -165,7 +165,7 @@ class ViperProgramVerificationFacade(val testServices: TestServices) :
             }
 
             null -> {
-                diagnostics.VIPER_VERIFICATION_ERROR.on(
+                diagnostics.viperVerificationError.on(
                     source, err.msg, positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
                     languageVersionSettings = module.languageVersionSettings
                 )

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -645,6 +645,28 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/error_severity")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Error_severity {
+      @Test
+      public void testAllFilesPresentInError_severity() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/verification/error_severity"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("default_severity.kt")
+      public void testDefault_severity() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/error_severity/default_severity.kt");
+      }
+
+      @Test
+      @TestMetadata("fail_on_verification_error.kt")
+      public void testFail_on_verification_error() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/error_severity/fail_on_verification_error.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/inlining")
     @TestDataPath("$PROJECT_ROOT")
     public class Inlining {

--- a/formver.compiler-plugin/testData/diagnostics/verification/error_severity/default_severity.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/error_severity/default_severity.fir.diag.txt
@@ -1,0 +1,10 @@
+/default_severity.kt: info: Generated Viper text for unprovablePostcondition:
+method unprovablePostcondition(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) > intFromRef(x)
+{
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/error_severity/default_severity.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/error_severity/default_severity.kt
@@ -1,0 +1,11 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+// The postcondition does not hold. By default a failed proof is a warning, so
+// that turning the plugin on cannot break a build.
+<!VIPER_VERIFICATION_ERROR!>@AlwaysVerify
+fun <!VIPER_TEXT!>unprovablePostcondition<!>(x: Int): Int {
+    postconditions<Int> { result -> result > x }
+    return x
+}<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/error_severity/default_severity.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/error_severity/default_severity.viper.diag.txt
@@ -1,0 +1,1 @@
+/default_severity.kt: warning: Viper verification error: Postcondition of unprovablePostcondition might not hold. Assertion intFromRef(v_ret_0) > intFromRef(x) might not hold.

--- a/formver.compiler-plugin/testData/diagnostics/verification/error_severity/fail_on_verification_error.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/error_severity/fail_on_verification_error.fir.diag.txt
@@ -1,0 +1,10 @@
+/fail_on_verification_error.kt: info: Generated Viper text for unprovablePostcondition:
+method unprovablePostcondition(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) > intFromRef(x)
+{
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/error_severity/fail_on_verification_error.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/error_severity/fail_on_verification_error.kt
@@ -1,0 +1,12 @@
+// FULL_JDK
+// FAIL_ON_VERIFICATION_ERROR
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+// The same failed proof as in default_severity.kt, reported as an error rather
+// than a warning.
+<!VIPER_VERIFICATION_ERROR!>@AlwaysVerify
+fun <!VIPER_TEXT!>unprovablePostcondition<!>(x: Int): Int {
+    postconditions<Int> { result -> result > x }
+    return x
+}<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/error_severity/fail_on_verification_error.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/error_severity/fail_on_verification_error.viper.diag.txt
@@ -1,0 +1,1 @@
+/fail_on_verification_error.kt: error: Viper verification error: Postcondition of unprovablePostcondition might not hold. Assertion intFromRef(v_ret_0) > intFromRef(x) might not hold.

--- a/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
+++ b/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/FormVerExtension.kt
@@ -15,6 +15,7 @@ open class FormVerExtension {
     internal var myCheckUniqueness: Boolean? = null
     internal var myCheckLocality: Boolean? = null
     internal var myDumpUniquenessCFG: Boolean? = null
+    internal var myVerificationErrorSeverity: String? = null
 
     open fun logLevel(logLevel: String) {
         myLogLevel = logLevel
@@ -46,5 +47,9 @@ open class FormVerExtension {
 
     open fun dumpUniquenessCFG(enabled: Boolean) {
         myDumpUniquenessCFG = enabled
+    }
+
+    open fun verificationErrorSeverity(severity: String) {
+        myVerificationErrorSeverity = severity
     }
 }

--- a/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
+++ b/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/FormVerSubplugin.kt
@@ -72,6 +72,10 @@ class FormVerGradleSubplugin
                 options += SubpluginOption(FormalVerificationPluginNames.DUMP_UNIQUENESS_CFG_OPTION_NAME, it.toString())
             }
 
+            formVerExtension.myVerificationErrorSeverity?.let {
+                options += SubpluginOption(FormalVerificationPluginNames.VERIFICATION_ERROR_SEVERITY_OPTION_NAME, it)
+            }
+
             options
         }
     }

--- a/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/FormVer.kt
+++ b/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/FormVer.kt
@@ -76,4 +76,11 @@ interface FormVer {
      * @return the configured value, or null if unset
      */
     val dumpUniquenessCFG: Boolean?
+
+    /**
+     * Returns the severity at which a failed proof is reported.
+     *
+     * @return the configured severity, or null if unset
+     */
+    val verificationErrorSeverity: String?
 }

--- a/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
+++ b/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/builder/FormVerModelBuilder.kt
@@ -28,6 +28,7 @@ class FormVerModelBuilder : ToolingModelBuilder {
             extension.myCheckUniqueness,
             extension.myCheckLocality,
             extension.myDumpUniquenessCFG,
+            extension.myVerificationErrorSeverity,
         )
     }
 

--- a/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
+++ b/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
@@ -21,10 +21,11 @@ data class FormVerImpl(
     override val checkUniqueness: Boolean?,
     override val checkLocality: Boolean?,
     override val dumpUniquenessCFG: Boolean?,
+    override val verificationErrorSeverity: String?,
 ) : FormVer, Serializable {
     override val modelVersion = serialVersionUID
 
     companion object {
-        private const val serialVersionUID = 2L
+        private const val serialVersionUID = 3L
     }
 }

--- a/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
+++ b/formver.gradle-plugin/src/org/jetbrains/kotlin/formver/gradle/model/impl/FormVerImpl.kt
@@ -26,6 +26,10 @@ data class FormVerImpl(
     override val modelVersion = serialVersionUID
 
     companion object {
+        /**
+         * Version of this class as both a serialized form and a [FormVer] model:
+         * bump it whenever the properties change.
+         */
         private const val serialVersionUID = 3L
     }
 }


### PR DESCRIPTION
Adds `formver { verificationErrorSeverity("error") }` and the matching
`verification_error_severity` plugin option, so a failed proof can fail the
build instead of warning.

The Kotlin diagnostic API fixes a severity per factory, so this needs one
factory per severity: `VerificationErrors` (warnings) and
`StrictVerificationErrors` (errors). Both use the same property names, so a
diagnostic's name — and any `@Suppress` or expected test tag — is the same
either way. A `VerificationDiagnostics` holder with required parameters for
every factory keeps the two sets in step.