### PR TITLE
Improve existential verification with ground instances

### DIFF
--- a/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
+++ b/formver.compiler-plugin/core/src/org/jetbrains/kotlin/formver/core/linearization/LinearizationVisitor.kt
@@ -43,6 +43,31 @@ data class LinearizationVisitor(
         return conjunction to viperTriggers
     }
 
+    /**
+     * Find terms which can be used as concrete values for a quantified variable.
+     *
+     * Quantifiers are deliberately treated as leaves: a term below a nested quantifier may
+     * mention that quantifier's local variable and is therefore not a valid term at the outer
+     * quantifier's scope.
+     */
+    private fun groundTermsFor(variable: VariableEmbedding, conditions: List<ExpEmbedding>): List<ExpEmbedding> {
+        fun ExpEmbedding.containsVariable(): Boolean =
+            this === variable || children().any { it.containsVariable() }
+
+        fun ExpEmbedding.collectInto(result: MutableList<ExpEmbedding>) {
+            if (this is ForAllEmbedding || this is ExistsEmbedding) return
+            if (type == variable.type && !containsVariable()) {
+                result += this
+                // Keep the maximal term. Metadata wrappers and conversions often have the same
+                // type as their child; descending would emit the same candidate several times.
+                return
+            }
+            children().forEach { it.collectInto(result) }
+        }
+
+        return buildList { conditions.forEach { it.collectInto(this) } }.distinct()
+    }
+
     // region Control Flow
 
     override fun visitBlock(e: Block): Linearizable = object : OptionalResultLinearizable(e) {
@@ -522,17 +547,41 @@ data class LinearizationVisitor(
     override fun visitExistsEmbedding(e: ExistsEmbedding): Linearizable = object : OnlyToBuiltinLinearizable(e, this@LinearizationVisitor) {
         override fun toViperBuiltinType(ctx: LinearizationContext): Exp {
             val (conjunction, viperTriggers) = getQuantifierParts(e.conditions, e.triggerExpressions, ctx)
-            return Exp.Exists(
+            val body = if (e.variable.isOriginallyRef) Exp.And(
+                e.variable.toViperExp(ctx).isOf(e.variable.type.runtimeType),
+                conjunction
+            ) else conjunction
+            val quantified = Exp.Exists(
                 variables = listOf(e.variable.toLocalVarDecl()),
                 triggers = viperTriggers,
-                exp = if (e.variable.isOriginallyRef) Exp.And(
-                    e.variable.toViperExp(ctx).isOf(e.variable.type.runtimeType),
-                    conjunction
-                )
-                else conjunction,
+                exp = body,
                 pos = ctx.source.asPosition,
                 info = e.sourceRole.asInfo,
             )
+
+            // Each ground instance implies the existential. Consequently
+            //
+            //   (exists x :: P(x)) <==> (exists x :: P(x)) || P(t1) || ... || P(tn)
+            //
+            // This equivalence gives the solver several small, quantifier-free ways of proving
+            // the larger scheme, without relying on trigger selection or changing its meaning.
+            val groundTerms = groundTermsFor(e.variable, e.conditions)
+                .map { it.linearize().toViperBuiltinType(ctx) }
+                .distinct()
+            return groundTerms.fold(quantified as Exp) { result, term ->
+                Exp.Or(
+                    result,
+                    Exp.LetBinding(
+                        e.variable.toLocalVarDecl(),
+                        term,
+                        body,
+                        ctx.source.asPosition,
+                        e.sourceRole.asInfo,
+                    ),
+                    ctx.source.asPosition,
+                    e.sourceRole.asInfo,
+                )
+            }
         }
     }
 

--- a/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/max_character.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/expensive_verification/algorithms/max_character.fir.diag.txt
@@ -6,9 +6,17 @@ method maxCharacter(s: Ref) returns (v_ret_0: Ref)
   ensures (forall anon_builtin_0: Int ::0 <= anon_builtin_0 &&
       anon_builtin_0 < |stringFromRef(s)| ==>
       stringFromRef(s)[anon_builtin_0] <= charFromRef(v_ret_0)) &&
-    (exists anon_builtin_1: Int :: 0 <= anon_builtin_1 &&
+    ((exists anon_builtin_1: Int :: 0 <= anon_builtin_1 &&
       anon_builtin_1 < |stringFromRef(s)| &&
-      stringFromRef(s)[anon_builtin_1] == charFromRef(v_ret_0))
+      stringFromRef(s)[anon_builtin_1] == charFromRef(v_ret_0)) ||
+    (let anon_builtin_1 ==
+      (0) in
+      0 <= anon_builtin_1 && anon_builtin_1 < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin_1] == charFromRef(v_ret_0)) ||
+    (let anon_builtin_1 ==
+      (|stringFromRef(s)|) in
+      0 <= anon_builtin_1 && anon_builtin_1 < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin_1] == charFromRef(v_ret_0)))
 {
   var m: Ref
   var i: Ref
@@ -25,6 +33,14 @@ method maxCharacter(s: Ref) returns (v_ret_0: Ref)
         stringFromRef(s)[anon_builtin_2] <= charFromRef(m))
     invariant (exists anon_builtin_3: Int :: 0 <= anon_builtin_3 &&
         anon_builtin_3 < intFromRef(i) &&
+        stringFromRef(s)[anon_builtin_3] == charFromRef(m)) ||
+      (let anon_builtin_3 ==
+        (0) in
+        0 <= anon_builtin_3 && anon_builtin_3 < intFromRef(i) &&
+        stringFromRef(s)[anon_builtin_3] == charFromRef(m)) ||
+      (let anon_builtin_3 ==
+        (intFromRef(i)) in
+        0 <= anon_builtin_3 && anon_builtin_3 < intFromRef(i) &&
         stringFromRef(s)[anon_builtin_3] == charFromRef(m))
   anon_0 := ltInts(i, stringLength(s))
   if (boolFromRef(anon_0)) {
@@ -44,6 +60,14 @@ method maxCharacter(s: Ref) returns (v_ret_0: Ref)
       stringFromRef(s)[anon_builtin_2] <= charFromRef(m))
   assert (exists anon_builtin_3: Int :: 0 <= anon_builtin_3 &&
       anon_builtin_3 < intFromRef(i) &&
+      stringFromRef(s)[anon_builtin_3] == charFromRef(m)) ||
+    (let anon_builtin_3 ==
+      (0) in
+      0 <= anon_builtin_3 && anon_builtin_3 < intFromRef(i) &&
+      stringFromRef(s)[anon_builtin_3] == charFromRef(m)) ||
+    (let anon_builtin_3 ==
+      (intFromRef(i)) in
+      0 <= anon_builtin_3 && anon_builtin_3 < intFromRef(i) &&
       stringFromRef(s)[anon_builtin_3] == charFromRef(m))
   v_ret_0 := m
   goto lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists.fir.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists.fir.diag.txt
@@ -1,6 +1,9 @@
 /exists.kt: info: Generated Viper text for simpleExists:
 method simpleExists() returns (v_ret_0: Ref)
-  requires (exists anon: Int :: anon == 0)
+  requires (exists anon: Int :: anon == 0) ||
+    (let anon ==
+      (0) in
+      anon == 0)
   ensures isSubtype(typeOf(v_ret_0), intType())
 {
   v_ret_0 := intToRef(0)
@@ -15,10 +18,25 @@ method symbolExists(s: Ref) returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures 0 <= intFromRef(v_ret_0) &&
     intFromRef(v_ret_0) < |stringFromRef(s)| &&
-    (exists anon_builtin_0: Int :: 0 <= anon_builtin_0 &&
+    ((exists anon_builtin_0: Int :: 0 <= anon_builtin_0 &&
       anon_builtin_0 < |stringFromRef(s)| &&
       stringFromRef(s)[anon_builtin_0] ==
-      stringFromRef(s)[intFromRef(v_ret_0)])
+      stringFromRef(s)[intFromRef(v_ret_0)]) ||
+    (let anon_builtin_0 ==
+      (0) in
+      0 <= anon_builtin_0 && anon_builtin_0 < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin_0] ==
+      stringFromRef(s)[intFromRef(v_ret_0)]) ||
+    (let anon_builtin_0 ==
+      (|stringFromRef(s)|) in
+      0 <= anon_builtin_0 && anon_builtin_0 < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin_0] ==
+      stringFromRef(s)[intFromRef(v_ret_0)]) ||
+    (let anon_builtin_0 ==
+      (intFromRef(v_ret_0)) in
+      0 <= anon_builtin_0 && anon_builtin_0 < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin_0] ==
+      stringFromRef(s)[intFromRef(v_ret_0)]))
 {
   var c: Ref
   var i: Ref
@@ -32,6 +50,14 @@ method symbolExists(s: Ref) returns (v_ret_0: Ref)
     invariant 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(s)|
     invariant (exists anon_builtin_1: Int :: 0 <= anon_builtin_1 &&
         anon_builtin_1 < |stringFromRef(s)| &&
+        stringFromRef(s)[anon_builtin_1] == charFromRef(c)) ||
+      (let anon_builtin_1 ==
+        (0) in
+        0 <= anon_builtin_1 && anon_builtin_1 < |stringFromRef(s)| &&
+        stringFromRef(s)[anon_builtin_1] == charFromRef(c)) ||
+      (let anon_builtin_1 ==
+        (|stringFromRef(s)|) in
+        0 <= anon_builtin_1 && anon_builtin_1 < |stringFromRef(s)| &&
         stringFromRef(s)[anon_builtin_1] == charFromRef(c))
   anon_0 := ltInts(i, stringLength(s))
   if (boolFromRef(anon_0)) {
@@ -45,6 +71,14 @@ method symbolExists(s: Ref) returns (v_ret_0: Ref)
   assert 0 <= intFromRef(i) && intFromRef(i) <= |stringFromRef(s)|
   assert (exists anon_builtin_1: Int :: 0 <= anon_builtin_1 &&
       anon_builtin_1 < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin_1] == charFromRef(c)) ||
+    (let anon_builtin_1 ==
+      (0) in
+      0 <= anon_builtin_1 && anon_builtin_1 < |stringFromRef(s)| &&
+      stringFromRef(s)[anon_builtin_1] == charFromRef(c)) ||
+    (let anon_builtin_1 ==
+      (|stringFromRef(s)|) in
+      0 <= anon_builtin_1 && anon_builtin_1 < |stringFromRef(s)| &&
       stringFromRef(s)[anon_builtin_1] == charFromRef(c))
   v_ret_0 := intToRef(0)
   goto lbl_ret_0
@@ -58,8 +92,20 @@ method symbolExistsWithoutGroundTerm(s: Ref) returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), intType())
   ensures 0 <= intFromRef(v_ret_0) &&
     intFromRef(v_ret_0) < |stringFromRef(s)| &&
