### PR TITLE
Find spec blocks in one place, and treat them as contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ The plugin accepts a number of command line options which can be passed via
   `only_warnings`).
 - Option `error_style`: permitted values `user_friendly`, `original_viper` and `both` (default: `user_friendly`).
 - Options `conversion_targets_selection` and `verification_targets_selection`: permitted values `no_targets`,
-  `targets_with_contract`, `all_targets` (default: `targets_with_contract`).
+  `targets_with_contract`, `all_targets` (default: `targets_with_contract`). A function counts as having a
+  contract if it has a Kotlin `contract { }` block or a SnaKt `preconditions`/`postconditions` block.
 - Option `unsupported_feature_behaviour`: permitted values `throw_exception`, `assume_unreachable` (default:
   `throw_exception`).
 

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -4,17 +4,25 @@ SnaKt translates Kotlin code with formal specifications to [Viper](https://www.p
 
 ## Verification Control
 
-By default, SnaKt only verifies functions with Kotlin `contract { }` blocks. To verify functions with SnaKt specifications:
+By default, SnaKt verifies the functions that have a contract: a Kotlin `contract { }` block, or a
+SnaKt `preconditions { }` or `postconditions<T> { }` block. Everything else is left alone:
 
 ```kotlin
 import org.jetbrains.kotlin.formver.plugin.*
 
-@AlwaysVerify  // Enables verification for this function
 fun divide(numerator: Int, denominator: Int): Int {
-    preconditions { denominator != 0 }
+    preconditions { denominator != 0 }   // enough on its own to make this a target
     return numerator / denominator
 }
+
+@AlwaysVerify  // verify this one too, though it specifies nothing
+fun half(x: Int) = divide(x, 2)
 ```
+
+Callers of a specified function may assume its postconditions, so a function that carries a
+specification is verified against it rather than believed. Suppressing that — with `@NeverVerify`,
+or by setting the selection to `no_targets` — turns the specification into an assumption that
+nothing checks.
 
 **Annotations:**
 - `@AlwaysVerify` — verify this function regardless of plugin settings
@@ -25,7 +33,7 @@ fun divide(numerator: Int, denominator: Int): Int {
 ```kotlin
 formver {
     verificationTargetsSelection("all_targets")  // Verify all functions
-    // or "targets_with_contract" (default) — only Kotlin contract { } blocks
+    // or "targets_with_contract" (default) — only functions carrying a contract
     // or "no_targets" — disable verification
 }
 ```
@@ -46,6 +54,10 @@ fun abs(x: Int): Int {
 ```
 
 Multiple conditions are implicitly conjoined. The postconditions block receives the return value as its parameter.
+
+`preconditions` must be the first statement of the function body, and `postconditions` must
+immediately follow it, or be first if there is no `preconditions`. A block anywhere else is
+reported as ignored rather than silently dropped.
 
 ## Loop Invariants
 
@@ -73,6 +85,8 @@ The rules are as follows:
 - Loop invariant must hold after each iteration.
 - Loop invariant must hold when the loop is exited.
 - Code after the loop may assume the condition fails.
+
+`loopInvariants` must be the first statement of the loop body; elsewhere it is reported as ignored.
 
 ## Universal Quantification
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -48,6 +48,9 @@ Which checks run:
 - `ALWAYS_VALIDATE` — verify every target. Verification is already the default,
   so this changes nothing on its own; it earns its place by overriding the two
   `*_CHECK_ONLY` directives above.
+- `DEFAULT_SELECTION` — pick targets the way an unconfigured plugin does, rather
+  than taking every function in the file. For tests about which functions get
+  selected at all; elsewhere it only hides code from the verifier.
 
 What the diagnostic contains:
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/FormverFirBlock.kt
@@ -5,27 +5,112 @@
 
 package org.jetbrains.kotlin.formver.core.conversion
 
+import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.FirAnonymousFunction
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.expressions.*
 import org.jetbrains.kotlin.fir.symbols.impl.FirFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.visitors.FirVisitorVoid
 import org.jetbrains.kotlin.formver.core.isFormverFunctionNamed
 
-fun FirStatement.extractFormverFirBlock(predicate: FirFunctionSymbol<*>.() -> Boolean): FirAnonymousFunction? {
-    if (this !is FirFunctionCall) return null
-    val firFunction = toResolvedCallableSymbol() as? FirFunctionSymbol<*> ?: return null
-    if (!predicate(firFunction)) return null
-    val formverInvariantsArgument = argument
-    if (formverInvariantsArgument !is FirAnonymousFunctionExpression)
-        error("Only lambdas are allowed as arguments of ${firFunction.name}.")
-    return formverInvariantsArgument.anonymousFunction
+enum class SpecBlockKind(val functionName: String) {
+    PRECONDITIONS("preconditions"),
+    POSTCONDITIONS("postconditions"),
+    LOOP_INVARIANTS("loopInvariants"),
 }
 
-fun extractLoopInvariants(parentBlock: FirBlock): FirBlock? {
-    val firstStmt = parentBlock.statements.firstOrNull() ?: return null
-    return firstStmt.extractFormverFirBlock { isFormverFunctionNamed("loopInvariants") }?.body
+/** The specification block [this] calls, or `null` if it is not such a call. */
+fun FirStatement.specBlockKind(): SpecBlockKind? {
+    if (this !is FirFunctionCall) return null
+    val symbol = toResolvedCallableSymbol() as? FirFunctionSymbol<*> ?: return null
+    return SpecBlockKind.entries.firstOrNull { symbol.isFormverFunctionNamed(it.functionName) }
 }
+
+private fun FirFunctionCall.specBlockLambda(): FirAnonymousFunction {
+    val argument = argument
+    if (argument !is FirAnonymousFunctionExpression)
+        error("Only lambdas are allowed as arguments of ${specBlockKind()?.functionName}.")
+    return argument.anonymousFunction
+}
+
+/** What a statement list is, which is what decides where specification blocks may sit in it. */
+enum class SpecBlockPosition { FUNCTION_BODY, LOOP_BODY, NONE }
+
+/**
+ * The specification-block calls conversion picks up from [block].
+ *
+ * The single authority on where a specification block counts: extraction reads what this returns,
+ * target selection asks whether it returns anything, and [findIgnoredSpecBlocks] treats everything
+ * else as dropped. Resolves names only, so it is safe to ask about a body conversion may yet reject.
+ */
+fun usedSpecBlocks(block: FirBlock, position: SpecBlockPosition): Map<SpecBlockKind, FirFunctionCall> {
+    fun statementAt(index: Int, kind: SpecBlockKind): FirFunctionCall? =
+        (block.statements.getOrNull(index) as? FirFunctionCall)?.takeIf { it.specBlockKind() == kind }
+
+    return when (position) {
+        SpecBlockPosition.NONE -> emptyMap()
+        SpecBlockPosition.LOOP_BODY -> buildMap {
+            statementAt(0, SpecBlockKind.LOOP_INVARIANTS)?.let { put(SpecBlockKind.LOOP_INVARIANTS, it) }
+        }
+        SpecBlockPosition.FUNCTION_BODY -> buildMap {
+            val precond = statementAt(0, SpecBlockKind.PRECONDITIONS)
+            if (precond != null) put(SpecBlockKind.PRECONDITIONS, precond)
+            val postcond = statementAt(if (precond != null) 1 else 0, SpecBlockKind.POSTCONDITIONS)
+            if (postcond != null) put(SpecBlockKind.POSTCONDITIONS, postcond)
+        }
+    }
+}
+
+/**
+ * Every specification-block call inside [body] that conversion will not pick up, in source order.
+ *
+ * Conversion resolves these calls by name wherever they appear and no-ops them, so a block outside
+ * the position [usedSpecBlocks] reads is dropped without a word. Nested statement lists count: a
+ * block in an `if` branch is ignored just as surely as one further down the body. Lambdas and nested
+ * functions are skipped, having their own specification blocks in their own right.
+ */
+fun findIgnoredSpecBlocks(body: FirBlock): List<Pair<SpecBlockKind, FirFunctionCall>> =
+    IgnoredSpecBlockCollector().run {
+        visitStatements(body, SpecBlockPosition.FUNCTION_BODY)
+        ignored
+    }
+
+private class IgnoredSpecBlockCollector : FirVisitorVoid() {
+    val ignored = mutableListOf<Pair<SpecBlockKind, FirFunctionCall>>()
+    private val used = mutableListOf<FirFunctionCall>()
+
+    fun visitStatements(block: FirBlock, position: SpecBlockPosition) {
+        used.addAll(usedSpecBlocks(block, position).values)
+        block.statements.forEach { it.accept(this) }
+    }
+
+    override fun visitBlock(block: FirBlock) = visitStatements(block, SpecBlockPosition.NONE)
+
+    override fun visitWhileLoop(whileLoop: FirWhileLoop) {
+        whileLoop.condition.accept(this)
+        visitStatements(whileLoop.block, SpecBlockPosition.LOOP_BODY)
+    }
+
+    override fun visitFunctionCall(functionCall: FirFunctionCall) {
+        val kind = functionCall.specBlockKind()
+        if (kind == null) {
+            visitElement(functionCall)
+            return
+        }
+        if (used.none { it === functionCall }) ignored.add(kind to functionCall)
+    }
+
+    override fun visitAnonymousFunction(anonymousFunction: FirAnonymousFunction) = Unit
+
+    override fun visitSimpleFunction(simpleFunction: FirSimpleFunction) = Unit
+
+    override fun visitElement(element: FirElement) = element.acceptChildren(this)
+}
+
+fun extractLoopInvariants(parentBlock: FirBlock): FirBlock? =
+    usedSpecBlocks(parentBlock, SpecBlockPosition.LOOP_BODY)[SpecBlockKind.LOOP_INVARIANTS]?.specBlockLambda()?.body
 
 data class FirSpecification(val precond: FirBlock?, val postcond: FirBlock?, val returnVar: FirValueParameterSymbol?) {
     constructor() : this(null, null, null)
@@ -38,16 +123,13 @@ private fun FirAnonymousFunction.extractFormverReturnVar(returnType: ConeKotlinT
     return param.symbol
 }
 
+/** Whether callers of a function with body [parentBlock] may assume a SnaKt specification of it. */
+fun hasFirSpecification(parentBlock: FirBlock): Boolean =
+    usedSpecBlocks(parentBlock, SpecBlockPosition.FUNCTION_BODY).isNotEmpty()
+
 fun extractFirSpecification(parentBlock: FirBlock, returnType: ConeKotlinType): FirSpecification {
-    val firstStmt = parentBlock.statements.firstOrNull() ?: return FirSpecification()
-
-    firstStmt.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }?.let { lambda ->
-        return FirSpecification(null, lambda.body, lambda.extractFormverReturnVar(returnType))
-    }
-
-    val precond = firstStmt.extractFormverFirBlock { isFormverFunctionNamed("preconditions") }
-        ?: return FirSpecification()
-    val postcond =
-        parentBlock.statements.getOrNull(1)?.extractFormverFirBlock { isFormverFunctionNamed("postconditions") }
-    return FirSpecification(precond.body, postcond?.body, postcond?.extractFormverReturnVar(returnType))
+    val blocks = usedSpecBlocks(parentBlock, SpecBlockPosition.FUNCTION_BODY)
+    val precond = blocks[SpecBlockKind.PRECONDITIONS]?.specBlockLambda()
+    val postcond = blocks[SpecBlockKind.POSTCONDITIONS]?.specBlockLambda()
+    return FirSpecification(precond?.body, postcond?.body, postcond?.extractFormverReturnVar(returnType))
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/ProgramConverter.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.kotlin.formver.core.conversion
 
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.fir.expressions.FirBlock
 import org.jetbrains.kotlin.descriptors.isInterface
 import org.jetbrains.kotlin.diagnostics.DiagnosticContext
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
@@ -78,6 +79,22 @@ class ProgramConverter(
 
     override fun reportMinorInternalError(msg: String) =
         emit(currentDeclarationSource, ConversionErrors.MINOR_INTERNAL_ERROR, msg)
+
+    private fun reportIgnoredSpecBlocks(body: FirBlock) {
+        for ((kind, call) in findIgnoredSpecBlocks(body)) {
+            val expectedPosition = when (kind) {
+                SpecBlockKind.PRECONDITIONS -> "be the first statement of the function body"
+                SpecBlockKind.POSTCONDITIONS ->
+                    "immediately follow `preconditions`, or be the first statement of the function body"
+                SpecBlockKind.LOOP_INVARIANTS -> "be the first statement of a loop body"
+            }
+            emit(
+                call.source,
+                ConversionErrors.IGNORED_SPEC_BLOCK,
+                "This `${kind.functionName}` block is ignored: it must $expectedPosition.",
+            )
+        }
+    }
 
     private fun reportVerificationSkipped(source: KtSourceElement?, msg: String) {
         context(diagnosticContext) {
@@ -376,6 +393,7 @@ class ProgramConverter(
             return Pair(emptyList(), emptyList())
         }
 
+        reportIgnoredSpecBlocks(body)
         val firSpec = extractFirSpecification(body, declaration.symbol.resolvedReturnType)
 
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrorMessages.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrorMessages.kt
@@ -26,5 +26,10 @@ object ConversionErrorMessages : BaseDiagnosticRendererFactory() {
             "{0}",
             CommonRenderers.STRING,
         )
+        map.put(
+            ConversionErrors.IGNORED_SPEC_BLOCK,
+            "{0}",
+            CommonRenderers.STRING,
+        )
     }
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrors.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/diagnostics/ConversionErrors.kt
@@ -20,6 +20,9 @@ object ConversionErrors : KtDiagnosticsContainer() {
     val PURITY_VIOLATION by error1<PsiElement, String>()
     val MINOR_INTERNAL_ERROR by error1<PsiElement, String>(SourceElementPositioningStrategies.DECLARATION_NAME)
 
+    /** A `preconditions`/`postconditions`/`loopInvariants` block sits where conversion never looks for it. */
+    val IGNORED_SPEC_BLOCK by error1<PsiElement, String>()
+
     /**
      * Per-function summary fired by `ProgramConverter.validateAll` whenever a registered declaration's
      * pipeline (signature embedding, body conversion, or validation) produced any blocking errors.

--- a/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
+++ b/formver.compiler-plugin/plugin/src/org/jetbrains/kotlin/formver/plugin/compiler/ViperPoweredDeclarationChecker.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.formver.common.PluginConfiguration
 import org.jetbrains.kotlin.formver.common.SnaktInternalException
 import org.jetbrains.kotlin.formver.common.TargetsSelection
 import org.jetbrains.kotlin.formver.core.conversion.ProgramConverter
+import org.jetbrains.kotlin.formver.core.conversion.hasFirSpecification
 import org.jetbrains.kotlin.formver.core.embeddings.expression.debug.print
 import org.jetbrains.kotlin.formver.core.names.SimpleNameResolver
 import org.jetbrains.kotlin.formver.core.shouldVerify
@@ -36,11 +37,23 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
-private val FirContractDescriptionOwner.hasContract: Boolean
+private val FirContractDescriptionOwner.hasKotlinContract: Boolean
     get() = when (val description = contractDescription) {
         is FirResolvedContractDescription -> description.effects.isNotEmpty()
         else -> false
     }
+
+private val FirSimpleFunction.hasSnaktSpecification: Boolean
+    get() = body?.let { hasFirSpecification(it) } == true
+
+/**
+ * Whether callers of [this] may assume anything about it that its own body has to establish.
+ *
+ * Both a Kotlin `contract { }` and a SnaKt specification block qualify: a callee that is not a
+ * target is never checked against the conditions its callers assume of it.
+ */
+private val FirSimpleFunction.hasContract: Boolean
+    get() = hasKotlinContract || hasSnaktSpecification
 
 private fun TargetsSelection.applicable(declaration: FirSimpleFunction): Boolean = when (this) {
     TargetsSelection.ALL_TARGETS -> true

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/services/ExtensionRegistrarConfigurator.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.formver.common.*
 import org.jetbrains.kotlin.formver.locality.plugin.LocalityExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.compiler.FormalVerificationPluginExtensionRegistrar
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.ALWAYS_VALIDATE
+import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DEFAULT_SELECTION
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.DUMP_UNIQUENESS_CFG
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.FULL_VIPER_DUMP
 import org.jetbrains.kotlin.formver.plugin.services.FormVerDirectives.LOCALITY_CHECK_ONLY
@@ -51,14 +52,17 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
         val uniquenessOnly = UNIQUE_CHECK_ONLY in module.directives
         val localityOnly = LOCALITY_CHECK_ONLY in module.directives
         val dumpUniquenessCFG = DUMP_UNIQUENESS_CFG in module.directives
+        val defaultSelection = DEFAULT_SELECTION in module.directives
         val verificationSelection = when {
             conversionOnly -> TargetsSelection.FORCE_DISABLE
             ALWAYS_VALIDATE in module.directives -> TargetsSelection.ALL_TARGETS
             uniquenessOnly || localityOnly -> TargetsSelection.NO_TARGETS
+            defaultSelection -> TargetsSelection.defaultBehaviour()
             else -> TargetsSelection.ALL_TARGETS
         }
         val conversionSelection = when {
             uniquenessOnly || localityOnly -> TargetsSelection.NO_TARGETS
+            defaultSelection -> TargetsSelection.defaultBehaviour()
             else -> TargetsSelection.ALL_TARGETS
         }
         val checkUniqueness = uniquenessOnly
@@ -116,6 +120,10 @@ object FormVerDirectives : SimpleDirectivesContainer() {
 
     val NEVER_VALIDATE by directive(
         description = "Run in conversion-only mode: skip verification, keep consistency checking"
+    )
+
+    val DEFAULT_SELECTION by directive(
+        description = "Select targets the way an unconfigured plugin does, rather than taking every function"
     )
 }
 

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -815,6 +815,22 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Nested
+    @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/target_selection")
+    @TestDataPath("$PROJECT_ROOT")
+    public class Target_selection {
+      @Test
+      public void testAllFilesPresentInTarget_selection() {
+        KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("formver.compiler-plugin/testData/diagnostics/verification/target_selection"), Pattern.compile("^(.+)\\.kt$"), null, true);
+      }
+
+      @Test
+      @TestMetadata("spec_block_is_a_contract.kt")
+      public void testSpec_block_is_a_contract() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.kt");
+      }
+    }
+
+    @Nested
     @TestMetadata("formver.compiler-plugin/testData/diagnostics/verification/types")
     @TestDataPath("$PROJECT_ROOT")
     public class Types {
@@ -885,6 +901,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       @TestMetadata("loops.kt")
       public void testLoops() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/loops.kt");
+      }
+
+      @Test
+      @TestMetadata("misplaced_spec_blocks.kt")
+      public void testMisplaced_spec_blocks() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.kt");
       }
 
       @Test

--- a/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.fir.diag.txt
@@ -1,0 +1,56 @@
+/spec_block_is_a_contract.kt: info: Generated Viper text for alwaysPositive:
+method alwaysPositive(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) > 0
+{
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/spec_block_is_a_contract.kt: info: Generated Viper text for atLeastTen:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method atLeastTen(x: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(x), intType())
+  requires intFromRef(x) >= 10
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  assert intFromRef(x) > 100
+  v_ret_0 := x
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/spec_block_is_a_contract.kt: info: Generated Viper text for caller:
+function size(this: Ref): Ref
+  requires isSubtype(typeOf(this), BooleanArray())
+  ensures isSubtype(typeOf(result), intType())
+
+
+method alwaysPositive(x: Ref) returns (ret_1: Ref)
+  requires isSubtype(typeOf(x), intType())
+  ensures isSubtype(typeOf(ret_1), intType())
+  ensures intFromRef(ret_1) > 0
+
+
+method atLeastTen(x: Ref) returns (ret_2: Ref)
+  requires isSubtype(typeOf(x), intType())
+  requires intFromRef(x) >= 10
+  ensures isSubtype(typeOf(ret_2), intType())
+
+
+method caller() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var positive: Ref
+  positive := alwaysPositive(intToRef(-1))
+  assert intFromRef(positive) > 0
+  v_ret_0 := atLeastTen(intToRef(20))
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.kt
@@ -1,0 +1,32 @@
+// FULL_JDK
+// DEFAULT_SELECTION
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+// A specification block is the only thing marking these two functions as worth verifying.
+// Callers may assume what they promise, so their bodies have to be checked against it.
+
+<!VIPER_VERIFICATION_ERROR!>fun <!VIPER_TEXT!>alwaysPositive<!>(x: Int): Int {
+    postconditions<Int> {
+        it > 0
+    }
+    return x
+}<!>
+
+fun <!VIPER_TEXT!>atLeastTen<!>(x: Int): Int {
+    preconditions {
+        x >= 10
+    }
+    verify(<!VIPER_VERIFICATION_ERROR!>x > 100<!>)
+    return x
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>caller<!>(): Int {
+    val positive = alwaysPositive(-1)
+    verify(positive > 0)
+    return atLeastTen(20)
+}
+
+// Neither specified nor annotated: not a target, and nothing is assumed of it.
+fun unspecified(x: Int): Int = x + 1

--- a/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/target_selection/spec_block_is_a_contract.viper.diag.txt
@@ -1,0 +1,3 @@
+/spec_block_is_a_contract.kt: warning: Viper verification error: Postcondition of alwaysPositive might not hold. Assertion intFromRef(v_ret_0) > 0 might not hold.
+
+/spec_block_is_a_contract.kt: warning: Viper verification error: Assert might fail. Assertion intFromRef(x) > 100 might not hold.

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.fir.diag.txt
@@ -1,0 +1,19 @@
+/misplaced_spec_blocks.kt: error: Function 'preconditionsAfterPostconditions' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `preconditions` block is ignored: it must be the first statement of the function body.
+
+/misplaced_spec_blocks.kt: error: Function 'postconditionsNotImmediatelyAfterPreconditions' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `postconditions` block is ignored: it must immediately follow `preconditions`, or be the first statement of the function body.
+
+/misplaced_spec_blocks.kt: error: Function 'loopInvariantsNotFirstInLoop' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `loopInvariants` block is ignored: it must be the first statement of a loop body.
+
+/misplaced_spec_blocks.kt: error: Function 'nestedPreconditions' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `preconditions` block is ignored: it must be the first statement of the function body.
+
+/misplaced_spec_blocks.kt: error: Function 'nestedLoopInvariants' was not verified because of errors in its declaration
+
+/misplaced_spec_blocks.kt: error: This `loopInvariants` block is ignored: it must be the first statement of a loop body.

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/misplaced_spec_blocks.kt
@@ -1,0 +1,57 @@
+// FULL_JDK
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.preconditions
+import org.jetbrains.kotlin.formver.plugin.postconditions
+import org.jetbrains.kotlin.formver.plugin.loopInvariants
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>preconditionsAfterPostconditions<!>(arg: Boolean): Boolean {
+    postconditions<Boolean> { ret -> ret == arg }
+    <!IGNORED_SPEC_BLOCK!>preconditions {
+        arg == true
+    }<!>
+    return arg
+}
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>postconditionsNotImmediatelyAfterPreconditions<!>(arg: Boolean): Boolean {
+    preconditions {
+        arg == true
+    }
+    val unrelated = arg
+    <!IGNORED_SPEC_BLOCK!>postconditions<Boolean> { ret -> ret == arg }<!>
+    return unrelated
+}
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>loopInvariantsNotFirstInLoop<!>() {
+    var i = 0
+    while (i < 10) {
+        i = i + 1
+        <!IGNORED_SPEC_BLOCK!>loopInvariants {
+            i <= 10
+        }<!>
+    }
+}
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>nestedPreconditions<!>(arg: Boolean) {
+    if (arg) {
+        <!IGNORED_SPEC_BLOCK!>preconditions {
+            arg == true
+        }<!>
+    }
+}
+
+@AlwaysVerify
+fun <!VERIFICATION_SKIPPED!>nestedLoopInvariants<!>() {
+    var i = 0
+    while (i < 10) {
+        if (i > 5) {
+            <!IGNORED_SPEC_BLOCK!>loopInvariants {
+                i <= 10
+            }<!>
+        }
+        i = i + 1
+    }
+}


### PR DESCRIPTION
Unifies #230 and #233, which touch the same seam.

`preconditions`/`postconditions`/`loopInvariants` are resolved by name wherever they appear and
turned into no-ops, so a block outside the position conversion reads was dropped silently — same
source, opposite verification outcome. Separately, a function whose only specification was a spec
block was not a verification target under the default selection, while its callers still assumed
its postconditions, making the spec an axiom nothing checked.

`usedSpecBlocks` is now the single authority on where a spec block counts. Extraction reads what it
returns, `TARGETS_WITH_CONTRACT` asks whether it returns anything, and `findIgnoredSpecBlocks` walks
a body — nested blocks and loops included — reporting everything else as the new
`IGNORED_SPEC_BLOCK` error. It resolves names only, so target selection can ask about a body
conversion may yet reject.

Tests: `misplaced_spec_blocks.kt` (misordered and nested blocks), and `spec_block_is_a_contract.kt`
under a new `DEFAULT_SELECTION` directive, since the existing suite runs everything at
`all_targets`.