### PR TITLE
Drop explicit Unit invariant error test

### DIFF
--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.fir.diag.txt
@@ -38,7 +38,3 @@ method testInsertedReturn() returns (v_ret_0: Ref)
   label lbl_ret_0
   inhale isSubtype(typeOf(v_ret_0), unitType())
 }
-
-/empty.kt: error: An internal error has occurred.
-Details: Every statement in invariant block must be a pure boolean invariant.
-Please report this at https://github.com/jesyspa/kotlin

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/empty.kt
@@ -31,13 +31,3 @@ fun <!VIPER_TEXT!>testInsertedReturn<!>() {
     }
     return
 }
-
-<!INTERNAL_ERROR!>fun testInsertedUnit() {
-    preconditions {
-        Unit
-    }
-    postconditions<Unit> {
-        Unit
-    }
-    return
-}<!>


### PR DESCRIPTION
## Summary

Remove the `testInsertedUnit` case that treated explicit `Unit` expressions in specification blocks as an expected internal compiler error.

The useful empty-block and labeled-return coverage remains. Internal compiler errors should not be preserved as expected golden output.

## Testing

- `./agent-scripts/test.sh --update-goldens empty` (reviewed removal only)
- `./agent-scripts/test.sh empty`
- `./agent-scripts/check-all.sh`
