### PR TITLE
Fix loop-carried uniqueness state over recursive structures

### DIFF
--- a/formver.common/src/org/jetbrains/kotlin/formver/common/services/TagCollector.kt
+++ b/formver.common/src/org/jetbrains/kotlin/formver/common/services/TagCollector.kt
@@ -120,6 +120,15 @@ abstract class TagCollector(
     }
 
     /**
+     * The expected side of a filtered comparison comes from parsing markers back out of the test file, and a marker
+     * names a tag and a range and nothing else: it cannot say that one diagnostic fired twice at one position. The
+     * reported side is matched to that by collapsing such repeats. The message of each individual report is still
+     * checked against the `.diag.txt` golden.
+     */
+    private fun deduplicatedReportedInfos(): Map<TestFile, List<CodeMetaInfo>> =
+        reportedInfos.mapValues { (_, infos) -> infos.distinctBy { Triple(it.tag, it.start, it.end) } }
+
+    /**
      * Renders the expected output but ignores tags that are not considered for comparison
      */
     private fun expectedFileFilteredForTags(): String {
@@ -137,7 +146,7 @@ abstract class TagCollector(
      */
     fun assertFileEqualFilteredForTags() {
         val expectedOutput = expectedFileFilteredForTags()
-        val actualOutput = renderText(reportedInfos, testServices.sourceFileProvider::getContentOfSourceFile)
+        val actualOutput = renderText(deduplicatedReportedInfos(), testServices.sourceFileProvider::getContentOfSourceFile)
         testServices.assertions.assertEquals(expectedOutput, actualOutput) {
             "Actual tags differ from golden file"
         }

--- a/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/runners/PluginPrototypeTests.kt
+++ b/formver.compiler-plugin/test-fixtures/org/jetbrains/kotlin/formver/plugin/runners/PluginPrototypeTests.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.formver.common.services.PluginAnnotationsProvider
 import org.jetbrains.kotlin.formver.common.services.TagCollector
 import org.jetbrains.kotlin.formver.plugin.compiler.PluginErrors
 import org.jetbrains.kotlin.formver.plugin.services.*
+import org.jetbrains.kotlin.formver.uniqueness.plugin.UniquenessErrors
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.TargetBackend
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
@@ -48,7 +49,7 @@ class VerificationDiagnosticsCollector(testServices: TestServices) : Diagnostics
 }
 
 class ConversionTagCollector(testService: TestServices) : TagCollector(testService) {
-    override val tagsToConsider: List<String> = PluginErrors.tags()
+    override val tagsToConsider: List<String> = PluginErrors.tags() + UniquenessErrors.tags()
 }
 
 class AllTagCollector(testService: TestServices) : TagCollector(testService)

--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -171,6 +171,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     }
 
     @Test
+    @TestMetadata("binary_tree.kt")
+    public void testBinary_tree() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt");
+    }
+
+    @Test
     @TestMetadata("break.kt")
     public void testBreak() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/break.kt");
