### PR TITLE
Pass an argument for every parameter of a call

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionContext.kt
@@ -149,6 +149,17 @@ fun StmtConversionContext.embedPropertyAccess(accessExpression: FirPropertyAcces
     }
 
 
+/**
+ * Declares a fresh variable of [type] and inhales that its type is a subtype of [type].
+ *
+ * No access permissions are inhaled, so the caller gets no permission to the fields of a
+ * reference nobody handed it.
+ */
+fun StmtConversionContext.unconstrainedValue(type: TypeEmbedding): Pair<Declare, ExpEmbedding> {
+    val declaration = declareAnonVar(type, null)
+    return declaration to declaration.variable.withInvariants(typeResolver) { proven = true }
+}
+
 fun StmtConversionContext.argumentDeclaration(
     arg: ExpEmbedding,
     callType: TypeEmbedding

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.common.UnsupportedFeatureBehaviour
 import org.jetbrains.kotlin.formver.core.embeddings.LabelLink
 import org.jetbrains.kotlin.formver.core.embeddings.callables.CallableEmbedding
+import org.jetbrains.kotlin.formver.core.embeddings.callables.FunctionSignature
 import org.jetbrains.kotlin.formver.core.embeddings.callables.insertCall
 import org.jetbrains.kotlin.formver.core.embeddings.callables.isVerifyFunction
 import org.jetbrains.kotlin.formver.core.embeddings.expression.*
@@ -264,34 +265,79 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         }
     }
 