-    (exists anon: Int :: 0 <= anon && anon < |stringFromRef(s)| &&
-      stringFromRef(s)[anon] == stringFromRef(s)[intFromRef(v_ret_0)])
+    ((exists anon: Int :: 0 <= anon && anon < |stringFromRef(s)| &&
+      stringFromRef(s)[anon] == stringFromRef(s)[intFromRef(v_ret_0)]) ||
+    (let anon ==
+      (0) in
+      0 <= anon && anon < |stringFromRef(s)| &&
+      stringFromRef(s)[anon] == stringFromRef(s)[intFromRef(v_ret_0)]) ||
+    (let anon ==
+      (|stringFromRef(s)|) in
+      0 <= anon && anon < |stringFromRef(s)| &&
+      stringFromRef(s)[anon] == stringFromRef(s)[intFromRef(v_ret_0)]) ||
+    (let anon ==
+      (intFromRef(v_ret_0)) in
+      0 <= anon && anon < |stringFromRef(s)| &&
+      stringFromRef(s)[anon] == stringFromRef(s)[intFromRef(v_ret_0)]))
 {
   v_ret_0 := intToRef(0)
   goto lbl_ret_0
@@ -69,7 +115,31 @@ method symbolExistsWithoutGroundTerm(s: Ref) returns (v_ret_0: Ref)
 /exists.kt: info: Generated Viper text for existsPostcondWithoutTrigger:
 method existsPostcondWithoutTrigger() returns (v_ret_0: Ref)
   ensures isSubtype(typeOf(v_ret_0), intType())
-  ensures (exists anon: Int :: anon == 0)
+  ensures (exists anon: Int :: anon == 0) || (let anon == (0) in anon == 0)
+{
+  v_ret_0 := intToRef(0)
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/exists.kt: info: Generated Viper text for existsWithGroundLocal:
+method existsWithGroundLocal(n: Ref) returns (v_ret_0: Ref)
+  requires isSubtype(typeOf(n), intType())
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures (exists anon: Int :: anon == intFromRef(n)) ||
+    (let anon ==
+      (intFromRef(n)) in
+      anon == intFromRef(n))
+{
+  v_ret_0 := n
+  goto lbl_ret_0
+  label lbl_ret_0
+}
+
+/exists.kt: info: Generated Viper text for falseExistsRemainsFalse:
+method falseExistsRemainsFalse() returns (v_ret_0: Ref)
+  ensures isSubtype(typeOf(v_ret_0), intType())
+  ensures (exists anon: Int :: !(anon == anon))
 {
   v_ret_0 := intToRef(0)
   goto lbl_ret_0

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists.kt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists.kt
@@ -35,9 +35,9 @@ fun <!VIPER_TEXT!>symbolExists<!>(s: String): Int {
     return 0
 }
 
-// Without `val c = s[0]`, `s[0]` is never read before the loop so there is no ground
-// term for the `s[it]` trigger to match — the solver cannot construct the witness.
-<!VIPER_VERIFICATION_ERROR!>@AlwaysVerify
+// The postcondition supplies `res` as a finite ground candidate for `it`. Instantiating the
+// body with that candidate reduces the existential to its three quantifier-free conjuncts.
+@AlwaysVerify
 fun <!VIPER_TEXT!>symbolExistsWithoutGroundTerm<!>(s: String): Int {
     preconditions {
         s.length > 0
@@ -47,17 +47,31 @@ fun <!VIPER_TEXT!>symbolExistsWithoutGroundTerm<!>(s: String): Int {
         exists<Int> { 0 <= it && it < s.length && s[it] == s[res] }
     }
     return 0
-}<!>
+}
 
-// Incompleteness path: this existential (`it == 0`) is plainly true, but its body is bare
-// arithmetic with no trigger term for the solver to match on. Without model-based quantifier
-// instantiation the witness cannot be constructed, so the postcondition is reported as a
-// verification warning. This pins "witness not found" — not "existential is false" — and is the
-// counterpart to max_character.kt, where a `s[i]` trigger plus a loop invariant let it verify.
-<!VIPER_VERIFICATION_ERROR!>@AlwaysVerify
+// Literal candidates are instances too, so this proves the obvious witness without a trigger.
+@AlwaysVerify
 fun <!VIPER_TEXT!>existsPostcondWithoutTrigger<!>(): Int {
     postconditions<Int> {
         exists<Int> { it == 0 }
+    }
+    return 0
+}
+
+@AlwaysVerify
+fun <!VIPER_TEXT!>existsWithGroundLocal<!>(n: Int): Int {
+    postconditions<Int> {
+        exists<Int> { it == n }
+    }
+    return n
+}
+
+// Finite instantiation is only a proof aid: retaining the original existential is essential.
+// A false ground instance must not make a false existential verify.
+<!VIPER_VERIFICATION_ERROR!>@AlwaysVerify
+fun <!VIPER_TEXT!>falseExistsRemainsFalse<!>(): Int {
+    postconditions<Int> {
+        exists<Int> { it != it }
     }
     return 0
 }<!>

--- a/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists.viper.diag.txt
+++ b/formver.compiler-plugin/testData/diagnostics/verification/user_invariants/exists.viper.diag.txt
@@ -1,3 +1,1 @@
-/exists.kt: warning: Viper verification error: Postcondition of symbolExistsWithoutGroundTerm might not hold. Assertion (exists anon: Int :: { stringFromRef(s)[anon] } 0 <= anon && anon < |stringFromRef(s)| && stringFromRef(s)[anon] == stringFromRef(s)[intFromRef(v_ret_0)]) might not hold.
-
-/exists.kt: warning: Viper verification error: Postcondition of existsPostcondWithoutTrigger might not hold. Assertion (exists anon: Int :: anon == 0) might not hold.
+/exists.kt: warning: Viper verification error: Postcondition of falseExistsRemainsFalse might not hold. Assertion (exists anon: Int :: !(anon == anon)) might not hold.

--- a/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
+++ b/formver.compiler-plugin/viper/src/org/jetbrains/kotlin/formver/viper/ast/Exp.kt
@@ -708,7 +708,7 @@ sealed interface Exp : WithSilverMetadata, IntoSilver<viper.silver.ast.Exp> {
         override val pos: Position = Position.NoPosition,
         override val info: Info = Info.NoInfo,
     ): Exp {
-        override val type: Type = variable.type
+        override val type: Type = body.type
 
         context(nameResolver: NameResolver)
         override fun toSilver(): viper.silver.ast.Let =
@@ -717,6 +717,7 @@ sealed interface Exp : WithSilverMetadata, IntoSilver<viper.silver.ast.Exp> {
         context(nameResolver: NameResolver)
         override fun registerNames() {
             nameResolver.register(variable.name)
+            varExp.registerNames()
             body.registerNames()
         }
     }


### PR DESCRIPTION
## Summary

- collect finite ground candidates already present in existential bodies
- encode the sound equivalence `exists x. P(x) <==> (exists x. P(x)) || P(t1) || ... || P(tn)` using Viper let bindings
- cover literal, local-variable, and indexed-expression witness cases while retaining a negative soundness test
- correct Viper let expression typing and name registration

## Tests

- `./agent-scripts/test.sh exists`
- `./agent-scripts/test.sh max_character`
- `./agent-scripts/check-testdata.sh`
- `./agent-scripts/check-all.sh` (compilation/static analysis pass; verification cannot run because this environment has no Z3 executable; pre-commit is not installed)

The verification golden removes the two former incompleteness warnings and retains the deliberately false existential warning.