@@ -222,6 +228,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
     @TestMetadata("leak.kt")
     public void testLeak() {
       runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/leak.kt");
+    }
+
+    @Test
+    @TestMetadata("linked_list.kt")
+    public void testLinked_list() {
+      runTest("formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt");
     }
 
     @Test

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.fir.diag.txt
@@ -1,0 +1,5 @@
+/binary_tree.kt: error: Escaping value has moved field: 'pivot.right'.
+
+/binary_tree.kt: error: Attempt to pass the same unique argument 't.left' twice.
+
+/binary_tree.kt: error: Attempt to pass the same unique argument 't.left' twice.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/binary_tree.kt
@@ -1,0 +1,34 @@
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class Tree(var left: @Unique Tree?, var right: @Unique Tree?)
+
+fun consumeBoth(a: @Unique Tree?, b: @Unique Tree?) {}
+
+fun `insert leaf into an empty child slot`(t: @Unique Tree, leaf: @Unique Tree) {
+    if (t.left == null) {
+        t.left = leaf
+    } else {
+        t.right = leaf
+    }
+}
+
+// The checker does not see `pivot?.right = root` as restoring `pivot.right`, so the pivot escapes with a moved field.
+// The same rotation on a non-null pivot checks clean, which places the gap in the safe-call assignment.
+fun `rotate right around the root`(root: @Unique Tree): @Unique Tree? {
+    val pivot: @Unique Tree? = root.left
+    root.left = pivot?.right
+    pivot?.right = root
+    return <!ESCAPE_UNIQUENESS_INCONSISTENCY!>pivot<!>
+}
+
+fun `swap the children through a temporary`(t: @Unique Tree) {
+    val tmp: @Unique Tree? = t.left
+    t.left = t.right
+    t.right = tmp
+}
+
+fun `pass the same child as two unique arguments`(t: @Unique Tree) {
+    consumeBoth(<!INVALID_DUPLICATE_UNIQUE_ARGUMENT!>t.left<!>, <!INVALID_DUPLICATE_UNIQUE_ARGUMENT!>t.left<!>)
+}

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.fir.diag.txt
@@ -1,0 +1,5 @@
+/linked_list.kt: error: Invalid access to moved reference.
+
+/linked_list.kt: error: Escaping value has moved field: 'head.next'.
+
+/linked_list.kt: error: Invalid access to moved reference.

--- a/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
+++ b/formver.compiler-plugin/testData/diagnostics/uniqueness_checker/linked_list.kt
@@ -1,0 +1,119 @@
+// FULL_JDK
+// WITH_STDLIB
+// UNIQUE_CHECK_ONLY
+
+import org.jetbrains.kotlin.formver.plugin.Borrowed
+import org.jetbrains.kotlin.formver.plugin.Unique
+
+class Node(var value: Int, var next: @Unique Node?)
+
+fun consume(n: @Unique Node?) {}
+
+fun borrow(n: @Borrowed Node?) {}
+
+fun `push front`(head: @Unique Node?): @Unique Node {
+    return Node(0, head)
+}
+
+fun `use old head after push front`(head: @Unique Node?) {
+    val fresh: @Unique Node = Node(0, head)
+    consume(fresh)
+    consume(<!INVALID_MOVED_ACCESS!>head<!>)
+}
+
+fun `detach tail`(head: @Unique Node): @Unique Node? {
+    return head.next
+}
+
+fun `return node after detaching tail`(head: @Unique Node): @Unique Node {
+    val tail: @Unique Node? = head.next
+    consume(tail)
+    return <!ESCAPE_UNIQUENESS_INCONSISTENCY!>head<!>
+}
+
+// Advancing the cursor reads `next` out of the node it is leaving; the same assignment points the cursor at what it
+// read, so nothing moved stays reachable through the cursor.
+fun `sum values`(head: @Borrowed Node?): Int {
+    var current: @Borrowed Node? = head
+    var total = 0
+    while (current != null) {
+        total = total + current.value
+        current = current.next
+    }
+    return total
+}
+
+fun `traverse then consume list`(head: @Unique Node) {
+    val total = `sum values`(head)
+    consume(head)
+}
+
+// The same walk by recursion: each call restores the node it borrowed at exit.
+fun length(n: @Borrowed Node?): Int = if (n == null) 0 else 1 + length(n.next)
+
+fun contains(n: @Borrowed Node?, v: Int): Boolean =
+    if (n == null) false else if (n.value == v) true else contains(n.next, v)
+
+fun `use list after recursive length`(head: @Unique Node) {
+    val len = length(head)
+    consume(head)
+}
+
+fun `use list after recursive search`(head: @Unique Node) {
+    val found = contains(head, 3)
+    consume(head)
+}
+
+// `next` is a `val` here, so only the payload is mutable.
+class RoNode(var value: Int, val next: @Unique RoNode?)
+
+fun consumeRo(n: @Unique RoNode?) {}
+
+fun `sum a readonly spine in a loop`(head: @Borrowed RoNode?): Int {
+    var current: @Borrowed RoNode? = head
+    var total = 0
+    while (current != null) {
+        total = total + current.value
+        current = current.next
+    }
+    return total
+}
+
+fun `sum a readonly spine recursively`(n: @Borrowed RoNode?): Int =
+    if (n == null) 0 else n.value + `sum a readonly spine recursively`(n.next)
+
+fun `bump a readonly spine recursively`(n: @Borrowed RoNode?) {
+    if (n == null) return
+    n.value = n.value + 1
+    `bump a readonly spine recursively`(n.next)
+}
+
+fun `use readonly spine list after recursion`(head: @Unique RoNode) {
+    val total = `sum a readonly spine recursively`(head)
+    `bump a readonly spine recursively`(head)
+    consumeRo(head)
+}
+
+// The field goes to `consume` before the assignment reads it, so the advance is a read of a reference already handed
+// away.
+fun `drop the tail in a loop`(head: @Unique Node?) {
+    var current: @Unique Node? = head
+    while (current != null) {
+        consume(current.next)
+        current = <!INVALID_MOVED_ACCESS!>current.next<!>
+    }
+}
+
+// `prev` gains the spine of the node assigned to it and that spine is written into `current.next` next time round,
+// which is what deepened the tracked paths until summarization bounded them.
+fun `reverse in place`(head: @Unique Node?): @Unique Node? {
+    var prev: @Unique Node? = null
+    var current: @Unique Node? = head
+    while (current != null) {
+        val next: @Unique Node? = current.next
+        current.next = prev
+        prev = current
+        current = next
+    }
+    return prev
+}

