### PR TITLE
Cover explicit triggers on the existential quantifier

### DIFF
--- a/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
+++ b/formver.compiler-plugin/test-gen/org/jetbrains/kotlin/formver/plugin/runners/PhasedDiagnosticTestGenerated.java
@@ -888,6 +888,12 @@ public class PhasedDiagnosticTestGenerated extends AbstractPhasedDiagnosticTest 
       }
 
       @Test
+      @TestMetadata("exists_with_triggers.kt")
+      public void testExists_with_triggers() {
+        runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists_with_triggers.kt");
+      }
+
+      @Test
       @TestMetadata("factorial.kt")
       public void testFactorial() {
         runTest("formver.compiler-plugin/testData/diagnostics/verification/user_invariants/factorial.kt");

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists_with_triggers.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists_with_triggers.fir.diag.txt
@@ -1,0 +1,64 @@
+/exists_with_triggers.kt: info: Generated Viper text for existsWithSimpleTriggerInPrecondition:
+method existsWithSimpleTriggerInPrecondition(n: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(n), intType())
+  requires (exists anon: Int :: { anon * anon } anon * anon ==
+      intFromRef(n))
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := n
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/exists_with_triggers.kt: info: Generated Viper text for existsWithMultipleTriggersInPrecondition:
+method existsWithMultipleTriggersInPrecondition(n: Ref)
+  returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(n), intType())
+  requires (exists anon: Int :: { anon * anon } { anon + 1 } anon * anon ==
+      intFromRef(n) &&
+      anon + 1 > 0)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  v_ret_0 := n
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/exists_with_triggers.kt: info: Generated Viper text for existsWithTriggerInLoopInvariant:
+method existsWithTriggerInLoopInvariant(s: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(s), stringType())
+  requires |stringFromRef(s)| > 0
+  ensures isSubtype(typeOf(v_ret_0), intType())
+{
+  var c: Ref
+  var i: Ref
+  var anon_0: Ref
+  c := stringGet(s, intToRef(0))
+  i := intToRef(0)
+  label cont
+    invariant isSubtype(typeOf(c), charType())
+    invariant isSubtype(typeOf(i), intType())
+    invariant isSubtype(typeOf(s), stringType())
+    invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(s)|
+    invariant (exists anon_builtin: Int :: { stringFromRef(s)[anon_builtin] } 0 <=
+        anon_builtin &&
+        anon_builtin < |stringFromRef(s)| &&
+        stringFromRef(s)[anon_builtin] == charFromRef(c))
+  anon_0 := ltInts(i, stringLength(s))
+  if (boolFromRef(anon_0)) {
+    i := plusInts(i, intToRef(1))
+    goto cont
+  }
+  label break
+  assert isSubtype(typeOf(c), charType())
+  assert isSubtype(typeOf(i), intType())
+  assert isSubtype(typeOf(s), stringType())
+  assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(s)|
+  assert (exists anon_builtin: Int :: { stringFromRef(s)[anon_builtin] } 0 <=
+      anon_builtin &&
+      anon_builtin < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin] == charFromRef(c))
+  v_ret_0 := i
+  goto lbl_ret_0
+  label lbl_ret_0
+}

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists_with_triggers.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists_with_triggers.kt
@@ -1,0 +1,56 @@
+// FULL_JDK
+
+import org.jetbrains.kotlin.formver.plugin.*
+
+// `triggers(...)` is documented for `exists` as well as `forAll`. This file is the
+// existential counterpart of forall_with_triggers.kt: it pins that explicit triggers reach
+// the emitted `exists` as `{ ... }` groups, in each specification position that admits a
+// quantifier. Without it, dropping the triggers on an `exists` changes no golden.
+
+// An existential in a precondition is assumed rather than proved, so the trigger only has
+// to survive conversion into the `requires` clause.
+fun <!VIPER_TEXT!>existsWithSimpleTriggerInPrecondition<!>(n: Int): Int {
+    preconditions {
+        exists<Int> {
+            // Specify trigger expression to guide SMT solver
+            triggers(it * it)
+            it * it == n
+        }
+    }
+    return n
+}
+
+// Each argument of `triggers()` becomes a separate trigger group on the quantifier.
+fun <!VIPER_TEXT!>existsWithMultipleTriggersInPrecondition<!>(n: Int): Int {
+    preconditions {
+        exists<Int> {
+            // Multiple trigger expressions can be provided
+            triggers(it * it, it + 1)
+            it * it == n && it + 1 > 0
+        }
+    }
+    return n
+}
+
+// Triggers can also be attached to an existential in a loop invariant. `val c = s[0]`
+// reads `s[0]` before the loop, so the explicit `s[it]` trigger has a ground term to
+// match and the solver can instantiate `it = 0` as the witness on every iteration.
+fun <!VIPER_TEXT!>existsWithTriggerInLoopInvariant<!>(s: String): Int {
+    preconditions {
+        s.length > 0
+    }
+    val c = s[0]
+    var i = 0
+    while (i < s.length) {
+        loopInvariants {
+            0 <= i && i <= s.length
+            exists<Int> {
+                // Triggers can be used in loop invariants
+                triggers(s[it])
+                0 <= it && it < s.length && s[it] == c
+            }
+        }
+        i += 1
+    }
+    return i
+}


### PR DESCRIPTION
## The gap

`triggers(...)` is documented as usable "within a `forAll` or `exists` block", and
`ExistsEmbedding` carries `triggerExpressions` through to `Exp.Exists(triggers = ...)`.
No test used the two together — every `triggers(...)` in `testData` sat inside a
`forAll`, so the existential half of that path was never exercised.

Confirmed by sabotage: replacing `e.triggerExpressions` with `emptyList()` in
`LinearizationVisitor.visitExistsEmbedding` left **all 172 tests passing**.

## The test

`exists_with_triggers.kt`, the existential counterpart of the existing
`forall_with_triggers.kt`, covering the three cases that file covers for `forAll`:

- a single explicit trigger,
- several triggers (each becomes its own `{ ... }` group),
- a trigger on an `exists` in a loop invariant.

The loop-invariant case reuses the ground-term reasoning already documented in
`exists.kt`: `val c = s[0]` reads `s[0]` before the loop, so the explicit `s[it]`
trigger has a term to match and the witness `it = 0` can be constructed.

With the test in place, that same one-line edit fails the conversion golden in all
three positions:

```diff
-  requires (exists anon: Int :: { anon * anon } { anon + 1 } anon * anon ==
-      intFromRef(n) &&
+  requires (exists anon: Int :: anon * anon == intFromRef(n) &&
       anon + 1 > 0)
```

## Verification

All three functions verify — no `.viper.diag.txt` golden is produced.

- `./agent-scripts/test.sh --verify exists_with_triggers` — 1 passed
- `./agent-scripts/check-all.sh` — `gradle check` passed, `check-testdata.sh` passed.
  `pre-commit` reported skipped because it is not installed and this environment
  blocks `files.pythonhosted.org`; its three hooks were run directly instead
  (`check-testdata`, `agent-scripts/tests/run.sh`, and an `end-of-file-fixer`
  check on each changed file) and all pass.

The only non-testData change is the regenerated test registration in
`PhasedDiagnosticTestGenerated.java`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)