### PR TITLE
Allow field reads in specifications

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/conversion/StmtConversionVisitor.kt
@@ -336,6 +336,9 @@ object StmtConversionVisitor : FirVisitor<ExpEmbedding, StmtConversionContext>()
         val invariants = buildList {
             data.retrievePropertiesAndParameters().forEach {
                 addAll(it.provenInvariants())
+                // Without these the loop gives up the permissions to the fields of everything in scope, so
+                // no invariant may mention such a field and nothing may be read from one after the loop.
+                addAll(it.accessInvariants(data.typeResolver))
             }
             extractLoopInvariants(whileLoop.block)?.let {
                 addAll(data.withScopeImpl(ScopeIndex.NoScope) { data.collectInvariants(it) })

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationContext.kt
@@ -40,6 +40,15 @@ interface LinearizationContext {
 
     val typeResolver: TypeResolver
 
+    /**
+     * Whether an assumption can be recorded here.
+     *
+     * An `inhale` is a statement, so a context producing a single Viper expression has nowhere to put one.
+     * Facts that would have been inhaled are dropped there, which costs the verifier information but never
+     * adds any.
+     */
+    val canInhale: Boolean
+
     fun freshAnonVar(type: TypeEmbedding): AnonymousVariableEmbedding
 
     fun asBlock(action: LinearizationContext.() -> Unit): Stmt.Seqn

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -244,7 +244,10 @@ data class LinearizationVisitor(
         }
     }
 
-    override fun visitInhaleInvariants(e: InhaleInvariants): Linearizable {
+    override fun visitInhaleInvariants(e: InhaleInvariants): Linearizable =
+        InhalingIfPossible(inhaling = linearizeInhaleInvariants(e), plain = e.exp.linearize())
+
+    private fun linearizeInhaleInvariants(e: InhaleInvariants): Linearizable {
         // InhaleInvariantsForVariable: expression is a variable, use OnlyToViper-style
         // (toViperUnusedResult must call toViper, not just iterate children, to emit the inhales)
         if (e.exp.underlyingVariable != null) {
@@ -605,4 +608,26 @@ data class LinearizationVisitor(
     }
 
     // endregion
+}
+
+/**
+ * Emits the invariants where the context can hold an `inhale`, and the bare expression where it cannot.
+ *
+ * The choice depends on the context, not on the embedding, so it can only be made with the
+ * [LinearizationContext] in hand.
+ */
+private class InhalingIfPossible(private val inhaling: Linearizable, private val plain: Linearizable) : Linearizable {
+    private fun LinearizationContext.pick(): Linearizable = if (canInhale) inhaling else plain
+
+    override fun toViper(ctx: LinearizationContext): Exp = ctx.pick().toViper(ctx)
+
+    override fun toViperStoringIn(result: VariableEmbedding, ctx: LinearizationContext) =
+        ctx.pick().toViperStoringIn(result, ctx)
+
+    override fun toViperMaybeStoringIn(result: VariableEmbedding?, ctx: LinearizationContext) =
+        ctx.pick().toViperMaybeStoringIn(result, ctx)
+
+    override fun toViperBuiltinType(ctx: LinearizationContext): Exp = ctx.pick().toViperBuiltinType(ctx)
+
+    override fun toViperUnusedResult(ctx: LinearizationContext) = ctx.pick().toViperUnusedResult(ctx)
 }

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/Linearizer.kt
@@ -38,6 +38,9 @@ data class Linearizer(
     override val logicOperatorPolicy: LogicOperatorPolicy
         get() = LogicOperatorPolicy.CONVERT_TO_IF
 
+    override val canInhale: Boolean
+        get() = true
+
     override fun freshAnonVar(type: TypeEmbedding): AnonymousVariableEmbedding {
         val variable = state.freshAnonVar(type)
         addDeclaration(variable.toLocalVarDecl())

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureExpLinearizer.kt
@@ -39,6 +39,9 @@ data class PureExpLinearizer(
     override val logicOperatorPolicy: LogicOperatorPolicy
         get() = LogicOperatorPolicy.CONVERT_TO_EXPRESSION
 
+    override val canInhale: Boolean
+        get() = false
+
     override fun <R> withPosition(newSource: KtSourceElement, action: LinearizationContext.() -> R): R =
         copy(source = newSource).action()
 

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/PureFunBodyLinearizer.kt
@@ -39,6 +39,9 @@ data class PureFunBodyLinearizer(
     override val logicOperatorPolicy: LogicOperatorPolicy
         get() = LogicOperatorPolicy.CONVERT_TO_EXPRESSION
 
+    override val canInhale: Boolean
+        get() = false
+
     override fun <R> withPosition(newSource: KtSourceElement, action: LinearizationContext.() -> R): R =
         copy(source = newSource).action()
 

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -112,6 +112,18 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       public void testList() {
         runTest("formver.compiler-plugin/testData/diagnostics/stdlib/list/list.kt");
       }
+
+      @Test
+      @TestMetadata("size_across_loop.kt")
+      public void testSize_across_loop() {
+        runTest("formver.compiler-plugin/testData/diagnostics/stdlib/list/size_across_loop.kt");
+      }
+
+      @Test
+      @TestMetadata("size_in_specs.kt")
+      public void testSize_in_specs() {
+        runTest("formver.compiler-plugin/testData/diagnostics/stdlib/list/size_in_specs.kt");
+      }
     }
 
     @Nested

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_across_loop.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_across_loop.fir.diag.txt
@@ -1,0 +1,93 @@
+/size_across_loop.kt: info: Generated Viper text for size_read_after_loop:
+field size: Ref
+
+method size_read_after_loop(a: Ref, b: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(a), List())
+  requires acc(a.size, write)
+  requires intFromRef(a.size) >= 0
+  requires isSubtype(typeOf(b), List())
+  requires acc(b.size, write)
+  requires intFromRef(b.size) >= 0
+  ensures acc(a.size, write)
+  ensures intFromRef(a.size) >= 0
+  ensures acc(b.size, write)
+  ensures intFromRef(b.size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var i: Ref
+  var anon_0: Ref
+  var anon_1: Ref
+  i := intToRef(0)
+  label cont
+    invariant isSubtype(typeOf(i), intType())
+    invariant isSubtype(typeOf(a), List())
+    invariant acc(a.size, write)
+    invariant intFromRef(a.size) >= 0
+    invariant isSubtype(typeOf(b), List())
+    invariant acc(b.size, write)
+    invariant intFromRef(b.size) >= 0
+  anon_1 := a.size
+  inhale isSubtype(typeOf(anon_1), intType())
+  anon_0 := ltInts(i, anon_1)
+  if (boolFromRef(anon_0)) {
+    i := plusInts(i, intToRef(1))
+    goto cont
+  }
+  label break
+  assert isSubtype(typeOf(i), intType())
+  assert isSubtype(typeOf(a), List())
+  assert acc(a.size, write)
+  assert intFromRef(a.size) >= 0
+  assert isSubtype(typeOf(b), List())
+  assert acc(b.size, write)
+  assert intFromRef(b.size) >= 0
+  v_ret_0 := b.size
+  inhale isSubtype(typeOf(v_ret_0), intType())
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/size_across_loop.kt: info: Generated Viper text for size_of_aliased_list:
+field size: Ref
+
+method size_of_aliased_list(l: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(l), List())
+  requires acc(l.size, write)
+  requires intFromRef(l.size) >= 0
+  ensures acc(l.size, write)
+  ensures intFromRef(l.size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var m: Ref
+  var i: Ref
+  var anon_0: Ref
+  var anon_1: Ref
+  m := l
+  i := intToRef(0)
+  label cont
+    invariant isSubtype(typeOf(m), List())
+    invariant acc(m.size, write)
+    invariant intFromRef(m.size) >= 0
+    invariant isSubtype(typeOf(i), intType())
+    invariant isSubtype(typeOf(l), List())
+    invariant acc(l.size, write)
+    invariant intFromRef(l.size) >= 0
+  anon_1 := m.size
+  inhale isSubtype(typeOf(anon_1), intType())
+  anon_0 := ltInts(i, anon_1)
+  if (boolFromRef(anon_0)) {
+    i := plusInts(i, intToRef(1))
+    goto cont
+  }
+  label break
+  assert isSubtype(typeOf(m), List())
+  assert acc(m.size, write)
+  assert intFromRef(m.size) >= 0
+  assert isSubtype(typeOf(i), intType())
+  assert isSubtype(typeOf(l), List())
+  assert acc(l.size, write)
+  assert intFromRef(l.size) >= 0
+  v_ret_0 := i
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_across_loop.kt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_across_loop.kt
@@ -1,0 +1,25 @@
+// FULL_JDK
+// WITH_STDLIB
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>size_read_after_loop<!>(a: List<Int>, b: List<Int>): Int {
+    var i = 0
+    while (i < a.size) {
+        i = i + 1
+    }
+    return b.size
+}
+
+// The loop invariant asks for full permission to the size of both `l` and its alias `m`, which is twice
+// the permission the caller can hold. Method parameters of the same type have the same limitation.
+@AlwaysVerify
+fun <!VIPER_TEXT!>size_of_aliased_list<!>(l: List<Int>): Int {
+    val m = l
+    var i = 0
+    <!VIPER_VERIFICATION_ERROR!>while (i < m.size) {
+        i = i + 1
+    }<!>
+    return i
+}

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_across_loop.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_across_loop.viper.diag.txt
@@ -1,0 +1,1 @@
+/size_across_loop.kt: warning: Viper verification error: Loop invariant acc(l.size, write) might not hold on entry. There might be insufficient permission to access l.size

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_in_specs.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_in_specs.fir.diag.txt
@@ -1,0 +1,108 @@
+/size_in_specs.kt: info: Generated Viper text for size_in_postcondition:
+field size: Ref
+
+method size_in_postcondition(l: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(l), List())
+  requires acc(l.size, write)
+  requires intFromRef(l.size) >= 0
+  ensures acc(l.size, write)
+  ensures intFromRef(l.size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) == intFromRef(l.size)
+{
+  v_ret_0 := l.size
+  inhale isSubtype(typeOf(v_ret_0), intType())
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/size_in_specs.kt: info: Generated Viper text for size_in_precondition:
+field size: Ref
+
+method get(this: Ref, index: Ref) returns (ret_2: Ref)
+  requires isSubtype(typeOf(this), List())
+  requires acc(this.size, write)
+  requires intFromRef(this.size) >= 0
+  requires isSubtype(typeOf(index), intType())
+  requires intFromRef(index) >= 0
+  requires intFromRef(this.size) > intFromRef(index)
+  ensures acc(this.size, write)
+  ensures intFromRef(this.size) >= 0
+  ensures isSubtype(typeOf(ret_2), intType())
+  ensures intFromRef(this.size) == old(intFromRef(this.size))
+
+
+method size_in_precondition(l: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(l), List())
+  requires acc(l.size, write)
+  requires intFromRef(l.size) >= 0
+  requires intFromRef(l.size) > 0
+  ensures acc(l.size, write)
+  ensures intFromRef(l.size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := get(l, intToRef(0))
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/size_in_specs.kt: info: Generated Viper text for count_up_over_list:
+field size: Ref
+
+method count_up_over_list(l: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(l), List())
+  requires acc(l.size, write)
+  requires intFromRef(l.size) >= 0
+  ensures acc(l.size, write)
+  ensures intFromRef(l.size) >= 0
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures intFromRef(v_ret_0) == intFromRef(l.size)
+{
+  var i: Ref
+  var acc: Ref
+  var anon_0: Ref
+  var anon_1: Ref
+  i := intToRef(0)
+  acc := intToRef(0)
+  label cont
+    invariant isSubtype(typeOf(i), intType())
+    invariant isSubtype(typeOf(acc), intType())
+    invariant isSubtype(typeOf(l), List())
+    invariant acc(l.size, write)
+    invariant intFromRef(l.size) >= 0
+    invariant 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(l.size)
+    invariant intFromRef(acc) == intFromRef(i)
+  anon_1 := l.size
+  inhale isSubtype(typeOf(anon_1), intType())
+  anon_0 := ltInts(i, anon_1)
+  if (boolFromRef(anon_0)) {
+    var element: Ref
+    element := get(l, i)
+    acc := plusInts(acc, intToRef(1))
+    i := plusInts(i, intToRef(1))
+    goto cont
+  }
+  label break
+  assert isSubtype(typeOf(i), intType())
+  assert isSubtype(typeOf(acc), intType())
+  assert isSubtype(typeOf(l), List())
+  assert acc(l.size, write)
+  assert intFromRef(l.size) >= 0
+  assert 0 <= intFromRef(i) && intFromRef(i) <= intFromRef(l.size)
+  assert intFromRef(acc) == intFromRef(i)
+  v_ret_0 := acc
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+method get(this: Ref, index: Ref) returns (ret_3: Ref)
+  requires isSubtype(typeOf(this), List())
+  requires acc(this.size, write)
+  requires intFromRef(this.size) >= 0
+  requires isSubtype(typeOf(index), intType())
+  requires intFromRef(index) >= 0
+  requires intFromRef(this.size) > intFromRef(index)
+  ensures acc(this.size, write)
+  ensures intFromRef(this.size) >= 0
+  ensures isSubtype(typeOf(ret_3), intType())
+  ensures intFromRef(this.size) == old(intFromRef(this.size))

--- a/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_in_specs.kt
+++ b/formver.compiler-plugin/testData/diagnostics/stdlib/list/size_in_specs.kt
@@ -1,0 +1,43 @@
+// FULL_JDK
+// WITH_STDLIB
+
+import org.jetbrains.kotlin.formver.plugin.AlwaysVerify
+import org.jetbrains.kotlin.formver.plugin.loopInvariants
+import org.jetbrains.kotlin.formver.plugin.postconditions
+import org.jetbrains.kotlin.formver.plugin.preconditions
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>size_in_postcondition<!>(l: List<Int>): Int {
+    postconditions<Int> { res ->
+        res == l.size
+    }
+    return l.size
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>size_in_precondition<!>(l: List<Int>): Int {
+    preconditions {
+        l.size > 0
+    }
+    return l[0]
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>count_up_over_list<!>(l: List<Int>): Int {
+    postconditions<Int> { res ->
+        res == l.size
+    }
+
+    var i = 0
+    var acc = 0
+    while (i < l.size) {
+        loopInvariants {
+            0 <= i && i <= l.size
+            acc == i
+        }
+        val element = l[i]
+        acc = acc + 1
+        i = i + 1
+    }
+    return acc
+}


### PR DESCRIPTION
Reading `list.size` in a `preconditions`, `postconditions` or `loopInvariants` block crashed conversion: the field read is wrapped in `InhaleInvariants`, which needs a temporary and a statement position, and a specification is a single Viper expression. `LinearizationContext` now says whether it can hold an `inhale`; where it cannot, the invariants are dropped and the bare expression is emitted. That only withholds information from the verifier. There is no sound alternative — every `pureToViper` call site is a spec, a predicate body or a `forall` body, and conjoining a fact into one of those makes it an obligation rather than an assumption.

A while loop also has to carry the access invariants of everything in scope. Without them it gives up the permission to those fields, so on `main` the loop condition cannot re-read `a.size` on the second iteration and nothing may be read from a collection after the loop.

On the permission question: SnaKt emits an unstructured loop, so this turns on how Silver treats a label's invariants. `CfgGenerator` rewrites a `Label` with non-empty `invs` into a `LoopHeadBlock` — the same CFG block a structured `while` becomes — and Silicon consumes the invariants on entry (`LoopInvariantNotEstablished`) and on each back jump (`LoopInvariantNotPreserved`) before producing them into a fresh heap. Permission stated in a loop invariant is therefore taken from the current state, not conjured. It is also the same permission the enclosing method already holds: the loop reuses the `accessInvariantsForParameter()` that produces the method's own `requires acc(l.size, write)`.

The known gap is aliasing: with `val m = l` in scope the invariant asks for full permission to both `l.size` and `m.size`. `size_across_loop.kt` records that failure alongside the read-after-loop case the change fixes. It is the existing modelling choice, not a regression — `f(a: List<Int>, b: List<Int>)` already emits `requires acc(_.size, write)` twice, so the call boundary has the same limitation. Holding a collection's `size` at `wildcard` would fix both; that is a separate change.

`./agent-scripts/check-all.sh` passes.