--- a/formver.compiler-plugin/uniqueness/README.md
+++ b/formver.compiler-plugin/uniqueness/README.md
@@ -40,18 +40,21 @@ The checker tracks two kinds of uniqueness:
   - `AccessState = PathTrie<Access>`
   - `UniquenessState = PathTrie<Uniqueness>`
 - `ExpressionAccessStateResolver.kt` extracts the paths touched by each expression.
+- A trie node can be a **summary node**: a leaf whose value is the join of everything that would otherwise be below it, standing for both its own prefix and every path under it. A lookup or update that would descend past a summary node lands on the node itself instead. `UniquenessState.summarizeRecursivePaths` collapses any path that revisits a symbol into a summary, which bounds the trie's depth by the number of distinct symbols a function mentions — the mechanism that keeps recursive types from growing the trie without bound.
 
 ### CFG uniqueness state analysis
 
-`GraphUniquenessStatesAnalyzer.kt` computes a fixed point over the following CFG nodes:
+`GraphUniquenessStatesAnalyzer.kt` computes a fixed point over the following CFG nodes. The outgoing state of every node is normalized by `UniquenessState.summarizeRecursivePaths` before it is recorded, so recursion through a symbol never deepens the trie past a summary node — this is what makes the fixed point terminate over recursive types.
 
 - **Initialization**
   - The initial state contains the uniqueness information of the function's parameters.
 
 - **Variable declaration/assignment**
-  - Project RHS' uniqueness substate into LHS' path.
+  - Project RHS' uniqueness substate against the incoming state.
+  - Move RHS access paths, also against the incoming state.
+  - Insert the projected substate into LHS' path.
   - Initialize LHS path to declared uniqueness.
-  - Move RHS access paths.
+  - The order matters when the LHS is a prefix of an RHS path: advancing a cursor with `current = current.next` moves the field out of the node the cursor is leaving, and overwriting `current` then drops that mark, because it describes a location the cursor no longer reaches.
 
 - **Function-call enter**
   - Move all receivers (including context receivers) and value arguments.
@@ -95,6 +98,7 @@ Current scenarios include:
 - return/throw escape consistency
 - loops, `when`, `try/catch`, nullable flows
 - constructor/operator cases
+- recursive data structures: linked lists and binary trees, walked both by loop and by recursion
 
 ## Current Limitations / Untested Behavior
 
@@ -116,4 +120,7 @@ Known limitations in current code/tests:
 
 - **Interaction with closures** 
   - The current `GraphUniquenessStatesAnalyzer.kt` visits the lambda subgraphs as if they were part of the local control flows, which can result in unexpected behavior.
