### PR TITLE
Test agent script helper behavior

### DIFF
--- a/agent-scripts/lib.sh
+++ b/agent-scripts/lib.sh
@@ -25,9 +25,12 @@ need_python3() {
 # and --tests is case-sensitive. A name already in method form, and a path to
 # the .kt, are both accepted.
 gradle_filter() {
-    local pattern="${1##*/}"
-    pattern="${pattern%.kt}"
-    if [[ "$pattern" == test* ]]; then
+    local pattern="${1##*/}" source_file=0
+    if [[ "$pattern" == *.kt ]]; then
+        pattern="${pattern%.kt}"
+        source_file=1
+    fi
+    if [[ "$source_file" -eq 0 && "$pattern" == test* ]]; then
         printf '%s' "$pattern"
     else
         printf '%s%s' "$(printf '%s' "${pattern:0:1}" | tr '[:lower:]' '[:upper:]')" "${pattern:1}" \

--- a/agent-scripts/tests/run.sh
+++ b/agent-scripts/tests/run.sh
@@ -8,6 +8,9 @@ TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$(cd "$TESTS_DIR/.." && pwd)"
 FIXTURES="$TESTS_DIR/fixtures"
 
+# shellcheck source=../lib.sh
+source "$LIB_DIR/lib.sh"
+
 failures=0
 
 # assert_eq NAME EXPECTED_STDOUT EXPECTED_EXIT -- CMD...
@@ -90,6 +93,30 @@ assert_eq "counts: a skipped test is neither passed nor failed" \
 assert_eq "counts: malformed XML is reported, not silently dropped" \
     "1 0 0 0 1" 0 \
     -- python3 "$LIB_DIR/junit_counts.py" "$FIXTURES/malformed.xml" "$FIXTURES/passing.xml"
+
+assert_eq "gradle_filter: a source path becomes its generated test method" \
+    "Non_local_returns" 0 \
+    -- gradle_filter "diagnostics/verification/non-local-returns.kt"
+
+assert_eq "gradle_filter: an existing method name remains unchanged" \
+    "testNon_local_returns" 0 \
+    -- gradle_filter "testNon_local_returns"
+
+assert_eq "gradle_filter: source names beginning with test are not mistaken for methods" \
+    "Test_helpers" 0 \
+    -- gradle_filter "diagnostics/verification/test_helpers.kt"
+
+assert_eq "assertion types: opentest4j failures carry a golden diff" \
+    "" 0 \
+    -- is_assertion_failure_type "org.opentest4j.AssertionFailedError"
+
+assert_eq "assertion types: any ComparisonFailure carries a golden diff" \
+    "" 0 \
+    -- is_assertion_failure_type "com.intellij.rt.execution.junit.ComparisonFailure"
+
+assert_eq "assertion types: ordinary exceptions do not carry a golden diff" \
+    "" 1 \
+    -- is_assertion_failure_type "java.lang.IllegalStateException"
 
 if [[ "$failures" -gt 0 ]]; then
     echo "$failures assertion(s) failed"


### PR DESCRIPTION
## Summary

- exercise `gradle_filter` and golden-assertion classification in the no-build script test suite
- distinguish `.kt` source names from generated test method names
- fix filtering for source files whose names begin with `test`

## Testing

- `agent-scripts/tests/run.sh`
- `./agent-scripts/check-all.sh`

## Friction observed

- The repository has few isolated unit-test targets; most compiler behavior uses generated golden tests.
- `check-all.sh` is comprehensive but took about 3m38s for this shell-only change.
- Running ShellCheck directly against all agent scripts reports pre-existing findings and lacks a configured project command; the repository's actual pre-commit hooks passed.
