### PR TITLE
Fix three typos in comments and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ formver {
 }
 ```
 
-However, keep in mind that the Viper is dump is provided as an info message: this message will not be shown
+However, keep in mind that the Viper dump is provided as an info message: this message will not be shown
 unless you run `gradle` with the `--info` flag.
 
 ### Annotations

--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/names/FreshName.kt
@@ -66,7 +66,7 @@ data class AnonymousBuiltinName(override val n: Int) : NumberedName, NameTypeIsV
 
 
 /**
- * If you need a the name for the return value of a function, use [FunctionResultVariableName] instead.
+ * If you need the name for the return value of a function, use [FunctionResultVariableName] instead.
  */
 data class ReturnVariableName(override val n: Int) : NumberedName, NameTypeIsVariable {
     override val inViper: Boolean = true

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/Collections.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/Collections.kt
@@ -4,7 +4,7 @@
  */
 
 /**
- * Utility helper filer for creating Scala's datastructures
+ * Utility helper file for creating Scala's data structures
  * in a Kotlin-idiomatic way.
  */
 


### PR DESCRIPTION
Three unrelated typos found while reading through the codebase. Comment and prose only — no behaviour change, and nothing here affects compilation.

- `README.md:80` — "the Viper **is dump is** provided as an info message" had a duplicated `is`.
- `formver.compiler-plugin/viper/.../Collections.kt:7` — "Utility helper **filer**" → "file"; "**datastructures**" → "data structures".
- `formver.compiler-plugin/core/.../names/FreshName.kt:69` — "If you need **a the** name for the return value" → "the name".

## Testing

`agent-scripts/check-testdata.sh` and `agent-scripts/tests/run.sh` (the two pre-commit hooks that need no build) both pass. The Kotlin changes are inside comment blocks, so no build was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)