+
+- **Summary nodes are approximate**
+  - A summary node stands for a whole region of paths rather than one path, so an operation that reaches past it applies to that entire region: a read there is treated as touching everything the summary covers, and a move marks all of it. Operations at a summary join their result with the value already held, so a restore cannot clear a fact that holds of another path in the region — the approximation only ever over-reports.
   

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/AccessState.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/AccessState.kt
@@ -97,12 +97,24 @@ fun AccessState.append(other: AccessState): AccessState {
  * If any of the intermediate path components is not resolved within [uniquenessState], the uniqueness of those
  * components is automatically inferred to be the join between the declared uniqueness of the component's symbol and the
  * uniqueness of the parent.
+ *
+ * An access that reaches past a summary node lands on the summary itself, which is the only node standing for the path
+ * it names. The transform there applies to the whole region the summary covers rather than to one path in it, so its
+ * result is joined with the value already held rather than replacing it: a transform that raises the value, such as a
+ * move, still takes effect, while one that lowers it, such as restoring a borrow, cannot clear a fact that holds of
+ * some other path in the region.
  */
 context(context: CheckerContext)
 fun AccessState.transformOnTerminals(
     uniquenessState: UniquenessState,
     transform: (FirBasedSymbol<*>, UniquenessState) -> UniquenessState
 ): UniquenessState {
+    if (uniquenessState.summarizesDescendants) {
+        return children.keys.fold(uniquenessState) { state, symbol ->
+            state.copy(data = state.data.join(transform(symbol, state).data))
+        }
+    }
+
     var newUniquenessState = uniquenessState
 
     for ((symbol, accessChild) in children) {

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStateRenderer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStateRenderer.kt
@@ -18,7 +18,9 @@ private fun UniquenessState?.renderOrNull(): String =
 private fun UniquenessState.render(): String? =
     children.takeIf { it.isNotEmpty() }?.entries
         ?.flatMap { (symbol, state) ->
-            val current = "${symbol.render()} ${UniquenessRenderer.render(state.data)}"
+            // A summary node covers everything below it, so its line has to say so: it has no children to render.
+            val descendants = if (state.summarizesDescendants) " (and below)" else ""
+            val current = "${symbol.render()} ${UniquenessRenderer.render(state.data)}$descendants"
             val children = state.render()?.prependIndent("    ")
             listOfNotNull(current, children)
         }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/GraphUniquenessStatesAnalyzer.kt
@@ -83,6 +83,16 @@ class GraphUniquenessStatesAnalyzer(
     private fun UniquenessStateFlow.getOrInitialize(): UniquenessState =
         this[Unit] ?: initialState
 
+    /**
+     * Records [state] as the outcome of a node, summarized so that no path in it revisits a symbol.
+     *
+     * Normalizing at every node, rather than only where control flow merges, keeps the bound on the state space
+     * independent of which nodes the traversal happens to merge at, so the fixed point is reached whatever shape the
+     * graph has.
+     */
+    private fun UniquenessStateFlow.putSummarized(state: UniquenessState): UniquenessStateFlow =
+        put(Unit, state.summarizeRecursivePaths())
+
     override fun visitSubGraph(node: CFGNodeWithSubgraphs<*>, graph: ControlFlowGraph): Boolean {
         return node.extendsLocalFlow
     }
@@ -91,7 +101,7 @@ class GraphUniquenessStatesAnalyzer(
         node: CFGNode<*>,
         data: PathAwareUniquenessStateFlow
     ): PathAwareUniquenessStateFlow {
-        return data.transformValues { data -> data.put(Unit, data.getOrInitialize()) }
+        return data.transformValues { data -> data.putSummarized(data.getOrInitialize()) }
     }
 
     override fun visitVariableDeclarationNode(
@@ -111,21 +121,20 @@ class GraphUniquenessStatesAnalyzer(
 
             return data.transformValues { data ->
                 val uniquenessState = data.getOrInitialize()
+                val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(uniquenessState)
                 var newUniquenessState = uniquenessState
-
-                if (initializer != null) {
-                    val rightAccessState = initializer.resolveAccessState()
-                    val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(uniquenessState)
-                    newUniquenessState = newUniquenessState.insert(listOf(leftSymbol), rightUniquenessState)
-                }
-
-                newUniquenessState = leftAccessState.initialize(newUniquenessState)
 
                 if (leftSymbol.source?.kind != KtFakeSourceElementKind.WhenGeneratedSubject) {
                     newUniquenessState = rightAccessState.move(newUniquenessState)
                 }
 
-                data.put(Unit, newUniquenessState)
+                if (initializer != null) {
+                    newUniquenessState = newUniquenessState.insert(listOf(leftSymbol), rightUniquenessState)
+                }
+
+                newUniquenessState = leftAccessState.initialize(newUniquenessState)
+
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -142,20 +151,25 @@ class GraphUniquenessStatesAnalyzer(
             val leftAccessState = leftValue.resolveAccessState()
 
             return data.transformValues { data ->
-                var newUniquenessState = data.getOrInitialize()
+                val uniquenessState = data.getOrInitialize()
                 val leftAccessPaths = leftAccessState.enumeratePaths()
                 val rightAccessState = rightValue.resolveAccessState()
 
+                // The right-hand side is read before the assignment takes effect, so both what it projects and the move
+                // of the paths it reads are computed against the incoming state, and the move is applied first. That
+                // ordering matters when the left-hand side is a prefix of what was read: advancing a cursor with
+                // `current = current.next` moves the field out of the node the cursor is leaving, and overwriting
+                // `current` then drops that mark, because it described a location the cursor no longer reaches.
+                val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(uniquenessState)
+                var newUniquenessState = rightAccessState.move(uniquenessState)
+
                 if (leftAccessPaths.count() == 1) {
-                    val leftPath = leftAccessPaths.first()
-                    val rightUniquenessState = rightAccessState.projectTerminalUniquenessState(newUniquenessState)
-                    newUniquenessState = newUniquenessState.insert(leftPath, rightUniquenessState)
+                    newUniquenessState = newUniquenessState.insert(leftAccessPaths.first(), rightUniquenessState)
                 }
 
                 newUniquenessState = leftAccessState.initialize(newUniquenessState)
-                newUniquenessState = rightAccessState.move(newUniquenessState)
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -179,7 +193,7 @@ class GraphUniquenessStatesAnalyzer(
                     newUniquenessState = argument.resolveAccessState().move(newUniquenessState)
                 }
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -206,7 +220,7 @@ class GraphUniquenessStatesAnalyzer(
                     newUniquenessState = argument.resolveAccessState().initialize(newUniquenessState)
                 }
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -227,7 +241,7 @@ class GraphUniquenessStatesAnalyzer(
                 val defaultValueUniquenessState = defaultValueAccessState.projectTerminalUniquenessState(newUniquenessState)
                 newUniquenessState = newUniquenessState.insert(valueParameterPath, defaultValueUniquenessState)
                 newUniquenessState = defaultValueAccessState.move(newUniquenessState)
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }
@@ -244,7 +258,7 @@ class GraphUniquenessStatesAnalyzer(
                         val resultAccessState = jumpExpression.result.resolveAccessState()
                         newUniquenessState = resultAccessState.move(newUniquenessState)
 
-                        data.put(Unit, newUniquenessState)
+                        data.putSummarized(newUniquenessState)
                     }
                 }
             }
@@ -264,7 +278,7 @@ class GraphUniquenessStatesAnalyzer(
                 val exceptionAccessState = throwExpression.exception.resolveAccessState()
                 newUniquenessState = exceptionAccessState.move(newUniquenessState)
 
-                data.put(Unit, newUniquenessState)
+                data.putSummarized(newUniquenessState)
             }
         }
     }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/PathTrie.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/PathTrie.kt
@@ -20,12 +20,19 @@ import org.jetbrains.kotlin.formver.type.plugin.TypeFactUnifier
  * For example, for a FIR access path like `a.b.c`, the trie contains:
  * `children[a] -> children[b] -> children[c]`.
  *
- * @property data value attached to the current path prefix.
- * @property children map keyed by the next symbol component.
+ * A node may instead stand for a whole region of the path space: when [summarizesDescendants] is set, [data] is the
+ * join of the values of every path under the node, the node carries no children, and a lookup that would descend past
+ * it lands on the node itself. Summary nodes are what keeps the trie finite over recursive types; see
+ * [UniquenessState.summarizeRecursivePaths].
+ *
+ * @property data value attached to the current path prefix, and to everything below it when [summarizesDescendants].
+ * @property children map keyed by the next symbol component; empty when [summarizesDescendants].
+ * @property summarizesDescendants whether this node stands for every path below it as well as for its own prefix.
  */
 data class PathTrie<Type>(
     val data: Type,
     val children: PersistentMap<FirBasedSymbol<*>, PathTrie<Type>> = persistentMapOf(),
+    val summarizesDescendants: Boolean = false,
 )
 
 fun <Type> PathTrie<Type>.putChild(symbol: FirBasedSymbol<*>, child: PathTrie<Type>): PathTrie<Type> =
@@ -34,7 +41,23 @@ fun <Type> PathTrie<Type>.putChild(symbol: FirBasedSymbol<*>, child: PathTrie<Ty
 val PathTrie<*>.symbols: Sequence<FirBasedSymbol<*>>
     get() = children.keys.asSequence() + children.values.flatMap { it.symbols }
 
+/**
+ * Replaces this subtrie by a single summary node covering it: a leaf whose value is the join of every value in the
+ * subtrie, standing for the node's own prefix and for all paths below it.
+ */
+fun <Type> PathTrie<Type>.summarizeDescendants(typeUnifier: TypeFactUnifier<Type>): PathTrie<Type> =
+    if (summarizesDescendants) this else PathTrie(joinChildren(typeUnifier), summarizesDescendants = true)
+
 fun <Type> PathTrie<Type>.join(other: PathTrie<Type>, typeUnifier: TypeFactUnifier<Type>): PathTrie<Type> {
+    // A summary on either side absorbs the other side's children: the result has to stand for every path that either
+    // input stands for, and only a summary can do that for the paths the summary itself no longer spells out.
+    if (summarizesDescendants || other.summarizesDescendants) {
+        return PathTrie(
+            typeUnifier.join(joinChildren(typeUnifier), other.joinChildren(typeUnifier)),
+            summarizesDescendants = true,
+        )
+    }
+
     var joinedChildren = children
 
     for ((symbol, otherChild) in other.children) {
@@ -77,13 +100,10 @@ fun <Type> PathTrie<Type>.joinChildren(typeUnifier: TypeFactUnifier<Type>): Type
 }
 
 fun <Type> PathTrie<Type>.find(path: List<FirBasedSymbol<*>>): PathTrie<Type>? {
-    val head = path.firstOrNull()
+    val head = path.firstOrNull() ?: return this
+    val child = children[head] ?: return this.takeIf { summarizesDescendants }
 
-    return if (head != null) {
-        children[head]?.find(path.drop(1))
-    } else {
-        this
-    }
+    return child.find(path.drop(1))
 }
 
 fun <Type> PathTrie<Type>.enumerate(isTerminal: PathTrie<Type>.() -> Boolean): Sequence<List<FirBasedSymbol<*>>> =

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessErrors.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessErrors.kt
@@ -33,4 +33,16 @@ object UniquenessErrors : KtDiagnosticsContainer() {
     val INVALID_UNIQUENESS_TYPE_TARGET by error0<PsiElement>()
 
     override fun getRendererFactory() = UniquenessErrorMessages
+
+    fun tags() = listOf(
+        UNIQUENESS_MISMATCH.name,
+        CONTEXT_UNIQUENESS_MISMATCH.name,
+        ESCAPE_UNIQUENESS_INCONSISTENCY.name,
+        CONTEXT_ESCAPE_UNIQUENESS_INCONSISTENCY.name,
+        EXIT_UNIQUENESS_INCONSISTENCY.name,
+        INVALID_DUPLICATE_UNIQUE_ARGUMENT.name,
+        INVALID_OVERLAPPING_UNIQUE_ARGUMENTS.name,
+        INVALID_MOVED_ACCESS.name,
+        INVALID_UNIQUENESS_TYPE_TARGET.name,
+    )
 }

--- a/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessState.kt
+++ b/formver.compiler-plugin/uniqueness/src/org/jetbrains/kotlin/formver/uniqueness/plugin/UniquenessState.kt
@@ -28,13 +28,53 @@ fun UniquenessState.enumerateInconsistentPaths(): Sequence<Path> =
 
 /**
  * Replaces the substate at [path] with [child].
+ *
+ * Writing into a summary node cannot single out one path out of the region the summary stands for, so the write is
+ * weak there: the summary absorbs [child] instead of replacing anything.
  */
 fun UniquenessState.insert(path: Path, child: UniquenessState): UniquenessState =
-    if (path.isEmpty()) {
-        child
-    } else {
-        val head = path.first()
-        copy(
-            children = children.put(head, (children[head] ?: EmptyUniquenessState).insert(path.drop(1), child))
-        )
+    when {
+        path.isEmpty() -> child
+        summarizesDescendants -> copy(data = data.join(child.joinChildren(UniquenessUnifier)))
+        else -> {
+            val head = path.first()
+            copy(
+                children = children.put(head, (children[head] ?: EmptyUniquenessState).insert(path.drop(1), child))
+            )
+        }
     }
+
+/**
+ * Collapses every path that revisits a symbol into a summary of the region below the repeat.
+ *
+ * Assignment projects the substate of the right-hand side under the path of the left-hand side, so a loop over a
+ * recursive type can deepen the trie once per iteration - `prev.next`, then `prev.next.next`, and so on - and the
+ * chain of states never stabilizes. Cutting the trie wherever a symbol comes round a second time bounds its depth by
+ * the number of distinct symbols the function mentions, which makes the state space finite and the fixed point
+ * reachable. Any growth that is unbounded has to repeat a symbol, because a loop body can only ever append the finitely
+ * many components its own syntax spells out; paths over non-recursive data are therefore left exactly as they are.
+ */
+fun UniquenessState.summarizeRecursivePaths(): UniquenessState =
+    summarizeRecursivePaths(emptySet())
+
+private fun UniquenessState.summarizeRecursivePaths(seen: Set<FirBasedSymbol<*>>): UniquenessState {
+    if (summarizesDescendants || children.isEmpty()) return this
+
+    var newChildren = children
+
+    for ((symbol, child) in children) {
+        // States are normalized at every node, so most of the time there is nothing to collapse: keep the subtries
+        // that come back unchanged rather than rebuilding the trie on each visit.
+        val newChild = if (symbol in seen) {
+            child.summarizeDescendants(UniquenessUnifier)
+        } else {
+            child.summarizeRecursivePaths(seen + symbol)
+        }
+
+        if (newChild !== child) {
+            newChildren = newChildren.put(symbol, newChild)
+        }
+    }
+
+    return if (newChildren === children) this else copy(children = newChildren)
+}


### PR DESCRIPTION
Unifies #259 and #262: the test suites and the fixes that make them run.

Two fixes:
- The assignment transfer function projected the RHS substate into the LHS path before moving the paths the RHS read, so `current = current.next` marked the wrong node's `next`. The RHS is now read against the incoming state and moved first.
- The fixed point did not terminate over recursive types. A `PathTrie` path is now collapsed wherever a symbol comes round a second time, giving a summary node whose data is the join of everything below it. Operations at a summary join rather than replace, so the approximation only over-reports.

Also adds linked list and binary tree suites and asserts the uniqueness diagnostics' inline markers, which `tagsToConsider` did not cover. `pivot?.right = root` is still not recognised as restoring `pivot.right` — safe-call desugaring hides the path; documented in the test file.