-    private fun List<FirExpression>.withVarargsHandled(data: StmtConversionContext, function: CallableEmbedding?) =
-        flatMap { arg ->
-            when (arg) {
-                is FirVarargArgumentsExpression -> {
-                    if (function == null || !function.isVerifyFunction) {
-                        throw SnaktInternalException(
-                            arg.source, "Vararg arguments are currently supported for `verify` function only."
-                        )
-                    }
-                    data.withNoScope {
-                        arg.arguments.map { this.convert(it) }
-                    }
-                }
-
-                else -> listOf(data.convert(arg))
+    /**
+     * Converts [arguments] into the actuals of a call to [callee].
+     *
+     * A `null` entry is a formal argument the call leaves to its default value, which requires
+     * [arguments] to be in the order of the callee's formal arguments. The default value is not
+     * available at the call site, and a Viper call that omits the actual leaves the callee's formal
+     * unbound, which makes the verification state inconsistent and proves anything afterwards. Such
+     * a formal gets a value of its own type that nothing else is assumed about: that loses what the
+     * default would have told us, but only that. The declarations of those values are collected in
+     * [declarations], and belong in front of the call.
+     */
+    private fun buildCallArguments(
+        arguments: List<FirExpression?>,
+        data: StmtConversionContext,
+        callee: CallableEmbedding?,
+        declarations: MutableList<Declare> = mutableListOf(),
+    ): List<ExpEmbedding> = arguments.flatMapIndexed { index, arg ->
+        when (arg) {
+            null -> {
+                val formal = (callee as? FunctionSignature)?.formalArgs?.getOrNull(index)
+                    ?: throw SnaktInternalException(
+                        null, "Cannot fill in the argument at index $index of a call to $callee."
+                    )
+                val (declaration, value) = data.unconstrainedValue(formal.type)
+                declarations.add(declaration)
+                listOf(value)
             }
+
+            is FirVarargArgumentsExpression -> {
+                if (callee == null || !callee.isVerifyFunction) {
+                    throw SnaktInternalException(
+                        arg.source, "Vararg arguments are currently supported for `verify` function only."
+                    )
+                }
+                data.withNoScope {
+                    arg.arguments.map { this.convert(it) }
+                }
+            }
+
+            else -> listOf(data.convert(arg))
         }
+    }
+
+    /**
+     * The call's arguments in the order of the callee's formal arguments: receivers first, then one
+     * entry per value parameter, `null` where the call leaves the parameter to its default value.
+     *
+     * Falls back to the arguments as they come when the call has no argument mapping.
+     */
+    private fun FirFunctionCall.argumentsPerParameter(symbol: FirFunctionSymbol<*>): List<FirExpression?> {
+        val mapping = resolvedArgumentMapping ?: return functionCallArguments
+        val byParameter = mapping.entries.groupBy({ (_, parameter) -> parameter.symbol }) { (argument, _) -> argument }
+        val valueArguments = symbol.valueParameterSymbols.map { parameter ->
+            val arguments = byParameter[parameter] ?: return@map null
+            arguments.singleOrNull() ?: throw SnaktInternalException(
+                source, "Parameter ${parameter.name} of ${symbol.name} is given ${arguments.size} arguments."
+            )
+        }
+        return listOfNotNull(dispatchReceiver, extensionReceiver) + valueArguments
+    }
 
     override fun visitFunctionCall(functionCall: FirFunctionCall, data: StmtConversionContext): ExpEmbedding {
         val symbol = functionCall.toResolvedCallableSymbol() as? FirFunctionSymbol<*>
             ?: throw NotImplementedError("Only functions are expected as callables of function calls, got ${functionCall.toResolvedCallableSymbol()}")
 
         val callee = data.embedAnyFunction(symbol)
-        return callee.insertCall(
-            functionCall.functionCallArguments.withVarargsHandled(data, callee),
-            data,
-            data.embedType(functionCall.resolvedType),
-        )
+        val arguments =
+            if (callee.takesArgumentPerParameter) functionCall.argumentsPerParameter(symbol)
+            else functionCall.functionCallArguments
+        val declarations = mutableListOf<Declare>()
+        val args = buildCallArguments(arguments, data, callee, declarations)
+        val call = callee.insertCall(args, data, data.embedType(functionCall.resolvedType))
+        return if (declarations.isEmpty()) call else (declarations + call).toBlock()
     }
 
     override fun visitImplicitInvokeCall(
@@ -305,7 +351,7 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
             )
         val returnType = data.embedType(implicitInvokeCall.resolvedType)
         val receiverSymbol = receiver.calleeReference.toResolvedSymbol<FirBasedSymbol<*>>()!!
-        val args = implicitInvokeCall.argumentList.arguments.withVarargsHandled(data, function = null)
+        val args = buildCallArguments(implicitInvokeCall.argumentList.arguments, data, callee = null)
         return when (val exp = data.embedLocalSymbol(receiverSymbol).ignoringMetaNodes()) {
             is LambdaExp -> {
                 // The lambda is already the receiver, so we do not need to convert it.

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/CallableEmbedding.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/CallableEmbedding.kt
@@ -16,6 +16,16 @@ import org.jetbrains.kotlin.formver.core.embeddings.types.TypeEmbedding
  */
 interface CallableEmbedding {
     val callableType: FunctionTypeEmbedding
+
+    /**
+     * Whether [insertCall] expects one argument per formal argument of the Kotlin callable:
+     * receivers first, then one per value parameter, in declaration order.
+     *
+     * `false` for callables that interpret whatever arguments the call site provides; those get no
+     * argument for a parameter left at its default value.
+     */
+    val takesArgumentPerParameter: Boolean
+
     fun insertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding
 }
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionSignature.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/FunctionSignature.kt
@@ -86,6 +86,8 @@ interface NamedCallableEmbedding : NamedFunctionSignature, CallableEmbedding
 
 
 interface NonInlineCallable : NamedCallableEmbedding {
+    override val takesArgumentPerParameter: Boolean
+        get() = true
 
     override fun insertCall(args: List<ExpEmbedding>, ctx: StmtConversionContext): ExpEmbedding = insertCall(args)
 
@@ -170,6 +172,9 @@ data class InlineNamedFunction(
     override val postconditions: List<ExpEmbedding>,
     override val symbol: FirFunctionSymbol<*>,
 ) : CompleteFunctionSignature, NamedCallableEmbedding, NamedFunctionSignature by signature {
+    override val takesArgumentPerParameter: Boolean
+        get() = true
+
     override fun insertCall(
         args: List<ExpEmbedding>,
         ctx: StmtConversionContext,

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/callables/SpecialKotlinFunction.kt
@@ -17,6 +17,11 @@ import org.jetbrains.kotlin.formver.core.embeddings.expression.ExpEmbedding
  * sometimes.
  */
 sealed interface SpecialKotlinFunction : CallableEmbedding {
+    // Special handling means interpreting the arguments the call site provides, so these callables
+    // do not line their arguments up against the Kotlin parameters.
+    override val takesArgumentPerParameter: Boolean
+        get() = false
+
     val packageName: List<String>
     val className: String?
         get() = null

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/LambdaExp.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/embeddings/expression/LambdaExp.kt
@@ -27,6 +27,10 @@ class LambdaExp(
     override val type: TypeEmbedding
         get() = callableType.asTypeEmbedding()
 
+    // A lambda cannot declare default values, so a call to it always supplies every parameter.
+    override val takesArgumentPerParameter: Boolean
+        get() = false
+
     override fun insertCall(
         args: List<ExpEmbedding>,
         ctx: StmtConversionContext,

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -130,6 +130,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("prefix_suffix.kt")
+      public void testPrefix_suffix() {
+        runTest("formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.kt");
+      }
+
+      @Test
       @TestMetadata("strings.kt")
       public void testStrings() {
         runTest("formver.compiler-plugin/testData/diagnostics/stdlib/string/strings.kt");
@@ -292,6 +298,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     @TestMetadata("basic.kt")
     public void testBasic() {
       runTest("formver.compiler-plugin/testData/diagnostics/verification/basic.kt");
+    }
+
+    @Test
+    @TestMetadata("default_arguments.kt")
+    public void testDefault_arguments() {
+      runTest("formver.compiler-plugin/testData/diagnostics/verification/default_arguments.kt");
     }
 
     @Test

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.fir.diag.txt
@@ -1,0 +1,56 @@
+/prefix_suffix.kt: info: Generated Viper text for startsWithKeepsStateConsistent:
+function size(v_this: Ref): Ref
+  requires isSubtype(typeOf(v_this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method startsWith(v_this_extension: Ref, prefix: Ref, ignoreCase: Ref)
+  returns (ret_1: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
+  requires isSubtype(typeOf(prefix), stringType())
+  requires isSubtype(typeOf(ignoreCase), boolType())
+  ensures isSubtype(typeOf(ret_1), boolType())
+
+
+method startsWithKeepsStateConsistent(a: Ref, b: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), stringType())
+  requires isSubtype(typeOf(b), stringType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), boolType())
+  anon_1 := startsWith(a, b, anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/prefix_suffix.kt: info: Generated Viper text for endsWithKeepsStateConsistent:
+function size(v_this: Ref): Ref
+  requires isSubtype(typeOf(v_this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method endsWith(v_this_extension: Ref, suffix: Ref, ignoreCase: Ref)
+  returns (ret_1: Ref)
+  requires isSubtype(typeOf(v_this_extension), stringType())
+  requires isSubtype(typeOf(suffix), stringType())
+  requires isSubtype(typeOf(ignoreCase), boolType())
+  ensures isSubtype(typeOf(ret_1), boolType())
+
+
+method endsWithKeepsStateConsistent(a: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), stringType())
+  requires isSubtype(typeOf(b), stringType())
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), boolType())
+  anon_1 := endsWith(a, b, anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.kt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.kt
@@ -1,0 +1,18 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.verify
+
+// A prefix/suffix query is a pure observation: it may not make the verification
+// state inconsistent, so `false` has to stay unprovable after one.
+@AlwaysVerify
+fun <!VIPER_TEXT!>startsWithKeepsStateConsistent<!>(a: String, b: String) {
+    a.startsWith(b)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>endsWithKeepsStateConsistent<!>(a: String, b: String) {
+    a.endsWith(b)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/string/prefix_suffix.viper.diag.txt
@@ -1,0 +1,3 @@
+/prefix_suffix.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/prefix_suffix.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.

--- a/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.fir.diag.txt
@@ -1,0 +1,472 @@
+/default_arguments.kt: info: Generated Viper text for trailingDefault:
+method trailingDefault(a: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := plusInts(a, b)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for pureTrailingDefault:
+function pureTrailingDefault(a: Ref, b: Ref): Ref
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(result), intType())
+{
+  plusInts(a, b)
+}
+
+/default_arguments.kt: info: Generated Viper text for inlineTrailingDefault:
+method inlineTrailingDefault(a: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := plusInts(a, b)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for defaultInTheMiddle:
+method defaultInTheMiddle(a: Ref, skipped: Ref, c: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(skipped), intType())
+  requires isSubtype(typeOf(c), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := plusInts(plusInts(a, skipped), c)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedTrailingDefault:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method omittedTrailingDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), intType())
+  anon_1 := trailingDefault(intToRef(1), anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+method trailingDefault(a: Ref, b: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+/default_arguments.kt: info: Generated Viper text for omittedDefaultInTheMiddle:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method defaultInTheMiddle(a: Ref, skipped: Ref, c: Ref)
+  returns (ret_1: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(skipped), intType())
+  requires isSubtype(typeOf(c), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+method omittedDefaultInTheMiddle() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), intType())
+  anon_1 := defaultInTheMiddle(intToRef(1), anon_0, intToRef(2))
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedInlineDefault:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method inlineTrailingDefault(a: Ref, b: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+method omittedInlineDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var v_ret_2: Ref
+  var anon_1: Ref
+  anon_1 := intToRef(1)
+  inhale isSubtype(typeOf(anon_0), intType())
+  v_ret_2 := plusInts(anon_1, anon_0)
+  goto lbl_ret_2
+  label lbl_ret_2
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedConstructorDefault:
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method con(par_a: Ref, par_b: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_b), intType())
+  ensures isSubtype(typeOf(ret_1), Boxed())
+  ensures acc(Boxed_unique(ret_1), write)
+  ensures intFromRef(g_a(ret_1)) == intFromRef(par_a)
+  ensures intFromRef(g_b(ret_1)) == intFromRef(par_b)
+
+
+method omittedConstructorDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), intType())
+  anon_1 := con(intToRef(1), anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for defaultValueIsNotAssumed:
+function pureTrailingDefault(a: Ref, b: Ref): Ref
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(result), intType())
+{
+  plusInts(a, b)
+}
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method defaultValueIsNotAssumed() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var defaulted: Ref
+  var anon: Ref
+  var given: Ref
+  inhale isSubtype(typeOf(anon), intType())
+  defaulted := pureTrailingDefault(intToRef(1), anon)
+  given := pureTrailingDefault(intToRef(1), intToRef(0))
+  assert intFromRef(given) == 1
+  assert intFromRef(defaulted) == 1
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for refDefault:
+function b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method refDefault(par_a: Ref, par_r: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_r), Boxed())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := par_a
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for inlineRefDefault:
+function b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method inlineRefDefault(par_a: Ref, par_r: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_r), Boxed())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := par_a
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for nullableDefault:
+function b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method nullableDefault(par_a: Ref, par_r: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_r), nullable(Boxed()))
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := par_a
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for functionDefault:
+method functionDefault(a: Ref, f: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(f), functionType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := a
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for varargAndDefault:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), IntArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method varargAndDefault(xs: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(xs), IntArray())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := b
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedReferenceDefault:
+function b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method omittedReferenceDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), Boxed())
+  anon_1 := refDefault(intToRef(1), anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+method refDefault(par_a: Ref, par_r: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_r), Boxed())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+/default_arguments.kt: info: Generated Viper text for omittedInlineReferenceDefault:
+function b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method inlineRefDefault(par_a: Ref, par_r: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_r), Boxed())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+method omittedInlineReferenceDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var v_ret_2: Ref
+  var anon_1: Ref
+  anon_1 := intToRef(1)
+  v_ret_2 := anon_1
+  goto lbl_ret_2
+  label lbl_ret_2
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedNullableDefault:
+function b(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function g_a(this: Ref): Ref
+  requires isSubtype(typeOf(this), Boxed())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method nullableDefault(par_a: Ref, par_r: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(par_a), intType())
+  requires isSubtype(typeOf(par_r), nullable(Boxed()))
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+method omittedNullableDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), nullable(Boxed()))
+  anon_1 := nullableDefault(intToRef(1), anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: info: Generated Viper text for omittedFunctionDefault:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method functionDefault(a: Ref, f: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(f), functionType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+method omittedFunctionDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  inhale isSubtype(typeOf(anon_0), functionType())
+  anon_1 := functionDefault(intToRef(1), anon_0)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+/default_arguments.kt: error: An internal error has occurred.
+Details: Vararg arguments are currently supported for `verify` function only.
+Please report this at https://github.com/jesyspa/kotlin
+
+/default_arguments.kt: info: Generated Viper text for emptyVarargWithOmittedDefault:
+function BooleanArray_g_size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+function IntArray_g_size(this: Ref): Ref
+  requires isSubtype(typeOf(this), IntArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method emptyVarargWithOmittedDefault() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  var anon_0: Ref
+  var anon_1: Ref
+  var anon_2: Ref
+  inhale isSubtype(typeOf(anon_0), IntArray())
+  inhale isSubtype(typeOf(anon_1), intType())
+  anon_2 := varargAndDefault(anon_0, anon_1)
+  assert false
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}
+
+method varargAndDefault(xs: Ref, b: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(xs), IntArray())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+
+
+/default_arguments.kt: info: Generated Viper text for pureDifference:
+function pureDifference(a: Ref, b: Ref): Ref
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(result), intType())
+{
+  minusInts(a, b)
+}
+
+/default_arguments.kt: info: Generated Viper text for namedArgumentsOutOfOrder:
+function pureDifference(a: Ref, b: Ref): Ref
+  requires isSubtype(typeOf(a), intType())
+  requires isSubtype(typeOf(b), intType())
+  ensures isSubtype(typeOf(result), intType())
+{
+  minusInts(a, b)
+}
+
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method namedArgumentsOutOfOrder() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), unitType())
+{
+  assert intFromRef(pureDifference(intToRef(3), intToRef(1))) == 2
+  label lbl_ret_0
+  inhale isSubtype(typeOf(v_ret_0), unitType())
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.kt
@@ -1,0 +1,115 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.Pure
+import org.jetbrains.kotlin.formver.plugin.verify
+
+fun <!VIPER_TEXT!>trailingDefault<!>(a: Int, b: Int = 0): Int = a + b
+
+@Pure
+fun <!VIPER_TEXT!>pureTrailingDefault<!>(a: Int, b: Int = 0): Int = a + b
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <!VIPER_TEXT!>inlineTrailingDefault<!>(a: Int, b: Int = 0): Int = a + b
+
+fun <!VIPER_TEXT!>defaultInTheMiddle<!>(a: Int, skipped: Int = 0, c: Int): Int = a + skipped + c
+
+class Boxed(val a: Int, val b: Int = 0)
+
+// A parameter left at its default tells the caller nothing, but the call still may not
+// make the verification state inconsistent.
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedTrailingDefault<!>() {
+    trailingDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedDefaultInTheMiddle<!>() {
+    defaultInTheMiddle(1, c = 2)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedInlineDefault<!>() {
+    inlineTrailingDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedConstructorDefault<!>() {
+    Boxed(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+// Nothing is assumed about the omitted argument, so the default value itself does not
+// reach the caller.
+@AlwaysVerify
+fun <!VIPER_TEXT!>defaultValueIsNotAssumed<!>() {
+    val defaulted = pureTrailingDefault(1)
+    val given = pureTrailingDefault(1, 0)
+    verify(given == 1)
+    verify(<!VIPER_VERIFICATION_ERROR!>defaulted == 1<!>)
+}
+
+fun <!VIPER_TEXT!>refDefault<!>(a: Int, r: Boxed = Boxed(0)): Int = a
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <!VIPER_TEXT!>inlineRefDefault<!>(a: Int, r: Boxed = Boxed(0)): Int = a
+
+fun <!VIPER_TEXT!>nullableDefault<!>(a: Int, r: Boxed? = null): Int = a
+
+fun <!VIPER_TEXT!>functionDefault<!>(a: Int, f: (Int) -> Int = { it }): Int = a
+
+fun <!VIPER_TEXT!>varargAndDefault<!>(vararg xs: Int, b: Int = 0): Int = b
+
+// The filled-in value carries no access permissions, so nothing can be read off it, but the
+// call still may not make the verification state inconsistent.
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedReferenceDefault<!>() {
+    refDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedInlineReferenceDefault<!>() {
+    inlineRefDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedNullableDefault<!>() {
+    nullableDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>omittedFunctionDefault<!>() {
+    functionDefault(1)
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+// A vararg argument of a user function is not supported; filling in the omitted default must
+// keep reporting that, rather than a different failure.
+@AlwaysVerify
+fun varargWithOmittedDefault() {
+    varargAndDefault(<!INTERNAL_ERROR!>1, 2<!>)
+    verify(false)
+}
+
+// A vararg parameter given no arguments has no entry in the argument mapping, so it is filled
+// in like any omitted parameter: a value of the array type, not known to be empty.
+@AlwaysVerify
+fun <!VIPER_TEXT!>emptyVarargWithOmittedDefault<!>() {
+    varargAndDefault()
+    verify(<!VIPER_VERIFICATION_ERROR!>false<!>)
+}
+
+@Pure
+fun <!VIPER_TEXT!>pureDifference<!>(a: Int, b: Int): Int = a - b
+
+// The arguments reach the parameters they name, not the ones in their own order.
+@AlwaysVerify
+fun <!VIPER_TEXT!>namedArgumentsOutOfOrder<!>() {
+    verify(pureDifference(b = 1, a = 3) == 2)
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/default_arguments.viper.diag.txt
@@ -1,0 +1,19 @@
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion intFromRef(defaulted) == 1 might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.
+
+/default_arguments.kt: warning: Viper verification error: Assert might fail. Assertion false might not hold.


### PR DESCRIPTION
A call omitting a defaulted argument emitted fewer actuals than the callee has
formals. Silicon leaves the formal unbound, the state after the call is
inconsistent, and everything downstream is proved vacuously — `a.startsWith(b)`
made `verify(false)` succeed.

Omitted parameters are now filled with a value constrained only by the
parameter's type. Whether a callee takes one argument per parameter is a member
of `CallableEmbedding`, so a new implementation must answer it; all arguments of
a call are built in one place, vararg handling included. Named arguments out of
order now reach the parameters they name.

Takes over #234 (rebased, review comments addressed). Tests cover reference,
nullable and function-typed defaults, non-inline and inline callees, and a
vararg parameter alongside an omitted default.